### PR TITLE
perf: cache AppLanguage.currentLocale to avoid per-call UserDefaults read + Locale alloc (#28)

### DIFF
--- a/whitenoise-mac/Core/AppLanguage.swift
+++ b/whitenoise-mac/Core/AppLanguage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 enum AppLanguage: String, CaseIterable, Identifiable {
     case system
@@ -34,19 +35,39 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         [.system] + supportedAppLanguages
     }
 
-    // `L10n.string` resolves this on every localized lookup (many per message during
-    // mapping). Cache the constructed Locale and only rebuild it when the stored
-    // language preference actually changes.
-    nonisolated(unsafe) private static var cachedLocale: (raw: String?, locale: Locale)?
+    // `currentLocale` is read from many hot paths (SwiftUI view bodies that
+    // re-evaluate frequently, per-message mapping) on the main thread. Resolving
+    // it must not read `UserDefaults` or allocate a `Locale` on every call. We
+    // cache the resolved locale in memory and only recompute it when the stored
+    // language preference actually changes. `refreshCachedLocale()` is invoked
+    // from `WorkspaceState.languagePreference` (the only production writer of
+    // `storageKey`) so the cache stays correct, while the common-case read is an
+    // allocation-free in-memory lookup. The unfair lock keeps the cache safe if
+    // `currentLocale` is ever touched off the main thread.
+    private static let cachedLocale = OSAllocatedUnfairLock<Locale?>(initialState: nil)
 
     static var currentLocale: Locale {
-        let rawValue = UserDefaults.standard.string(forKey: storageKey)
-        if let cached = cachedLocale, cached.raw == rawValue {
-            return cached.locale
+        cachedLocale.withLock { cache in
+            if let cache {
+                return cache
+            }
+            let locale = resolvedLocaleFromDefaults()
+            cache = locale
+            return locale
         }
-        let locale = resolved(rawValue: rawValue).locale ?? .autoupdatingCurrent
-        cachedLocale = (rawValue, locale)
-        return locale
+    }
+
+    /// Recompute the cached locale from the stored language preference. Call this
+    /// whenever the preference changes so `currentLocale` remains an
+    /// allocation-free in-memory read in the common case.
+    static func refreshCachedLocale() {
+        let locale = resolvedLocaleFromDefaults()
+        cachedLocale.withLock { $0 = locale }
+    }
+
+    private static func resolvedLocaleFromDefaults() -> Locale {
+        let rawValue = UserDefaults.standard.string(forKey: storageKey)
+        return resolved(rawValue: rawValue).locale ?? .autoupdatingCurrent
     }
 
     static func resolved(rawValue: String?) -> AppLanguage {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -156,6 +156,7 @@ final class WorkspaceState {
     var languagePreference: AppLanguage {
         didSet {
             UserDefaults.standard.set(languagePreference.rawValue, forKey: AppLanguage.storageKey)
+            AppLanguage.refreshCachedLocale()
         }
     }
     var isLoadingSettings = false

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -238,6 +238,7 @@ struct whitenoise_macTests {
         let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
         defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
         UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
 
         let messageDate = Date(timeIntervalSince1970: 1_700_000_000)
         let sameWeekNow = messageDate.addingTimeInterval(86_400)
@@ -254,6 +255,7 @@ struct whitenoise_macTests {
         let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
         defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
         UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
 
         let messageDate = Date(timeIntervalSince1970: 1_700_000_000)
         let expected = messageDate.formatted(
@@ -2894,6 +2896,7 @@ struct whitenoise_macTests {
         let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
         defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
         UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
 
         let publishedAt = Date(timeIntervalSince1970: 1_700_000_000)
         let package = KeyPackageItem(
@@ -5222,5 +5225,11 @@ private func restoreDefault(_ value: Any?, forKey key: String) {
         UserDefaults.standard.set(value, forKey: key)
     } else {
         UserDefaults.standard.removeObject(forKey: key)
+    }
+    // Tests mutate `UserDefaults` directly (bypassing `WorkspaceState`), so the
+    // in-memory locale cache must be invalidated when the language key is
+    // restored — otherwise a stale cached locale leaks into later tests.
+    if key == AppLanguage.storageKey {
+        AppLanguage.refreshCachedLocale()
     }
 }


### PR DESCRIPTION
## Summary

`L10n.string(_:)` is invoked pervasively from SwiftUI view bodies, model computed properties, and the per-message mapping layer — all of which re-evaluate frequently on the main thread. Each call resolved `AppLanguage.currentLocale`, which read `UserDefaults` (disk-backed) on **every** invocation to detect language changes.

This makes `currentLocale` an allocation- and disk-free in-memory lookup in the common case, recomputed only when the language preference actually changes.

## Changes

- `Core/AppLanguage.swift`: replace the per-call `(raw, locale)` cache + `UserDefaults` read with a cached `Locale` guarded by `OSAllocatedUnfairLock` (the lock also removes the prior `nonisolated(unsafe)` data race). The cache lazily seeds from `UserDefaults` on first read.
- `Core/WorkspaceState.swift`: invalidate the cache from `languagePreference.didSet` — the sole production writer of the storage key — so behavior is unchanged.
- `whitenoise-macTests`: the 3 white-box tests mutate `UserDefaults` directly (bypassing `WorkspaceState`); they now flush the cache via `AppLanguage.refreshCachedLocale()` so synchronous reads stay correct and no stale locale leaks between tests.

## Behavior

No functional change. `currentLocale` returns the same locale as before; only the redundant per-call `UserDefaults` read and `Locale` allocation on hot render paths are eliminated.

## Test plan

- [ ] `xcodebuild test` (CI) — existing AppLanguage/locale tests pass
- Note: validated by review only; no Swift toolchain on the fixer host.

Closes #28

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->