### PR TITLE
fix: require visible key window for read state

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -39,8 +39,22 @@ struct ContentView: View {
             ) { _ in
                 // The app just regained focus. Flush any read-marking that was deferred
                 // while it was in the background so the selected chat clears its unread
-                // state now that the user is actually looking at it.
-                Task { await workspace.handleAppActivationChange() }
+                // state now that the user may be looking at it again.
+                Task { await workspace.handleConversationVisibilityChange() }
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: NSWindow.didBecomeKeyNotification
+                )
+            ) { _ in
+                Task { await workspace.handleConversationVisibilityChange() }
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: NSWindow.didDeminiaturizeNotification
+                )
+            ) { _ in
+                Task { await workspace.handleConversationVisibilityChange() }
             }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -204,6 +204,7 @@ final class WorkspaceState {
     private let clientFactory: @MainActor () throws -> any MarmotRuntime
     private let localNotificationCenter: any LocalNotificationCenter
     private let appActivityProvider: @MainActor () -> Bool
+    private let conversationWindowVisibilityProvider: @MainActor () -> Bool
     private let copyTextHandler: @MainActor (String) -> Void
     private let telemetryBuildConfigProvider: @MainActor () -> TelemetryBuildConfig
     private let groupImageSearchClient: any GroupImageSearchClient
@@ -288,6 +289,9 @@ final class WorkspaceState {
         messagesByChat: [String: [MessageItem]] = [:],
         localNotificationCenter: (any LocalNotificationCenter)? = nil,
         appActivityProvider: @escaping @MainActor () -> Bool = { NSApplication.shared.isActive },
+        conversationWindowVisibilityProvider: @escaping @MainActor () -> Bool = {
+            WorkspaceState.defaultConversationWindowVisibilityProvider()
+        },
         copyTextHandler: @escaping @MainActor (String) -> Void = WorkspaceState.copyToGeneralPasteboard,
         telemetryBuildConfigProvider: @escaping @MainActor () -> TelemetryBuildConfig = { TelemetryBuildConfig.current() },
         groupImageSearchClient: (any GroupImageSearchClient)? = nil,
@@ -302,6 +306,7 @@ final class WorkspaceState {
         self.messageIDsByChat = messagesByChat.mapValues { $0.map(\.id) }
         self.localNotificationCenter = localNotificationCenter ?? MacLocalNotificationCenter()
         self.appActivityProvider = appActivityProvider
+        self.conversationWindowVisibilityProvider = conversationWindowVisibilityProvider
         self.copyTextHandler = copyTextHandler
         self.telemetryBuildConfigProvider = telemetryBuildConfigProvider
         self.groupImageSearchClient = groupImageSearchClient ?? OpenverseGroupImageSearchClient()
@@ -323,6 +328,15 @@ final class WorkspaceState {
         self.localNotificationCenter.setResponseHandler { [weak self] userInfo in
             self?.handleNotificationResponse(userInfo)
         }
+    }
+
+    private static func defaultConversationWindowVisibilityProvider() -> Bool {
+        guard let keyWindow = NSApplication.shared.keyWindow else { return false }
+        return keyWindow.isVisible && !keyWindow.isMiniaturized
+    }
+
+    private func selectedConversationIsVisible() -> Bool {
+        appActivityProvider() && conversationWindowVisibilityProvider()
     }
 
     static func preview() -> WorkspaceState {
@@ -1744,7 +1758,7 @@ final class WorkspaceState {
         guard !deliveredNotificationKeys.contains(update.notificationKey) else { return }
         guard localNotificationsEnabled(for: update) else { return }
 
-        if appActivityProvider(), selectedChat?.id == update.groupIdHex {
+        if selectedChat?.id == update.groupIdHex, selectedConversationIsVisible() {
             return
         }
 
@@ -2565,12 +2579,13 @@ final class WorkspaceState {
     ) async {
         guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
         // A selected chat is necessary but not sufficient: only advance the read marker
-        // when the app is actually frontmost. If the user has switched away (app inactive,
-        // window occluded/minimized) incoming live deltas must not silently clear unread
-        // state for messages they have not seen — this mirrors the focus gate the
-        // notification path already applies in handleNotificationUpdate(_:). Marking is
-        // deferred until the app regains focus (see handleAppActivationChange()).
-        guard appActivityProvider() else { return }
+        // when the app is active and the conversation window is actually visible. If the
+        // user has switched away or the window is hidden/minimized, incoming live deltas
+        // must not silently clear unread state for messages they have not seen — this
+        // mirrors the focus gate the notification path already applies in
+        // handleNotificationUpdate(_:). Marking is deferred until the conversation becomes
+        // visible again (see handleConversationVisibilityChange()).
+        guard selectedConversationIsVisible() else { return }
         guard let latest = (messagesByChat[groupIdHex] ?? []).last(where: { message in
             message.timelineKind == 9 && !message.isDeleted
         }) else {
@@ -2600,21 +2615,25 @@ final class WorkspaceState {
         }
     }
 
-    /// Flush any read-marking that was deferred while the app was in the background.
+    /// Flush any read-marking that was deferred while the conversation was not visible.
     ///
-    /// `markLatestVisibleMessageRead(_:)` refuses to advance the read marker while the
-    /// app is inactive, so messages that arrive on the selected chat while the user is
-    /// away stay unread. When the app regains focus the user is now actually looking at
-    /// the selected chat, so it is safe to advance the marker to the latest visible
-    /// message. Call this from the app/window activation hook (see ContentView).
-    func handleAppActivationChange() async {
-        guard appActivityProvider() else { return }
+    /// `markLatestVisibleMessageRead(_:)` refuses to advance the read marker while the app
+    /// is inactive or its conversation window has no visible key window, so messages that
+    /// arrive while the user is away stay unread. When the conversation becomes visible
+    /// again it is safe to advance the marker to the latest visible message. Call this from
+    /// app/window activation hooks (see ContentView).
+    func handleConversationVisibilityChange() async {
+        guard selectedConversationIsVisible() else { return }
         guard let client, let activeAccount, let selectedChat else { return }
         await markLatestVisibleMessageRead(
             groupIdHex: selectedChat.id,
             account: activeAccount,
             client: client
         )
+    }
+
+    func handleAppActivationChange() async {
+        await handleConversationVisibilityChange()
     }
 
     private func rememberDeliveredNotificationKey(_ key: String) {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -2632,10 +2632,6 @@ final class WorkspaceState {
         )
     }
 
-    func handleAppActivationChange() async {
-        await handleConversationVisibilityChange()
-    }
-
     private func rememberDeliveredNotificationKey(_ key: String) {
         guard deliveredNotificationKeys.insert(key).inserted else { return }
         deliveredNotificationKeyOrder.append(key)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -966,7 +966,7 @@ struct whitenoise_macTests {
         #expect(runtime.markedReadMessageIds.isEmpty)
 
         isActive = true
-        await state.handleAppActivationChange()
+        await state.handleConversationVisibilityChange()
 
         #expect(runtime.markedReadMessageIds == ["latest"])
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -808,7 +808,11 @@ struct whitenoise_macTests {
                 )
             ))
         ], groupIdHex: "direct-group")
-        let state = WorkspaceState(appActivityProvider: { true }, clientFactory: { runtime })
+        let state = WorkspaceState(
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
 
         await state.bootstrap()
         await state.loadMessages(groupIdHex: "direct-group")
@@ -866,6 +870,55 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func selectedChatDoesNotMarkReadWhileConversationWindowIsHidden() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages([
+            appMessage(
+                id: "latest",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Latest message",
+                kind: 9,
+                recordedAt: 1_700_000_010
+            )
+        ], groupIdHex: "direct-group")
+        // The app process can stay active while its only window is minimized or has no
+        // key window; a selected chat is still not visible in that state.
+        let state = WorkspaceState(
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+
+        #expect(state.messagesByChat["direct-group"]?.count == 1)
+        #expect(runtime.markedReadMessageIds.isEmpty)
+    }
+
+    @MainActor
     @Test func regainingFocusFlushesDeferredReadMarking() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -902,7 +955,11 @@ struct whitenoise_macTests {
         // Start inactive so the initial open defers marking, then flip to active and
         // simulate the app regaining focus.
         var isActive = false
-        let state = WorkspaceState(appActivityProvider: { isActive }, clientFactory: { runtime })
+        let state = WorkspaceState(
+            appActivityProvider: { isActive },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
 
         await state.bootstrap()
         await state.loadMessages(groupIdHex: "direct-group")
@@ -910,6 +967,57 @@ struct whitenoise_macTests {
 
         isActive = true
         await state.handleAppActivationChange()
+
+        #expect(runtime.markedReadMessageIds == ["latest"])
+    }
+
+    @MainActor
+    @Test func restoringConversationWindowFlushesDeferredReadMarking() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages([
+            appMessage(
+                id: "latest",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Latest message",
+                kind: 9,
+                recordedAt: 1_700_000_010
+            )
+        ], groupIdHex: "direct-group")
+        var isWindowVisible = false
+        let state = WorkspaceState(
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { isWindowVisible },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        #expect(runtime.markedReadMessageIds.isEmpty)
+
+        isWindowVisible = true
+        await state.handleConversationVisibilityChange()
 
         #expect(runtime.markedReadMessageIds == ["latest"])
     }
@@ -1465,7 +1573,11 @@ struct whitenoise_macTests {
                 hasMoreAfter: false
             ))
         ], groupIdHex: "direct-group")
-        let state = WorkspaceState(appActivityProvider: { true }, clientFactory: { runtime })
+        let state = WorkspaceState(
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
 
         await state.bootstrap()
         await state.loadMessages(groupIdHex: "direct-group")
@@ -1557,7 +1669,11 @@ struct whitenoise_macTests {
                 )
             ))
         ], groupIdHex: "direct-group")
-        let state = WorkspaceState(appActivityProvider: { true }, clientFactory: { runtime })
+        let state = WorkspaceState(
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
 
         await state.bootstrap()
         await state.loadMessages(groupIdHex: "direct-group")
@@ -3289,6 +3405,7 @@ struct whitenoise_macTests {
         let state = WorkspaceState(
             localNotificationCenter: notificationCenter,
             appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
             clientFactory: { runtime }
         )
 
@@ -3303,6 +3420,51 @@ struct whitenoise_macTests {
 
         #expect(state.selection == .chat("direct-group"))
         #expect(notificationCenter.postedRequests.isEmpty)
+    }
+
+    @MainActor
+    @Test func activeSelectedChatNotificationPostsLocalAlertWhenConversationWindowIsHidden() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: true)
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        await state.handleNotificationUpdate(notificationUpdate(
+            account: account,
+            notificationKey: "notice-1",
+            groupIdHex: "direct-group",
+            senderName: "Alice",
+            previewText: "See you there."
+        ))
+
+        #expect(state.selection == .chat("direct-group"))
+        #expect(notificationCenter.postedRequests.map(\.identifier) == ["notice-1"])
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Gate selected-chat notification suppression and automatic read marking on app activity plus a visible key conversation window.
- Add a window visibility provider to `WorkspaceState` so minimized/no-key-window states can be tested directly.
- Flush deferred read marking when the app activates, the window becomes key, or the window is deminiaturized.

## Tests
- `git diff --check`
- Not run: `xcodebuild test` (xcodebuild unavailable on this Linux host)
- Not run: Swift tests (swift toolchain unavailable on this Linux host)

Closes #53

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-marking behavior to only mark messages as read when the app window is actually visible and focused.
  * Enhanced detection of window visibility changes (including minimization and focus events) to properly sync notification and read states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->