### PR TITLE
fix: advance read marker over agent/system messages (#36)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -2648,8 +2648,14 @@ final class WorkspaceState {
         // handleNotificationUpdate(_:). Marking is deferred until the conversation becomes
         // visible again (see handleConversationVisibilityChange()).
         guard selectedConversationIsVisible() else { return }
+        // Mark read against the newest visible, non-deleted message regardless of
+        // timelineKind. The timeline surfaces agent (1200–1202) and group-system (1210)
+        // events alongside human chat (kind 9), so a conversation whose newest content
+        // is non-chat — or which has no kind-9 messages at all — must still advance its
+        // read marker to what the user has actually seen. Filtering to kind 9 here pinned
+        // the marker to the last human message, leaving such chats permanently unread.
         guard let latest = (messagesByChat[groupIdHex] ?? []).last(where: { message in
-            message.timelineKind == 9 && !message.isDeleted
+            !message.isDeleted
         }) else {
             return
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1090,6 +1090,112 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func readMarkerAdvancesOverTrailingAgentMessage() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        // Newest content is an agent-operation event (kind 1202), not a human chat
+        // message. The read marker must still advance to it — previously the kind-9-only
+        // filter pinned the marker to "human" and left the conversation unread.
+        runtime.installMessages([
+            appMessage(
+                id: "human",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Latest human message",
+                kind: 9,
+                recordedAt: 1_700_000_010
+            ),
+            appMessage(
+                id: "agent",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Agent ran an operation",
+                kind: 1202,
+                recordedAt: 1_700_000_020
+            )
+        ], groupIdHex: "direct-group")
+        let state = WorkspaceState(appActivityProvider: { true }, clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+
+        #expect(runtime.markedReadMessageIds == ["agent"])
+    }
+
+    @MainActor
+    @Test func readMarkerAdvancesInAgentOnlyConversation() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        // Conversation contains no kind-9 message at all — only agent/system events.
+        // Previously last(where:) returned nil and the read marker never advanced, so
+        // the chat stayed unread for its entire lifetime.
+        runtime.installMessages([
+            appMessage(
+                id: "system",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Group renamed",
+                kind: 1210,
+                recordedAt: 1_700_000_010
+            ),
+            appMessage(
+                id: "agent-stream",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Agent started",
+                kind: 1200,
+                recordedAt: 1_700_000_020
+            )
+        ], groupIdHex: "direct-group")
+        let state = WorkspaceState(appActivityProvider: { true }, clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+
+        #expect(runtime.markedReadMessageIds == ["agent-stream"])
+    }
+
+    @MainActor
     @Test func chatListUsesSubscriptionSnapshotAndTypedDeltas() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
## Summary

`markLatestVisibleMessageRead(...)` chose the message to mark read by scanning **only for `timelineKind == 9`** (human chat). Newer agent (1200–1202) and group-system (1210) events were ignored, so:

- **Stuck unread badges** — a chat whose newest content is an agent/system event kept its read marker pinned to the last *human* message.
- **Agent-only / system-only chats never marked read** — with no kind-9 message at all, `last(where:)` returned `nil` and the read marker never advanced for the conversation's entire lifetime.

## Fix

All these timeline kinds are already rendered in the conversation view (chat as bubbles, agent/system/unsupported as `TimelineNoticeRow`s — see `ConversationMessageRow`). The read target should therefore be the newest *visible, non-deleted* message regardless of kind. Relaxed the `last(where:)` predicate from `timelineKind == 9 && !isDeleted` to `!isDeleted`.

Ordering, focus-gating, and the backwards-marker guard (`previousMarker < marker`) are all unchanged — `messagesByChat` is still ascending-sorted and `.last` still picks the newest visible message.

## Tests

Two regression tests added to `whitenoise-macTests`:
- `readMarkerAdvancesOverTrailingAgentMessage` — kind-9 followed by a newer kind-1202; marker must land on the agent event.
- `readMarkerAdvancesInAgentOnlyConversation` — only kind-1210/1200 events, no chat; marker must advance instead of staying `nil`.

## Notes

The issue flagged a dependency on how MarmotKit computes `unreadCount`/read receipts relative to `markTimelineMessageRead`. This change reports the read position against the newest message the user actually saw, which is correct regardless of whether the backend counts all kinds or only kind-9. No backend change is made here.

Swift/Xcode toolchain is macOS-only; could not compile locally on the Linux worker. Relying on CI for build + test verification.

Closes #36

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/66">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->