### PR TITLE
fix: honor app language for timestamp labels

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -6348,6 +6348,65 @@
         }
       }
     },
+    "Fetched" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abgerufen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtenido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Récupéré"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recuperato"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Получено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alındı"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已获取"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已擷取"
+          }
+        }
+      }
+    },
     "Generate Identity" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -9985,6 +10044,124 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "限本地"
+          }
+        }
+      }
+    },
+    "Local" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lokal"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locale"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Локальный"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yerel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機"
+          }
+        }
+      }
+    },
+    "Local + fetched" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lokal + abgerufen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local + obtenido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local + récupéré"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locale + recuperato"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local + obtido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Локальный + получено"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yerel + alındı"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地 + 已获取"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機 + 已擷取"
           }
         }
       }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -588,19 +588,19 @@ struct KeyPackageItem: Identifiable, Equatable {
     var sourceLabel: String {
         switch (isLocal, isRelayDiscovered) {
         case (true, true):
-            "Local + fetched"
+            L10n.string("Local + fetched")
         case (true, false):
-            "Local"
+            L10n.string("Local")
         case (false, true):
-            "Fetched"
+            L10n.string("Fetched")
         case (false, false):
-            "Unknown"
+            L10n.string("Unknown")
         }
     }
 
     var publishedLabel: String {
-        guard let publishedAt else { return "Unknown" }
-        return publishedAt.formatted(date: .abbreviated, time: .shortened)
+        guard let publishedAt else { return L10n.string("Unknown") }
+        return DisplayText.dateTimeTimestamp(for: publishedAt)
     }
 }
 
@@ -665,21 +665,25 @@ nonisolated enum DisplayText {
         return String(source.prefix(2)).uppercased()
     }
 
-    static func relativeTimestamp(for date: Date, now: Date = Date()) -> String {
+    static func relativeTimestamp(for date: Date, now: Date = Date(), locale: Locale = AppLanguage.currentLocale) -> String {
         if calendar.isDateInToday(date) {
-            return date.formatted(timeOnlyStyle)
+            return date.formatted(timeOnlyStyle.locale(locale))
         }
         if calendar.isDate(date, equalTo: now, toGranularity: .weekOfYear) {
-            return date.formatted(weekdayStyle)
+            return date.formatted(weekdayStyle.locale(locale))
         }
-        return date.formatted(monthDayStyle)
+        return date.formatted(monthDayStyle.locale(locale))
     }
 
-    static func messageTimestamp(for date: Date, now: Date = Date()) -> String {
+    static func messageTimestamp(for date: Date, now: Date = Date(), locale: Locale = AppLanguage.currentLocale) -> String {
         if calendar.isDateInToday(date) {
-            return date.formatted(timeOnlyStyle)
+            return date.formatted(timeOnlyStyle.locale(locale))
         }
-        return date.formatted(dateTimeStyle)
+        return dateTimeTimestamp(for: date, locale: locale)
+    }
+
+    static func dateTimeTimestamp(for date: Date, locale: Locale = AppLanguage.currentLocale) -> String {
+        date.formatted(dateTimeStyle.locale(locale))
     }
 }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2773,7 +2773,7 @@ private struct AuditLogFileRow: View {
         var parts = [shortAccountRef(file.accountRef)]
         if let modifiedAtMs = file.modifiedAtMs {
             let date = Date(timeIntervalSince1970: TimeInterval(modifiedAtMs) / 1_000)
-            parts.append(date.formatted(date: .abbreviated, time: .shortened))
+            parts.append(DisplayText.dateTimeTimestamp(for: date))
         }
         return parts.joined(separator: " - ")
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -136,6 +136,37 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func chatListRelativeTimestampUsesSelectedAppLanguage() async throws {
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+
+        let messageDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let sameWeekNow = messageDate.addingTimeInterval(86_400)
+        let expected = messageDate.formatted(
+            Date.FormatStyle.dateTime.weekday(.abbreviated)
+                .locale(Locale(identifier: AppLanguage.spanish.rawValue))
+        )
+
+        #expect(DisplayText.relativeTimestamp(for: messageDate, now: sameWeekNow) == expected)
+    }
+
+    @MainActor
+    @Test func messageTimestampUsesSelectedAppLanguage() async throws {
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+
+        let messageDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let expected = messageDate.formatted(
+            Date.FormatStyle(date: .abbreviated, time: .shortened)
+                .locale(Locale(identifier: AppLanguage.spanish.rawValue))
+        )
+
+        #expect(DisplayText.messageTimestamp(for: messageDate) == expected)
+    }
+
+    @MainActor
     @Test func projectedChatRowTimestampUsesLastMessageTime() async throws {
         let lastMessageAt: UInt64 = 1_700_000_000
         let projectionRefreshedAt: UInt64 = 1_800_000_000
@@ -2219,6 +2250,50 @@ struct whitenoise_macTests {
         #expect(state.keyPackages.map(\.eventIdHex) == ["event-local", "event-fetched"])
         #expect(state.keyPackages.first?.sourceLabel == "Local")
         #expect(runtime.lastPackageFetchBootstrapRelays == MarmotClient.seedRelays)
+    }
+
+    @MainActor
+    @Test func keyPackageLabelsUseSelectedAppLanguage() async throws {
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+
+        let publishedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let package = KeyPackageItem(
+            accountRef: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            keyPackageId: "key-package",
+            keyPackageRefHex: "key-package-ref",
+            eventIdHex: "event-fetched",
+            publishedAt: publishedAt,
+            keyPackageBytes: 128,
+            sourceRelays: ["wss://relay.example"],
+            isLocal: false,
+            isRelayDiscovered: true
+        )
+        let expectedPublished = publishedAt.formatted(
+            Date.FormatStyle(date: .abbreviated, time: .shortened)
+                .locale(Locale(identifier: AppLanguage.spanish.rawValue))
+        )
+
+        #expect(package.sourceLabel == "Obtenido")
+        #expect(package.publishedLabel == expectedPublished)
+
+        let unknownPackage = KeyPackageItem(
+            accountRef: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            keyPackageId: "unknown-package",
+            keyPackageRefHex: "unknown-key-package-ref",
+            eventIdHex: "event-unknown",
+            publishedAt: nil,
+            keyPackageBytes: 0,
+            sourceRelays: [],
+            isLocal: false,
+            isRelayDiscovered: false
+        )
+
+        #expect(unknownPackage.sourceLabel == "Desconocido")
+        #expect(unknownPackage.publishedLabel == "Desconocido")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Route chat-list, message-bubble, key-package, and audit-log date formatting through `AppLanguage.currentLocale` instead of the system locale.
- Localize key-package source / unknown labels through `L10n.string(...)`.
- Add Spanish app-language regression tests for timestamp and key-package labels.

## Test Plan
- `git diff --check`
- `python3` JSON parse of `whitenoise-mac/Localizable.xcstrings`
- `python3` static scan: no production `.formatted(...)` callsites without explicit locale
- Not run: `xcodebuild test ...` (blocked locally: `xcodebuild: command not found` on this Linux worker)

Closes #23


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->