### PR TITLE
fix: show loading state for cold chat timelines

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -133,6 +133,7 @@ final class WorkspaceState {
     var mutatingGroupMemberId: String?
     private(set) var storageRootPath = MarmotClient.defaultStorageRootPath()
     private(set) var timelinePagingByChat: [String: TimelinePagingState] = [:]
+    private(set) var timelineInitialLoadGroupId: String?
 
     private let clientFactory: @MainActor () throws -> any MarmotRuntime
     private let localNotificationCenter: any LocalNotificationCenter
@@ -299,6 +300,12 @@ final class WorkspaceState {
         return timelinePagingByChat[selectedChat.id] ?? .empty
     }
 
+    var selectedTimelineIsLoadingInitialPage: Bool {
+        guard let selectedChat else { return false }
+        return timelineInitialLoadGroupId == selectedChat.id
+            && messagesByChat[selectedChat.id] == nil
+    }
+
     func timelineMessage(groupIdHex: String, messageId: String) -> MessageItem? {
         messageLookupByChat[groupIdHex]?[messageId]
     }
@@ -396,8 +403,17 @@ final class WorkspaceState {
         closeNewChatComposer()
         pruneMessageCache(keeping: nil)
         refreshObservabilityRuntime()
-        selection = activeChats.first.map { .chat($0.id) }
-        Task { await reloadChats() }
+        let chatToLoad = activeChats.first
+        selection = chatToLoad.map { .chat($0.id) }
+        if let chatToLoad {
+            beginTimelineInitialLoadIfNeeded(groupIdHex: chatToLoad.id)
+        }
+        Task {
+            await reloadChats()
+            if let selectedChat {
+                await loadMessages(groupIdHex: selectedChat.id)
+            }
+        }
     }
 
     func selectAccountFromSettings(_ account: AccountItem) {
@@ -423,6 +439,7 @@ final class WorkspaceState {
         replyDraftContext = nil
         closeNewChatComposer()
         pruneMessageCache(keeping: chat.id)
+        beginTimelineInitialLoadIfNeeded(groupIdHex: chat.id)
         Task { await loadMessages(groupIdHex: chat.id) }
     }
 
@@ -961,6 +978,7 @@ final class WorkspaceState {
             )
             selection = .chat(groupIdHex)
             closeNewChatComposer()
+            beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
             await loadMessages(groupIdHex: groupIdHex)
         } catch {
             lastError = error.localizedDescription
@@ -992,10 +1010,16 @@ final class WorkspaceState {
     func loadMessages(groupIdHex: String) async {
         guard let client, let activeAccount else { return }
         if timelineTaskGroupId == groupIdHex, messagesByChat[groupIdHex] != nil {
+            finishTimelineInitialLoad(groupIdHex: groupIdHex)
             return
         }
         stopTimelineListener()
-        guard selectedChat?.id == groupIdHex else { return }
+        guard selectedChat?.id == groupIdHex else {
+            finishTimelineInitialLoad(groupIdHex: groupIdHex)
+            return
+        }
+        beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
+        defer { finishTimelineInitialLoad(groupIdHex: groupIdHex) }
         do {
             let accountRef = activeAccount.accountRef
             if let row = try await runOffMain({
@@ -1649,6 +1673,7 @@ final class WorkspaceState {
         closeNewChatComposer()
         pruneMessageCache(keeping: groupIdHex)
         NSApplication.shared.activate(ignoringOtherApps: true)
+        beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
 
         Task {
             await reloadChats()
@@ -1746,6 +1771,7 @@ final class WorkspaceState {
         mutatingGroupMemberId = nil
         self.storageRootPath = storageRootPath
         timelinePagingByChat = [:]
+        timelineInitialLoadGroupId = nil
         lastMarkedReadMarkers = [:]
         deliveredNotificationKeys = []
         deliveredNotificationKeyOrder = []
@@ -2173,6 +2199,9 @@ final class WorkspaceState {
         messagesByChat[groupIdHex] = nil
         messageLookupByChat[groupIdHex] = nil
         timelinePagingByChat[groupIdHex] = nil
+        if timelineInitialLoadGroupId == groupIdHex {
+            timelineInitialLoadGroupId = nil
+        }
         lastMarkedReadMarkers[groupIdHex] = nil
 
         guard case .chat(let selectedGroupId) = selection,
@@ -2183,6 +2212,7 @@ final class WorkspaceState {
         selection = nextChat.map { .chat($0.id) }
         pruneMessageCache(keeping: nextChat?.id)
         if let nextChat {
+            beginTimelineInitialLoadIfNeeded(groupIdHex: nextChat.id)
             Task { await loadMessages(groupIdHex: nextChat.id) }
         }
     }
@@ -2209,6 +2239,7 @@ final class WorkspaceState {
         } else {
             timelinePagingByChat = [groupIdHex: nextPaging]
         }
+        finishTimelineInitialLoad(groupIdHex: groupIdHex)
     }
 
     private func pruneMessageCache(keeping groupIdHex: String?) {
@@ -2216,6 +2247,7 @@ final class WorkspaceState {
             messagesByChat = [:]
             messageLookupByChat = [:]
             timelinePagingByChat = [:]
+            timelineInitialLoadGroupId = nil
             return
         }
 
@@ -2230,6 +2262,25 @@ final class WorkspaceState {
             timelinePagingByChat = [groupIdHex: paging]
         } else {
             timelinePagingByChat = [:]
+        }
+        if timelineInitialLoadGroupId != groupIdHex {
+            timelineInitialLoadGroupId = nil
+        } else if messagesByChat[groupIdHex] != nil {
+            timelineInitialLoadGroupId = nil
+        }
+    }
+
+    private func beginTimelineInitialLoadIfNeeded(groupIdHex: String) {
+        if messagesByChat[groupIdHex] == nil {
+            timelineInitialLoadGroupId = groupIdHex
+        } else if timelineInitialLoadGroupId == groupIdHex {
+            timelineInitialLoadGroupId = nil
+        }
+    }
+
+    private func finishTimelineInitialLoad(groupIdHex: String) {
+        if timelineInitialLoadGroupId == groupIdHex {
+            timelineInitialLoadGroupId = nil
         }
     }
 
@@ -2341,6 +2392,7 @@ final class WorkspaceState {
         replyDraftContext = nil
         closeNewChatComposer()
         pruneMessageCache(keeping: chat.id)
+        beginTimelineInitialLoadIfNeeded(groupIdHex: chat.id)
         await loadMessages(groupIdHex: chat.id)
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1008,7 +1008,10 @@ final class WorkspaceState {
     }
 
     func loadMessages(groupIdHex: String) async {
-        guard let client, let activeAccount else { return }
+        guard let client, let activeAccount else {
+            finishTimelineInitialLoad(groupIdHex: groupIdHex)
+            return
+        }
         if timelineTaskGroupId == groupIdHex, messagesByChat[groupIdHex] != nil {
             finishTimelineInitialLoad(groupIdHex: groupIdHex)
             return

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -520,6 +520,7 @@ private struct ConversationView: View {
         let messages = workspace.selectedMessages
         let messageIDs = messages.map(\.id)
         let paging = workspace.selectedTimelinePaging
+        let isLoadingInitialPage = workspace.selectedTimelineIsLoadingInitialPage
 
         VStack(spacing: 0) {
             ConversationHeader(chat: chat)
@@ -529,7 +530,11 @@ private struct ConversationView: View {
                 ScrollView {
                     LazyVStack(spacing: 12) {
                         if messageIDs.isEmpty {
-                            EmptyConversationView()
+                            if isLoadingInitialPage {
+                                TimelineInitialLoadingView()
+                            } else {
+                                EmptyConversationView()
+                            }
                         } else {
                             if paging.hasMoreBefore {
                                 TimelinePageLoadingRow(isLoading: paging.isLoadingBefore)
@@ -711,6 +716,22 @@ private struct ConversationView: View {
                 proxy.scrollTo(bottomAnchorId, anchor: .bottom)
             }
         }
+    }
+}
+
+private struct TimelineInitialLoadingView: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            ProgressView()
+                .controlSize(.regular)
+            Text("Loading messages...")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 48)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Loading messages")
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -864,6 +864,39 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func initialTimelineLoadClearsWhenRuntimeIsUnavailable() async throws {
+        let account = AccountItem(
+            id: "Desktop Account",
+            accountRef: "Desktop Account",
+            displayName: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        )
+        let chat = ChatItem(
+            id: "group",
+            title: "General",
+            subtitle: "Group chat",
+            preview: "",
+            updatedAt: nil,
+            avatarSeed: "group",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        UserDefaults.standard.set(account.id, forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [chat]],
+            clientFactory: { FakeMarmotRuntime(accounts: []) }
+        )
+
+        state.selectChat(chat)
+
+        #expect(state.selectedTimelineIsLoadingInitialPage)
+        await state.loadMessages(groupIdHex: chat.id)
+        #expect(!state.selectedTimelineIsLoadingInitialPage)
+        #expect(state.messagesByChat["group"] == nil)
+    }
+
+    @MainActor
     @Test func loadingOlderMessagesExtendsWindowViaSubscription() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -809,6 +809,61 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func selectingUncachedChatTracksInitialTimelineLoadUntilSnapshotApplies() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        runtime.installMessages([
+            appMessage(
+                id: "group-message",
+                groupIdHex: "group",
+                sender: account.accountIdHex,
+                plaintext: "Group history should not look empty while loading",
+                kind: 9,
+                recordedAt: 1_700_000_000
+            )
+        ], groupIdHex: "group")
+        runtime.installMessages([
+            appMessage(
+                id: "direct-message",
+                groupIdHex: "direct-group",
+                sender: account.accountIdHex,
+                plaintext: "Most recent chat loads during bootstrap",
+                kind: 9,
+                recordedAt: 1_700_000_010
+            )
+        ], groupIdHex: "direct-group")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.selection == .chat("direct-group"))
+        #expect(state.messagesByChat["group"] == nil)
+        guard let group = state.activeChats.first(where: { $0.id == "group" }) else {
+            Issue.record("Expected group chat")
+            return
+        }
+
+        runtime.timelineSubscriptionDelayNanoseconds = 50_000_000
+        state.selectChat(group)
+
+        #expect(state.selectedTimelineIsLoadingInitialPage)
+        #expect(state.selectedMessages.isEmpty)
+        #expect(state.messagesByChat["group"] == nil)
+
+        let didLoadGroup = await waitFor {
+            state.messagesByChat["group"]?.map(\.id) == ["group-message"]
+        }
+        #expect(didLoadGroup)
+        #expect(!state.selectedTimelineIsLoadingInitialPage)
+        #expect(state.selectedMessages.map(\.id) == ["group-message"])
+    }
+
+    @MainActor
     @Test func loadingOlderMessagesExtendsWindowViaSubscription() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -2853,6 +2908,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// When set, `subscribeNotifications()` throws this error, simulating a background
     /// notification-listener failure for routing tests.
     var subscribeNotificationsError: Error?
+    /// Simulates the async relay/runtime delay before the first timeline snapshot is available.
+    var timelineSubscriptionDelayNanoseconds: UInt64 = 0
     var timelineUpdateDelayNanoseconds: UInt64 = 0
     private var profilesByAccountId: [String: UserProfileMetadataFfi] = [:]
     private var normalizedMembersByRef: [String: MemberRefFfi] = [:]
@@ -3464,6 +3521,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func subscribeTimelineMessages(accountRef: String, groupIdHex: String?, limit: UInt32?) async throws -> TimelineMessagesSubscription {
         timelineSubscriptionCount += 1
+        if timelineSubscriptionDelayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: timelineSubscriptionDelayNanoseconds)
+        }
         let ordered: [TimelineMessageRecordFfi]
         if let groupIdHex {
             ordered = timelinePagesByGroupId[groupIdHex]?.messages ?? []


### PR DESCRIPTION
## Summary
- Track initial timeline loading per selected chat to distinguish cold async loads from genuinely empty conversations.
- Show a centered `ProgressView` with "Loading messages..." while the first timeline snapshot is pending.
- Add a regression test that delays the runtime timeline subscription and verifies the loading flag clears when messages arrive.

## Test Plan
- `swift test --filter selectingUncachedChatTracksInitialTimelineLoadUntilSnapshotApplies` *(blocked: `swift` is not installed in this worker environment)*
- `xcodebuild test` *(blocked: `xcodebuild` is not installed in this worker environment)*
- Manual code/diff review

Closes #45


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading indication when switching between chats—now displays a "Loading messages..." state instead of an empty chat while messages are being retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->