### PR TITLE
fix: start runtime after onboarding auth

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -266,6 +266,7 @@ final class WorkspaceState {
     private let telemetryBuildConfigProvider: @MainActor () -> TelemetryBuildConfig
     private let groupImageSearchClient: any GroupImageSearchClient
     private var client: (any MarmotRuntime)?
+    private var hasStartedRuntime = false
     private var notificationTask: Task<Void, Never>?
     private var chatListTask: Task<Void, Never>?
     private var chatListTaskAccountId: String?
@@ -528,7 +529,7 @@ final class WorkspaceState {
                 return
             }
 
-            try await runtime.start()
+            try await startRuntimeIfNeeded(runtime)
             accounts = try runtime.listAccounts().map { accountItem(from: $0) }
             restoreOrSelectFirstAccount()
             try await configureObservabilityRuntime()
@@ -646,6 +647,8 @@ final class WorkspaceState {
                 bootstrapRelays: MarmotClient.seedRelays
             )
             try refreshAccounts(preferred: summary)
+            try await startRuntimeIfNeeded(client)
+            try refreshAccounts(preferred: summary)
             authenticationMode = .landing
             phase = .ready
             try await configureObservabilityRuntime()
@@ -679,6 +682,8 @@ final class WorkspaceState {
                 defaultRelays: MarmotClient.seedRelays,
                 bootstrapRelays: MarmotClient.seedRelays
             )
+            try refreshAccounts(preferred: summary)
+            try await startRuntimeIfNeeded(client)
             try refreshAccounts(preferred: summary)
             authenticationMode = .landing
             phase = .ready
@@ -752,6 +757,7 @@ final class WorkspaceState {
 
             try await client.deleteAllLocalData()
             self.client = nil
+            hasStartedRuntime = false
             resetToNewInstallState(storageRootPath: client.storageRootPath)
 
             let runtime = try clientFactory()
@@ -1885,6 +1891,12 @@ final class WorkspaceState {
         searchText = ""
         clearAllComposerDrafts()
         selection = nil
+    }
+
+    private func startRuntimeIfNeeded(_ runtime: any MarmotRuntime) async throws {
+        guard !hasStartedRuntime else { return }
+        try await runtime.start()
+        hasStartedRuntime = true
     }
 
     private func resetToNewInstallState(storageRootPath: String) {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -34,7 +34,7 @@ struct whitenoise_macTests {
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
             localSigning: true,
-            running: true
+            running: false
         )
         let runtime = FakeMarmotRuntime(accounts: [], createdAccount: created)
         let state = WorkspaceState(clientFactory: { runtime })
@@ -46,7 +46,35 @@ struct whitenoise_macTests {
         #expect(state.showsMessengerChrome)
         #expect(state.accounts.map(\.displayName) == ["Desktop Account"])
         #expect(state.accounts.first?.pictureURL == "https://example.com/avatar.png")
+        #expect(state.accounts.first?.isRunning == true)
         #expect(state.activeAccountId == "Desktop Account")
+        #expect(runtime.didStart)
+        #expect(runtime.startCallCount == 1)
+    }
+
+    @MainActor
+    @Test func loginStartsRuntimeAndEntersMessengerShell() async throws {
+        let loggedIn = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [], createdAccount: loggedIn)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showLogin()
+        state.loginIdentity = "nsec1desktop"
+        await state.login()
+
+        #expect(state.phase == .ready)
+        #expect(state.showsMessengerChrome)
+        #expect(state.accounts.map(\.displayName) == ["Desktop Account"])
+        #expect(state.accounts.first?.isRunning == true)
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(runtime.didStart)
+        #expect(runtime.startCallCount == 1)
     }
 
     @MainActor
@@ -3899,7 +3927,8 @@ private actor FakeGroupImageSearchClient: GroupImageSearchClient {
 private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sendable {
     private var storedAccounts: [AccountSummaryFfi]
     private let createdAccount: AccountSummaryFfi?
-    private(set) var didStart = false
+    private(set) var startCallCount = 0
+    var didStart: Bool { startCallCount > 0 }
     let storageRootPath = "/tmp/whitenoise-mac-tests"
     private var profile = UserProfileMetadataFfi(
         name: "desktop",
@@ -4026,7 +4055,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func start() async throws {
-        didStart = true
+        startCallCount += 1
+        storedAccounts = storedAccounts.map { account in
+            var runningAccount = account
+            runningAccount.running = true
+            return runningAccount
+        }
     }
 
     func listAccounts() throws -> [AccountSummaryFfi] {


### PR DESCRIPTION
## Summary
- start the Marmot runtime after first-run sign-up/login before entering the ready messenger session
- keep bootstrap using the same guarded start path so repeated state transitions do not double-start the runtime
- add onboarding auth regression coverage for sign-up and login, including the account running flag after start

## Test Plan
- `git diff --check`
- `xcodebuild test -scheme whitenoise-mac -destination 'platform=macOS'` (blocked: xcodebuild is not installed on this Linux worker)

Closes #31


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->