### PR TITLE
refactor: separate notification-settings sync from enabled predicate (#16)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1835,6 +1835,11 @@ final class WorkspaceState {
     func handleNotificationUpdate(_ update: NotificationUpdateFfi) async {
         guard !update.isFromSelf else { return }
         guard !deliveredNotificationKeys.contains(update.notificationKey) else { return }
+
+        // Keep the published settings snapshot in sync for the active account.
+        // This is an explicit step rather than a side effect of the guard below.
+        syncNotificationSettingsIfActive(for: update)
+
         guard localNotificationsEnabled(for: update) else { return }
 
         if selectedChat?.id == update.groupIdHex, selectedConversationIsVisible() {
@@ -2725,17 +2730,31 @@ final class WorkspaceState {
         }
     }
 
+    /// Pure predicate: reports whether local notifications are enabled for the
+    /// account targeted by `update`. Has no side effects — callers that also need
+    /// to refresh the published `notificationSettings` snapshot must invoke
+    /// `syncNotificationSettingsIfActive(for:)` explicitly.
     private func localNotificationsEnabled(for update: NotificationUpdateFfi) -> Bool {
         guard let client else { return false }
         guard let settings = try? client.notificationSettings(accountRef: update.accountRef) else {
             return false
         }
 
-        if activeAccount?.accountIdHex == update.accountIdHex {
-            notificationSettings = NotificationSettingsSnapshot(settings: settings)
+        return settings.localNotificationsEnabled
+    }
+
+    /// Refreshes the published `notificationSettings` snapshot when `update`
+    /// targets the active account. Kept separate from
+    /// `localNotificationsEnabled(for:)` so that evaluating the predicate does
+    /// not mutate UI state as a hidden side effect.
+    private func syncNotificationSettingsIfActive(for update: NotificationUpdateFfi) {
+        guard activeAccount?.accountIdHex == update.accountIdHex else { return }
+        guard let client else { return }
+        guard let settings = try? client.notificationSettings(accountRef: update.accountRef) else {
+            return
         }
 
-        return settings.localNotificationsEnabled
+        notificationSettings = NotificationSettingsSnapshot(settings: settings)
     }
 
     private func handleNotificationPermissionError(_ error: Error) async {


### PR DESCRIPTION
## Summary

`localNotificationsEnabled(for:)` read like a pure boolean query but had a
side effect: evaluating it overwrote the published `notificationSettings`
snapshot. That coupled a read-only-looking guard in `handleNotificationUpdate`
to UI state and made the notification path harder to reason about and test.

## Change

- `localNotificationsEnabled(for:)` is now a **pure predicate** — it only
  reads and returns `settings.localNotificationsEnabled`, no mutation.
- The snapshot refresh moves to a new, explicitly named
  `syncNotificationSettingsIfActive(for:)` step, invoked from
  `handleNotificationUpdate` *before* the guard.

## Behavior preservation

The original refreshed the active-account snapshot during guard evaluation,
independent of the boolean result. The new code calls
`syncNotificationSettingsIfActive(for:)` unconditionally before the guard, so
the active-account snapshot is still refreshed on every applicable update —
behavior is unchanged.

Minor trade-off: on the active-account path this now performs two
`client.notificationSettings(accountRef:)` reads (one per helper) instead of
one. The call is local and only runs for the active account, so the cost is
negligible and buys a clean separation of concerns.

## Verification

No Swift/Xcode toolchain available on the Linux CI host (macOS-only Xcode
project, no GitHub Actions workflows in-repo). Verified by manual review:
- Sole caller of `localNotificationsEnabled(for:)` is `handleNotificationUpdate`.
- No other references to the mutated snapshot depend on the old side-effect ordering.
- `WorkspaceState.swift` is not in the repo's sensitive-paths set.

Closes #16


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification handling by ensuring notification settings are properly synchronized when updates arrive, preventing inconsistent state between notification updates and user preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->