### PR TITLE
fix: re-validate prepend scroll-restoration against live state (#42)

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -637,6 +637,16 @@ private struct ConversationView: View {
                           messageIDs.contains(anchorId)
                     else { return }
                     DispatchQueue.main.async {
+                        // Re-validate against live state: the user may have switched
+                        // chats (which clears pendingPrependAnchorId) or another prepend
+                        // may have landed between scheduling and execution of this block.
+                        // Without re-checking, proxy.scrollTo would run against the new
+                        // conversation using a stale anchor, and the unconditional clear
+                        // would drop restoration for a subsequent legitimate prepend.
+                        guard workspace.selectedChat?.id == chat.id,
+                              pendingPrependAnchorId == anchorId,
+                              workspace.selectedMessageIDs.contains(anchorId)
+                        else { return }
                         proxy.scrollTo(anchorId, anchor: .top)
                         pendingPrependAnchorId = nil
                     }


### PR DESCRIPTION
## Summary
Fixes #42. The async scroll-restoration block in `ConversationView` (scheduled on `onChange(of: messageIDs.first)`) captured a stale `messageIDs` snapshot and **unconditionally** cleared `pendingPrependAnchorId`. With no re-validation when the `DispatchQueue.main.async` block actually ran:

- If the user switched chats (or another prepend landed) between scheduling and execution, `proxy.scrollTo(anchorId, …)` ran against the **new** conversation's scroll view using a stale anchor. (`onChange(of: chat.id)` clears the flag, but the already-scheduled async block still executed.)
- `pendingPrependAnchorId = nil` was set unconditionally, which could drop restoration for a subsequent legitimate prepend.

## Fix
Re-validate inside the async block against **live** `WorkspaceState` before scrolling/clearing:

- `workspace.selectedChat?.id == chat.id` — same conversation still selected
- `pendingPrependAnchorId == anchorId` — flag still references this prepend
- `workspace.selectedMessageIDs.contains(anchorId)` — anchor still present in the live timeline

Only then does it call `proxy.scrollTo` and clear the flag. If any check fails, the block bails out, leaving `pendingPrependAnchorId` intact for the correct prepend to restore.

## Files changed
- `whitenoise-mac/Views/MessengerShellView.swift` (1 hunk, +10 lines)

## Test plan
- macOS build + tests run in CI (no Swift toolchain on the Linux fixer host).
- Manual: open chat A, scroll up to trigger a prepend, immediately switch to chat B before the prepend resolves — verify B does not get yank-scrolled and A's restoration is not lost.

Severity: LOW. No sensitive paths touched (UI scroll logic only).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->