### PR TITLE
refactor: consolidate first-non-blank / trimmed-or-nil string helpers

### DIFF
--- a/whitenoise-mac/Core/DisplayString.swift
+++ b/whitenoise-mac/Core/DisplayString.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+// Canonical "usable display string" helpers.
+//
+// The rule is: trim surrounding whitespace/newlines, treat the empty result as
+// absent, and pick the first candidate that survives. This used to be
+// reimplemented in half a dozen slightly different shapes across the codebase
+// (see marmot-protocol/whitenoise-mac#20); centralising it here keeps the
+// definition of "what counts as a usable string" in one place.
+
+extension String {
+    /// The string trimmed of surrounding whitespace and newlines, or `nil`
+    /// when the trimmed result is empty.
+    var nilIfBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+/// Returns the first candidate that is non-blank after trimming surrounding
+/// whitespace and newlines, or `nil` when every candidate is absent or blank.
+///
+/// The returned value is always trimmed. Prefer this (and `String.nilIfBlank`)
+/// over re-implementing trim/empty checks inline.
+func firstNonBlank(_ values: [String?]) -> String? {
+    for value in values {
+        if let trimmed = value?.nilIfBlank { return trimmed }
+    }
+    return nil
+}

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -280,21 +280,11 @@ extension MessageItem {
     }
 
     private static func displayName(for sender: String, profile: ChatPeerProfile?) -> String {
-        for value in [profile?.displayName] {
-            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if !trimmed.isEmpty { return trimmed }
-        }
-        return DisplayText.short(sender)
+        firstNonBlank([profile?.displayName]) ?? DisplayText.short(sender)
     }
 
     private static func tagValue(_ name: String, in tags: [MessageTagFfi]) -> String? {
         tags.first { $0.values.first == name }?.values.dropFirst().first
-    }
-
-    private static func firstNonBlank(_ values: [String?]) -> String? {
-        values
-            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .first { !$0.isEmpty }
     }
 
     private static func humanized(_ value: String) -> String {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -3070,14 +3070,6 @@ final class WorkspaceState {
         return trimmed.count == 64 && trimmed.allSatisfy(\.isHexDigit)
     }
 
-    private func firstNonBlank(_ values: [String?]) -> String? {
-        for value in values {
-            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if !trimmed.isEmpty { return trimmed }
-        }
-        return nil
-    }
-
     private var isShowingSettings: Bool {
         if case .settings = selection { return true }
         return false
@@ -3401,11 +3393,7 @@ private extension ProfileDraft {
     }
 
     func primaryDisplayName(fallback: String) -> String {
-        for value in [displayName, name, fallback] {
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { return trimmed }
-        }
-        return fallback
+        firstNonBlank([displayName, name, fallback]) ?? fallback
     }
 }
 
@@ -3438,12 +3426,5 @@ private extension KeyPackageItem {
             isLocal: package.local,
             isRelayDiscovered: package.relay
         )
-    }
-}
-
-private extension String {
-    var nilIfBlank: String? {
-        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2491,11 +2491,11 @@ private struct ProfileSettingsView: View {
     }
 
     private func profilePreviewName(fallback account: AccountItem) -> String {
-        for value in [workspace.profileDraft.displayName, workspace.profileDraft.name, account.displayName] {
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { return trimmed }
-        }
-        return account.displayName
+        firstNonBlank([
+            workspace.profileDraft.displayName,
+            workspace.profileDraft.name,
+            account.displayName
+        ]) ?? account.displayName
     }
 }
 


### PR DESCRIPTION
## Summary

Consolidates the duplicated "trim whitespace, treat empty as absent, take the first non-blank candidate" logic that issue #20 found scattered across at least six places.

New canonical home: `whitenoise-mac/Core/DisplayString.swift`
- `String.nilIfBlank` — trimmed string, or `nil` if empty after trimming
- `firstNonBlank(_ values: [String?]) -> String?` — first trimmed non-blank candidate

### Removed duplicates
- `WorkspaceState.firstNonBlank(_:)` (private instance method)
- `MessageItem.firstNonBlank(_:)` (private static, in MarmotMapping)
- file-scoped `private extension String { nilIfBlank }` in WorkspaceState

### Rewritten in terms of the canonical helper
- `ProfileDraft.primaryDisplayName(fallback:)` → `firstNonBlank([displayName, name, fallback]) ?? fallback`
- `MessageItem.displayName(for:profile:)` → `firstNonBlank([profile?.displayName]) ?? DisplayText.short(sender)`
- `ProfileSettingsView.profilePreviewName(fallback:)` → `firstNonBlank([...]) ?? account.displayName`

## Design notes
- The free function keeps the exact `[String?]` parameter type rather than a `Collection<String?>` extension, **on purpose**: every existing call site passes an array literal that mixes optional and non-optional `String`s and relies on Swift's array-literal coercion to `String?`. Preserving the signature means zero type-inference changes at call sites.
- The project uses `fileSystemSynchronizedGroups`, so the new file under `Core/` is picked up automatically — no `project.pbxproj` edit needed.

## Behavior
Pure refactor. Each rewritten helper is semantically identical to its prior loop:
trim → first non-empty → same fallback. No logic change.

## Test plan
- [ ] Builds under Xcode (no Swift toolchain available on the fixer host — needs compile verification in review)
- [ ] Display-name rendering unchanged in chat list, group member list, profile preview, notifications

Closes #20

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->