### PR TITLE
fix: dismiss group image picker when chat clears

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -49,7 +49,9 @@ final class WorkspaceState {
     private(set) var backgroundStatus: String?
 
     var activeAccountId: String?
-    var selection: WorkspaceSelection?
+    var selection: WorkspaceSelection? {
+        didSet { dismissGroupImagePickerIfSelectedChatUnavailable() }
+    }
     var searchText = ""
     var isChatListVisible = true
     var draftText = ""
@@ -1456,6 +1458,11 @@ final class WorkspaceState {
         isSavingGroupImage = false
     }
 
+    private func dismissGroupImagePickerIfSelectedChatUnavailable() {
+        guard isGroupImagePickerPresented, selectedChat == nil else { return }
+        closeGroupImagePicker()
+    }
+
     func searchGroupImages() async {
         let query = groupImageSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {
@@ -2183,6 +2190,7 @@ final class WorkspaceState {
 
         let chatItems = rows.map { baseChatItem(from: $0, account: account) }
         chatsByAccount[account.id] = sortedChatItems(chatItems)
+        dismissGroupImagePickerIfSelectedChatUnavailable()
         startChatListEnrichment(rows: rows, account: account)
     }
 
@@ -2236,6 +2244,7 @@ final class WorkspaceState {
               selectedGroupId == groupIdHex
         else { return }
 
+        closeGroupImagePicker()
         let nextChat = mostRecentChat(in: chats)
         selection = nextChat.map { .chat($0.id) }
         pruneMessageCache(keeping: nextChat?.id)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1770,6 +1770,37 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func groupImagePickerDismissesWhenSelectedChatIsRemoved() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        guard let groupChat = state.activeChats.first else {
+            Issue.record("Expected a group chat")
+            return
+        }
+
+        state.showGroupImagePicker(for: groupChat)
+        runtime.installChatListUpdates([
+            .removeRow(trigger: .removed, groupIdHex: groupChat.id)
+        ])
+        await state.reloadChats()
+        let didRemoveSelectedChat = await waitFor {
+            state.activeChats.isEmpty && state.selectedChat == nil
+        }
+
+        #expect(didRemoveSelectedChat)
+        #expect(!state.isGroupImagePickerPresented)
+    }
+
+    @MainActor
     @Test func directChatDoesNotOpenGroupImagePicker() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1770,6 +1770,31 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func groupImagePickerDismissesWhenSelectionClears() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        guard let groupChat = state.activeChats.first else {
+            Issue.record("Expected a group chat")
+            return
+        }
+
+        state.showGroupImagePicker(for: groupChat)
+        state.selection = nil
+
+        #expect(state.selectedChat == nil)
+        #expect(!state.isGroupImagePickerPresented)
+    }
+
+    @MainActor
     @Test func groupImagePickerDismissesWhenSelectedChatIsRemoved() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -1797,6 +1822,38 @@ struct whitenoise_macTests {
         }
 
         #expect(didRemoveSelectedChat)
+        #expect(!state.isGroupImagePickerPresented)
+    }
+
+    @MainActor
+    @Test func groupImagePickerDismissesWhenRemovedChatAutoReselectsNextChat() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        guard let groupChat = state.activeChats.first(where: { $0.id == "group" }) else {
+            Issue.record("Expected a group chat")
+            return
+        }
+
+        state.selectChat(groupChat)
+        state.showGroupImagePicker(for: groupChat)
+        runtime.installChatListUpdates([
+            .removeRow(trigger: .removed, groupIdHex: groupChat.id)
+        ])
+        await state.reloadChats()
+        let didReselectNextChat = await waitFor {
+            state.selection == .chat("direct-group") && state.selectedChat?.id == "direct-group"
+        }
+
+        #expect(didReselectNextChat)
         #expect(!state.isGroupImagePickerPresented)
     }
 


### PR DESCRIPTION
## Summary
- Dismiss the group image picker when the selected chat becomes unavailable.
- Close the picker when a selected group is removed from the live chat list.
- Add a regression test covering live removal while the picker is open.

## Test Plan
- `git diff --check`
- Local XCTest not run: `xcodebuild` is unavailable on this Linux worker.

Closes #43


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->