### PR TITLE
fix: make reaction chips interactive

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -362,12 +362,20 @@ private extension MessageReaction {
     static func summarize(_ summary: TimelineReactionSummaryFfi, activeAccountIdHex: String?) -> [MessageReaction] {
         summary.byEmoji
             .map { reaction in
-                MessageReaction(
+                let ownReactionMessageId = activeAccountIdHex.flatMap { accountIdHex in
+                    summary.userReactions.first { userReaction in
+                        userReaction.emoji == reaction.emoji && userReaction.sender == accountIdHex
+                    }?.reactionMessageIdHex
+                }
+                let isOwn = activeAccountIdHex.map { reaction.senders.contains($0) } ?? false
+
+                return MessageReaction(
                     emoji: reaction.emoji,
                     count: reaction.senders.count,
-                    isOwn: activeAccountIdHex.map { reaction.senders.contains($0) } ?? false
+                    isOwn: isOwn,
+                    ownReactionMessageId: ownReactionMessageId
                 )
-        }
+            }
             .sorted { lhs, rhs in
                 if lhs.count != rhs.count { return lhs.count > rhs.count }
                 return lhs.emoji < rhs.emoji

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1157,6 +1157,21 @@ final class WorkspaceState {
         }
     }
 
+    func removeReaction(_ reaction: MessageReaction, from message: MessageItem) async {
+        guard message.supportsChatActions else { return }
+        guard reaction.canRemoveOwnReaction, let reactionMessageId = reaction.ownReactionMessageId else { return }
+        guard let client, let activeAccount, let selectedChat else { return }
+        do {
+            _ = try await client.deleteMessage(
+                accountRef: activeAccount.accountRef,
+                groupIdHex: selectedChat.id,
+                targetMessageId: reactionMessageId
+            )
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
     func deleteMessage(_ message: MessageItem) async {
         guard message.supportsChatActions else { return }
         guard let client, let activeAccount, let selectedChat else { return }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -150,7 +150,7 @@ struct MessageReaction: Identifiable, Hashable {
     }
 
     var canRemoveOwnReaction: Bool {
-        isOwn && ownReactionMessageId != nil
+        ownReactionMessageId != nil
     }
 }
 

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -134,11 +134,23 @@ struct MessageReaction: Identifiable, Hashable {
     let emoji: String
     let count: Int
     let isOwn: Bool
+    let ownReactionMessageId: String?
+
+    init(emoji: String, count: Int, isOwn: Bool, ownReactionMessageId: String? = nil) {
+        self.emoji = emoji
+        self.count = count
+        self.isOwn = isOwn
+        self.ownReactionMessageId = ownReactionMessageId
+    }
 
     var id: String { emoji }
 
     var label: String {
         count > 1 ? "\(emoji) \(count)" : emoji
+    }
+
+    var canRemoveOwnReaction: Bool {
+        isOwn && ownReactionMessageId != nil
     }
 }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1678,15 +1678,28 @@ private struct MessageBubble: View {
                 if !message.reactions.isEmpty {
                     HStack(spacing: 5) {
                         ForEach(message.reactions) { reaction in
-                            Text(reaction.label)
-                                .font(.caption.weight(.semibold))
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 3)
-                                .background {
-                                    GlassCapsuleBackground(
-                                        borderColor: reaction.isOwn ? MessagesPalette.sentBubble.opacity(0.45) : Color.white.opacity(0.18)
-                                    )
+                            Button {
+                                Task {
+                                    if reaction.isOwn {
+                                        await workspace.removeReaction(reaction, from: message)
+                                    } else {
+                                        await workspace.react(to: message, emoji: reaction.emoji)
+                                    }
                                 }
+                            } label: {
+                                Text(reaction.label)
+                                    .font(.caption.weight(.semibold))
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 3)
+                                    .background {
+                                        GlassCapsuleBackground(
+                                            borderColor: reaction.isOwn ? MessagesPalette.sentBubble.opacity(0.45) : Color.white.opacity(0.18)
+                                        )
+                                    }
+                            }
+                            .buttonStyle(.plain)
+                            .contentShape(Capsule())
+                            .help(reaction.isOwn ? "Remove \(reaction.emoji) reaction" : "React with \(reaction.emoji)")
                         }
                     }
                     .padding(.horizontal, 4)

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1680,7 +1680,7 @@ private struct MessageBubble: View {
                         ForEach(message.reactions) { reaction in
                             Button {
                                 Task {
-                                    if reaction.isOwn {
+                                    if reaction.canRemoveOwnReaction {
                                         await workspace.removeReaction(reaction, from: message)
                                     } else {
                                         await workspace.react(to: message, emoji: reaction.emoji)
@@ -1693,13 +1693,13 @@ private struct MessageBubble: View {
                                     .padding(.vertical, 3)
                                     .background {
                                         GlassCapsuleBackground(
-                                            borderColor: reaction.isOwn ? MessagesPalette.sentBubble.opacity(0.45) : Color.white.opacity(0.18)
+                                            borderColor: reaction.canRemoveOwnReaction ? MessagesPalette.sentBubble.opacity(0.45) : Color.white.opacity(0.18)
                                         )
                                     }
                             }
                             .buttonStyle(.plain)
                             .contentShape(Capsule())
-                            .help(reaction.isOwn ? "Remove \(reaction.emoji) reaction" : "React with \(reaction.emoji)")
+                            .help(reaction.canRemoveOwnReaction ? "Remove \(reaction.emoji) reaction" : "React with \(reaction.emoji)")
                         }
                     }
                     .padding(.horizontal, 4)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -312,7 +312,7 @@ struct whitenoise_macTests {
         #expect(state.messagesByChat["group"]?.count == 1)
         #expect(state.messagesByChat["group"]?.first?.body == "The launch plan is ready.")
         #expect(state.messagesByChat["group"]?.first?.reactions == [
-            MessageReaction(emoji: "👍", count: 1, isOwn: true)
+            MessageReaction(emoji: "👍", count: 1, isOwn: true, ownReactionMessageId: "reaction")
         ])
     }
 
@@ -1239,6 +1239,55 @@ struct whitenoise_macTests {
             groupIdHex: "direct-group",
             targetMessageId: "parent"
         ))
+    }
+
+    @MainActor
+    @Test func messageActionsRemoveOwnReactionByDeletingReactionEvent() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        let ownReaction = MessageReaction(
+            emoji: "👍",
+            count: 1,
+            isOwn: true,
+            ownReactionMessageId: "reaction-event"
+        )
+        let message = MessageItem(
+            id: "parent",
+            senderName: "Alice",
+            body: "The launch plan is ready.",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            reactions: [ownReaction]
+        )
+
+        await state.bootstrap()
+        await state.removeReaction(ownReaction, from: message)
+
+        #expect(runtime.deletedMessage == DeletedMessage(
+            groupIdHex: "direct-group",
+            targetMessageId: "reaction-event"
+        ))
+        #expect(runtime.reactedMessage == nil)
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1290,6 +1290,23 @@ struct whitenoise_macTests {
         #expect(runtime.reactedMessage == nil)
     }
 
+    @Test func reactionRemovalCapabilityFollowsReactionEventId() throws {
+        let ownSummaryWithoutEventId = MessageReaction(
+            emoji: "👍",
+            count: 1,
+            isOwn: true
+        )
+        let userReactionWithEventId = MessageReaction(
+            emoji: "👍",
+            count: 1,
+            isOwn: false,
+            ownReactionMessageId: "reaction-event"
+        )
+
+        #expect(!ownSummaryWithoutEventId.canRemoveOwnReaction)
+        #expect(userReactionWithEventId.canRemoveOwnReaction)
+    }
+
     @MainActor
     @Test func copyingMessageTextUsesConfiguredClipboardWriter() async throws {
         var copiedText = ""


### PR DESCRIPTION
## Summary
- Make message reaction chips real buttons instead of static text.
- Preserve the current user's reaction event id in `MessageReaction` so tapping an owned chip deletes that kind-7 reaction event.
- Tapping an unowned chip reacts with that emoji.

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS'` (not run locally: xcodebuild unavailable on Linux worker; deferred to CI)

Closes #25


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->