### PR TITLE
fix: stable, trap-free avatar palette selection (#14)

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -3350,8 +3350,24 @@ private enum AvatarPalette {
     ]
 
     static func gradient(for seed: String) -> LinearGradient {
-        let index = abs(seed.hashValue) % palettes.count
+        // Use a deterministic hash so a given seed always maps to the same
+        // palette across launches. `String.hashValue` is seeded with
+        // per-process randomness (unstable colors) and `abs(_:)` traps on
+        // `Int.min`; an unsigned FNV-1a over the UTF-8 bytes avoids both.
+        let index = Int(stableHash(seed) % UInt64(palettes.count))
         return LinearGradient(colors: palettes[index], startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    /// FNV-1a (64-bit) over the seed's UTF-8 bytes. Deterministic across
+    /// launches and overflow-safe via wrapping arithmetic.
+    private static func stableHash(_ seed: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325 // FNV offset basis
+        let prime: UInt64 = 0x0000_0100_0000_01b3 // FNV prime
+        for byte in seed.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* prime
+        }
+        return hash
     }
 }
 


### PR DESCRIPTION
## Summary

`AvatarPalette.gradient(for:)` selected a palette with `abs(seed.hashValue) % palettes.count`. Two problems:

- **Crash (rare):** `abs(_:)` traps when its argument is `Int.min` — an avoidable latent fatal error.
- **Unstable colors:** `String.hashValue` is seeded with per-process randomness, so a given account/chat got a different avatar color on every launch.

## Fix

Replace the seed→index derivation with an unsigned 64-bit **FNV-1a** hash over `seed.utf8`, reduced into range via unsigned modulo:

- Deterministic across launches — a seed always maps to the same palette.
- Overflow-safe — wrapping multiply (`&*`), no `abs`.
- Index is always in `0..<palettes.count` (count is 5, non-zero).

## Test Plan

- [ ] Builds (macOS / Xcode — no Swift toolchain on the fixer host; compile verification deferred to CI/reviewer)
- [ ] Same seed yields the same avatar color across relaunches

Closes #14

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->