### PR TITLE
fix: gate unavailable message actions

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1334,6 +1334,7 @@ final class WorkspaceState {
     }
 
     func copyText(of message: MessageItem) {
+        guard message.canCopyText else { return }
         copyText(message.body)
     }
 
@@ -1381,7 +1382,7 @@ final class WorkspaceState {
     }
 
     func deleteMessage(_ message: MessageItem) async {
-        guard message.supportsChatActions else { return }
+        guard message.canDelete else { return }
         guard let client, let activeAccount, let selectedChat else { return }
         do {
             _ = try await client.deleteMessage(

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -280,8 +280,36 @@ struct MessageItem: Identifiable, Hashable {
         "\(DisplayText.short(id, head: 10, tail: 8)) - \(timelineAt)"
     }
 
+    private var hasCopyableBody: Bool {
+        !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var isActionableContent: Bool {
+        !isDeleted && invalidationStatus == nil
+    }
+
+    private var isActionableChatBubble: Bool {
+        presentation.isChatBubble && isActionableContent
+    }
+
     var supportsChatActions: Bool {
-        presentation.isChatBubble && !isDeleted && invalidationStatus == nil
+        isActionableChatBubble
+    }
+
+    var canCopyText: Bool {
+        isActionableContent && hasCopyableBody
+    }
+
+    var canReact: Bool {
+        isActionableChatBubble
+    }
+
+    var canReply: Bool {
+        isActionableChatBubble
+    }
+
+    var canDelete: Bool {
+        isActionableChatBubble && isOutgoing
     }
 }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1805,7 +1805,7 @@ private struct MessageBubble: View {
                     .foregroundStyle(.tertiary)
                     .padding(.horizontal, 5)
 
-                if !message.reactions.isEmpty {
+                if message.supportsChatActions && !message.reactions.isEmpty {
                     HStack(spacing: 5) {
                         ForEach(message.reactions) { reaction in
                             Button {
@@ -1843,14 +1843,8 @@ private struct MessageBubble: View {
         }
         .contentShape(Rectangle())
         .contextMenu {
-            if message.supportsChatActions {
+            if message.canCopyText || message.canDelete {
                 MessageOverflowMenuItems(message: message)
-            } else {
-                Button {
-                    workspace.copyText(of: message)
-                } label: {
-                    Label("Copy Text", systemImage: "doc.on.doc")
-                }
             }
         }
         .onHover { isHovering = $0 }
@@ -1944,40 +1938,46 @@ private struct MessageInlineActions: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Button {
-                isEmojiPickerPresented = true
-            } label: {
-                MessageInlineActionIcon(systemName: "face.smiling", label: "React")
-            }
-            .buttonStyle(.plain)
-            .popover(isPresented: $isEmojiPickerPresented, arrowEdge: .bottom) {
-                MessageEmojiPickerPopover { emoji in
-                    isEmojiPickerPresented = false
-                    Task { await workspace.react(to: message, emoji: emoji) }
+            if message.canReact {
+                Button {
+                    isEmojiPickerPresented = true
+                } label: {
+                    MessageInlineActionIcon(systemName: "face.smiling", label: "React")
                 }
-            }
-            .help("React")
-
-            Button {
-                workspace.startReply(to: message)
-            } label: {
-                MessageInlineActionIcon(systemName: "arrowshape.turn.up.left", label: "Reply")
-            }
-            .buttonStyle(.plain)
-            .help("Reply")
-
-            Button {
-                isOverflowPresented = true
-            } label: {
-                MessageInlineActionIcon(systemName: "ellipsis", label: "More")
-            }
-            .buttonStyle(.plain)
-            .popover(isPresented: $isOverflowPresented, arrowEdge: .bottom) {
-                MessageOverflowPopover(message: message) {
-                    isOverflowPresented = false
+                .buttonStyle(.plain)
+                .popover(isPresented: $isEmojiPickerPresented, arrowEdge: .bottom) {
+                    MessageEmojiPickerPopover { emoji in
+                        isEmojiPickerPresented = false
+                        Task { await workspace.react(to: message, emoji: emoji) }
+                    }
                 }
+                .help("React")
             }
-            .help("More")
+
+            if message.canReply {
+                Button {
+                    workspace.startReply(to: message)
+                } label: {
+                    MessageInlineActionIcon(systemName: "arrowshape.turn.up.left", label: "Reply")
+                }
+                .buttonStyle(.plain)
+                .help("Reply")
+            }
+
+            if message.canCopyText || message.canDelete {
+                Button {
+                    isOverflowPresented = true
+                } label: {
+                    MessageInlineActionIcon(systemName: "ellipsis", label: "More")
+                }
+                .buttonStyle(.plain)
+                .popover(isPresented: $isOverflowPresented, arrowEdge: .bottom) {
+                    MessageOverflowPopover(message: message) {
+                        isOverflowPresented = false
+                    }
+                }
+                .help("More")
+            }
         }
         .frame(width: 92, height: 32)
         .onChange(of: isEmojiPickerPresented) { _, _ in
@@ -2056,16 +2056,22 @@ private struct MessageOverflowPopover: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            overflowButton("Copy Text", systemImage: "doc.on.doc") {
-                workspace.copyText(of: message)
-                dismiss()
+            if message.canCopyText {
+                overflowButton("Copy Text", systemImage: "doc.on.doc") {
+                    workspace.copyText(of: message)
+                    dismiss()
+                }
             }
 
-            Divider()
+            if message.canCopyText && message.canDelete {
+                Divider()
+            }
 
-            overflowButton("Delete", systemImage: "trash", role: .destructive) {
-                dismiss()
-                Task { await workspace.deleteMessage(message) }
+            if message.canDelete {
+                overflowButton("Delete", systemImage: "trash", role: .destructive) {
+                    dismiss()
+                    Task { await workspace.deleteMessage(message) }
+                }
             }
         }
         .padding(.vertical, 6)
@@ -2101,18 +2107,24 @@ private struct MessageOverflowMenuItems: View {
     let message: MessageItem
 
     var body: some View {
-        Button {
-            workspace.copyText(of: message)
-        } label: {
-            Label("Copy Text", systemImage: "doc.on.doc")
+        if message.canCopyText {
+            Button {
+                workspace.copyText(of: message)
+            } label: {
+                Label("Copy Text", systemImage: "doc.on.doc")
+            }
         }
 
-        Divider()
+        if message.canCopyText && message.canDelete {
+            Divider()
+        }
 
-        Button(role: .destructive) {
-            Task { await workspace.deleteMessage(message) }
-        } label: {
-            Label("Delete", systemImage: "trash")
+        if message.canDelete {
+            Button(role: .destructive) {
+                Task { await workspace.deleteMessage(message) }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
         }
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -417,6 +417,75 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func messageActionEligibilityTracksOwnershipAndState() async throws {
+        let sentAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let outgoing = MessageItem(
+            id: "outgoing",
+            senderName: "Jeff",
+            body: "Ship it",
+            sentAt: sentAt,
+            isOutgoing: true
+        )
+        let incoming = MessageItem(
+            id: "incoming",
+            senderName: "Alice",
+            body: "Looks good",
+            sentAt: sentAt,
+            isOutgoing: false
+        )
+        let deleted = MessageItem(
+            id: "deleted",
+            senderName: "Jeff",
+            body: "Message deleted",
+            sentAt: sentAt,
+            isDeleted: true,
+            isOutgoing: true
+        )
+        let failed = MessageItem(
+            id: "failed",
+            senderName: "Jeff",
+            body: "Message did not reach the group",
+            sentAt: sentAt,
+            invalidationStatus: "signature-check-failed",
+            isOutgoing: true
+        )
+        let systemNotice = MessageItem(
+            id: "system",
+            senderName: "System",
+            body: "Member added",
+            sentAt: sentAt,
+            isOutgoing: false,
+            presentation: .groupSystem
+        )
+
+        #expect(outgoing.supportsChatActions)
+        #expect(outgoing.canCopyText)
+        #expect(outgoing.canReact)
+        #expect(outgoing.canReply)
+        #expect(outgoing.canDelete)
+
+        #expect(incoming.supportsChatActions)
+        #expect(incoming.canCopyText)
+        #expect(incoming.canReact)
+        #expect(incoming.canReply)
+        #expect(!incoming.canDelete)
+
+        for message in [deleted, failed] {
+            #expect(!message.supportsChatActions)
+            #expect(!message.canCopyText)
+            #expect(!message.canReact)
+            #expect(!message.canReply)
+            #expect(!message.canDelete)
+        }
+
+        #expect(!systemNotice.supportsChatActions)
+        #expect(systemNotice.canCopyText)
+        #expect(!systemNotice.canReact)
+        #expect(!systemNotice.canReply)
+        #expect(!systemNotice.canDelete)
+    }
+
+    @MainActor
     @Test func timelineMappingClassifiesAgentAndGroupSystemRows() async throws {
         let page = TimelinePageFfi(
             messages: [
@@ -1864,10 +1933,10 @@ struct whitenoise_macTests {
         let state = WorkspaceState(clientFactory: { runtime })
         let message = MessageItem(
             id: "parent",
-            senderName: "Alice",
+            senderName: "Desktop Account",
             body: "The launch plan is ready.",
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
-            isOutgoing: false
+            isOutgoing: true
         )
 
         await state.bootstrap()
@@ -1953,10 +2022,10 @@ struct whitenoise_macTests {
         let state = WorkspaceState(clientFactory: { runtime })
         let message = MessageItem(
             id: "parent",
-            senderName: "Alice",
+            senderName: "Desktop Account",
             body: "The launch plan is ready.",
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
-            isOutgoing: false
+            isOutgoing: true
         )
 
         await state.bootstrap()
@@ -1972,6 +2041,44 @@ struct whitenoise_macTests {
             groupIdHex: "direct-group",
             targetMessageId: "parent"
         ))
+    }
+
+    @MainActor
+    @Test func incomingMessageDeleteActionDoesNotPublishDeletion() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        let message = MessageItem(
+            id: "incoming-parent",
+            senderName: "Alice",
+            body: "The launch plan is ready.",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false
+        )
+
+        await state.bootstrap()
+        await state.deleteMessage(message)
+
+        #expect(runtime.deletedMessage == nil)
     }
 
     @MainActor
@@ -2054,6 +2161,32 @@ struct whitenoise_macTests {
         ))
 
         #expect(copiedText == "Copy this")
+    }
+
+    @MainActor
+    @Test func deletedAndFailedMessageTextDoesNotCopyPlaceholder() async throws {
+        var copiedText = "initial"
+        let state = WorkspaceState(copyTextHandler: { copiedText = $0 })
+        let sentAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+        state.copyText(of: MessageItem(
+            id: "deleted",
+            senderName: "Alice",
+            body: "Message deleted",
+            sentAt: sentAt,
+            isDeleted: true,
+            isOutgoing: false
+        ))
+        state.copyText(of: MessageItem(
+            id: "failed",
+            senderName: "Alice",
+            body: "Message did not reach the group",
+            sentAt: sentAt,
+            invalidationStatus: "signature-check-failed",
+            isOutgoing: true
+        ))
+
+        #expect(copiedText == "initial")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Adds explicit per-message action eligibility so deleted/failed messages cannot copy, react, reply, or show overflow actions.
- Hides Delete for incoming messages while keeping Copy/React/Reply available for actionable messages.
- Guards WorkspaceState copy/delete entry points and adds regression coverage for deleted, failed, incoming, and outgoing message actions.

## Test Plan
- `git diff --check`
- `xcodebuild -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS' test` (not run: xcodebuild unavailable on this Linux worker)

Closes #29


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->