### PR TITLE
fix: require wss:// relays, allow cleartext ws:// only on loopback (#18)

### DIFF
--- a/whitenoise-mac/Core/RelayURLValidator.swift
+++ b/whitenoise-mac/Core/RelayURLValidator.swift
@@ -38,6 +38,20 @@ enum RelayURLValidator {
         var isInsecure: Bool {
             self == .insecureLoopback
         }
+
+        /// Whether a relay with this classification uses cleartext `ws://`
+        /// transport of any kind — loopback dev relays *and* rejected public
+        /// relays. The UI uses this to mark every non-`wss://` relay as
+        /// insecure, including pre-existing public `ws://` entries that loaded
+        /// from a saved relay list and would be rejected on the next save.
+        var isCleartext: Bool {
+            switch self {
+            case .insecureLoopback, .insecureRejected:
+                return true
+            case .secure, .invalid:
+                return false
+            }
+        }
     }
 
     /// Classifies a trimmed relay URL string.
@@ -65,6 +79,13 @@ enum RelayURLValidator {
     /// Whether the relay URL is cleartext and should be flagged as insecure in the UI.
     static func isInsecure(_ value: String) -> Bool {
         classify(value).isInsecure
+    }
+
+    /// Whether the relay URL uses cleartext `ws://` transport (loopback dev
+    /// relay or a non-loopback public relay). The UI flags all of these as
+    /// insecure so pre-existing public `ws://` entries are visibly marked.
+    static func isCleartext(_ value: String) -> Bool {
+        classify(value).isCleartext
     }
 
     /// Extracts the host from a `ws://` URL and checks whether it is a loopback address.

--- a/whitenoise-mac/Core/RelayURLValidator.swift
+++ b/whitenoise-mac/Core/RelayURLValidator.swift
@@ -59,16 +59,27 @@ enum RelayURLValidator {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .invalid }
 
-        let lowered = trimmed.lowercased()
-        if lowered.hasPrefix("wss://") {
-            return .secure
-        }
-        guard lowered.hasPrefix("ws://") else {
+        // Parse with URLComponents (rather than a bare prefix check) so a
+        // schemeless or hostless input — e.g. `wss://` with no host — is
+        // treated as malformed instead of being silently accepted as secure.
+        guard
+            let components = URLComponents(string: trimmed),
+            let scheme = components.scheme?.lowercased(),
+            let host = components.host,
+            !host.isEmpty
+        else {
             return .invalid
         }
 
-        // Cleartext ws:// — only acceptable for loopback hosts.
-        return isLoopbackRelay(trimmed) ? .insecureLoopback : .insecureRejected
+        switch scheme {
+        case "wss":
+            return .secure
+        case "ws":
+            // Cleartext ws:// — only acceptable for loopback hosts.
+            return isLoopbackHost(host) ? .insecureLoopback : .insecureRejected
+        default:
+            return .invalid
+        }
     }
 
     /// Whether the relay URL may be saved (secure, or loopback dev relay).
@@ -86,20 +97,6 @@ enum RelayURLValidator {
     /// insecure so pre-existing public `ws://` entries are visibly marked.
     static func isCleartext(_ value: String) -> Bool {
         classify(value).isCleartext
-    }
-
-    /// Extracts the host from a `ws://` URL and checks whether it is a loopback address.
-    private static func isLoopbackRelay(_ value: String) -> Bool {
-        guard let host = host(from: value) else { return false }
-        return isLoopbackHost(host)
-    }
-
-    private static func host(from value: String) -> String? {
-        // URLComponents handles ports, paths, and bracketed IPv6 literals.
-        if let components = URLComponents(string: value), let host = components.host, !host.isEmpty {
-            return host
-        }
-        return nil
     }
 
     private static func isLoopbackHost(_ host: String) -> Bool {

--- a/whitenoise-mac/Core/RelayURLValidator.swift
+++ b/whitenoise-mac/Core/RelayURLValidator.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Validates relay WebSocket URLs with a security-first policy.
+///
+/// In a privacy-focused E2EE messenger, relay transport carries connection
+/// metadata, subscription filters, timing, and the client IP. Cleartext
+/// `ws://` relays expose all of that to passive observers and allow active
+/// tampering of the relay stream, even though MLS message *contents* stay
+/// encrypted. So:
+///
+/// - `wss://` (TLS) relays are always accepted and considered secure.
+/// - `ws://` (cleartext) relays are accepted **only** when they point at a
+///   loopback host (`localhost`, `127.0.0.0/8`, `::1`), to keep local/dev
+///   relays usable. They are still flagged as insecure for the UI.
+/// - Any other `ws://` relay, or any other scheme, is rejected.
+enum RelayURLValidator {
+    enum Classification: Equatable {
+        /// `wss://` relay — encrypted transport.
+        case secure
+        /// `ws://` relay on a loopback host — accepted for local/dev, but cleartext.
+        case insecureLoopback
+        /// `ws://` relay on a non-loopback host — rejected (would leak metadata over the network).
+        case insecureRejected
+        /// Not a relay URL at all (wrong scheme / malformed).
+        case invalid
+
+        /// Whether a relay with this classification may be saved.
+        var isAcceptable: Bool {
+            switch self {
+            case .secure, .insecureLoopback:
+                return true
+            case .insecureRejected, .invalid:
+                return false
+            }
+        }
+
+        /// Whether a relay with this classification should be surfaced as insecure in the UI.
+        var isInsecure: Bool {
+            self == .insecureLoopback
+        }
+    }
+
+    /// Classifies a trimmed relay URL string.
+    static func classify(_ value: String) -> Classification {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .invalid }
+
+        let lowered = trimmed.lowercased()
+        if lowered.hasPrefix("wss://") {
+            return .secure
+        }
+        guard lowered.hasPrefix("ws://") else {
+            return .invalid
+        }
+
+        // Cleartext ws:// — only acceptable for loopback hosts.
+        return isLoopbackRelay(trimmed) ? .insecureLoopback : .insecureRejected
+    }
+
+    /// Whether the relay URL may be saved (secure, or loopback dev relay).
+    static func isAcceptable(_ value: String) -> Bool {
+        classify(value).isAcceptable
+    }
+
+    /// Whether the relay URL is cleartext and should be flagged as insecure in the UI.
+    static func isInsecure(_ value: String) -> Bool {
+        classify(value).isInsecure
+    }
+
+    /// Extracts the host from a `ws://` URL and checks whether it is a loopback address.
+    private static func isLoopbackRelay(_ value: String) -> Bool {
+        guard let host = host(from: value) else { return false }
+        return isLoopbackHost(host)
+    }
+
+    private static func host(from value: String) -> String? {
+        // URLComponents handles ports, paths, and bracketed IPv6 literals.
+        if let components = URLComponents(string: value), let host = components.host, !host.isEmpty {
+            return host
+        }
+        return nil
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+            // URLComponents.host strips brackets from IPv6 literals, but be defensive.
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+
+        if normalized == "localhost" || normalized == "::1" {
+            return true
+        }
+
+        // 127.0.0.0/8 is the IPv4 loopback range.
+        let octets = normalized.split(separator: ".", omittingEmptySubsequences: false)
+        if octets.count == 4, octets.first == "127", octets.allSatisfy({ isByte($0) }) {
+            return true
+        }
+
+        return false
+    }
+
+    private static func isByte(_ component: Substring) -> Bool {
+        guard !component.isEmpty, component.allSatisfy({ $0.isNumber }), let value = Int(component) else {
+            return false
+        }
+        return (0...255).contains(value)
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -3058,10 +3058,11 @@ final class WorkspaceState {
         RelayURLValidator.isAcceptable(value)
     }
 
-    /// Whether a saved relay uses cleartext `ws://` transport (loopback dev relay)
-    /// and should be surfaced as insecure in the UI.
+    /// Whether a saved relay uses cleartext `ws://` transport (loopback dev
+    /// relay, or a pre-existing public `ws://` relay that loaded from a saved
+    /// relay list) and should be surfaced as insecure in the UI.
     func isInsecureRelay(_ value: String) -> Bool {
-        RelayURLValidator.isInsecure(value)
+        RelayURLValidator.isCleartext(value)
     }
 
     private func looksLikeMemberRef(_ value: String) -> Bool {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -969,7 +969,7 @@ final class WorkspaceState {
         let url = newRelayURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !url.isEmpty else { return }
         guard isRelayURL(url) else {
-            lastError = L10n.string("Relay URLs must start with ws:// or wss://")
+            lastError = L10n.string("Relay URLs must use wss:// (cleartext ws:// is allowed only for localhost).")
             return
         }
         if !relayDraft.contains(url) {
@@ -995,7 +995,7 @@ final class WorkspaceState {
             return
         }
         guard relays.allSatisfy(isRelayURL) else {
-            lastError = L10n.string("Relay URLs must start with ws:// or wss://")
+            lastError = L10n.string("Relay URLs must use wss:// (cleartext ws:// is allowed only for localhost).")
             return
         }
 
@@ -3055,7 +3055,13 @@ final class WorkspaceState {
     }
 
     private func isRelayURL(_ value: String) -> Bool {
-        value.hasPrefix("wss://") || value.hasPrefix("ws://")
+        RelayURLValidator.isAcceptable(value)
+    }
+
+    /// Whether a saved relay uses cleartext `ws://` transport (loopback dev relay)
+    /// and should be surfaced as insecure in the UI.
+    func isInsecureRelay(_ value: String) -> Bool {
+        RelayURLValidator.isInsecure(value)
     }
 
     private func looksLikeMemberRef(_ value: String) -> Bool {

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -17590,6 +17590,65 @@
         }
       }
     },
+    "Relay URLs must use wss:// (cleartext ws:// is allowed only for localhost)." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relay-URLs müssen wss:// verwenden (Klartext ws:// ist nur für localhost erlaubt)."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las URL de relays deben usar wss:// (ws:// en texto plano solo se permite para localhost)."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les URL de relais doivent utiliser wss:// (ws:// en clair n’est autorisé que pour localhost)."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gli URL dei relay devono usare wss:// (ws:// in chiaro è consentito solo per localhost)."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URLs de relays devem usar wss:// (ws:// em texto não criptografado só é permitido para localhost)."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL ретрансляторов должны использовать wss:// (незашифрованный ws:// разрешён только для localhost)."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relay URL’leri wss:// kullanmalı (şifresiz ws:// yalnızca localhost için kullanılabilir)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中继 URL 必须使用 wss://（明文 ws:// 仅允许用于 localhost）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中繼 URL 必須使用 wss://（明文 ws:// 僅允許用於 localhost）。"
+          }
+        }
+      }
+    },
     "Relays" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -3029,7 +3029,7 @@ private struct RelaySettingsView: View {
                         .frame(minHeight: 160)
                 } else {
                     ForEach(workspace.relayDraft, id: \.self) { relay in
-                        RelayRow(url: relay) {
+                        RelayRow(url: relay, isInsecure: workspace.isInsecureRelay(relay)) {
                             workspace.removeRelayDraftURL(relay)
                         }
                     }
@@ -3291,18 +3291,28 @@ private struct KeyPackageRow: View {
 
 private struct RelayRow: View {
     let url: String
+    var isInsecure: Bool = false
     let remove: () -> Void
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: "network")
+            Image(systemName: isInsecure ? "lock.open.trianglebadge.exclamationmark" : "network")
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(isInsecure ? AnyShapeStyle(.orange) : AnyShapeStyle(.secondary))
                 .frame(width: 20)
+                .help(isInsecure ? L10n.string("Insecure cleartext relay (ws://). Relay metadata is not encrypted in transit.") : "")
 
-            Text(url)
-                .font(.system(.callout, design: .monospaced))
-                .textSelection(.enabled)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(url)
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
+
+                if isInsecure {
+                    Text("Insecure — cleartext ws:// (loopback only)")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
 
             Spacer()
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -3308,7 +3308,9 @@ private struct RelayRow: View {
                     .textSelection(.enabled)
 
                 if isInsecure {
-                    Text("Insecure — cleartext ws:// (loopback only)")
+                    Text(RelayURLValidator.classify(url) == .insecureLoopback
+                        ? "Insecure — cleartext ws:// (loopback only)"
+                        : "Insecure — cleartext ws:// (public host)")
                         .font(.caption2)
                         .foregroundStyle(.orange)
                 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4233,6 +4233,17 @@ struct whitenoise_macTests {
         #expect(!RelayURLValidator.isCleartext(""))
     }
 
+    @Test func relayValidatorRejectsSchemeOnlyAndHostlessURLs() async throws {
+        // Regression: a scheme prefix with no host must be malformed, not secure.
+        // Previously `wss://` was accepted as `.secure` purely on its prefix.
+        #expect(RelayURLValidator.classify("wss://") == .invalid)
+        #expect(RelayURLValidator.classify("ws://") == .invalid)
+        #expect(RelayURLValidator.classify("wss://  ") == .invalid)
+        #expect(!RelayURLValidator.isAcceptable("wss://"))
+        #expect(!RelayURLValidator.isInsecure("wss://"))
+        #expect(!RelayURLValidator.isCleartext("wss://"))
+    }
+
     @Test func relayValidatorRejectsSpoofedLoopbackHosts() async throws {
         // Hostnames that merely *contain* a loopback token must not be treated as loopback.
         #expect(RelayURLValidator.classify("ws://127.0.0.1.evil.com") == .insecureRejected)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4175,6 +4175,87 @@ struct whitenoise_macTests {
         #expect(state.selection == .chat("chat-nvk"))
     }
 
+    // MARK: - Relay URL validation (issue #18)
+
+    @Test func relayValidatorAcceptsSecureWssRelays() async throws {
+        #expect(RelayURLValidator.classify("wss://relay.example.com") == .secure)
+        #expect(RelayURLValidator.classify("wss://relay.us.whitenoise.chat") == .secure)
+        #expect(RelayURLValidator.classify("WSS://Relay.Example.com") == .secure)
+        #expect(RelayURLValidator.isAcceptable("wss://relay.example.com"))
+        #expect(!RelayURLValidator.isInsecure("wss://relay.example.com"))
+    }
+
+    @Test func relayValidatorRejectsCleartextWsOnPublicHosts() async throws {
+        #expect(RelayURLValidator.classify("ws://relay.example.com") == .insecureRejected)
+        #expect(RelayURLValidator.classify("ws://192.168.1.10:7777") == .insecureRejected)
+        #expect(RelayURLValidator.classify("ws://10.0.0.1") == .insecureRejected)
+        #expect(!RelayURLValidator.isAcceptable("ws://relay.example.com"))
+        // Rejected relays are not "insecure-but-allowed" — they simply cannot be saved.
+        #expect(!RelayURLValidator.isInsecure("ws://relay.example.com"))
+    }
+
+    @Test func relayValidatorAllowsCleartextWsOnLoopbackForDev() async throws {
+        for url in [
+            "ws://localhost",
+            "ws://localhost:7000",
+            "ws://127.0.0.1",
+            "ws://127.0.0.1:8080/relay",
+            "ws://127.1.2.3",
+            "ws://[::1]:7000"
+        ] {
+            #expect(RelayURLValidator.classify(url) == .insecureLoopback, "expected loopback for \(url)")
+            #expect(RelayURLValidator.isAcceptable(url), "expected acceptable for \(url)")
+            #expect(RelayURLValidator.isInsecure(url), "expected insecure flag for \(url)")
+        }
+    }
+
+    @Test func relayValidatorRejectsNonRelaySchemesAndJunk() async throws {
+        for url in ["", "   ", "https://relay.example.com", "relay.example.com", "wssx://foo", " wss://relay.example.com"] {
+            #expect(!RelayURLValidator.isAcceptable(url), "expected rejection for \(String(reflecting: url))")
+        }
+        // Leading/trailing whitespace is trimmed before classification.
+        #expect(RelayURLValidator.classify("  wss://relay.example.com  ") == .secure)
+    }
+
+    @Test func relayValidatorRejectsSpoofedLoopbackHosts() async throws {
+        // Hostnames that merely *contain* a loopback token must not be treated as loopback.
+        #expect(RelayURLValidator.classify("ws://127.0.0.1.evil.com") == .insecureRejected)
+        #expect(RelayURLValidator.classify("ws://localhost.evil.com") == .insecureRejected)
+        #expect(RelayURLValidator.classify("ws://notlocalhost") == .insecureRejected)
+        #expect(RelayURLValidator.classify("ws://127.0.0.256") == .insecureRejected)
+    }
+
+    @MainActor
+    @Test func addRelayDraftRejectsCleartextPublicWsRelay() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [])
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let before = state.relayDraft
+        state.newRelayURL = "ws://relay.example.com"
+        state.addRelayDraftURL()
+
+        #expect(state.relayDraft == before)
+        #expect(state.lastError != nil)
+    }
+
+    @MainActor
+    @Test func addRelayDraftAcceptsSecureAndLoopbackRelays() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [])
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        state.relayDraft = []
+
+        state.newRelayURL = "wss://relay.example.com"
+        state.addRelayDraftURL()
+        state.newRelayURL = "ws://127.0.0.1:7000"
+        state.addRelayDraftURL()
+
+        #expect(state.relayDraft == ["wss://relay.example.com", "ws://127.0.0.1:7000"])
+        #expect(!state.isInsecureRelay("wss://relay.example.com"))
+        #expect(state.isInsecureRelay("ws://127.0.0.1:7000"))
+    }
+
 }
 
 private actor FakeGroupImageSearchClient: GroupImageSearchClient {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4210,11 +4210,27 @@ struct whitenoise_macTests {
     }
 
     @Test func relayValidatorRejectsNonRelaySchemesAndJunk() async throws {
-        for url in ["", "   ", "https://relay.example.com", "relay.example.com", "wssx://foo", " wss://relay.example.com"] {
+        for url in ["", "   ", "https://relay.example.com", "relay.example.com", "wssx://foo", "ws://"] {
             #expect(!RelayURLValidator.isAcceptable(url), "expected rejection for \(String(reflecting: url))")
         }
-        // Leading/trailing whitespace is trimmed before classification.
+        // Leading/trailing whitespace is trimmed before classification, so a
+        // surrounded wss:// relay is still accepted as secure.
         #expect(RelayURLValidator.classify("  wss://relay.example.com  ") == .secure)
+        #expect(RelayURLValidator.isAcceptable(" wss://relay.example.com "))
+    }
+
+    @Test func relayValidatorFlagsAllCleartextWsAsInsecureForUI() async throws {
+        // Loopback dev relays are cleartext.
+        #expect(RelayURLValidator.isCleartext("ws://127.0.0.1:7000"))
+        #expect(RelayURLValidator.isCleartext("ws://localhost"))
+        // Pre-existing public ws:// relays loaded from a saved list are also
+        // cleartext and must be flagged, even though they cannot be saved again.
+        #expect(RelayURLValidator.isCleartext("ws://relay.example.com"))
+        #expect(RelayURLValidator.isCleartext("ws://192.168.1.10:7777"))
+        // wss:// and junk are not cleartext.
+        #expect(!RelayURLValidator.isCleartext("wss://relay.example.com"))
+        #expect(!RelayURLValidator.isCleartext("https://relay.example.com"))
+        #expect(!RelayURLValidator.isCleartext(""))
     }
 
     @Test func relayValidatorRejectsSpoofedLoopbackHosts() async throws {


### PR DESCRIPTION
## Summary

Fixes #18. Relay URL validation accepted any `ws://` (cleartext) relay with no warning, silently downgrading relay transport to an unencrypted, MITM-able channel. That exposes connection metadata, subscription filters, timing, and the client IP to passive/active network observers — even though MLS message *contents* stay encrypted.

## Changes

- **New `RelayURLValidator`** (`Core/RelayURLValidator.swift`): security-first policy.
  - `wss://` → always accepted (secure).
  - `ws://` → accepted **only** for loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) to keep local/dev relays usable; flagged insecure.
  - Any other `ws://` host or non-relay scheme → rejected.
  - Spoofed hosts like `ws://127.0.0.1.evil.com` / `ws://localhost.evil.com` are correctly rejected (host parsed via `URLComponents`, not substring matching).
- **`WorkspaceState`**: `addRelayDraftURL` / `saveRelaySettings` now validate through `RelayURLValidator`; error copy updated to state the `wss://` requirement. Added `isInsecureRelay(_:)`.
- **UI** (`Views/MessengerShellView.swift`): loopback `ws://` relays render with an orange warning icon, an "Insecure — cleartext ws:// (loopback only)" label, and a tooltip.
- **Tests**: validator coverage (secure / loopback / rejected-public / junk / spoofed-loopback) plus `WorkspaceState` draft-add behaviour.

## Test plan

- [ ] CI: `xcodebuild test` (macOS) — Swift toolchain not available on the Linux fixer host; relying on CI.
- Added unit tests: `relayValidator*`, `addRelayDraft{Rejects,Accepts}*`.

## Notes

Default posture is now "require `wss://`". The loopback exception is a deliberate, narrow allowance for local/dev relays per the issue's suggested fix, and such relays are visibly marked insecure rather than silently accepted.

🤖 Generated with Pip (agent-p1p)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual warning indicators in the relay settings UI to help users identify insecure relay connections, with orange warning labels for cleartext connections.
  * Enhanced relay URL validation to enforce secure `wss://` connections, while allowing cleartext `ws://` for local loopback addresses only.

* **Improvements**
  * Strengthened in-app messaging to guide users toward secure relay URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->