### PR TITLE
fix: scope background-task errors off the shared per-screen lastError (#24)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -38,7 +38,15 @@ final class WorkspaceState {
     private(set) var accounts: [AccountItem]
     private(set) var chatsByAccount: [String: [ChatItem]]
     private(set) var messagesByChat: [String: [MessageItem]]
+    /// Error for the user-initiated action on the *current* screen. Rendered by form
+    /// surfaces (login, settings, new-chat composer). Must never be written by
+    /// background tasks — see `backgroundStatus`.
     private(set) var lastError: String?
+    /// Status for failures originating in background tasks (subscription listeners,
+    /// observability refresh, read-marking). These are not tied to anything the user
+    /// just did, so they are surfaced on a non-modal global banner instead of the
+    /// per-screen error view, preventing misattribution and clobbering of `lastError`.
+    private(set) var backgroundStatus: String?
 
     var activeAccountId: String?
     var selection: WorkspaceSelection?
@@ -1759,9 +1767,22 @@ final class WorkspaceState {
             do {
                 try await self?.configureObservabilityRuntime()
             } catch {
-                self?.lastError = error.localizedDescription
+                self?.setBackgroundStatus(error.localizedDescription)
             }
         }
+    }
+
+    /// Record a background-task failure on the non-modal global status surface.
+    /// Background failures must never write `lastError`, which is reserved for the
+    /// user-initiated action on the current screen.
+    private func setBackgroundStatus(_ message: String?) {
+        backgroundStatus = message
+    }
+
+    /// Dismiss the background status banner (e.g. user tapped the close control, or a
+    /// later background operation succeeded).
+    func clearBackgroundStatus() {
+        backgroundStatus = nil
     }
 
     private func configureObservabilityRuntime() async throws {
@@ -1966,7 +1987,7 @@ final class WorkspaceState {
         } catch is CancellationError {
             return
         } catch {
-            lastError = error.localizedDescription
+            setBackgroundStatus(error.localizedDescription)
         }
 
         notificationTask = nil
@@ -2023,7 +2044,7 @@ final class WorkspaceState {
             return
         } catch {
             if activeAccountId == account.id {
-                lastError = error.localizedDescription
+                setBackgroundStatus(error.localizedDescription)
             }
         }
 
@@ -2094,7 +2115,7 @@ final class WorkspaceState {
             return
         } catch {
             if activeAccountId == account.id, selectedChat?.id == groupIdHex {
-                lastError = error.localizedDescription
+                setBackgroundStatus(error.localizedDescription)
             }
         }
 
@@ -2373,7 +2394,7 @@ final class WorkspaceState {
             }
         } catch {
             lastMarkedReadMarkers[groupIdHex] = previousMarker
-            lastError = error.localizedDescription
+            setBackgroundStatus(error.localizedDescription)
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1630,7 +1630,7 @@ final class WorkspaceState {
             try await localNotificationCenter.post(request)
             rememberDeliveredNotificationKey(update.notificationKey)
         } catch {
-            lastError = error.localizedDescription
+            setBackgroundStatus(error.localizedDescription)
         }
     }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -24,6 +24,13 @@ struct MessengerShellView: View {
                     DetailPaneView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
+                // Background-task failures (subscription listeners, observability
+                // refresh, read-marking) surface here as a non-modal banner rather
+                // than on the per-screen error view, so they are never misattributed
+                // to a user action on the login/settings/new-chat forms.
+                .overlay(alignment: .top) {
+                    BackgroundStatusBanner()
+                }
             } else {
                 DetailPaneView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -33,6 +40,42 @@ struct MessengerShellView: View {
             MessagesWindowBackground()
         }
         .animation(.smooth(duration: 0.18), value: workspace.isChatListVisible)
+    }
+}
+
+private struct BackgroundStatusBanner: View {
+    @Environment(WorkspaceState.self) private var workspace
+
+    var body: some View {
+        if let status = workspace.backgroundStatus {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(status)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 8)
+                Button {
+                    workspace.clearBackgroundStatus()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .help(L10n.string("Dismiss"))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .frame(maxWidth: 520)
+            .background {
+                GlassRoundedBackground(cornerRadius: 10)
+            }
+            .padding(.top, 12)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .animation(.smooth(duration: 0.2), value: workspace.backgroundStatus)
+        }
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2193,6 +2193,39 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func backgroundListenerFailureRoutesToBackgroundStatusNotLastError() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        // A background notification-listener failure must not surface on the shared
+        // per-screen error field that login/settings/new-chat render (issue #24).
+        runtime.subscribeNotificationsError = NSError(
+            domain: "test.background",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "background listener dropped"]
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+
+        let routedToBackground = await waitFor {
+            state.backgroundStatus == "background listener dropped"
+        }
+        #expect(routedToBackground)
+        // The user-facing per-screen error field must remain untouched.
+        #expect(state.lastError == nil)
+
+        // The banner is dismissible without affecting lastError.
+        state.clearBackgroundStatus()
+        #expect(state.backgroundStatus == nil)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
     @Test func auditLogFileActionsRefreshDeleteAndUploadThroughRuntime() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -2683,6 +2716,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var profileRefreshDelaysByAccountId: [String: UInt64] = [:]
     var accountIdsMissingProfiles = Set<String>()
     var timelineMessagesHandler: ((TimelineMessageQueryFfi) -> TimelinePageFfi)?
+    /// When set, `subscribeNotifications()` throws this error, simulating a background
+    /// notification-listener failure for routing tests.
+    var subscribeNotificationsError: Error?
     var timelineUpdateDelayNanoseconds: UInt64 = 0
     private var profilesByAccountId: [String: UserProfileMetadataFfi] = [:]
     private var normalizedMembersByRef: [String: MemberRefFfi] = [:]
@@ -3279,7 +3315,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func subscribeNotifications() async throws -> NotificationsSubscription {
-        FakeNotificationsSubscription()
+        if let subscribeNotificationsError {
+            throw subscribeNotificationsError
+        }
+        return FakeNotificationsSubscription()
     }
 
     func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi) throws -> TimelinePageFfi {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2226,6 +2226,48 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func notificationDeliveryFailureRoutesToBackgroundStatusNotLastError() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: true)
+        // `handleNotificationUpdate(_:)` runs on the background notification listener.
+        // A failure posting the local notification must surface on the non-modal
+        // background banner, never on the per-screen `lastError` that login/settings/
+        // new-chat render (issue #24 — see PR #49 review finding).
+        let notificationCenter = FakeLocalNotificationCenter(
+            status: .authorized,
+            postError: NSError(
+                domain: "test.notification",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "notification delivery failed"]
+            )
+        )
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        await state.handleNotificationUpdate(notificationUpdate(
+            account: account,
+            notificationKey: "notice-1",
+            groupIdHex: "direct-group",
+            senderName: "Alice",
+            previewText: "See you there."
+        ))
+
+        #expect(state.backgroundStatus == "notification delivery failed")
+        // The user-facing per-screen error field must remain untouched.
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
     @Test func auditLogFileActionsRefreshDeleteAndUploadThroughRuntime() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -3677,6 +3719,7 @@ private final class FakeLocalNotificationCenter: LocalNotificationCenter {
     private(set) var status: LocalNotificationAuthorizationStatus
     private let requestedStatus: LocalNotificationAuthorizationStatus
     private let requestError: Error?
+    private let postError: Error?
     private(set) var didRequestAuthorization = false
     private(set) var postedRequests: [LocalNotificationRequest] = []
     private var responseHandler: (@MainActor ([String: String]) -> Void)?
@@ -3684,11 +3727,13 @@ private final class FakeLocalNotificationCenter: LocalNotificationCenter {
     init(
         status: LocalNotificationAuthorizationStatus = .authorized,
         requestedStatus: LocalNotificationAuthorizationStatus = .authorized,
-        requestError: Error? = nil
+        requestError: Error? = nil,
+        postError: Error? = nil
     ) {
         self.status = status
         self.requestedStatus = requestedStatus
         self.requestError = requestError
+        self.postError = postError
     }
 
     func authorizationStatus() async -> LocalNotificationAuthorizationStatus {
@@ -3705,6 +3750,9 @@ private final class FakeLocalNotificationCenter: LocalNotificationCenter {
     }
 
     func post(_ notification: LocalNotificationRequest) async throws {
+        if let postError {
+            throw postError
+        }
         postedRequests.append(notification)
     }
 


### PR DESCRIPTION
## Summary

`WorkspaceState.lastError` is a single shared field rendered by many unrelated form screens (login, settings, new-chat composer), but it was *also* written by background tasks. A transient background failure therefore rendered a red error on whatever screen the user happened to be on — misattributing it to an unrelated action, and clobbering (or being clobbered by) the real error from the user's current action.

Closes #24.

## Fix

- Add a dedicated `WorkspaceState.backgroundStatus` field for failures originating in background tasks.
- Route all five background write sites off `lastError` to `setBackgroundStatus(...)`:
  - `refreshObservabilityRuntime()`
  - `runNotificationListener()`
  - `runChatListListener(...)`
  - `runTimelineListener(...)`
  - `markLatestVisibleMessageRead(...)`
- `lastError` is now written only by user-initiated flows (41 user-action sites unchanged).
- Surface `backgroundStatus` on a non-modal, dismissible banner (`BackgroundStatusBanner`) shown only inside the messenger chrome — never on the login/settings/new-chat forms.

This satisfies the issue's minimum bar ("do not let background listeners write the field that login/settings/new-chat render") and follows the suggested global-status-surface approach.

## Test plan

- [ ] CI: build + `whitenoise-macTests`
- Added regression test `backgroundListenerFailureRoutesToBackgroundStatusNotLastError`: injects a `subscribeNotifications()` failure and asserts `backgroundStatus` is populated while `lastError` stays `nil`; also verifies `clearBackgroundStatus()` dismisses without touching `lastError`.

> Note: built/validated structurally on Linux (no Xcode); relying on CI for the macOS build + test run.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->