### PR TITLE
feat: add notification message-preview privacy control (#30)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -171,6 +171,11 @@ final class WorkspaceState {
             UserDefaults.standard.set(appearancePreference.rawValue, forKey: Self.appearancePreferenceKey)
         }
     }
+    var notificationPreviewMode: NotificationPreviewMode {
+        didSet {
+            UserDefaults.standard.set(notificationPreviewMode.rawValue, forKey: Self.notificationPreviewModeKey)
+        }
+    }
     var languagePreference: AppLanguage {
         didSet {
             UserDefaults.standard.set(languagePreference.rawValue, forKey: AppLanguage.storageKey)
@@ -306,6 +311,7 @@ final class WorkspaceState {
     private static let developerModeKey = "whitenoise.mac.developerMode"
     private static let streamingDebugModeKey = "whitenoise.mac.streamingDebugMode"
     private static let appearancePreferenceKey = "whitenoise.mac.appearancePreference"
+    private static let notificationPreviewModeKey = "whitenoise.mac.notificationPreviewMode"
     private static let deliveredNotificationKeyLimit = 256
     private static let timelinePageLimit: UInt32 = 100
 
@@ -372,6 +378,8 @@ final class WorkspaceState {
         self.streamingDebugMode = UserDefaults.standard.bool(forKey: Self.streamingDebugModeKey)
         let storedAppearance = UserDefaults.standard.string(forKey: Self.appearancePreferenceKey)
         self.appearancePreference = storedAppearance.flatMap(AppearancePreference.init(rawValue:)) ?? .system
+        let storedPreviewMode = UserDefaults.standard.string(forKey: Self.notificationPreviewModeKey)
+        self.notificationPreviewMode = storedPreviewMode.flatMap(NotificationPreviewMode.init(rawValue:)) ?? .full
         let storedLanguage = UserDefaults.standard.string(forKey: AppLanguage.storageKey)
         self.languagePreference = AppLanguage.resolved(rawValue: storedLanguage)
         self.activeAccountId = UserDefaults.standard.string(forKey: Self.activeAccountKey)
@@ -2750,19 +2758,46 @@ final class WorkspaceState {
         ]) ?? L10n.string("Someone")
         let previewText = firstNonBlank([update.previewText]) ?? L10n.string("New message")
 
+        // For an E2EE messenger, notification content is rendered as banners,
+        // persisted in Notification Center, and shown on the lock screen — i.e.
+        // it leaves the app's control. Honor the user's preview-privacy choice:
+        // `.hidden` reveals nothing, `.senderOnly` keeps who-it's-from but never
+        // the decrypted message text, `.full` is the legacy behavior. See #30.
+        let previewMode = notificationPreviewMode
+        let genericBody = L10n.string("New message")
+
         let title: String
         let body: String
         switch update.trigger {
         case .groupInvite:
-            title = L10n.string("Group invite")
-            body = firstNonBlank([update.groupName, senderName]) ?? L10n.string("New group invite")
-        case .newMessage:
-            if update.isDm {
-                title = senderName
-                body = previewText
+            if previewMode == .hidden {
+                title = L10n.string("White Noise")
+                body = L10n.string("New group invite")
             } else {
-                title = firstNonBlank([update.groupName]) ?? L10n.string("New message")
-                body = "\(senderName): \(previewText)"
+                title = L10n.string("Group invite")
+                body = firstNonBlank([update.groupName, senderName]) ?? L10n.string("New group invite")
+            }
+        case .newMessage:
+            switch previewMode {
+            case .full:
+                if update.isDm {
+                    title = senderName
+                    body = previewText
+                } else {
+                    title = firstNonBlank([update.groupName]) ?? L10n.string("New message")
+                    body = "\(senderName): \(previewText)"
+                }
+            case .senderOnly:
+                if update.isDm {
+                    title = senderName
+                    body = genericBody
+                } else {
+                    title = firstNonBlank([update.groupName]) ?? L10n.string("New message")
+                    body = senderName
+                }
+            case .hidden:
+                title = L10n.string("White Noise")
+                body = genericBody
             }
         }
 

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -449,6 +449,45 @@ struct NotificationSettingsSnapshot: Equatable {
     )
 }
 
+/// Controls how much of an incoming message is revealed in a macOS local
+/// notification. macOS renders notification content as banners, persists it in
+/// Notification Center, and shows it on the lock screen, so for an E2EE
+/// messenger the notification body is content that leaves the app's control.
+/// This lets a user trade convenience for privacy, mirroring the conservative,
+/// individually-toggleable defaults used elsewhere in Privacy & Security.
+enum NotificationPreviewMode: String, CaseIterable, Identifiable {
+    /// Show the sender/group name and the decrypted message text (legacy behavior).
+    case full
+    /// Show who the message is from (and the group name), but never the message text.
+    case senderOnly
+    /// Reveal nothing: generic "New message" with no sender, group, or content.
+    case hidden
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .full:
+            L10n.string("Show message preview")
+        case .senderOnly:
+            L10n.string("Sender only")
+        case .hidden:
+            L10n.string("Hide all")
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .full:
+            L10n.string("Notifications show who sent the message and its contents.")
+        case .senderOnly:
+            L10n.string("Notifications show who sent the message but not its contents.")
+        case .hidden:
+            L10n.string("Notifications only say a new message arrived.")
+        }
+    }
+}
+
 struct PrivacySecuritySettingsSnapshot: Equatable {
     var relayTelemetryEnabled: Bool
     var relayTelemetryIntervalSeconds: UInt64

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2870,6 +2870,8 @@ private struct NotificationsSettingsView: View {
     @Environment(WorkspaceState.self) private var workspace
 
     var body: some View {
+        @Bindable var workspace = workspace
+
         SettingsScaffold(
             title: "Notifications",
             subtitle: "Local alerts for this Mac."
@@ -2909,6 +2911,19 @@ private struct NotificationsSettingsView: View {
                         Label("Open System Settings", systemImage: "gear")
                     }
                 }
+            }
+
+            Section("Privacy") {
+                Picker(L10n.string("Message preview"), selection: $workspace.notificationPreviewMode) {
+                    ForEach(NotificationPreviewMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .disabled(!workspace.notificationSettings.localNotificationsEnabled)
+
+                Text(workspace.notificationPreviewMode.detail)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3594,6 +3594,140 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func senderOnlyPreviewModeOmitsDecryptedMessageBody() async throws {
+        // Issue #30: notification body must never leak decrypted plaintext when
+        // the user opts into sender-only previews. DM => body is generic, group
+        // => body is just the sender name; neither contains the message text.
+        let previousMode = UserDefaults.standard.object(forKey: "whitenoise.mac.notificationPreviewMode")
+        defer { restoreDefault(previousMode, forKey: "whitenoise.mac.notificationPreviewMode") }
+
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: true)
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        state.notificationPreviewMode = .senderOnly
+
+        await state.handleNotificationUpdate(notificationUpdate(
+            account: account,
+            notificationKey: "dm-notice",
+            groupIdHex: "direct-group",
+            senderName: "Alice",
+            previewText: "Top secret plaintext."
+        ))
+        await state.handleNotificationUpdate(notificationUpdate(
+            account: account,
+            notificationKey: "group-notice",
+            groupIdHex: "team-group",
+            senderName: "Bob",
+            previewText: "More secret plaintext.",
+            isDm: false,
+            groupName: "Engineering"
+        ))
+
+        #expect(notificationCenter.postedRequests.count == 2)
+        let dm = notificationCenter.postedRequests[0]
+        #expect(dm.title == "Alice")
+        #expect(dm.body == "New message")
+        #expect(!dm.body.contains("Top secret plaintext."))
+
+        let group = notificationCenter.postedRequests[1]
+        #expect(group.title == "Engineering")
+        #expect(group.body == "Bob")
+        #expect(!group.body.contains("More secret plaintext."))
+    }
+
+    @MainActor
+    @Test func hiddenPreviewModeRevealsNeitherSenderNorContents() async throws {
+        // Issue #30: hidden mode must reveal nothing about who or what — generic
+        // title and body for both DMs and groups.
+        let previousMode = UserDefaults.standard.object(forKey: "whitenoise.mac.notificationPreviewMode")
+        defer { restoreDefault(previousMode, forKey: "whitenoise.mac.notificationPreviewMode") }
+
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: true)
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        state.notificationPreviewMode = .hidden
+
+        await state.handleNotificationUpdate(notificationUpdate(
+            account: account,
+            notificationKey: "dm-notice",
+            groupIdHex: "direct-group",
+            senderName: "Alice",
+            previewText: "Top secret plaintext."
+        ))
+        await state.handleNotificationUpdate(notificationUpdate(
+            account: account,
+            notificationKey: "group-notice",
+            groupIdHex: "team-group",
+            senderName: "Bob",
+            previewText: "More secret plaintext.",
+            isDm: false,
+            groupName: "Engineering"
+        ))
+
+        #expect(notificationCenter.postedRequests.count == 2)
+        for request in notificationCenter.postedRequests {
+            #expect(request.title == "White Noise")
+            #expect(request.body == "New message")
+            #expect(!request.body.contains("plaintext"))
+            #expect(request.title != "Alice")
+            #expect(request.title != "Engineering")
+        }
+    }
+
+    @MainActor
+    @Test func fullPreviewModeIsDefaultAndPreservesLegacyBody() async throws {
+        // Backward-compatible default: full previews keep the prior behavior so
+        // existing users see no change unless they opt into a stricter mode.
+        let previousMode = UserDefaults.standard.object(forKey: "whitenoise.mac.notificationPreviewMode")
+        UserDefaults.standard.removeObject(forKey: "whitenoise.mac.notificationPreviewMode")
+        defer { restoreDefault(previousMode, forKey: "whitenoise.mac.notificationPreviewMode") }
+
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: true)
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.notificationPreviewMode == .full)
+
+        await state.handleNotificationUpdate(notificationUpdate(
+            account: account,
+            notificationKey: "group-notice",
+            groupIdHex: "team-group",
+            senderName: "Bob",
+            previewText: "The launch plan is ready.",
+            isDm: false,
+            groupName: "Engineering"
+        ))
+
+        #expect(notificationCenter.postedRequests.count == 1)
+        #expect(notificationCenter.postedRequests.first?.title == "Engineering")
+        #expect(notificationCenter.postedRequests.first?.body == "Bob: The launch plan is ready.")
+    }
+
+
+    @MainActor
     @Test func activeChatNotificationIsSuppressedWhileAppIsActive() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -5289,6 +5423,8 @@ private func notificationUpdate(
     groupIdHex: String = "direct-group",
     senderName: String,
     previewText: String,
+    isDm: Bool = true,
+    groupName: String? = nil,
     isFromSelf: Bool = false
 ) -> NotificationUpdateFfi {
     NotificationUpdateFfi(
@@ -5298,8 +5434,8 @@ private func notificationUpdate(
         accountRef: account.label,
         accountIdHex: account.accountIdHex,
         groupIdHex: groupIdHex,
-        groupName: nil,
-        isDm: true,
+        groupName: groupName,
+        isDm: isDm,
         messageIdHex: "\(notificationKey)-message",
         sender: NotificationUserFfi(
             accountIdHex: isFromSelf ? account.accountIdHex : "alice1234567890alice1234567890alice1234567890alice1234567890",


### PR DESCRIPTION
## Summary

Closes #30.

Local notifications previously assigned the **decrypted message plaintext** (plus sender/group display names) verbatim to `UNMutableNotificationContent.body`. macOS renders that as banners, persists it in Notification Center, and shows it on the lock screen, so message contents leaked to anyone with visual access to an unattended Mac — and there was no preview-hiding control, despite the app's otherwise privacy-conscious Privacy & Security design.

## Changes

- New `NotificationPreviewMode` enum (`full` / `senderOnly` / `hidden`) in `MessengerModels.swift`.
- `WorkspaceState.notificationPreviewMode`, persisted to `UserDefaults` via the existing `appearancePreference` `didSet` pattern (key `whitenoise.mac.notificationPreviewMode`).
- `localNotificationRequest(for:)` now reduces `title`/`body` per the selected mode:
  - **full** — legacy behavior: sender name + decrypted text.
  - **senderOnly** — DM shows sender as title with a generic "New message" body; group shows group name with sender-only body. Never the message text.
  - **hidden** — generic "White Noise" / "New message" for both DMs and groups; group invites are genericized too.
- New "Privacy → Message preview" `Picker` in `NotificationsSettingsView`, with a per-mode explanatory caption.
- Regression tests for all three modes across DM and group paths, plus a test asserting `.full` is the default and preserves the legacy body.

## Default choice (reviewer decision)

The issue *suggests* defaulting DMs to sender-only previews. I kept the default at **`.full`** to remain backward-compatible (no behavior change for existing users; existing notification-delivery tests stay green). The conservative default is a one-line change (`?? .full` → `?? .senderOnly` in the initializer) if reviewers prefer it. Flagging for the merge decision.

## Test plan

This is a macOS/Xcode app; build & test run in CI (no Swift toolchain on the fixer host). New tests:
- `senderOnlyPreviewModeOmitsDecryptedMessageBody`
- `hiddenPreviewModeRevealsNeitherSenderNorContents`
- `fullPreviewModeIsDefaultAndPreservesLegacyBody`

## Notes

- No crypto/MLS/CGKA/key/auth code touched. This is presentation-layer notification content + a UI setting. Not sensitive for merge-gate purposes.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->