### PR TITLE
fix: use single Window scene to prevent shared-state mirror windows (#46)

### DIFF
--- a/whitenoise-mac/whitenoise_macApp.swift
+++ b/whitenoise-mac/whitenoise_macApp.swift
@@ -12,7 +12,14 @@ struct whitenoise_macApp: App {
     @State private var workspace = WorkspaceState()
 
     var body: some Scene {
-        WindowGroup {
+        // A single `Window` scene (not `WindowGroup`) intentionally restricts the app to
+        // exactly one window. The whole UI is driven by one shared `WorkspaceState`
+        // (selection, search text, composer drafts, reply context, chat-list visibility,
+        // sheet-presentation flags, etc.), so a second window would not be an independent
+        // workspace — it would be a live mirror that fights the first over the same mutable
+        // state. `Window` also removes the automatic File ▸ New Window (⌘N) command and
+        // multi-window restoration that `WindowGroup` provides. See issue #46.
+        Window("White Noise", id: "main") {
             ContentView()
                 .environment(workspace)
                 .task {


### PR DESCRIPTION
## Summary

Fixes #46. The app was built on `WindowGroup`, which lets the user open multiple windows (File ▸ New Window / ⌘N, or multi-window restoration on launch). Every window shared the single `@State private var workspace = WorkspaceState()` instance, so a second window was not an independent workspace — it was a live mirror that fought the first over the same mutable navigation/composer state (`selection`, `searchText`, `draftText`, `replyDraftContext`, `isChatListVisible`, the new-chat composer fields, and sheet-presentation flags like `isGroupDetailsPresented`/`isGroupImagePickerPresented`).

## Approach

The issue offered two options. Multi-window is not intended for this messenger, so I took the first (simpler, lower-risk) path: replace the `WindowGroup` scene with a single `Window` scene.

`Window` (macOS 13+; the deployment target here is 15.6) permits exactly one window and automatically removes the File ▸ New Window (⌘N) command and multi-window restoration that `WindowGroup` provides. This eliminates the shared-state mirror problem at its source without the large, risky refactor of splitting per-window UI state out of `WorkspaceState` (which would touch every view).

Window styling (`.hiddenTitleBar`, `.unifiedCompact`, `.contentMinSize`) is unchanged. The window title "White Noise" matches `CFBundleDisplayName` and the localization catalog (the brand name is identical across all locales), and is hidden anyway via `.hiddenTitleBar`.

## Changed files

- `whitenoise-mac/whitenoise_macApp.swift` — `WindowGroup { … }` → `Window("White Noise", id: "main") { … }`, with an explanatory comment.

## Verification

- No Swift/Xcode toolchain on this Linux build host; relying on CI for compile/build verification.
- Change is a single-scene swap with no API surface change to `WorkspaceState` or `ContentView`.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->