### PR TITLE
fix: fail when Marmot storage root is unavailable

### DIFF
--- a/whitenoise-mac/Core/MarmotClient.swift
+++ b/whitenoise-mac/Core/MarmotClient.swift
@@ -458,6 +458,7 @@ enum MarmotStorageRoot {
         return root.path
     }
 
+    // Best-effort display label used before bootstrap; resolve() is the authoritative path.
     static func expectedPath(fileManager: FileManager = .default) -> String {
         guard let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return "Application Support unavailable"

--- a/whitenoise-mac/Core/MarmotClient.swift
+++ b/whitenoise-mac/Core/MarmotClient.swift
@@ -78,11 +78,11 @@ nonisolated final class MarmotClient: MarmotRuntime, @unchecked Sendable {
     var storageRootPath: String { rootPath }
 
     convenience init() throws {
-        try self.init(rootPath: Self.applicationSupportRoot(), relayUrls: Self.seedRelays)
+        try self.init(rootPath: MarmotStorageRoot.resolve(), relayUrls: Self.seedRelays)
     }
 
     static func defaultStorageRootPath() -> String {
-        applicationSupportRoot()
+        MarmotStorageRoot.expectedPath()
     }
 
     init(rootPath: String, relayUrls: [String]) throws {
@@ -394,24 +394,80 @@ nonisolated final class MarmotClient: MarmotRuntime, @unchecked Sendable {
             targetMessageId: targetMessageId
         )
     }
+}
 
-    private static func applicationSupportRoot() -> String {
-        let fileManager = FileManager.default
-        let base = (try? fileManager.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )) ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+enum MarmotStorageRootError: LocalizedError {
+    case applicationSupportUnavailable(Error)
+    case createDirectoryFailed(path: String, underlying: Error)
+    case rootIsNotDirectory(path: String)
 
-        let root = base
-            .appendingPathComponent("White Noise", isDirectory: true)
-            .appendingPathComponent("Marmot", isDirectory: true)
+    var errorDescription: String? {
+        switch self {
+        case .applicationSupportUnavailable(let error):
+            return "Unable to resolve a durable Application Support directory for Marmot storage: \(error.localizedDescription)"
+        case .createDirectoryFailed(let path, let error):
+            return "Unable to create durable Marmot storage directory at \(path): \(error.localizedDescription)"
+        case .rootIsNotDirectory(let path):
+            return "Marmot storage path exists but is not a directory: \(path)"
+        }
+    }
+}
 
-        if !fileManager.fileExists(atPath: root.path) {
-            try? fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+enum MarmotStorageRoot {
+    private static let appSupportDirectoryName = "White Noise"
+    private static let marmotDirectoryName = "Marmot"
+
+    static func resolve(
+        fileManager: FileManager = .default,
+        applicationSupportDirectory: (FileManager) throws -> URL = { fileManager in
+            try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        }
+    ) throws -> String {
+        let base: URL
+        do {
+            base = try applicationSupportDirectory(fileManager)
+        } catch {
+            throw MarmotStorageRootError.applicationSupportUnavailable(error)
+        }
+
+        return try resolve(baseURL: base, fileManager: fileManager)
+    }
+
+    static func resolve(baseURL: URL, fileManager: FileManager = .default) throws -> String {
+        let root = storageRootURL(baseURL: baseURL)
+        var isDirectory: ObjCBool = false
+
+        if fileManager.fileExists(atPath: root.path, isDirectory: &isDirectory) {
+            guard isDirectory.boolValue else {
+                throw MarmotStorageRootError.rootIsNotDirectory(path: root.path)
+            }
+            return root.path
+        }
+
+        do {
+            try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        } catch {
+            throw MarmotStorageRootError.createDirectoryFailed(path: root.path, underlying: error)
         }
 
         return root.path
+    }
+
+    static func expectedPath(fileManager: FileManager = .default) -> String {
+        guard let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return "Application Support unavailable"
+        }
+        return storageRootURL(baseURL: base).path
+    }
+
+    private static func storageRootURL(baseURL: URL) -> URL {
+        baseURL
+            .appendingPathComponent(appSupportDirectoryName, isDirectory: true)
+            .appendingPathComponent(marmotDirectoryName, isDirectory: true)
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -126,6 +126,77 @@ struct whitenoise_macTests {
         #expect(!state.showsMessengerChrome)
     }
 
+    @Test func marmotStorageRootRejectsUnavailableApplicationSupportDirectory() throws {
+        let underlying = NSError(
+            domain: "MarmotStorageRootTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "blocked Application Support"]
+        )
+
+        do {
+            _ = try MarmotStorageRoot.resolve(applicationSupportDirectory: { _ in throw underlying })
+            Issue.record("Expected storage root resolution to fail")
+        } catch let error as MarmotStorageRootError {
+            let message = error.localizedDescription
+            #expect(message.contains("Unable to resolve a durable Application Support directory"))
+            #expect(message.contains("blocked Application Support"))
+            #expect(!message.contains(NSTemporaryDirectory()))
+        } catch {
+            Issue.record("Expected MarmotStorageRootError, got \(error)")
+        }
+    }
+
+    @MainActor
+    @Test func bootstrapSurfacesStorageRootResolutionFailures() async throws {
+        let underlying = NSError(
+            domain: "MarmotStorageRootTests",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "blocked Application Support"]
+        )
+        let state = WorkspaceState(clientFactory: {
+            throw MarmotStorageRootError.applicationSupportUnavailable(underlying)
+        })
+
+        await state.bootstrap()
+
+        guard case .failed(let message) = state.phase else {
+            Issue.record("Expected bootstrap to fail when storage root resolution fails")
+            return
+        }
+        #expect(message.contains("Unable to resolve a durable Application Support directory"))
+        #expect(state.lastError == message)
+        #expect(!state.showsMessengerChrome)
+    }
+
+    @Test func marmotStorageRootPropagatesDirectoryCreationFailures() throws {
+        let fileManager = FileManager.default
+        let sandbox = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-storage-root-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: sandbox) }
+
+        let blockedParent = sandbox.appendingPathComponent("White Noise", isDirectory: false)
+        try Data().write(to: blockedParent)
+
+        let expectedRoot = sandbox
+            .appendingPathComponent("White Noise", isDirectory: true)
+            .appendingPathComponent("Marmot", isDirectory: true)
+            .path
+
+        do {
+            _ = try MarmotStorageRoot.resolve(baseURL: sandbox, fileManager: fileManager)
+            Issue.record("Expected storage root creation to fail")
+        } catch let error as MarmotStorageRootError {
+            let message = error.localizedDescription
+            #expect(message.contains("Unable to create durable Marmot storage directory"))
+            #expect(message.contains(expectedRoot))
+        } catch {
+            Issue.record("Expected MarmotStorageRootError, got \(error)")
+        }
+
+        #expect(!fileManager.fileExists(atPath: expectedRoot))
+    }
+
     @MainActor
     @Test func chatSearchMatchesTitleSubtitleAndPreview() async throws {
         let chats = ChatItem.samples

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -197,6 +197,33 @@ struct whitenoise_macTests {
         #expect(!fileManager.fileExists(atPath: expectedRoot))
     }
 
+    @Test func marmotStorageRootRejectsFileAtExpectedRoot() throws {
+        let fileManager = FileManager.default
+        let sandbox = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-storage-root-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: sandbox) }
+
+        let whiteNoiseDirectory = sandbox.appendingPathComponent("White Noise", isDirectory: true)
+        try fileManager.createDirectory(at: whiteNoiseDirectory, withIntermediateDirectories: true)
+
+        let marmotRoot = whiteNoiseDirectory.appendingPathComponent("Marmot", isDirectory: false)
+        try Data().write(to: marmotRoot)
+
+        do {
+            _ = try MarmotStorageRoot.resolve(baseURL: sandbox, fileManager: fileManager)
+            Issue.record("Expected storage root resolution to reject a file at the Marmot root")
+        } catch let error as MarmotStorageRootError {
+            guard case .rootIsNotDirectory(let path) = error else {
+                Issue.record("Expected rootIsNotDirectory, got \(error)")
+                return
+            }
+            #expect(path == marmotRoot.path)
+        } catch {
+            Issue.record("Expected MarmotStorageRootError, got \(error)")
+        }
+    }
+
     @MainActor
     @Test func chatSearchMatchesTitleSubtitleAndPreview() async throws {
         let chats = ChatItem.samples


### PR DESCRIPTION
## Summary
- Removes Marmot storage's silent fallback to `NSTemporaryDirectory()`.
- Resolves the durable Application Support storage root via a throwing helper and propagates directory-creation/path-shape failures.
- Keeps Developer settings pointed at the expected Application Support path without creating storage during `WorkspaceState` initialization.
- Adds regression coverage for Application Support resolution failure, bootstrap error surfacing, and directory-creation failure.

## Test Plan
- `git diff --check`
- Verified `whitenoise-mac/Core/MarmotClient.swift` no longer contains `NSTemporaryDirectory`, `applicationSupportRoot`, or `try? fileManager.createDirectory`.
- Attempted `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS'` (not run locally: `xcodebuild: command not found` on Linux worker).

Closes #27


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup reliability through enhanced storage management
  * Better error reporting when storage initialization encounters issues

* **Tests**
  * Added test coverage for storage initialization error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->