### PR TITLE
refactor: drop no-op firstNonBlank wrapper for sender picture (#38)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -2773,7 +2773,7 @@ final class WorkspaceState {
                     groupMemberNames[senderId],
                     resolved?.directoryDisplayName
                 ]),
-                pictureURL: firstNonBlank([resolved?.profilePicture])
+                pictureURL: resolved?.profilePicture?.nilIfBlank
             )
         }
 


### PR DESCRIPTION
## Summary

Collapses the no-op `firstNonBlank([resolved?.profilePicture])` single-element wrapper in `messageSenderProfiles(...)` to the codebase's established `nilIfBlank` idiom.

`firstNonBlank` over a single, already-trimmed value just trims and nils-out blanks — identical to `String.nilIfBlank`. Using `nilIfBlank` directly removes the misleading impression that multiple picture sources are being combined.

## Note on issue scope

The larger dead logic described in #38 (double display-name resolution where the outer `firstNonBlank([cachedName, groupMemberNames, displayName])` re-applied fallbacks already folded into `cachedName`) was **already refactored away** in a prior commit. The current display-name path resolves once over `resolved?.profileDisplayName / profileName / groupMemberNames / directoryDisplayName`. Only the redundant picture wrapper remained, which this PR removes.

## Verification

- Behavior-preserving: `firstNonBlank([x])` and `x?.nilIfBlank` are equivalent for a single value (both trim whitespace/newlines and return nil if empty).
- macOS-only Xcode app; no Swift toolchain on the build host, so no local compile/test. Single-line, semantically-identical change.

Closes #38

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->