### PR TITLE
fix: avoid prefilled group image searches

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1517,7 +1517,7 @@ final class WorkspaceState {
         guard !chat.isDirect else { return }
         lastError = nil
         closeGroupDetails()
-        groupImageSearchQuery = chat.title
+        groupImageSearchQuery = ""
         groupImageResults = []
         isGroupImagePickerPresented = true
     }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1596,7 +1596,7 @@ private struct GroupImagePickerSheet: View {
 
                 VStack(spacing: 12) {
                     HStack(spacing: 8) {
-                        TextField("Search Openverse", text: $workspace.groupImageSearchQuery)
+                        TextField("Search images", text: $workspace.groupImageSearchQuery)
                             .textFieldStyle(.roundedBorder)
                             .onSubmit {
                                 Task { await workspace.searchGroupImages() }
@@ -1616,6 +1616,11 @@ private struct GroupImagePickerSheet: View {
                         .disabled(workspace.groupImageSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || workspace.isSearchingGroupImages)
                         .help("Search")
                     }
+
+                    Text("Search terms are sent to Openverse.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
                     HStack {
                         SettingsErrorView(error: workspace.lastError)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2120,6 +2120,12 @@ struct whitenoise_macTests {
         }
 
         state.showGroupImagePicker(for: groupChat)
+        #expect(state.groupImageSearchQuery.isEmpty)
+        await state.searchGroupImages()
+        let emptyImageSearchQueries = await imageSearchClient.queries
+        #expect(emptyImageSearchQueries.isEmpty)
+
+        state.groupImageSearchQuery = "aurora"
         await state.searchGroupImages()
         guard let result = state.groupImageResults.first else {
             Issue.record("Expected an image result")
@@ -2128,7 +2134,7 @@ struct whitenoise_macTests {
         await state.setGroupImage(result)
 
         let imageSearchQueries = await imageSearchClient.queries
-        #expect(imageSearchQueries == ["Test Group"])
+        #expect(imageSearchQueries == ["aurora"])
         #expect(runtime.updatedGroupAvatar == UpdatedGroupAvatar(
             groupIdHex: "group",
             url: "https://example.com/aurora.jpg",


### PR DESCRIPTION
## Summary
- Stop pre-filling the group image search query with the private group title.
- Keep empty searches local/no-op, requiring the user to type an explicit Openverse query.
- Add an inline note that search terms are sent to Openverse.

## Test Plan
- `git diff --check`
- Not run: `xcodebuild` / Swift tests (xcodebuild and swift are not installed in this Linux worker environment).

Closes #37


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->