### PR TITLE
fix: auto-scroll live messages from bottom

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -512,10 +512,12 @@ enum TimelineNewestMessageScrollAction: Equatable {
 
 func timelineNewestMessageScrollAction(
     messageIDs: [String],
+    newMessageIsOutgoing: Bool,
     paging: TimelinePagingState,
     pendingPrependAnchorId: String?,
     pendingAppendAnchorId: String?,
-    newMessageId: String?
+    newMessageId: String?,
+    isPinnedToBottom: Bool
 ) -> TimelineNewestMessageScrollAction {
     if let pendingAppendAnchorId {
         return messageIDs.contains(pendingAppendAnchorId)
@@ -524,10 +526,17 @@ func timelineNewestMessageScrollAction(
     }
 
     guard newMessageId != nil,
-          !paging.hasMoreAfter,
           pendingPrependAnchorId == nil
     else { return .none }
 
+    // `hasMoreBefore` only means older history is loadable. It must not suppress
+    // live-edge appends. `hasMoreAfter` means the rendered window is detached from
+    // the live edge, so incoming updates should not yank the user out of history.
+    if paging.hasMoreAfter && !newMessageIsOutgoing {
+        return .none
+    }
+
+    guard isPinnedToBottom || newMessageIsOutgoing else { return .none }
     return .scrollToBottom
 }
 
@@ -535,6 +544,7 @@ private struct ConversationView: View {
     @Environment(WorkspaceState.self) private var workspace
     @State private var pendingPrependAnchorId: String?
     @State private var pendingAppendAnchorId: String?
+    @State private var isPinnedToBottom = true
     @State private var didRequestOlderForVisibleTopSentinel = false
     @State private var lastOlderLoadTriggerAnchorId: String?
     @State private var topSentinelResetTask: Task<Void, Never>?
@@ -642,6 +652,8 @@ private struct ConversationView: View {
                         Color.clear
                             .frame(height: bottomTranscriptPadding)
                             .id(bottomAnchorId)
+                            .onAppear { isPinnedToBottom = true }
+                            .onDisappear { isPinnedToBottom = false }
                     }
                     .padding(.horizontal, 28)
                     .padding(.top, 18)
@@ -654,6 +666,7 @@ private struct ConversationView: View {
                     bottomSentinelResetTask?.cancel()
                     pendingPrependAnchorId = nil
                     pendingAppendAnchorId = nil
+                    isPinnedToBottom = true
                     didRequestOlderForVisibleTopSentinel = false
                     lastOlderLoadTriggerAnchorId = nil
                     topSentinelResetTask = nil
@@ -664,10 +677,12 @@ private struct ConversationView: View {
                 .onChange(of: messageIDs.last) { _, newMessageId in
                     switch timelineNewestMessageScrollAction(
                         messageIDs: messageIDs,
+                        newMessageIsOutgoing: messages.last?.isOutgoing == true,
                         paging: paging,
                         pendingPrependAnchorId: pendingPrependAnchorId,
                         pendingAppendAnchorId: pendingAppendAnchorId,
-                        newMessageId: newMessageId
+                        newMessageId: newMessageId,
+                        isPinnedToBottom: isPinnedToBottom
                     ) {
                     case .restorePendingAppendAnchor(let anchorId):
                         DispatchQueue.main.async {
@@ -686,16 +701,10 @@ private struct ConversationView: View {
                         pendingAppendAnchorId = nil
                         return
                     case .scrollToBottom:
-                        break
+                        scrollToBottom(with: proxy)
                     case .none:
                         return
                     }
-
-                    // Pin to the newest message on initial load and when a new message
-                    // arrives at the live edge — but not while scrolled back into history
-                    // (hasMoreAfter), mid-prepend, or mid-forward paging, where it would
-                    // yank the user away.
-                    scrollToBottom(with: proxy)
                 }
                 .onChange(of: messageIDs.first) { _, _ in
                     guard let anchorId = pendingPrependAnchorId,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1218,32 +1218,101 @@ struct whitenoise_macTests {
 
         #expect(timelineNewestMessageScrollAction(
             messageIDs: ["message-150", "message-249", "message-349"],
+            newMessageIsOutgoing: false,
             paging: historicalPaging,
             pendingPrependAnchorId: nil,
             pendingAppendAnchorId: "message-249",
-            newMessageId: "message-349"
+            newMessageId: "message-349",
+            isPinnedToBottom: false
         ) == .restorePendingAppendAnchor("message-249"))
         #expect(timelineNewestMessageScrollAction(
             messageIDs: ["message-350", "message-449"],
+            newMessageIsOutgoing: false,
             paging: historicalPaging,
             pendingPrependAnchorId: nil,
             pendingAppendAnchorId: "message-249",
-            newMessageId: "message-449"
+            newMessageId: "message-449",
+            isPinnedToBottom: false
         ) == .clearPendingAppendAnchor)
         #expect(timelineNewestMessageScrollAction(
             messageIDs: ["message-350", "message-449"],
+            newMessageIsOutgoing: false,
             paging: historicalPaging,
             pendingPrependAnchorId: nil,
             pendingAppendAnchorId: nil,
-            newMessageId: "message-449"
+            newMessageId: "message-449",
+            isPinnedToBottom: true
         ) == .none)
         #expect(timelineNewestMessageScrollAction(
             messageIDs: ["message-350", "message-449"],
+            newMessageIsOutgoing: false,
             paging: liveEdgePaging,
             pendingPrependAnchorId: nil,
             pendingAppendAnchorId: nil,
-            newMessageId: "message-449"
+            newMessageId: "message-449",
+            isPinnedToBottom: true
         ) == .scrollToBottom)
+    }
+
+    @Test func newestMessageAutoScrollUsesBottomProximityNotOlderHistoryAvailability() {
+        let longLiveEdgePaging = TimelinePagingState(
+            hasMoreBefore: true,
+            hasMoreAfter: false,
+            isLoadingBefore: false,
+            isLoadingAfter: false
+        )
+        let detachedHistoryPaging = TimelinePagingState(
+            hasMoreBefore: true,
+            hasMoreAfter: true,
+            isLoadingBefore: false,
+            isLoadingAfter: false
+        )
+
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-001", "message-101"],
+            newMessageIsOutgoing: false,
+            paging: longLiveEdgePaging,
+            pendingPrependAnchorId: nil,
+            pendingAppendAnchorId: nil,
+            newMessageId: "message-101",
+            isPinnedToBottom: true
+        ) == .scrollToBottom)
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-001", "message-101"],
+            newMessageIsOutgoing: false,
+            paging: longLiveEdgePaging,
+            pendingPrependAnchorId: nil,
+            pendingAppendAnchorId: nil,
+            newMessageId: "message-101",
+            isPinnedToBottom: false
+        ) == .none)
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-001", "message-101"],
+            newMessageIsOutgoing: true,
+            paging: longLiveEdgePaging,
+            pendingPrependAnchorId: nil,
+            pendingAppendAnchorId: nil,
+            newMessageId: "message-101",
+            isPinnedToBottom: false
+        ) == .scrollToBottom)
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-001", "message-101"],
+            newMessageIsOutgoing: false,
+            paging: detachedHistoryPaging,
+            pendingPrependAnchorId: nil,
+            pendingAppendAnchorId: nil,
+            newMessageId: "message-101",
+            isPinnedToBottom: true
+        ) == .none)
+        #expect(timelineNewestMessageScrollAction(
+            messageIDs: ["message-001", "message-101"],
+            newMessageIsOutgoing: false,
+            paging: longLiveEdgePaging,
+            pendingPrependAnchorId: "message-000",
+            pendingAppendAnchorId: nil,
+            newMessageId: "message-101",
+            isPinnedToBottom: true
+        ) == .none)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- track whether the conversation bottom sentinel is visible instead of using `hasMoreBefore` as a scroll proxy
- auto-scroll appended live-edge messages only when the user is pinned to the bottom, while still surfacing outgoing sends
- add regression coverage for long conversations with older history, detached history windows, outgoing sends, and mid-prepend suppression

## Test Plan
- `git diff --check`
- attempted `xcodebuild test` / `swift test`; skipped because neither `xcodebuild` nor `swift` is installed on this Linux worker

Closes #39


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->