### PR TITLE
fix: gate auto read-marking on app focus (#22)

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by Jeff Gardner on 26/05/2026.
 //
 
+import AppKit
 import SwiftUI
 
 struct ContentView: View {
@@ -30,6 +31,16 @@ struct ContentView: View {
                 )
             ) { _ in
                 refreshSystemAppearance()
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: NSApplication.didBecomeActiveNotification
+                )
+            ) { _ in
+                // The app just regained focus. Flush any read-marking that was deferred
+                // while it was in the background so the selected chat clears its unread
+                // state now that the user is actually looking at it.
+                Task { await workspace.handleAppActivationChange() }
             }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -2348,6 +2348,13 @@ final class WorkspaceState {
         client: any MarmotRuntime
     ) async {
         guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        // A selected chat is necessary but not sufficient: only advance the read marker
+        // when the app is actually frontmost. If the user has switched away (app inactive,
+        // window occluded/minimized) incoming live deltas must not silently clear unread
+        // state for messages they have not seen — this mirrors the focus gate the
+        // notification path already applies in handleNotificationUpdate(_:). Marking is
+        // deferred until the app regains focus (see handleAppActivationChange()).
+        guard appActivityProvider() else { return }
         guard let latest = (messagesByChat[groupIdHex] ?? []).last(where: { message in
             message.timelineKind == 9 && !message.isDeleted
         }) else {
@@ -2375,6 +2382,23 @@ final class WorkspaceState {
             lastMarkedReadMarkers[groupIdHex] = previousMarker
             lastError = error.localizedDescription
         }
+    }
+
+    /// Flush any read-marking that was deferred while the app was in the background.
+    ///
+    /// `markLatestVisibleMessageRead(_:)` refuses to advance the read marker while the
+    /// app is inactive, so messages that arrive on the selected chat while the user is
+    /// away stay unread. When the app regains focus the user is now actually looking at
+    /// the selected chat, so it is safe to advance the marker to the latest visible
+    /// message. Call this from the app/window activation hook (see ContentView).
+    func handleAppActivationChange() async {
+        guard appActivityProvider() else { return }
+        guard let client, let activeAccount, let selectedChat else { return }
+        await markLatestVisibleMessageRead(
+            groupIdHex: selectedChat.id,
+            account: activeAccount,
+            client: client
+        )
     }
 
     private func rememberDeliveredNotificationKey(_ key: String) {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -581,7 +581,7 @@ struct whitenoise_macTests {
                 )
             ))
         ], groupIdHex: "direct-group")
-        let state = WorkspaceState(clientFactory: { runtime })
+        let state = WorkspaceState(appActivityProvider: { true }, clientFactory: { runtime })
 
         await state.bootstrap()
         await state.loadMessages(groupIdHex: "direct-group")
@@ -590,6 +590,100 @@ struct whitenoise_macTests {
         }
 
         #expect(didApplyProjection)
+        #expect(runtime.markedReadMessageIds == ["latest"])
+    }
+
+    @MainActor
+    @Test func selectedChatDoesNotMarkReadWhileAppIsInactive() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages([
+            appMessage(
+                id: "latest",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Latest message",
+                kind: 9,
+                recordedAt: 1_700_000_010
+            )
+        ], groupIdHex: "direct-group")
+        // App is backgrounded: a selected chat must NOT advance the read marker just
+        // because a message is visible in the timeline window.
+        let state = WorkspaceState(appActivityProvider: { false }, clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+
+        #expect(state.messagesByChat["direct-group"]?.count == 1)
+        #expect(runtime.markedReadMessageIds.isEmpty)
+    }
+
+    @MainActor
+    @Test func regainingFocusFlushesDeferredReadMarking() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages([
+            appMessage(
+                id: "latest",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Latest message",
+                kind: 9,
+                recordedAt: 1_700_000_010
+            )
+        ], groupIdHex: "direct-group")
+        // Start inactive so the initial open defers marking, then flip to active and
+        // simulate the app regaining focus.
+        var isActive = false
+        let state = WorkspaceState(appActivityProvider: { isActive }, clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        #expect(runtime.markedReadMessageIds.isEmpty)
+
+        isActive = true
+        await state.handleAppActivationChange()
+
         #expect(runtime.markedReadMessageIds == ["latest"])
     }
 
@@ -944,7 +1038,7 @@ struct whitenoise_macTests {
                 hasMoreAfter: false
             ))
         ], groupIdHex: "direct-group")
-        let state = WorkspaceState(clientFactory: { runtime })
+        let state = WorkspaceState(appActivityProvider: { true }, clientFactory: { runtime })
 
         await state.bootstrap()
         await state.loadMessages(groupIdHex: "direct-group")
@@ -1036,7 +1130,7 @@ struct whitenoise_macTests {
                 )
             ))
         ], groupIdHex: "direct-group")
-        let state = WorkspaceState(clientFactory: { runtime })
+        let state = WorkspaceState(appActivityProvider: { true }, clientFactory: { runtime })
 
         await state.bootstrap()
         await state.loadMessages(groupIdHex: "direct-group")


### PR DESCRIPTION
## Summary

Fixes #22. The selected chat marked incoming messages read regardless of whether the app/window was actually in the foreground.

`markLatestVisibleMessageRead(...)` advanced the read marker on every incoming timeline delta, guarding only on `activeAccountId == account.id` and `selectedChat?.id == groupIdHex` — never on focus. Since the code was refactored, all timeline rendering (initial open, pagination, and **live subscription deltas** via `runTimelineListener`) funnels through `applyTimelineWindow(...)`, which calls `markLatestVisibleMessageRead`. So a chat left selected while the app was backgrounded/occluded silently cleared unread state for messages the user never saw. The notification path already gates on `appActivityProvider()` (`handleNotificationUpdate`), so the app could simultaneously post a notification *and* mark the same message read.

## Changes

- **`Core/WorkspaceState.swift`**
  - Add an `appActivityProvider()` guard to `markLatestVisibleMessageRead(...)`: a selected chat is now necessary but not sufficient — the marker only advances when the app is frontmost.
  - Add `handleAppActivationChange()`: when the app regains focus, flush the deferred marking for the selected chat (the user is now actually looking at it).
- **`ContentView.swift`**
  - Observe `NSApplication.didBecomeActiveNotification` and call `handleAppActivationChange()`, mirroring the existing theme-change `onReceive` pattern. Added `import AppKit`.
- **`whitenoise-macTests/whitenoise_macTests.swift`**
  - Pin the three existing read-marking assertions to an active app (`appActivityProvider: { true }`) — their intent is "marker advances", not focus behavior, and a test bundle is not frontmost.
  - Add `selectedChatDoesNotMarkReadWhileAppIsInactive` (deferred path) and `regainingFocusFlushesDeferredReadMarking` (refocus flush path).

## Severity / privacy note

The issue flagged a potential HIGH if read state is published as an external receipt. The vendored MarmotKit doc comment for `markTimelineMessageRead` describes it as advancing the local read marker ("clears any earlier unread messages") and returning an updated chat-list row — i.e. local unread state, with no evidence of external receipt publication from the Swift FFI surface. On that basis severity stays **MEDIUM**. The underlying Rust runtime behavior could not be inspected (MarmotKit ships as a static `.a`); a reviewer with runtime access should confirm.

## Verification

Swift/AppKit cannot be built on the Linux fixer host (no swift toolchain; macOS-only project) and there are no in-repo CI workflows. Changes follow existing patterns; logic verified by reading. macOS build + `xcodebuild test` should be run by the reviewer / CI.

Closes #22


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->