### PR TITLE
refactor: remove unused MarmotRuntime methods (#26)

### DIFF
--- a/whitenoise-mac/Core/MarmotClient.swift
+++ b/whitenoise-mac/Core/MarmotClient.swift
@@ -50,15 +50,12 @@ nonisolated protocol MarmotRuntime: Sendable {
     func setGroupArchived(accountRef: String, groupIdHex: String, archived: Bool) async throws -> AppGroupRecordFfi
     func updateGroupAvatarUrl(accountRef: String, groupIdHex: String, url: String?, dim: String?, thumbhash: String?) async throws -> SendSummaryFfi
     func updateGroupProfile(accountRef: String, groupIdHex: String, name: String?, description: String?) async throws -> SendSummaryFfi
-    func chatList(accountRef: String, includeArchived: Bool) throws -> [ChatListRowFfi]
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws -> ChatListSubscription
-    func subscribeChats(accountRef: String, includeArchived: Bool) async throws -> ChatsSubscription
     func subscribeNotifications() async throws -> NotificationsSubscription
     func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi) throws -> TimelinePageFfi
     func subscribeTimelineMessages(accountRef: String, groupIdHex: String?, limit: UInt32?) async throws -> TimelineMessagesSubscription
     func initializeChatReadState(accountRef: String, groupIdHex: String) throws -> ChatListRowFfi?
     func markTimelineMessageRead(accountRef: String, groupIdHex: String, messageIdHex: String) throws -> ChatListRowFfi?
-    func messages(accountRef: String, groupIdHex: String?, limit: UInt32?) throws -> [AppMessageRecordFfi]
     func sendText(accountRef: String, groupIdHex: String, text: String) async throws -> SendSummaryFfi
     func replyToMessage(accountRef: String, groupIdHex: String, targetMessageId: String, text: String) async throws -> SendSummaryFfi
     func reactToMessage(accountRef: String, groupIdHex: String, targetMessageId: String, emoji: String) async throws -> SendSummaryFfi
@@ -321,16 +318,8 @@ nonisolated final class MarmotClient: MarmotRuntime, @unchecked Sendable {
         )
     }
 
-    func chatList(accountRef: String, includeArchived: Bool) throws -> [ChatListRowFfi] {
-        try marmot.chatList(accountRef: accountRef, includeArchived: includeArchived)
-    }
-
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws -> ChatListSubscription {
         try await marmot.subscribeChatList(accountRef: accountRef, includeArchived: includeArchived)
-    }
-
-    func subscribeChats(accountRef: String, includeArchived: Bool) async throws -> ChatsSubscription {
-        try await marmot.subscribeChats(accountRef: accountRef, includeArchived: includeArchived)
     }
 
     func subscribeNotifications() async throws -> NotificationsSubscription {
@@ -359,10 +348,6 @@ nonisolated final class MarmotClient: MarmotRuntime, @unchecked Sendable {
             groupIdHex: groupIdHex,
             messageIdHex: messageIdHex
         )
-    }
-
-    func messages(accountRef: String, groupIdHex: String?, limit: UInt32?) throws -> [AppMessageRecordFfi] {
-        try marmot.messages(accountRef: accountRef, groupIdHex: groupIdHex, limit: limit)
     }
 
     func sendText(accountRef: String, groupIdHex: String, text: String) async throws -> SendSummaryFfi {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -614,7 +614,6 @@ struct whitenoise_macTests {
         }
 
         #expect(didApplyRemoval)
-        #expect(runtime.chatListCallCount == 0)
         #expect(runtime.chatListSubscriptionCount == 1)
     }
 
@@ -2675,7 +2674,6 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var refreshedProfileIds: [String] = []
     private(set) var markedReadMessageIds: [String] = []
     private(set) var accountKeyPackagesCallCount = 0
-    private(set) var chatListCallCount = 0
     private(set) var chatListSubscriptionCount = 0
     private(set) var timelineSubscriptionCount = 0
     private(set) var lastTimelineSubscription: FakeTimelineMessagesSubscription?
@@ -3199,15 +3197,6 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         return relayLists
     }
 
-    func subscribeChats(accountRef: String, includeArchived: Bool) async throws -> ChatsSubscription {
-        FakeChatsSubscription(groups: groups)
-    }
-
-    func chatList(accountRef: String, includeArchived: Bool) throws -> [ChatListRowFfi] {
-        chatListCallCount += 1
-        return chatListRows(includeArchived: includeArchived)
-    }
-
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws -> ChatListSubscription {
         chatListSubscriptionCount += 1
         return FakeChatListSubscription(
@@ -3326,13 +3315,6 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         return groups.first(where: { $0.groupIdHex == groupIdHex }).map(chatListRow(for:))
     }
 
-    func messages(accountRef: String, groupIdHex: String?, limit: UInt32?) throws -> [AppMessageRecordFfi] {
-        if let groupIdHex {
-            return messagesByGroupId[groupIdHex] ?? []
-        }
-        return messagesByGroupId.values.flatMap { $0 }
-    }
-
     func sendText(accountRef: String, groupIdHex: String, text: String) async throws -> SendSummaryFfi {
         throw FakeMarmotRuntimeError.unused
     }
@@ -3422,28 +3404,6 @@ private struct UpdatedGroupProfile: Equatable {
 private struct ArchivedGroup: Equatable {
     let groupIdHex: String
     let archived: Bool
-}
-
-private final class FakeChatsSubscription: ChatsSubscription {
-    private let groups: [AppGroupRecordFfi]
-
-    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
-        self.groups = []
-        super.init(unsafeFromRawPointer: pointer)
-    }
-
-    init(groups: [AppGroupRecordFfi]) {
-        self.groups = groups
-        super.init(noPointer: NoPointer())
-    }
-
-    override func snapshot() -> [AppGroupRecordFfi] {
-        groups
-    }
-
-    override func next() async -> AppGroupRecordFfi? {
-        nil
-    }
 }
 
 private final class FakeChatListSubscription: ChatListSubscription {


### PR DESCRIPTION
## Summary

Removes three `MarmotRuntime` protocol methods that have no production call site, narrowing the protocol surface that must stay in sync with MarmotKit and the test fake.

Removed (verified dead via repo-wide search — only declaration + impl + test stub, no caller):
- `subscribeChats(accountRef:includeArchived:)` — app uses `subscribeChatList` instead
- `chatList(accountRef:includeArchived:)` — superseded by `subscribeChatList`
- `messages(accountRef:groupIdHex:limit:)` — superseded by `subscribeTimelineMessages`

Each removal drops: the protocol declaration, the `MarmotClient` implementation, and the `FakeMarmotRuntime` stub. Also removes the now-orphaned `FakeChatsSubscription` test double and the dead `chatListCallCount` spy field + its (vacuous) assertion.

## Deviation from issue evidence

The issue (#26) also listed `updateGroupAvatarUrl` and `timelineMessages` as dead. **They are not** — the repo evolved since the issue was filed and both now have live production callers:
- `updateGroupAvatarUrl` → `WorkspaceState.updateSelectedGroupImage` (`WorkspaceState.swift:1434`)
- `timelineMessages` → `ConversationTranscriptExport` (`ConversationTranscriptExport.swift:76`)

Removing them would break the build, so they are retained.

## Verification

55 deletions across 2 files; braces balanced; protocol / `MarmotClient` / `FakeMarmotRuntime` kept mutually consistent. This is a macOS/Xcode-only target — no Swift toolchain on the Linux fix host, so compile/test verification is deferred to CI / the macOS reviewer.

Closes #26

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->