### PR TITLE
perf: cache selectedMessageIDs instead of rebuilding [String] per access (#44)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -155,6 +155,12 @@ final class WorkspaceState {
     private var activeTimelineSubscription: TimelineMessagesSubscription?
     private var activeTimelineGroupId: String?
     private var messageLookupByChat: [String: [String: MessageItem]] = [:]
+    /// Cached per-chat message id arrays, materialized once per `messagesByChat`
+    /// mutation and maintained in lockstep with it (alongside `messageLookupByChat`).
+    /// SwiftUI re-evaluates `body` frequently; reading this cache avoids rebuilding a
+    /// fresh `[String]` on every access. Invalidated/recomputed only when the
+    /// underlying messages change.
+    private var messageIDsByChat: [String: [String]] = [:]
     private var lastMarkedReadMarkers: [String: ReadMarker] = [:]
     private var deliveredNotificationKeys = Set<String>()
     private var deliveredNotificationKeyOrder: [String] = []
@@ -219,6 +225,7 @@ final class WorkspaceState {
         self.messageLookupByChat = messagesByChat.mapValues { messages in
             Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
         }
+        self.messageIDsByChat = messagesByChat.mapValues { $0.map(\.id) }
         self.localNotificationCenter = localNotificationCenter ?? MacLocalNotificationCenter()
         self.appActivityProvider = appActivityProvider
         self.copyTextHandler = copyTextHandler
@@ -291,7 +298,7 @@ final class WorkspaceState {
 
     var selectedMessageIDs: [String] {
         guard let selectedChat else { return [] }
-        return messagesByChat[selectedChat.id]?.map(\.id) ?? []
+        return messageIDsByChat[selectedChat.id] ?? []
     }
 
     var selectedTimelinePaging: TimelinePagingState {
@@ -535,6 +542,7 @@ final class WorkspaceState {
             chatsByAccount[removedAccountId] = nil
             messagesByChat.removeAll()
             messageLookupByChat.removeAll()
+            messageIDsByChat.removeAll()
             peerProfileFFICache.removeAll()
             timelinePagingByChat.removeAll()
             profileDraft = ProfileDraft()
@@ -1703,6 +1711,7 @@ final class WorkspaceState {
         chatsByAccount = [:]
         messagesByChat = [:]
         messageLookupByChat = [:]
+        messageIDsByChat = [:]
         activeAccountId = nil
         selection = nil
         searchText = ""
@@ -2187,6 +2196,7 @@ final class WorkspaceState {
         chatsByAccount[account.id] = chats
         messagesByChat[groupIdHex] = nil
         messageLookupByChat[groupIdHex] = nil
+        messageIDsByChat[groupIdHex] = nil
         timelinePagingByChat[groupIdHex] = nil
         lastMarkedReadMarkers[groupIdHex] = nil
 
@@ -2211,13 +2221,16 @@ final class WorkspaceState {
         // so render it as-is.
         let nextPaging = paging ?? timelinePagingByChat[groupIdHex] ?? .empty
         let messageLookup = Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
+        let messageIDs = messages.map(\.id)
 
         if messagesByChat.count == 1, messagesByChat[groupIdHex] != nil {
             messagesByChat[groupIdHex] = messages
             messageLookupByChat[groupIdHex] = messageLookup
+            messageIDsByChat[groupIdHex] = messageIDs
         } else {
             messagesByChat = [groupIdHex: messages]
             messageLookupByChat = [groupIdHex: messageLookup]
+            messageIDsByChat = [groupIdHex: messageIDs]
         }
         if timelinePagingByChat.count == 1, timelinePagingByChat[groupIdHex] != nil {
             timelinePagingByChat[groupIdHex] = nextPaging
@@ -2230,6 +2243,7 @@ final class WorkspaceState {
         guard let groupIdHex else {
             messagesByChat = [:]
             messageLookupByChat = [:]
+            messageIDsByChat = [:]
             timelinePagingByChat = [:]
             return
         }
@@ -2237,9 +2251,11 @@ final class WorkspaceState {
         if let messages = messagesByChat[groupIdHex] {
             messagesByChat = [groupIdHex: messages]
             messageLookupByChat = [groupIdHex: Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })]
+            messageIDsByChat = [groupIdHex: messages.map(\.id)]
         } else {
             messagesByChat = [:]
             messageLookupByChat = [:]
+            messageIDsByChat = [:]
         }
         if let paging = timelinePagingByChat[groupIdHex] {
             timelinePagingByChat = [groupIdHex: paging]

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -518,6 +518,104 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func selectedMessageIDsCacheStaysInSyncAcrossTimelineMutations() async throws {
+        // Regression for #44: selectedMessageIDs is served from a cache maintained in
+        // lockstep with messagesByChat. Verify the cached ids always equal the live
+        // message ids before and after the timeline window is replaced via a projection.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages([
+            appMessage(
+                id: "m1",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "First.",
+                kind: 9,
+                recordedAt: 1_700_000_000
+            ),
+            appMessage(
+                id: "m2",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Second.",
+                kind: 9,
+                recordedAt: 1_700_000_001
+            )
+        ], groupIdHex: "direct-group")
+        let projected = timelineMessage(
+            id: "stream",
+            groupIdHex: "direct-group",
+            sender: account.accountIdHex,
+            plaintext: "Streaming…",
+            recordedAt: 1_700_000_010,
+            agentTextStreamJson: #"{"stream_id":"stream"}"#
+        )
+        let streamingChatRow = chatListRow(
+            groupIdHex: "direct-group",
+            title: "Alice",
+            preview: "Streaming…",
+            sender: account.accountIdHex,
+            timelineAt: 1_700_000_010
+        )
+        runtime.installTimelineUpdates([
+            .projection(update: RuntimeProjectionUpdateFfi(
+                accountIdHex: account.accountIdHex,
+                accountLabel: account.label,
+                update: TimelineProjectionUpdateFfi(
+                    groupIdHex: "direct-group",
+                    messages: [],
+                    changes: [
+                        .remove(messageIdHex: "m1", reason: .noLongerMatchesQuery),
+                        .upsert(trigger: .agentStreamStarted, message: projected)
+                    ],
+                    chatListRow: streamingChatRow,
+                    chatListTrigger: .newLastMessage
+                )
+            ))
+        ], groupIdHex: "direct-group")
+        runtime.installChatListUpdates([
+            .row(trigger: .newLastMessage, row: streamingChatRow)
+        ])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+
+        // Cache matches the live ids after initial load.
+        #expect(state.selectedMessageIDs == state.selectedMessages.map(\.id))
+        #expect(state.selectedMessageIDs == ["m1", "m2"])
+
+        let didApplyProjection = await waitFor {
+            state.messagesByChat["direct-group"]?.map(\.id) == ["m2", "stream"]
+        }
+        #expect(didApplyProjection)
+
+        // Cache stays in sync after the projection mutates the window.
+        #expect(state.selectedMessageIDs == state.selectedMessages.map(\.id))
+        #expect(state.selectedMessageIDs == ["m2", "stream"])
+    }
+
+    @MainActor
     @Test func olderTimelineProjectionDeltaDoesNotMoveReadMarkerBackward() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
## Summary
`WorkspaceState.selectedMessageIDs` mapped the entire message array to a fresh `[String]` on every access. SwiftUI re-evaluates `body` frequently and several `ConversationView` closures re-read the getter, so each access was a wasted O(n) allocation even though the id list only changes when `messagesByChat` changes.

## Fix
Add a `messageIDsByChat: [String: [String]]` cache maintained in lockstep with `messagesByChat` — mirroring the existing `messageLookupByChat` pattern — and serve `selectedMessageIDs` from it as an O(1) lookup. The cache is materialized/invalidated at every `messagesByChat` mutation site:
- init
- `removeActiveAccount` (`removeAll`)
- `resetToNewInstallState`
- `removeChat`
- `replaceMessages` (the hot path)
- `pruneMessageCache`

The two `workspace.selectedMessageIDs` re-reads in `MessengerShellView` Task closures now hit the cached getter unchanged.

## Test Plan
- [ ] Added `selectedMessageIDsCacheStaysInSyncAcrossTimelineMutations` — asserts the cached ids equal `selectedMessages.map(\.id)` both after initial load and after a timeline projection mutates the window.
- [ ] Existing WorkspaceState suite passes (build/test runs on macOS CI; no Swift/Xcode toolchain on the fixer host).

## Notes
- No behavioral change: `selectedMessageIDs` returns the same values, just from cache.
- Not sensitive code (no crypto/MLS/CGKA/key/auth/trust-anchor/protocol-spec paths touched).

Closes #44

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->