### PR TITLE
fix: preserve timeline position when paging newer messages

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -503,9 +503,38 @@ private struct DetailPaneView: View {
     }
 }
 
+enum TimelineNewestMessageScrollAction: Equatable {
+    case none
+    case clearPendingAppendAnchor
+    case restorePendingAppendAnchor(String)
+    case scrollToBottom
+}
+
+func timelineNewestMessageScrollAction(
+    messageIDs: [String],
+    paging: TimelinePagingState,
+    pendingPrependAnchorId: String?,
+    pendingAppendAnchorId: String?,
+    newMessageId: String?
+) -> TimelineNewestMessageScrollAction {
+    if let pendingAppendAnchorId {
+        return messageIDs.contains(pendingAppendAnchorId)
+            ? .restorePendingAppendAnchor(pendingAppendAnchorId)
+            : .clearPendingAppendAnchor
+    }
+
+    guard newMessageId != nil,
+          !paging.hasMoreAfter,
+          pendingPrependAnchorId == nil
+    else { return .none }
+
+    return .scrollToBottom
+}
+
 private struct ConversationView: View {
     @Environment(WorkspaceState.self) private var workspace
     @State private var pendingPrependAnchorId: String?
+    @State private var pendingAppendAnchorId: String?
     @State private var didRequestOlderForVisibleTopSentinel = false
     @State private var lastOlderLoadTriggerAnchorId: String?
     @State private var topSentinelResetTask: Task<Void, Never>?
@@ -580,20 +609,24 @@ private struct ConversationView: View {
                                     .onAppear {
                                         bottomSentinelResetTask?.cancel()
                                         guard let anchorId = messageIDs.last,
+                                              pendingAppendAnchorId == nil,
                                               !paging.isLoadingAfter,
                                               !didRequestNewerForVisibleBottomSentinel,
                                               lastNewerLoadTriggerAnchorId != anchorId
                                         else { return }
                                         didRequestNewerForVisibleBottomSentinel = true
                                         lastNewerLoadTriggerAnchorId = anchorId
+                                        pendingAppendAnchorId = anchorId
                                         Task {
                                             await workspace.loadNewerMessages(groupIdHex: chat.id)
-                                            if workspace.selectedMessageIDs.last == anchorId {
-                                                scrollToBottom(with: proxy)
+                                            if pendingAppendAnchorId == anchorId,
+                                               workspace.selectedMessageIDs.last == anchorId {
+                                                pendingAppendAnchorId = nil
                                             }
                                         }
                                     }
                                     .onDisappear {
+                                        guard pendingAppendAnchorId == nil else { return }
                                         bottomSentinelResetTask?.cancel()
                                         bottomSentinelResetTask = Task {
                                             try? await Task.sleep(nanoseconds: 300_000_000)
@@ -620,6 +653,7 @@ private struct ConversationView: View {
                     topSentinelResetTask?.cancel()
                     bottomSentinelResetTask?.cancel()
                     pendingPrependAnchorId = nil
+                    pendingAppendAnchorId = nil
                     didRequestOlderForVisibleTopSentinel = false
                     lastOlderLoadTriggerAnchorId = nil
                     topSentinelResetTask = nil
@@ -628,13 +662,39 @@ private struct ConversationView: View {
                     bottomSentinelResetTask = nil
                 }
                 .onChange(of: messageIDs.last) { _, newMessageId in
+                    switch timelineNewestMessageScrollAction(
+                        messageIDs: messageIDs,
+                        paging: paging,
+                        pendingPrependAnchorId: pendingPrependAnchorId,
+                        pendingAppendAnchorId: pendingAppendAnchorId,
+                        newMessageId: newMessageId
+                    ) {
+                    case .restorePendingAppendAnchor(let anchorId):
+                        DispatchQueue.main.async {
+                            // Re-validate against live state: the user may have switched
+                            // chats or a newer paging request may have landed since this
+                            // scroll restoration was scheduled.
+                            guard workspace.selectedChat?.id == chat.id,
+                                  pendingAppendAnchorId == anchorId,
+                                  workspace.selectedMessageIDs.contains(anchorId)
+                            else { return }
+                            proxy.scrollTo(anchorId, anchor: .bottom)
+                            pendingAppendAnchorId = nil
+                        }
+                        return
+                    case .clearPendingAppendAnchor:
+                        pendingAppendAnchorId = nil
+                        return
+                    case .scrollToBottom:
+                        break
+                    case .none:
+                        return
+                    }
+
                     // Pin to the newest message on initial load and when a new message
                     // arrives at the live edge — but not while scrolled back into history
-                    // (hasMoreAfter) or mid-prepend, where it would yank the user away.
-                    guard newMessageId != nil,
-                          !paging.hasMoreAfter,
-                          pendingPrependAnchorId == nil
-                    else { return }
+                    // (hasMoreAfter), mid-prepend, or mid-forward paging, where it would
+                    // yank the user away.
                     scrollToBottom(with: proxy)
                 }
                 .onChange(of: messageIDs.first) { _, _ in

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1202,6 +1202,50 @@ struct whitenoise_macTests {
         #expect(runtime.lastTimelineSubscription?.paginateForwardsCount == 1)
     }
 
+    @Test func newerTimelinePagingRestoresAnchorInsteadOfScrollingToBottom() {
+        let historicalPaging = TimelinePagingState(
+            hasMoreBefore: true,
+            hasMoreAfter: true,
+            isLoadingBefore: false,
+            isLoadingAfter: false
+        )
+        let liveEdgePaging = TimelinePagingState(
+            hasMoreBefore: true,
+            hasMoreAfter: false,
+            isLoadingBefore: false,
+            isLoadingAfter: false
+        )
+
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-150", "message-249", "message-349"],
+            paging: historicalPaging,
+            pendingPrependAnchorId: nil,
+            pendingAppendAnchorId: "message-249",
+            newMessageId: "message-349"
+        ) == .restorePendingAppendAnchor("message-249"))
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-350", "message-449"],
+            paging: historicalPaging,
+            pendingPrependAnchorId: nil,
+            pendingAppendAnchorId: "message-249",
+            newMessageId: "message-449"
+        ) == .clearPendingAppendAnchor)
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-350", "message-449"],
+            paging: historicalPaging,
+            pendingPrependAnchorId: nil,
+            pendingAppendAnchorId: nil,
+            newMessageId: "message-449"
+        ) == .none)
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-350", "message-449"],
+            paging: liveEdgePaging,
+            pendingPrependAnchorId: nil,
+            pendingAppendAnchorId: nil,
+            newMessageId: "message-449"
+        ) == .scrollToBottom)
+    }
+
     @MainActor
     @Test func latestSubscriptionPageDoesNotReplaceHistoricalTimelineWindow() async throws {
         let account = AccountSummaryFfi(


### PR DESCRIPTION
## Summary
- track the bottom paging anchor while loading newer timeline pages
- restore the prior bottom message after forward paging instead of jumping to the live-edge bottom anchor
- keep live-edge auto-scroll for actual latest-message changes when `hasMoreAfter` is false

## Test Plan
- `git diff --check`
- static check: verified the newer paging sentinel no longer calls `scrollToBottom(with: proxy)` directly and sets a pending append anchor

Linux worker note: `swift`/`xcodebuild` are not installed on this host, so macOS build/tests are left to CI.

Closes #41


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->