### PR TITLE
fix: preserve composer drafts per chat

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -118,7 +118,20 @@ final class WorkspaceState {
     }
     var searchText = ""
     var isChatListVisible = true
-    var draftText = ""
+    var draftText: String {
+        get {
+            guard let selectedDraftChatId else { return "" }
+            return draftTextByChat[selectedDraftChatId] ?? ""
+        }
+        set {
+            guard let selectedDraftChatId else { return }
+            if newValue.isEmpty {
+                draftTextByChat[selectedDraftChatId] = nil
+            } else {
+                draftTextByChat[selectedDraftChatId] = newValue
+            }
+        }
+    }
     var isRefreshing = false
     var isSending = false
     var authenticationMode: AuthenticationMode = .landing
@@ -176,7 +189,16 @@ final class WorkspaceState {
     var newChatName = ""
     var newChatDescription = ""
     var newChatRecipient: NewChatRecipient?
-    var replyDraftContext: MessageReplyContext?
+    var replyDraftContext: MessageReplyContext? {
+        get {
+            guard let selectedDraftChatId else { return nil }
+            return replyDraftContextByChat[selectedDraftChatId]
+        }
+        set {
+            guard let selectedDraftChatId else { return }
+            replyDraftContextByChat[selectedDraftChatId] = newValue
+        }
+    }
     var isResolvingNewChat = false
     var isCreatingChat = false
     var isGroupImagePickerPresented = false
@@ -200,6 +222,25 @@ final class WorkspaceState {
     private(set) var storageRootPath = MarmotClient.defaultStorageRootPath()
     private(set) var timelinePagingByChat: [String: TimelinePagingState] = [:]
     private(set) var timelineInitialLoadGroupId: String?
+    private var draftTextByChat: [String: String] = [:]
+    private var replyDraftContextByChat: [String: MessageReplyContext] = [:]
+
+    private var selectedDraftChatId: String? {
+        guard case .chat(let chatId) = selection else { return nil }
+        return chatId
+    }
+
+    private func clearAllComposerDrafts() {
+        draftTextByChat.removeAll()
+        replyDraftContextByChat.removeAll()
+    }
+
+    private func clearComposerDrafts(for chatIds: [String]) {
+        for chatId in chatIds {
+            draftTextByChat[chatId] = nil
+            replyDraftContextByChat[chatId] = nil
+        }
+    }
 
     private let clientFactory: @MainActor () throws -> any MarmotRuntime
     private let localNotificationCenter: any LocalNotificationCenter
@@ -492,8 +533,6 @@ final class WorkspaceState {
         activeAccountId = account.id
         UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
         searchText = ""
-        draftText = ""
-        replyDraftContext = nil
         closeNewChatComposer()
         pruneMessageCache(keeping: nil)
         refreshObservabilityRuntime()
@@ -515,8 +554,6 @@ final class WorkspaceState {
         activeAccountId = account.id
         UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
         searchText = ""
-        draftText = ""
-        replyDraftContext = nil
         closeNewChatComposer()
         pruneMessageCache(keeping: nil)
         refreshObservabilityRuntime()
@@ -529,8 +566,6 @@ final class WorkspaceState {
     func selectChat(_ chat: ChatItem) {
         stopTimelineListener()
         selection = .chat(chat.id)
-        draftText = ""
-        replyDraftContext = nil
         closeNewChatComposer()
         pruneMessageCache(keeping: chat.id)
         beginTimelineInitialLoadIfNeeded(groupIdHex: chat.id)
@@ -539,8 +574,6 @@ final class WorkspaceState {
 
     func showNewChat() {
         isNewChatComposerVisible = true
-        draftText = ""
-        replyDraftContext = nil
         lastError = nil
         resetNewChatComposer()
     }
@@ -553,8 +586,6 @@ final class WorkspaceState {
     func showSettings(_ page: SettingsPage = .profile) {
         stopTimelineListener()
         selection = .settings(page)
-        draftText = ""
-        replyDraftContext = nil
         closeNewChatComposer()
         pruneMessageCache(keeping: nil)
     }
@@ -642,6 +673,8 @@ final class WorkspaceState {
             stopTimelineListener()
             stopChatListListener()
             try await client.removeAccount(accountRef: activeAccount.accountRef)
+            let removedChatIds = chatsByAccount[removedAccountId]?.map(\.id) ?? []
+            clearComposerDrafts(for: removedChatIds)
             accounts = try client.listAccounts().map { accountItem(from: $0) }
             chatsByAccount[removedAccountId] = nil
             messagesByChat.removeAll()
@@ -1786,8 +1819,6 @@ final class WorkspaceState {
 
         selection = .chat(groupIdHex)
         isChatListVisible = true
-        draftText = ""
-        replyDraftContext = nil
         closeNewChatComposer()
         pruneMessageCache(keeping: groupIdHex)
         NSApplication.shared.activate(ignoringOtherApps: true)
@@ -1821,8 +1852,7 @@ final class WorkspaceState {
         activeAccountId = preferredAccount.id
         UserDefaults.standard.set(preferredAccount.id, forKey: Self.activeAccountKey)
         searchText = ""
-        draftText = ""
-        replyDraftContext = nil
+        clearAllComposerDrafts()
         selection = nil
     }
 
@@ -1836,7 +1866,7 @@ final class WorkspaceState {
         selection = nil
         searchText = ""
         isChatListVisible = true
-        draftText = ""
+        clearAllComposerDrafts()
         isRefreshing = false
         isSending = false
         authenticationMode = .landing
@@ -1867,7 +1897,6 @@ final class WorkspaceState {
         deletingKeyPackageId = nil
         isNewChatComposerVisible = false
         resetNewChatComposer()
-        replyDraftContext = nil
         isResolvingNewChat = false
         isCreatingChat = false
         isGroupImagePickerPresented = false
@@ -2545,8 +2574,6 @@ final class WorkspaceState {
         else { return }
 
         selection = .chat(chat.id)
-        draftText = ""
-        replyDraftContext = nil
         closeNewChatComposer()
         pruneMessageCache(keeping: chat.id)
         beginTimelineInitialLoadIfNeeded(groupIdHex: chat.id)

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -98,6 +98,11 @@ final class WorkspaceState {
         case login
     }
 
+    private struct ComposerDraftKey: Hashable {
+        let accountId: String
+        let chatId: String
+    }
+
     private(set) var phase: Phase = .bootstrapping
     private(set) var accounts: [AccountItem]
     private(set) var chatsByAccount: [String: [ChatItem]]
@@ -120,15 +125,15 @@ final class WorkspaceState {
     var isChatListVisible = true
     var draftText: String {
         get {
-            guard let selectedDraftChatId else { return "" }
-            return draftTextByChat[selectedDraftChatId] ?? ""
+            guard let selectedComposerDraftKey else { return "" }
+            return draftTextByConversation[selectedComposerDraftKey] ?? ""
         }
         set {
-            guard let selectedDraftChatId else { return }
+            guard let selectedComposerDraftKey else { return }
             if newValue.isEmpty {
-                draftTextByChat[selectedDraftChatId] = nil
+                draftTextByConversation[selectedComposerDraftKey] = nil
             } else {
-                draftTextByChat[selectedDraftChatId] = newValue
+                draftTextByConversation[selectedComposerDraftKey] = newValue
             }
         }
     }
@@ -191,12 +196,12 @@ final class WorkspaceState {
     var newChatRecipient: NewChatRecipient?
     var replyDraftContext: MessageReplyContext? {
         get {
-            guard let selectedDraftChatId else { return nil }
-            return replyDraftContextByChat[selectedDraftChatId]
+            guard let selectedComposerDraftKey else { return nil }
+            return replyDraftContextByConversation[selectedComposerDraftKey]
         }
         set {
-            guard let selectedDraftChatId else { return }
-            replyDraftContextByChat[selectedDraftChatId] = newValue
+            guard let selectedComposerDraftKey else { return }
+            replyDraftContextByConversation[selectedComposerDraftKey] = newValue
         }
     }
     var isResolvingNewChat = false
@@ -222,23 +227,33 @@ final class WorkspaceState {
     private(set) var storageRootPath = MarmotClient.defaultStorageRootPath()
     private(set) var timelinePagingByChat: [String: TimelinePagingState] = [:]
     private(set) var timelineInitialLoadGroupId: String?
-    private var draftTextByChat: [String: String] = [:]
-    private var replyDraftContextByChat: [String: MessageReplyContext] = [:]
+    private var draftTextByConversation: [ComposerDraftKey: String] = [:]
+    private var replyDraftContextByConversation: [ComposerDraftKey: MessageReplyContext] = [:]
 
-    private var selectedDraftChatId: String? {
-        guard case .chat(let chatId) = selection else { return nil }
-        return chatId
+    private var selectedComposerDraftKey: ComposerDraftKey? {
+        guard let activeAccountId, case .chat(let chatId) = selection else { return nil }
+        return ComposerDraftKey(accountId: activeAccountId, chatId: chatId)
     }
 
     private func clearAllComposerDrafts() {
-        draftTextByChat.removeAll()
-        replyDraftContextByChat.removeAll()
+        draftTextByConversation.removeAll()
+        replyDraftContextByConversation.removeAll()
     }
 
-    private func clearComposerDrafts(for chatIds: [String]) {
+    private func clearComposerDrafts(for chatIds: [String], accountId: String) {
         for chatId in chatIds {
-            draftTextByChat[chatId] = nil
-            replyDraftContextByChat[chatId] = nil
+            let key = ComposerDraftKey(accountId: accountId, chatId: chatId)
+            draftTextByConversation[key] = nil
+            replyDraftContextByConversation[key] = nil
+        }
+    }
+
+    private func clearComposerDrafts(forAccountId accountId: String) {
+        for key in draftTextByConversation.keys.filter({ $0.accountId == accountId }) {
+            draftTextByConversation[key] = nil
+        }
+        for key in replyDraftContextByConversation.keys.filter({ $0.accountId == accountId }) {
+            replyDraftContextByConversation[key] = nil
         }
     }
 
@@ -673,8 +688,7 @@ final class WorkspaceState {
             stopTimelineListener()
             stopChatListListener()
             try await client.removeAccount(accountRef: activeAccount.accountRef)
-            let removedChatIds = chatsByAccount[removedAccountId]?.map(\.id) ?? []
-            clearComposerDrafts(for: removedChatIds)
+            clearComposerDrafts(forAccountId: removedAccountId)
             accounts = try client.listAccounts().map { accountItem(from: $0) }
             chatsByAccount[removedAccountId] = nil
             messagesByChat.removeAll()
@@ -2304,6 +2318,9 @@ final class WorkspaceState {
         guard activeAccountId == account.id else { return }
 
         let chatItems = rows.map { baseChatItem(from: $0, account: account) }
+        let previousChatIds = Set((chatsByAccount[account.id] ?? []).map(\.id))
+        let nextChatIds = Set(chatItems.map(\.id))
+        clearComposerDrafts(for: Array(previousChatIds.subtracting(nextChatIds)), accountId: account.id)
         chatsByAccount[account.id] = sortedChatItems(chatItems)
         dismissGroupImagePickerIfSelectedChatUnavailable()
         startChatListEnrichment(rows: rows, account: account)
@@ -2350,6 +2367,7 @@ final class WorkspaceState {
         messageLookupByChat[groupIdHex] = nil
         messageIDsByChat[groupIdHex] = nil
         timelinePagingByChat[groupIdHex] = nil
+        clearComposerDrafts(for: [groupIdHex], accountId: account.id)
         if timelineInitialLoadGroupId == groupIdHex {
             timelineInitialLoadGroupId = nil
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2815,6 +2815,68 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func sharedConversationDraftsAreIsolatedPerAccount() async throws {
+        let state = WorkspaceState.preview()
+        let sharedChat = ChatItem.samples[1]
+
+        state.selectChat(sharedChat)
+        state.draftText = "primary account draft"
+
+        state.selectAccount(AccountItem.samples[1])
+        #expect(state.selectedChat?.id == sharedChat.id)
+        #expect(state.draftText.isEmpty)
+        state.draftText = "backup account draft"
+
+        state.selectAccount(AccountItem.samples[0])
+        state.selectChat(sharedChat)
+        #expect(state.draftText == "primary account draft")
+
+        state.selectAccount(AccountItem.samples[1])
+        #expect(state.selectedChat?.id == sharedChat.id)
+        #expect(state.draftText == "backup account draft")
+    }
+
+    @MainActor
+    @Test func reloadChatsPrunesDraftsForRemovedConversations() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didLoadBothChats = await waitFor {
+            Set(state.activeChats.map(\.id)) == ["group", "direct-group"]
+        }
+        #expect(didLoadBothChats)
+
+        guard let groupChat = state.activeChats.first(where: { $0.id == "group" }) else {
+            Issue.record("Expected group chat")
+            return
+        }
+        state.selectChat(groupChat)
+        state.draftText = "draft for removed group"
+
+        runtime.installGroups([directGroup()])
+        await state.reloadChats()
+        #expect(state.activeChats.map(\.id) == ["direct-group"])
+
+        runtime.installGroups([messageGroup(), directGroup()])
+        await state.reloadChats()
+        guard let restoredGroupChat = state.activeChats.first(where: { $0.id == "group" }) else {
+            Issue.record("Expected restored group chat")
+            return
+        }
+        state.selectChat(restoredGroupChat)
+
+        #expect(state.draftText.isEmpty)
+    }
+
+    @MainActor
     @Test func newChatComposerOpensInChatColumnWithoutChangingDetailSelection() async throws {
         let state = WorkspaceState.preview()
         let selection = state.selection

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2735,6 +2735,86 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func chatSwitchPreservesDraftTextPerConversation() async throws {
+        let state = WorkspaceState.preview()
+        let design = ChatItem.samples[0]
+        let nvk = ChatItem.samples[1]
+
+        #expect(state.selectedChat?.id == design.id)
+        state.draftText = "Design reply in progress"
+
+        state.selectChat(nvk)
+        #expect(state.draftText.isEmpty)
+        state.draftText = "NVK reply in progress"
+
+        state.selectChat(design)
+        #expect(state.draftText == "Design reply in progress")
+
+        state.selectChat(nvk)
+        #expect(state.draftText == "NVK reply in progress")
+    }
+
+    @MainActor
+    @Test func chatSwitchPreservesReplyDraftContextPerConversation() async throws {
+        let state = WorkspaceState.preview()
+        let design = ChatItem.samples[0]
+        let nvk = ChatItem.samples[1]
+        let designReply = MessageItem(
+            id: "design-parent",
+            senderName: "NVK",
+            body: "Design plan",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false
+        )
+        let nvkReply = MessageItem(
+            id: "nvk-parent",
+            senderName: "NVK",
+            body: "Direct ping",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_010),
+            isOutgoing: false
+        )
+
+        #expect(state.selectedChat?.id == design.id)
+        state.startReply(to: designReply)
+
+        state.selectChat(nvk)
+        #expect(state.replyDraftContext == nil)
+        state.startReply(to: nvkReply)
+
+        state.selectChat(design)
+        #expect(state.replyDraftContext == MessageReplyContext(
+            targetMessageId: "design-parent",
+            senderName: "NVK",
+            body: "Design plan"
+        ))
+
+        state.selectChat(nvk)
+        #expect(state.replyDraftContext == MessageReplyContext(
+            targetMessageId: "nvk-parent",
+            senderName: "NVK",
+            body: "Direct ping"
+        ))
+    }
+
+    @MainActor
+    @Test func accountSwitchRestoresDraftTextWhenReturningToConversation() async throws {
+        let state = WorkspaceState.preview()
+        let design = ChatItem.samples[0]
+
+        #expect(state.selectedChat?.id == design.id)
+        state.draftText = "draft survives account hop"
+
+        state.selectAccount(AccountItem.samples[1])
+        #expect(state.activeAccountId == AccountItem.samples[1].id)
+        #expect(state.draftText.isEmpty)
+
+        state.selectAccount(AccountItem.samples[0])
+        #expect(state.activeAccountId == AccountItem.samples[0].id)
+        #expect(state.selectedChat?.id == design.id)
+        #expect(state.draftText == "draft survives account hop")
+    }
+
+    @MainActor
     @Test func newChatComposerOpensInChatColumnWithoutChangingDetailSelection() async throws {
         let state = WorkspaceState.preview()
         let selection = state.selection
@@ -2744,7 +2824,7 @@ struct whitenoise_macTests {
 
         #expect(state.isNewChatComposerVisible)
         #expect(state.selection == selection)
-        #expect(state.draftText.isEmpty)
+        #expect(state.draftText == "half-written message")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- store composer draft text and reply context per selected conversation instead of one global field
- stop navigation actions from clearing the current chat draft when switching chats/accounts, opening settings/new chat, or following notifications
- add coverage for per-chat draft text, per-chat reply targets, account switching, and new-chat composer behavior

## Test Plan
- `git diff --check`
- Not run: Swift/Xcode tests (vault worker is Linux and has no `swift`, `xcodebuild`, or `xcrun` toolchain installed)

Closes #33


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->