### PR TITLE
fix: scrub entered nsec from WorkspaceState on every login exit path (#32)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -489,6 +489,7 @@ final class WorkspaceState {
 
     func selectAccount(_ account: AccountItem) {
         stopTimelineListener()
+        clearEnteredLoginIdentity()
         activeAccountId = account.id
         UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
         searchText = ""
@@ -512,6 +513,7 @@ final class WorkspaceState {
 
     func selectAccountFromSettings(_ account: AccountItem) {
         stopTimelineListener()
+        clearEnteredLoginIdentity()
         activeAccountId = account.id
         UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
         searchText = ""
@@ -528,6 +530,7 @@ final class WorkspaceState {
 
     func selectChat(_ chat: ChatItem) {
         stopTimelineListener()
+        clearEnteredLoginIdentity()
         selection = .chat(chat.id)
         draftText = ""
         replyDraftContext = nil
@@ -552,6 +555,7 @@ final class WorkspaceState {
 
     func showSettings(_ page: SettingsPage = .profile) {
         stopTimelineListener()
+        clearEnteredLoginIdentity()
         selection = .settings(page)
         draftText = ""
         replyDraftContext = nil
@@ -565,14 +569,22 @@ final class WorkspaceState {
 
     func showLogin() {
         authenticationMode = .login
-        loginIdentity = ""
+        clearEnteredLoginIdentity()
         lastError = nil
     }
 
     func cancelLogin() {
         authenticationMode = .landing
-        loginIdentity = ""
+        clearEnteredLoginIdentity()
         lastError = nil
+    }
+
+    /// Scrubs the entered nsec (private key) from `loginIdentity` so it does not
+    /// linger in observable memory longer than necessary. Used on login exit
+    /// paths and when navigating away from the login / add-account UI. See #32.
+    func clearEnteredLoginIdentity() {
+        guard !loginIdentity.isEmpty else { return }
+        loginIdentity = ""
     }
 
     func signUp() async {
@@ -607,7 +619,12 @@ final class WorkspaceState {
 
         lastError = nil
         isAuthenticating = true
-        defer { isAuthenticating = false }
+        // Scrub the entered nsec (private key) on every exit path so it never
+        // outlives the login call, including failures. See issue #32.
+        defer {
+            isAuthenticating = false
+            clearEnteredLoginIdentity()
+        }
 
         do {
             let summary = try await client.login(
@@ -616,7 +633,6 @@ final class WorkspaceState {
                 bootstrapRelays: MarmotClient.seedRelays
             )
             try refreshAccounts(preferred: summary)
-            loginIdentity = ""
             authenticationMode = .landing
             phase = .ready
             try await configureObservabilityRuntime()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -50,6 +50,71 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func failedLoginScrubsEnteredNsecFromMemory() async throws {
+        // No createdAccount => FakeMarmotRuntime.login throws, exercising the failure path.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showLogin()
+        state.loginIdentity = "nsec1faketestkeyfaketestkeyfaketestkeyfaketestkeyfaketest"
+
+        await state.login()
+
+        // Login failed (no account materialised) but the private key must not linger.
+        #expect(state.loginIdentity == "")
+        #expect(state.accounts.isEmpty)
+        #expect(state.lastError != nil)
+    }
+
+    @MainActor
+    @Test func successfulLoginScrubsEnteredNsecFromMemory() async throws {
+        let summary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [], createdAccount: summary)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showLogin()
+        state.loginIdentity = "nsec1faketestkeyfaketestkeyfaketestkeyfaketestkeyfaketest"
+
+        await state.login()
+
+        #expect(state.phase == .ready)
+        #expect(state.loginIdentity == "")
+    }
+
+    @MainActor
+    @Test func navigatingAwayFromAddAccountScrubsEnteredNsec() async throws {
+        let summary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [summary])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        // Simulate a typed-but-unsubmitted key in the Add Account field.
+        state.loginIdentity = "nsec1faketestkeyfaketestkeyfaketestkeyfaketestkeyfaketest"
+
+        state.showSettings(.accounts)
+        #expect(state.loginIdentity == "")
+
+        // And again when leaving for a chat.
+        state.loginIdentity = "nsec1anotherfakekeyanotherfakekeyanotherfakekeyanotherfake"
+        if let chat = state.activeChats.first {
+            state.selectChat(chat)
+            #expect(state.loginIdentity == "")
+        }
+    }
+
+    @MainActor
     @Test func removeActiveAccountCallsRuntimeAndSelectsNextAccount() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
## Summary

Fixes #32 — a failed login left the entered **nsec (private key)** retained in `WorkspaceState.loginIdentity` indefinitely, and most navigation paths never scrubbed it.

`loginIdentity` was previously cleared only on:
- `showLogin()` / `cancelLogin()`
- the **success** path of `login()`

So a *failed* login, or a typed-but-unsubmitted key in the settings **Add Account** `SecureField`, persisted in observable heap memory across the whole session (exposure surface: swap, crash reports, in-process reads).

## Changes

- Add `clearEnteredLoginIdentity()` helper and call it from `login()`'s `defer` so the nsec is scrubbed on **every** exit path — success, failure, and early returns.
- Scrub on navigation transitions that leave the login / add-account UI: `showSettings`, `selectChat`, `selectAccount`, `selectAccountFromSettings`.
- Route `showLogin()` / `cancelLogin()` through the same helper.

## Tests

- `failedLoginScrubsEnteredNsecFromMemory` — login throws, `loginIdentity` ends empty.
- `successfulLoginScrubsEnteredNsecFromMemory` — success path still scrubs.
- `navigatingAwayFromAddAccountScrubsEnteredNsec` — typed-but-unsubmitted key cleared on `showSettings`/`selectChat`.

## Notes

- Swift `String` makes true zeroization non-trivial; this minimizes the lifetime of the reference rather than guaranteeing memory zeroing, matching the issue's accepted scope.
- Touches account/identity input handling (private-key field) — flagging as **sensitive** for the merge gate.

Closes #32

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->