### PR TITLE
fix: track and coalesce incremental chat-list enrichment tasks (#40)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -19,6 +19,70 @@ struct TimelinePagingState: Equatable {
     )
 }
 
+/// Tracks ownership of incremental, per-row chat-list enrichment tasks (issue #40).
+///
+/// Single-row chat-list updates spawn one enrichment `Task` per group. Exactly one such task
+/// should "own" a group's slot at a time: a newer update must supersede (coalesce) an in-flight
+/// one, listener teardown / account switch must cancel them all, and a finishing task must
+/// release its slot only if it is still the current owner.
+///
+/// Ownership is keyed by a process-monotonic token that is **never reused** — not even after
+/// `cancelAll()` clears the maps on reload / account switch. That is the crux of the fix: a
+/// per-group counter that reset to its first value on clear would let a stale, already-canceled
+/// task match a *future* task's reused token and erroneously drop the future task's slot,
+/// reintroducing the untracked / uncancellable enrichment work this is meant to prevent.
+struct ChatListRowEnrichmentTracker {
+    private var tasks: [String: Task<Void, Never>] = [:]
+    private var tokens: [String: Int] = [:]
+    private var nextToken: Int = 0
+
+    /// Number of currently tracked (live) tasks. Diagnostic / test helper.
+    var trackedTaskCount: Int { tasks.count }
+
+    /// The current ownership token for `group`, if any. Diagnostic / test helper.
+    func currentToken(forGroup group: String) -> Int? { tokens[group] }
+
+    /// Allocates a globally unique, never-reused ownership token for `group` and cancels any
+    /// task currently owning it. Call before spawning the replacement task.
+    mutating func beginTask(forGroup group: String) -> Int {
+        tasks[group]?.cancel()
+        nextToken += 1
+        let token = nextToken
+        tokens[group] = token
+        return token
+    }
+
+    /// Records `task` as the owner of `group` for `token`. If `token` is no longer current
+    /// (a newer `beginTask` has since run for this group) the late registration is ignored and
+    /// the task canceled, so it cannot clobber a newer owner.
+    mutating func register(task: Task<Void, Never>, forGroup group: String, token: Int) {
+        guard tokens[group] == token else {
+            task.cancel()
+            return
+        }
+        tasks[group] = task
+    }
+
+    /// Releases `group`'s slot iff `token` is still the current owner. A stale token (from an
+    /// older, already-superseded or canceled task) is a no-op, so it can never drop a newer task.
+    mutating func finishTask(forGroup group: String, token: Int) {
+        guard tokens[group] == token else { return }
+        tasks[group] = nil
+        tokens[group] = nil
+    }
+
+    /// Cancels every tracked task and clears all ownership state. The token sequence is
+    /// deliberately **not** reset, so tokens issued after this call stay unique with respect to
+    /// any still-unwinding canceled task.
+    mutating func cancelAll() {
+        for task in tasks.values {
+            task.cancel()
+        }
+        tasks.removeAll()
+        tokens.removeAll()
+    }
+}
+
 @MainActor
 @Observable
 final class WorkspaceState {
@@ -146,15 +210,13 @@ final class WorkspaceState {
     private var chatListTask: Task<Void, Never>?
     private var chatListTaskAccountId: String?
     private var chatListEnrichmentTask: Task<Void, Never>?
-    /// Incremental, per-row chat-list enrichment tasks keyed by group id. Single-row updates
-    /// (the chat-list subscription delta path) spawn one enrichment task per group; tracking
-    /// them here lets `stopChatListListener` cancel them on listener teardown / account switch
-    /// and lets a newer update for the same group supersede (coalesce) an in-flight one.
-    private var chatListRowEnrichmentTasks: [String: Task<Void, Never>] = [:]
-    /// Monotonic per-group generation counter for incremental enrichment tasks. Lets a
-    /// finishing task remove itself from `chatListRowEnrichmentTasks` only when it is still
-    /// the current task for that group (its generation hasn't been superseded).
-    private var chatListRowEnrichmentGenerations: [String: Int] = [:]
+    /// Incremental, per-row chat-list enrichment task ownership (issue #40). Single-row updates
+    /// (the chat-list subscription delta path) spawn one enrichment task per group; this tracker
+    /// lets `stopChatListListener` cancel them on listener teardown / account switch and lets a
+    /// newer update for the same group supersede (coalesce) an in-flight one. Ownership tokens
+    /// are process-monotonic and never reused, so a stale canceled task can never match a future
+    /// task's token and drop its tracking slot. See `ChatListRowEnrichmentTracker`.
+    private var chatListRowEnrichment = ChatListRowEnrichmentTracker()
     private var timelineTask: Task<Void, Never>?
     private var timelineTaskGroupId: String?
     /// The live timeline subscription for the open conversation. It owns the
@@ -2077,11 +2139,7 @@ final class WorkspaceState {
         chatListTaskAccountId = nil
         chatListEnrichmentTask?.cancel()
         chatListEnrichmentTask = nil
-        for task in chatListRowEnrichmentTasks.values {
-            task.cancel()
-        }
-        chatListRowEnrichmentTasks.removeAll()
-        chatListRowEnrichmentGenerations.removeAll()
+        chatListRowEnrichment.cancelAll()
     }
 
     private func runChatListListener(
@@ -2351,11 +2409,7 @@ final class WorkspaceState {
             // Full-snapshot enrichment (bootstrap / reload): a fresh pass re-enriches every
             // row, so it supersedes any in-flight incremental per-row work.
             chatListEnrichmentTask?.cancel()
-            for task in chatListRowEnrichmentTasks.values {
-                task.cancel()
-            }
-            chatListRowEnrichmentTasks.removeAll()
-            chatListRowEnrichmentGenerations.removeAll()
+            chatListRowEnrichment.cancelAll()
 
             chatListEnrichmentTask = Task { [weak self] in
                 guard let self else { return }
@@ -2369,21 +2423,20 @@ final class WorkspaceState {
         // can be cancelled on listener teardown / account switch (issue #40).
         for row in rows {
             let groupId = row.groupIdHex
-            chatListRowEnrichmentTasks[groupId]?.cancel()
-            let generation = (chatListRowEnrichmentGenerations[groupId] ?? 0) + 1
-            chatListRowEnrichmentGenerations[groupId] = generation
+            // Allocate a globally unique ownership token and cancel any prior task for this
+            // group. The token is never reused (even across `cancelAll()` on reload / account
+            // switch), so a stale canceled task can never match a future task's token and drop
+            // its tracking slot.
+            let token = chatListRowEnrichment.beginTask(forGroup: groupId)
 
             let task = Task { [weak self] in
                 guard let self else { return }
                 await self.enrichChatRows([row], account: account)
                 // Release this group's slot only if a newer update hasn't superseded us;
                 // otherwise the newer task owns the slot and must not be dropped.
-                if self.chatListRowEnrichmentGenerations[groupId] == generation {
-                    self.chatListRowEnrichmentTasks[groupId] = nil
-                    self.chatListRowEnrichmentGenerations[groupId] = nil
-                }
+                self.chatListRowEnrichment.finishTask(forGroup: groupId, token: token)
             }
-            chatListRowEnrichmentTasks[groupId] = task
+            chatListRowEnrichment.register(task: task, forGroup: groupId, token: token)
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -146,6 +146,15 @@ final class WorkspaceState {
     private var chatListTask: Task<Void, Never>?
     private var chatListTaskAccountId: String?
     private var chatListEnrichmentTask: Task<Void, Never>?
+    /// Incremental, per-row chat-list enrichment tasks keyed by group id. Single-row updates
+    /// (the chat-list subscription delta path) spawn one enrichment task per group; tracking
+    /// them here lets `stopChatListListener` cancel them on listener teardown / account switch
+    /// and lets a newer update for the same group supersede (coalesce) an in-flight one.
+    private var chatListRowEnrichmentTasks: [String: Task<Void, Never>] = [:]
+    /// Monotonic per-group generation counter for incremental enrichment tasks. Lets a
+    /// finishing task remove itself from `chatListRowEnrichmentTasks` only when it is still
+    /// the current task for that group (its generation hasn't been superseded).
+    private var chatListRowEnrichmentGenerations: [String: Int] = [:]
     private var timelineTask: Task<Void, Never>?
     private var timelineTaskGroupId: String?
     /// The live timeline subscription for the open conversation. It owns the
@@ -2068,6 +2077,11 @@ final class WorkspaceState {
         chatListTaskAccountId = nil
         chatListEnrichmentTask?.cancel()
         chatListEnrichmentTask = nil
+        for task in chatListRowEnrichmentTasks.values {
+            task.cancel()
+        }
+        chatListRowEnrichmentTasks.removeAll()
+        chatListRowEnrichmentGenerations.removeAll()
     }
 
     private func runChatListListener(
@@ -2332,17 +2346,44 @@ final class WorkspaceState {
         replacingCurrent: Bool = true
     ) {
         guard !rows.isEmpty, client != nil else { return }
+
         if replacingCurrent {
+            // Full-snapshot enrichment (bootstrap / reload): a fresh pass re-enriches every
+            // row, so it supersedes any in-flight incremental per-row work.
             chatListEnrichmentTask?.cancel()
+            for task in chatListRowEnrichmentTasks.values {
+                task.cancel()
+            }
+            chatListRowEnrichmentTasks.removeAll()
+            chatListRowEnrichmentGenerations.removeAll()
+
+            chatListEnrichmentTask = Task { [weak self] in
+                guard let self else { return }
+                await self.enrichChatRows(rows, account: account)
+            }
+            return
         }
 
-        let task = Task { [weak self] in
-            guard let self else { return }
-            await self.enrichChatRows(rows, account: account)
-        }
+        // Incremental, per-row path (chat-list subscription deltas). Track every spawned task
+        // and coalesce per group so only one enrichment runs per group at a time, and so they
+        // can be cancelled on listener teardown / account switch (issue #40).
+        for row in rows {
+            let groupId = row.groupIdHex
+            chatListRowEnrichmentTasks[groupId]?.cancel()
+            let generation = (chatListRowEnrichmentGenerations[groupId] ?? 0) + 1
+            chatListRowEnrichmentGenerations[groupId] = generation
 
-        if replacingCurrent {
-            chatListEnrichmentTask = task
+            let task = Task { [weak self] in
+                guard let self else { return }
+                await self.enrichChatRows([row], account: account)
+                // Release this group's slot only if a newer update hasn't superseded us;
+                // otherwise the newer task owns the slot and must not be dropped.
+                if self.chatListRowEnrichmentGenerations[groupId] == generation {
+                    self.chatListRowEnrichmentTasks[groupId] = nil
+                    self.chatListRowEnrichmentGenerations[groupId] = nil
+                }
+            }
+            chatListRowEnrichmentTasks[groupId] = task
         }
     }
 
@@ -2399,6 +2440,12 @@ final class WorkspaceState {
             accountRef: account.accountRef,
             groupIdHex: row.groupIdHex
         ) {
+            // Bail before the second FFI hop (userProfile lookup) if this enrichment has been
+            // cancelled — e.g. the listener was torn down or a newer row update for this group
+            // superseded us. Avoids running the rest of the wasted FFI work to completion (#40).
+            guard !Task.isCancelled else {
+                return ChatItem(row: row, activeAccountIdHex: account.accountIdHex)
+            }
             groupAvatarURL = firstNonBlank([details.group.avatarUrl, groupAvatarURL])
             directPeer = await directPeerProfile(
                 from: details,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1800,6 +1800,79 @@ struct whitenoise_macTests {
         #expect((runtime.groupDetailsCallCounts["direct-group"] ?? 0) >= 2)
     }
 
+    // MARK: - ChatListRowEnrichmentTracker (issue #40 ownership invariants)
+
+    @Test func enrichmentTrackerStaleTaskAfterReloadDoesNotDropNewerTask() {
+        // Regression for the adversarial review on PR #62: a per-group generation counter that
+        // reset on `cancelAll()` (reload / account switch) reused token `1`, so an old canceled
+        // task finishing afterwards matched the *new* task's reused token and dropped its slot.
+        // Tokens are now process-monotonic and never reused, so this must not happen.
+        var tracker = ChatListRowEnrichmentTracker()
+        let group = "direct-group"
+
+        // 1. Incremental update starts task A for the group.
+        let tokenA = tracker.beginTask(forGroup: group)
+        tracker.register(task: Task {}, forGroup: group, token: tokenA)
+        #expect(tracker.currentToken(forGroup: group) == tokenA)
+
+        // 2. A full snapshot / reload (or listener stop) cancels everything and clears state.
+        tracker.cancelAll()
+        #expect(tracker.trackedTaskCount == 0)
+        #expect(tracker.currentToken(forGroup: group) == nil)
+
+        // 3. A later incremental update starts task B for the same group. Its token must differ
+        //    from A's — the sequence is not reset by `cancelAll()`.
+        let tokenB = tracker.beginTask(forGroup: group)
+        tracker.register(task: Task {}, forGroup: group, token: tokenB)
+        #expect(tokenB != tokenA)
+        #expect(tracker.currentToken(forGroup: group) == tokenB)
+
+        // 4. The old canceled task A finally unwinds and runs its cleanup with its stale token.
+        //    It must be a no-op: B still owns the slot.
+        tracker.finishTask(forGroup: group, token: tokenA)
+        #expect(tracker.currentToken(forGroup: group) == tokenB)
+        #expect(tracker.trackedTaskCount == 1)
+
+        // 5. When B itself finishes with its own token, the slot is released cleanly.
+        tracker.finishTask(forGroup: group, token: tokenB)
+        #expect(tracker.currentToken(forGroup: group) == nil)
+        #expect(tracker.trackedTaskCount == 0)
+    }
+
+    @Test func enrichmentTrackerNewerUpdateSupersedesInFlightTask() {
+        // A newer row update for the same group supersedes (coalesces) the in-flight one: the
+        // older task's later cleanup must not drop the newer task's slot.
+        var tracker = ChatListRowEnrichmentTracker()
+        let group = "g"
+
+        let first = tracker.beginTask(forGroup: group)
+        tracker.register(task: Task {}, forGroup: group, token: first)
+        let second = tracker.beginTask(forGroup: group)
+        tracker.register(task: Task {}, forGroup: group, token: second)
+        #expect(second != first)
+        #expect(tracker.currentToken(forGroup: group) == second)
+
+        // Stale older task cleanup is ignored; the newer task keeps the slot.
+        tracker.finishTask(forGroup: group, token: first)
+        #expect(tracker.currentToken(forGroup: group) == second)
+        #expect(tracker.trackedTaskCount == 1)
+    }
+
+    @Test func enrichmentTrackerLateRegistrationForStaleTokenIsRejected() {
+        // If a task's `register` lands after a newer `beginTask` for the same group (interleaving
+        // on the main actor), the stale registration must not clobber the newer owner.
+        var tracker = ChatListRowEnrichmentTracker()
+        let group = "g"
+
+        let stale = tracker.beginTask(forGroup: group)
+        let current = tracker.beginTask(forGroup: group)
+        // Late registration for the stale token is dropped.
+        tracker.register(task: Task {}, forGroup: group, token: stale)
+        tracker.register(task: Task {}, forGroup: group, token: current)
+        #expect(tracker.currentToken(forGroup: group) == current)
+        #expect(tracker.trackedTaskCount == 1)
+    }
+
     @MainActor
     @Test func groupImageSearchSelectionUpdatesGroupAvatarUrl() async throws {
         let account = AccountSummaryFfi(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1746,6 +1746,61 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func incrementalChatRowUpdateEnrichesDirectChatTitle() async throws {
+        // Regression for #40: single-row chat-list deltas go through the incremental
+        // enrichment path (startChatListEnrichment(replacingCurrent: false)). After the fix
+        // these tasks are tracked and coalesced per group, but the happy path must still
+        // enrich the row — verify a `.row` delta for a direct chat resolves the peer profile.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: "https://example.com/alice.png",
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        // Deliver an incremental row update (the buggy path) carrying a fresh last message.
+        let updatedRow = chatListRow(
+            groupIdHex: "direct-group",
+            title: "",
+            preview: "See you soon.",
+            sender: aliceId,
+            timelineAt: 1_700_000_500
+        )
+        runtime.installChatListUpdates([
+            .row(trigger: .newLastMessage, row: updatedRow)
+        ])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didEnrichIncrementally = await waitFor {
+            state.activeChats.first?.title == "Alice Actual"
+                && state.activeChats.first?.preview == "See you soon."
+        }
+
+        #expect(didEnrichIncrementally)
+        #expect(state.activeChats.first?.isDirect == true)
+        #expect(state.activeChats.first?.pictureURL == "https://example.com/alice.png")
+        // Enrichment must have run for the delta-delivered row (incremental path), in addition
+        // to the initial snapshot enrichment.
+        #expect((runtime.groupDetailsCallCounts["direct-group"] ?? 0) >= 2)
+    }
+
+    @MainActor
     @Test func groupImageSearchSelectionUpdatesGroupAvatarUrl() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -3170,6 +3225,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var refreshedProfileIds: [String] = []
     private(set) var markedReadMessageIds: [String] = []
     private(set) var accountKeyPackagesCallCount = 0
+    /// Per-group call count for `groupDetails`, used to assert chat-list enrichment runs
+    /// through the incremental per-row path (issue #40 regression).
+    private(set) var groupDetailsCallCounts: [String: Int] = [:]
     private(set) var chatListSubscriptionCount = 0
     private(set) var timelineSubscriptionCount = 0
     private(set) var lastTimelineSubscription: FakeTimelineMessagesSubscription?
@@ -3531,6 +3589,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func groupDetails(accountRef: String, groupIdHex: String) async throws -> GroupDetailsFfi {
+        groupDetailsCallCounts[groupIdHex, default: 0] += 1
         if let details = groupDetailsById[groupIdHex] {
             return details
         }


### PR DESCRIPTION
## Summary

Fixes #40 — single-row chat-list enrichment spawned untracked, uncancellable Tasks.

`startChatListEnrichment(rows:account:replacingCurrent:)` only stored the spawned `Task` in `chatListEnrichmentTask` when `replacingCurrent == true`. The incremental per-row path (`applyChatRow`, fed by the chat-list subscription) calls it with `replacingCurrent: false`, so those enrichment Tasks were created but never tracked and never cancelled. `stopChatListListener()` cancelled only the single full-snapshot task, so per-row tasks survived listener teardown / account switch, and a fast stream of row updates spawned unbounded concurrent `groupDetails` + `userProfile` FFI work with no coalescing.

## Changes

- **Track incremental tasks per group** (`chatListRowEnrichmentTasks: [String: Task]`), keyed by `groupIdHex`.
- **Coalesce per group**: a newer row update for the same group cancels and supersedes the prior in-flight enrichment, so only one enrichment runs per group at a time. A per-group generation counter (`chatListRowEnrichmentGenerations`) ensures a finishing task only releases its slot when it hasn't been superseded (no race dropping the newer task).
- **Cancel on teardown**: `stopChatListListener()` now cancels and clears all tracked incremental tasks (covers account switch via `reloadChats`, `removeActiveAccount`, `deleteAllData`).
- **Full-snapshot supersedes incremental**: a `replacingCurrent: true` pass cancels and clears any in-flight per-row work before re-enriching every row.
- **Mid-flight cancellation checkpoint**: `enrichedChatItem` now checks `Task.isCancelled` between the `groupDetails` and `userProfile` FFI hops, so a cancelled enrichment stops doing wasted FFI work to completion.

## Test plan

- [ ] `incrementalChatRowUpdateEnrichesDirectChatTitle` — drives the incremental per-row path via a chat-list `.row` delta and asserts the delta-delivered direct chat still gets enriched (title/picture resolved, `groupDetails` called for the delta in addition to the snapshot).
- [ ] Existing chat-list / enrichment tests remain green.

> Note: this repo is an Xcode-only macOS target with no Linux Swift toolchain and no GitHub Actions CI (review is via CodeRabbit). The fixer host cannot compile/run XCTest; verification of the Swift build + test suite must happen on a macOS reviewer/CI before merge.

## Relationship to #9 / #13

Distinct from #9 (redundancy of fetches) and #13 (listeners not restarting): this addresses Task **lifecycle** — untracked, uncancellable enrichment work — and complements #9.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chat list refresh reliability by optimizing background task management
  * Improved efficiency when enriching chat details during rapid updates

* **Tests**
  * Added regression test for incremental chat row enrichment with direct messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->