### PR TITLE
feat: add per-account sign out / removal to Accounts settings (#34)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -722,7 +722,19 @@ final class WorkspaceState {
             accounts = try client.listAccounts().map { accountItem(from: $0) }
             chatsByAccount[removedAccountId] = nil
 
-            if wasActive {
+            // `activeAccountId` may have changed during the await above — e.g. the user
+            // selected an account from settings while this removal was in flight. Decide
+            // recovery from the post-await state, not the pre-await `wasActive` snapshot,
+            // so we never leave `activeAccountId`/UserDefaults pointing at a removed
+            // account. `needsActiveReset` is true if the removed account was driving the
+            // UI, or if the (possibly newly-selected) active account no longer exists.
+            let activeAccountInvalid = activeAccountId == nil
+                || !accounts.contains(where: { $0.id == activeAccountId })
+            let needsActiveReset = wasActive || activeAccountInvalid
+
+            if needsActiveReset {
+                stopTimelineListener()
+                stopChatListListener()
                 messagesByChat.removeAll()
                 messageLookupByChat.removeAll()
                 messageIDsByChat.removeAll()
@@ -744,10 +756,11 @@ final class WorkspaceState {
                 return
             }
 
-            // Reselecting and reloading is only required when the account that was
-            // removed is the one currently driving the UI. Removing a background
-            // identity leaves the active session untouched.
-            if wasActive {
+            // Reselecting and reloading is only required when the account currently
+            // driving the UI was removed (directly, or via a racing selection of the
+            // soon-to-be-removed account). Removing a background identity that leaves a
+            // still-valid active account untouched needs no reselection.
+            if needsActiveReset {
                 restoreOrSelectFirstAccount()
                 selection = .settings(.accounts)
                 try await configureObservabilityRuntime()

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -694,29 +694,45 @@ final class WorkspaceState {
     }
 
     func removeActiveAccount() async {
-        guard let client, let activeAccount, !isRemovingAccount else { return }
+        guard let activeAccount else { return }
+        await removeAccount(activeAccount)
+    }
+
+    /// Removes a single identity (any account, not just the active one) from this Mac.
+    /// Deletes the account's private key and local Marmot/MLS state via the runtime, then
+    /// updates `accounts`/`chatsByAccount`. When the removed account is the active one, the
+    /// in-memory message/profile caches are cleared and a remaining account is reselected
+    /// (or the app returns to onboarding when none remain).
+    func removeAccount(_ account: AccountItem) async {
+        guard let client, !isRemovingAccount else { return }
 
         lastError = nil
         isRemovingAccount = true
         defer { isRemovingAccount = false }
 
-        let removedAccountId = activeAccount.id
+        let removedAccountId = account.id
+        let wasActive = activeAccountId == removedAccountId
         do {
-            stopTimelineListener()
-            stopChatListListener()
-            try await client.removeAccount(accountRef: activeAccount.accountRef)
+            if wasActive {
+                stopTimelineListener()
+                stopChatListListener()
+            }
+            try await client.removeAccount(accountRef: account.accountRef)
             clearComposerDrafts(forAccountId: removedAccountId)
             accounts = try client.listAccounts().map { accountItem(from: $0) }
             chatsByAccount[removedAccountId] = nil
-            messagesByChat.removeAll()
-            messageLookupByChat.removeAll()
-            messageIDsByChat.removeAll()
-            peerProfileFFICache.removeAll()
-            timelinePagingByChat.removeAll()
-            profileDraft = ProfileDraft()
-            keyPackages = []
-            auditLogFiles = []
-            auditLogUploadStatus = nil
+
+            if wasActive {
+                messagesByChat.removeAll()
+                messageLookupByChat.removeAll()
+                messageIDsByChat.removeAll()
+                peerProfileFFICache.removeAll()
+                timelinePagingByChat.removeAll()
+                profileDraft = ProfileDraft()
+                keyPackages = []
+                auditLogFiles = []
+                auditLogUploadStatus = nil
+            }
 
             if accounts.isEmpty {
                 activeAccountId = nil
@@ -728,11 +744,16 @@ final class WorkspaceState {
                 return
             }
 
-            restoreOrSelectFirstAccount()
-            selection = .settings(.accounts)
-            try await configureObservabilityRuntime()
-            await loadSettingsData()
-            await reloadChats()
+            // Reselecting and reloading is only required when the account that was
+            // removed is the one currently driving the UI. Removing a background
+            // identity leaves the active session untouched.
+            if wasActive {
+                restoreOrSelectFirstAccount()
+                selection = .settings(.accounts)
+                try await configureObservabilityRuntime()
+                await loadSettingsData()
+                await reloadChats()
+            }
         } catch {
             lastError = error.localizedDescription
         }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2300,6 +2300,7 @@ private struct SettingsScaffold<Content: View>: View {
 
 private struct AccountsSettingsView: View {
     @Environment(WorkspaceState.self) private var workspace
+    @State private var accountPendingRemoval: AccountItem?
 
     var body: some View {
         @Bindable var workspace = workspace
@@ -2309,15 +2310,26 @@ private struct AccountsSettingsView: View {
             subtitle: "Manage the identities available on this Mac.",
             errorSectionTitle: "Status"
         ) {
-            Section("Accounts") {
+            Section {
                 ForEach(workspace.accounts) { account in
                     AccountSettingsRow(
                         account: account,
-                        isActive: account.id == workspace.activeAccountId
-                    ) {
-                        workspace.selectAccountFromSettings(account)
-                    }
+                        isActive: account.id == workspace.activeAccountId,
+                        isRemoving: workspace.isRemovingAccount,
+                        onSelect: {
+                            workspace.selectAccountFromSettings(account)
+                        },
+                        onRemove: {
+                            accountPendingRemoval = account
+                        }
+                    )
                 }
+            } header: {
+                Text("Accounts")
+            } footer: {
+                Text("Removing an account deletes its private key and local message history from this Mac. The identity itself is not deleted from the network.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section("Add Account") {
@@ -2355,50 +2367,95 @@ private struct AccountsSettingsView: View {
             }
 
         }
+        .confirmationDialog(
+            removeAccountTitle,
+            isPresented: removeConfirmationBinding,
+            titleVisibility: .visible,
+            presenting: accountPendingRemoval
+        ) { account in
+            Button("Remove Account", role: .destructive) {
+                accountPendingRemoval = nil
+                Task { await workspace.removeAccount(account) }
+            }
+            Button("Cancel", role: .cancel) {
+                accountPendingRemoval = nil
+            }
+        } message: { _ in
+            Text("This deletes the private key and local message history for this identity from this Mac. This cannot be undone.")
+        }
+    }
+
+    private var removeConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { accountPendingRemoval != nil },
+            set: { isPresented in
+                if !isPresented { accountPendingRemoval = nil }
+            }
+        )
+    }
+
+    private var removeAccountTitle: String {
+        if let account = accountPendingRemoval {
+            return String(format: L10n.string("Remove %@?"), account.displayName)
+        }
+        return L10n.string("Remove account?")
     }
 }
 
 private struct AccountSettingsRow: View {
     let account: AccountItem
     let isActive: Bool
-    let action: () -> Void
+    let isRemoving: Bool
+    let onSelect: () -> Void
+    let onRemove: () -> Void
 
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 12) {
-                ProfileImageAvatarView(
-                    seed: account.accountIdHex,
-                    initials: account.initials,
-                    pictureURL: account.pictureURL,
-                    size: 44,
-                    isSelected: false
-                )
+        HStack(spacing: 12) {
+            Button(action: onSelect) {
+                HStack(spacing: 12) {
+                    ProfileImageAvatarView(
+                        seed: account.accountIdHex,
+                        initials: account.initials,
+                        pictureURL: account.pictureURL,
+                        size: 44,
+                        isSelected: false
+                    )
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(account.displayName)
-                        .font(.callout.weight(.semibold))
-                        .lineLimit(1)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(account.displayName)
+                            .font(.callout.weight(.semibold))
+                            .lineLimit(1)
 
-                    HStack(spacing: 8) {
-                        CopyableKeyLabel(accountIdHex: account.accountIdHex, showsCopyButton: false)
+                        HStack(spacing: 8) {
+                            CopyableKeyLabel(accountIdHex: account.accountIdHex, showsCopyButton: false)
 
-                        Text(account.localSigning ? L10n.string("Local signing") : L10n.string("Watch-only"))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                            Text(account.localSigning ? L10n.string("Local signing") : L10n.string("Watch-only"))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if isActive {
+                        Label("Active", systemImage: "checkmark.circle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.tint)
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                if isActive {
-                    Label("Active", systemImage: "checkmark.circle.fill")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.tint)
-                }
+                .padding(.vertical, 4)
+                .contentShape(Rectangle())
             }
-            .padding(.vertical, 4)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+
+            Button(role: .destructive, action: onRemove) {
+                Image(systemName: "person.crop.circle.badge.minus")
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.red)
+            .disabled(isRemoving)
+            .help(L10n.string("Remove this account from this Mac"))
+            .accessibilityLabel(Text(String(format: L10n.string("Remove %@"), account.displayName)))
         }
-        .buttonStyle(.plain)
     }
 }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2446,6 +2446,7 @@ private struct AccountSettingsRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .disabled(isRemoving)
 
             Button(role: .destructive, action: onRemove) {
                 Image(systemName: "person.crop.circle.badge.minus")

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -142,6 +142,35 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func removeNonActiveAccountLeavesActiveSessionUntouched() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        await state.removeAccount(backupAccount)
+
+        #expect(runtime.removedAccountRefs == ["Backup Account"])
+        #expect(state.accounts.map(\.id) == ["Desktop Account"])
+        // Removing a background identity must not switch the active account.
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.chatsByAccount["Backup Account"] == nil)
+    }
+
+    @MainActor
     @Test func deleteAllDataResetsToNewInstallState() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -171,6 +171,51 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func removingBackgroundAccountSelectedMidFlightRecoversActiveAccount() async throws {
+        // Regression for the account-switch/remove race: if the user selects the
+        // background account that is currently being removed while removal is in flight,
+        // `activeAccountId` transiently points at the soon-to-be-removed id. The pre-await
+        // `wasActive` snapshot is false, so naive code would skip recovery and leave
+        // `activeAccountId`/UserDefaults dangling at a deleted account. Removal must
+        // recompute against post-await state and reselect a surviving account.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+
+        // Simulate the racing UI selection of the account being removed, mid-await.
+        runtime.onRemoveAccountMidFlight = { _ in
+            await MainActor.run {
+                state.selectAccountFromSettings(backupAccount)
+            }
+        }
+
+        await state.removeAccount(backupAccount)
+
+        #expect(runtime.removedAccountRefs == ["Backup Account"])
+        #expect(state.accounts.map(\.id) == ["Desktop Account"])
+        // The active account must never point at the removed identity; recovery must
+        // reselect the surviving account.
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(UserDefaults.standard.string(forKey: "whitenoise.mac.activeAccountId") == "Desktop Account")
+        #expect(state.chatsByAccount["Backup Account"] == nil)
+    }
+
+    @MainActor
     @Test func deleteAllDataResetsToNewInstallState() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",
@@ -4048,6 +4093,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var relayTelemetryRuntimeConfig: RelayTelemetryRuntimeConfigFfi?
     private(set) var removedAccountRefs: [String] = []
     private(set) var didDeleteAllLocalData = false
+    /// Optional hook fired inside `removeAccount` after the ref is recorded but before the
+    /// account is actually dropped, used to simulate a racing UI action (e.g. the user
+    /// selecting the account currently being removed) mid-await.
+    var onRemoveAccountMidFlight: (@Sendable (String) async -> Void)?
 
     init(accounts: [AccountSummaryFfi], createdAccount: AccountSummaryFfi? = nil) {
         self.storedAccounts = accounts
@@ -4302,6 +4351,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func removeAccount(accountRef: String) async throws {
         removedAccountRefs.append(accountRef)
+        if let onRemoveAccountMidFlight {
+            await onRemoveAccountMidFlight(accountRef)
+        }
         storedAccounts.removeAll { $0.label == accountRef }
     }
 


### PR DESCRIPTION
## Summary

Closes #34.

The Accounts settings screen could only **switch to** or **add** identities — there was no way to sign out / remove / forget an account from this Mac via that list. Account removal (`removeActiveAccount` → `MarmotKit.removeAccount`, which deletes the Keychain entry and on-disk Marmot/MLS state) was already wired into the **Identity and Keys** screen and **Delete All Data** in Privacy, but the Accounts list — the screen the issue specifically calls out — had no removal affordance, and removal only worked for the *active* account.

This PR closes that gap.

## Changes

- **State:** Generalize `WorkspaceState.removeActiveAccount()` into `removeAccount(_ account:)` so any identity (active or background) can be removed. When the removed account is **not** the active one, the active session, message/profile caches, and current selection are left untouched — only that account's local state is dropped. `removeActiveAccount()` is retained as a thin wrapper (still used by Identity and Keys).
- **UI:** Add a destructive per-row "Remove" affordance to `AccountSettingsRow` in `AccountsSettingsView`, behind a confirmation dialog that clearly states it deletes the private key and local message history for that identity from this Mac (and that it cannot be undone). Section footer reiterates the scope. The empty-account case already returns to onboarding via existing logic.

## Backing

No new FFI required — uses the existing `MarmotKit.removeAccount(accountRef:)` bridge, which removes the account's Keychain entry and local Marmot/MLS state.

## Test Plan

- Added `removeNonActiveAccountLeavesActiveSessionUntouched` — removes a background account and asserts the runtime is called, the account list shrinks, the active account does **not** switch, and the removed account's chats are cleared.
- Existing `removeActiveAccountCallsRuntimeAndSelectsNextAccount` and `deleteAllDataResetsToNewInstallState` continue to cover the active-removal and full-wipe paths.

> Note: macOS/Xcode target — could not be compiled or run on the Linux fixer host (no Swift toolchain, repo has no CI). Changes verified by review; needs a green build/test run on a Mac before merge.

## Sensitive paths

Touches account / signing-key lifecycle (account removal deletes a private key from the Keychain). Flagged for merge-gate escalation; no auto-merge.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->