### PR TITLE
fix: bring runtime online when adding 2nd+ account (#74)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -271,7 +271,6 @@ final class WorkspaceState {
     private let telemetryBuildConfigProvider: @MainActor () -> TelemetryBuildConfig
     private let groupImageSearchClient: any GroupImageSearchClient
     private var client: (any MarmotRuntime)?
-    private var hasStartedRuntime = false
     private var notificationTask: Task<Void, Never>?
     private var chatListTask: Task<Void, Never>?
     private var chatListTaskAccountId: String?
@@ -537,7 +536,7 @@ final class WorkspaceState {
                 return
             }
 
-            try await startRuntimeIfNeeded(runtime)
+            try await bringRuntimeOnline(runtime)
             accounts = try runtime.listAccounts().map { accountItem(from: $0) }
             restoreOrSelectFirstAccount()
             try await configureObservabilityRuntime()
@@ -655,7 +654,7 @@ final class WorkspaceState {
                 bootstrapRelays: MarmotClient.seedRelays
             )
             try refreshAccounts(preferred: summary)
-            try await startRuntimeIfNeeded(client)
+            try await bringRuntimeOnline(client)
             try refreshAccounts(preferred: summary)
             authenticationMode = .landing
             phase = .ready
@@ -691,7 +690,7 @@ final class WorkspaceState {
                 bootstrapRelays: MarmotClient.seedRelays
             )
             try refreshAccounts(preferred: summary)
-            try await startRuntimeIfNeeded(client)
+            try await bringRuntimeOnline(client)
             try refreshAccounts(preferred: summary)
             authenticationMode = .landing
             phase = .ready
@@ -765,7 +764,6 @@ final class WorkspaceState {
 
             try await client.deleteAllLocalData()
             self.client = nil
-            hasStartedRuntime = false
             resetToNewInstallState(storageRootPath: client.storageRootPath)
 
             let runtime = try clientFactory()
@@ -1902,10 +1900,18 @@ final class WorkspaceState {
         selection = nil
     }
 
-    private func startRuntimeIfNeeded(_ runtime: any MarmotRuntime) async throws {
-        guard !hasStartedRuntime else { return }
+    /// Brings the Marmot runtime online so newly added accounts start their
+    /// workers and subscribe to transport events. `start()` is idempotent —
+    /// it reconciles all known accounts (spawning a worker for any that lacks
+    /// a live one) and rebuilds the user-directory subscriptions, and only
+    /// fails when the runtime is shutting down. It must therefore be re-invoked
+    /// after every `login()` / `signUp()`, not just once per launch: the
+    /// Settings → Add Account flow adds a 2nd+ account while the runtime is
+    /// already running, and that account stays offline (no live relay sync /
+    /// notifications) until relaunch unless the runtime is brought online
+    /// again. See issues #31 and #74.
+    private func bringRuntimeOnline(_ runtime: any MarmotRuntime) async throws {
         try await runtime.start()
-        hasStartedRuntime = true
     }
 
     private func resetToNewInstallState(storageRootPath: String) {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -78,6 +78,81 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func addingSecondAccountViaLoginBringsItOnlineWithoutRelaunch() async throws {
+        // Regression for #74: the Settings → Add Account flow reuses login()/
+        // signUp() while the runtime is already running. The new account must be
+        // brought online immediately (its worker started, transport subscribed)
+        // rather than staying offline until the next app launch.
+        let primary = AccountSummaryFfi(
+            label: "Primary Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        // First launch brings the runtime online once for the existing account.
+        await state.bootstrap()
+        #expect(state.phase == .ready)
+        #expect(runtime.startCallCount == 1)
+        #expect(state.accounts.map(\.isRunning) == [true])
+
+        // Add a second account via the Settings → Add Account login path.
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            running: false
+        )
+        runtime.createdAccount = secondary
+        state.showLogin()
+        state.loginIdentity = "nsec1backup"
+        await state.login()
+
+        // The runtime must have been brought online again so the newly added
+        // account's worker/transport sync starts now — not after a relaunch.
+        #expect(runtime.startCallCount == 2)
+        #expect(state.accounts.count == 2)
+        let backup = try #require(state.accounts.first { $0.accountIdHex == secondary.accountIdHex })
+        #expect(backup.isRunning == true)
+        #expect(state.accounts.allSatisfy(\.isRunning))
+        #expect(state.activeAccountId == "Backup Account")
+    }
+
+    @MainActor
+    @Test func addingSecondAccountViaSignUpBringsItOnlineWithoutRelaunch() async throws {
+        // Companion to the login case above: the Create Identity button in
+        // Settings → Add Account must also bring the new account online. See #74.
+        let primary = AccountSummaryFfi(
+            label: "Primary Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(runtime.startCallCount == 1)
+
+        let secondary = AccountSummaryFfi(
+            label: "Second Identity",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            running: false
+        )
+        runtime.createdAccount = secondary
+        await state.signUp()
+
+        #expect(runtime.startCallCount == 2)
+        #expect(state.accounts.count == 2)
+        let added = try #require(state.accounts.first { $0.accountIdHex == secondary.accountIdHex })
+        #expect(added.isRunning == true)
+        #expect(state.accounts.allSatisfy(\.isRunning))
+    }
+
+    @MainActor
     @Test func failedLoginScrubsEnteredNsecFromMemory() async throws {
         // No createdAccount => FakeMarmotRuntime.login throws, exercising the failure path.
         let runtime = FakeMarmotRuntime(accounts: [])
@@ -4193,7 +4268,9 @@ private actor FakeGroupImageSearchClient: GroupImageSearchClient {
 
 private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sendable {
     private var storedAccounts: [AccountSummaryFfi]
-    private let createdAccount: AccountSummaryFfi?
+    /// The account that `login` / `createIdentity` will materialise. `var` so a
+    /// test can point the next add at a different account (multi-account flows).
+    var createdAccount: AccountSummaryFfi?
     private(set) var startCallCount = 0
     var didStart: Bool { startCallCount > 0 }
     let storageRootPath = "/tmp/whitenoise-mac-tests"
@@ -4478,14 +4555,27 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func createIdentity(defaultRelays: [String], bootstrapRelays: [String]) async throws -> AccountSummaryFfi {
         guard let createdAccount else { throw FakeMarmotRuntimeError.missingCreatedAccount }
-        storedAccounts = [createdAccount]
+        addOrReplaceAccount(createdAccount)
         return createdAccount
     }
 
     func login(identity: String, defaultRelays: [String], bootstrapRelays: [String]) async throws -> AccountSummaryFfi {
         guard let createdAccount else { throw FakeMarmotRuntimeError.missingCreatedAccount }
-        storedAccounts = [createdAccount]
+        addOrReplaceAccount(createdAccount)
         return createdAccount
+    }
+
+    /// Mirrors the real runtime: `login` / `createIdentity` add the account to
+    /// the known set (replacing any existing entry with the same id) rather
+    /// than discarding accounts already brought up this session. The account is
+    /// not marked `running` here — only `start()` brings accounts online, which
+    /// is the behaviour issues #31 / #74 exercise.
+    private func addOrReplaceAccount(_ account: AccountSummaryFfi) {
+        if let index = storedAccounts.firstIndex(where: { $0.accountIdHex == account.accountIdHex }) {
+            storedAccounts[index] = account
+        } else {
+            storedAccounts.append(account)
+        }
     }
 
     func publishUserProfile(accountRef: String, profile: UserProfileMetadataFfi, defaultRelays: [String], bootstrapRelays: [String]) async throws -> UserProfileMetadataFfi {


### PR DESCRIPTION
## Summary

Fixes the Settings -> Add Account flow so the **2nd+ account** is brought online immediately, not after an app relaunch.

PR #73 fixed the first-run (0->1) case by calling `start()` after onboarding `login()`/`signUp()`, guarded by a once-per-launch `hasStartedRuntime` flag. But the Settings -> Add Account path (`MessengerShellView.swift`) reuses the same `WorkspaceState.login()`/`signUp()` methods while the runtime is **already started**, so `startRuntimeIfNeeded()` was a no-op for the new account -- its worker never spawned and it stayed offline (no live relay sync / notifications) until relaunch.

## Root cause (verified against darkmatter source at the vendored SHA `1164041`)

- `Marmot.start()` -> `reconcile_accounts()` -> `AccountManager::reconcile()`.
- `reconcile()` is **idempotent**: it spawns a per-account worker for any local-signing account that lacks a live one, leaves already-running workers untouched, and only errors when the runtime is *stopping* (`ensure_running()` just checks `is_stopping()`).
- Therefore `start()` is safe to re-invoke and **does** bring up accounts added after the initial `start()`. The once-only guard was exactly what stranded the 2nd+ account.

This matches the issue's first suggested resolution: since `start()` is idempotent and reconciles new accounts, drop the once-only guard.

## Changes

- Removed the `hasStartedRuntime` once-only guard and the dead reset in the delete-all-data path.
- Renamed `startRuntimeIfNeeded` -> `bringRuntimeOnline`, documenting why it must run after every `login()`/`signUp()`.
- Bootstrap, `login()`, and `signUp()` now all bring the runtime online (idempotent).

## Tests

Added two multi-account regression tests (`login` and `signUp` paths): bootstrap with one account, add a second via the Settings flow, and assert the new account is brought online (`startCallCount == 2`, `isRunning == true`) without a relaunch. The test `FakeMarmotRuntime` now models `login()`/`createIdentity()` as **adding** to the known account set (deduped by id) rather than replacing it, matching the real FFI.

Note: No Swift toolchain in the agent environment -- `xcodebuild test` runs on CI (macOS). Verified statically only.

Closes #74


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->