### PR TITLE
fix: cache observability runtime configuration

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -103,6 +103,13 @@ final class WorkspaceState {
         let chatId: String
     }
 
+    private struct ObservabilityRuntimeConfiguration: Equatable {
+        let buildConfig: TelemetryBuildConfig
+        let accountLabel: String?
+        let relayTelemetryRuntimeConfig: RelayTelemetryRuntimeConfigFfi
+        let auditLogTrackerConfig: AuditLogTrackerConfigFfi
+    }
+
     private(set) var phase: Phase = .bootstrapping
     private(set) var accounts: [AccountItem]
     private(set) var chatsByAccount: [String: [ChatItem]]
@@ -281,6 +288,7 @@ final class WorkspaceState {
     private let telemetryBuildConfigProvider: @MainActor () -> TelemetryBuildConfig
     private let groupImageSearchClient: any GroupImageSearchClient
     private var client: (any MarmotRuntime)?
+    private var observabilityRuntimeConfiguration: ObservabilityRuntimeConfiguration?
     private var notificationTask: Task<Void, Never>?
     private var chatListTask: Task<Void, Never>?
     private var chatListTaskAccountId: String?
@@ -815,6 +823,7 @@ final class WorkspaceState {
 
             try await client.deleteAllLocalData()
             self.client = nil
+            observabilityRuntimeConfiguration = nil
             resetToNewInstallState(storageRootPath: client.storageRootPath)
 
             let runtime = try clientFactory()
@@ -2049,6 +2058,7 @@ final class WorkspaceState {
         messagesByChat = [:]
         messageLookupByChat = [:]
         messageIDsByChat = [:]
+        observabilityRuntimeConfiguration = nil
         activeAccountId = nil
         selection = nil
         searchText = ""
@@ -2147,13 +2157,42 @@ final class WorkspaceState {
     }
 
     private func configureObservabilityRuntime() async throws {
-        guard let client else { return }
+        guard let client else {
+            observabilityRuntimeConfiguration = nil
+            return
+        }
+
         let config = telemetryBuildConfig
-        try await client.setRelayTelemetryRuntimeConfig(
-            config: config.runtimeConfig(installId: try client.telemetryInstallId())
-        )
-        _ = try client.setAuditLogTrackerConfig(
-            config: config.auditTrackerConfig(accountLabel: activeAccount?.displayName)
+        let accountLabel = activeAccount?.displayName
+        if let cached = observabilityRuntimeConfiguration,
+           cached.buildConfig == config,
+           cached.accountLabel == accountLabel {
+            privacySecuritySettings.telemetryCredentialsAvailable = config.telemetryCredentialsAvailable
+            privacySecuritySettings.auditLogCredentialsAvailable = config.auditLogCredentialsAvailable
+            return
+        }
+
+        let relayRuntimeConfig: RelayTelemetryRuntimeConfigFfi
+        if let cached = observabilityRuntimeConfiguration,
+           cached.buildConfig == config {
+            relayRuntimeConfig = cached.relayTelemetryRuntimeConfig
+        } else {
+            relayRuntimeConfig = config.runtimeConfig(installId: try client.telemetryInstallId())
+        }
+        let auditTrackerConfig = config.auditTrackerConfig(accountLabel: accountLabel)
+
+        if observabilityRuntimeConfiguration?.relayTelemetryRuntimeConfig != relayRuntimeConfig {
+            try await client.setRelayTelemetryRuntimeConfig(config: relayRuntimeConfig)
+        }
+        if observabilityRuntimeConfiguration?.auditLogTrackerConfig != auditTrackerConfig {
+            _ = try client.setAuditLogTrackerConfig(config: auditTrackerConfig)
+        }
+
+        observabilityRuntimeConfiguration = ObservabilityRuntimeConfiguration(
+            buildConfig: config,
+            accountLabel: accountLabel,
+            relayTelemetryRuntimeConfig: relayRuntimeConfig,
+            auditLogTrackerConfig: auditTrackerConfig
         )
         privacySecuritySettings.telemetryCredentialsAvailable = config.telemetryCredentialsAvailable
         privacySecuritySettings.auditLogCredentialsAvailable = config.auditLogCredentialsAvailable

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3803,6 +3803,77 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func observabilityRuntimeConfigurationSkipsUnchangedRequests() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.removeObject(forKey: "whitenoise.mac.activeAccountId")
+
+        let primary = AccountSummaryFfi(
+            label: "primary-account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "secondary-account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        runtime.installProfile(
+            accountIdHex: primary.accountIdHex,
+            profile: UserProfileMetadataFfi(
+                name: "primary",
+                displayName: "Primary Account",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installProfile(
+            accountIdHex: secondary.accountIdHex,
+            profile: UserProfileMetadataFfi(
+                name: "secondary",
+                displayName: "Secondary Account",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(
+            telemetryBuildConfigProvider: {
+                telemetryBuildConfig(
+                    telemetryToken: "otlp-token",
+                    auditToken: "audit-token",
+                    environment: "production"
+                )
+            },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+
+        #expect(runtime.telemetryInstallIdCallCount == 1)
+        #expect(runtime.relayTelemetryRuntimeConfigSetCallCount == 1)
+        #expect(runtime.auditLogTrackerConfigSetCallCount == 1)
+        #expect(runtime.auditLogTrackerConfig?.source.accountLabel == "Primary Account")
+
+        let secondaryItem = try #require(state.accounts.first { $0.accountRef == secondary.label })
+        state.selectAccount(secondaryItem)
+        let didRefreshAccountLabel = await waitFor {
+            runtime.auditLogTrackerConfig?.source.accountLabel == "Secondary Account"
+        }
+
+        #expect(didRefreshAccountLabel)
+        #expect(runtime.telemetryInstallIdCallCount == 1)
+        #expect(runtime.relayTelemetryRuntimeConfigSetCallCount == 1)
+        #expect(runtime.auditLogTrackerConfigSetCallCount == 2)
+    }
+
+    @MainActor
     @Test func enablingPrivacySecurityTogglesRequireConfiguredTokens() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -4723,9 +4794,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     )
     private(set) var localNotificationsEnabledSet: Bool?
     private(set) var auditLogTrackerConfig: AuditLogTrackerConfigFfi?
+    private(set) var auditLogTrackerConfigSetCallCount = 0
     private(set) var deletedAuditLogFilePaths: [String] = []
     private(set) var didPostAuditLogTrackerUpdate = false
     private(set) var relayTelemetryRuntimeConfig: RelayTelemetryRuntimeConfigFfi?
+    private(set) var relayTelemetryRuntimeConfigSetCallCount = 0
+    private(set) var telemetryInstallIdCallCount = 0
     private(set) var removedAccountRefs: [String] = []
     private(set) var didDeleteAllLocalData = false
     /// Optional hook fired inside `removeAccount` after the ref is recorded but before the
@@ -4970,6 +5044,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func setAuditLogTrackerConfig(config: AuditLogTrackerConfigFfi) throws -> AuditLogTrackerConfigFfi {
+        auditLogTrackerConfigSetCallCount += 1
         auditLogTrackerConfig = config
         return config
     }
@@ -4981,6 +5056,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func setRelayTelemetryRuntimeConfig(config: RelayTelemetryRuntimeConfigFfi) async throws {
+        relayTelemetryRuntimeConfigSetCallCount += 1
         relayTelemetryRuntimeConfig = config
     }
 
@@ -4990,7 +5066,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func telemetryInstallId() throws -> String {
-        "test-install-id"
+        telemetryInstallIdCallCount += 1
+        return "test-install-id"
     }
 
     func deleteAllLocalData() async throws {


### PR DESCRIPTION
## Summary
- Cache the last applied observability runtime configuration in `WorkspaceState` and skip unchanged reconfiguration calls.
- Reuse the cached relay telemetry runtime config when only the active account label changes, so account switches update the audit tracker without re-calling `telemetryInstallId()` or re-pushing relay telemetry config.
- Add regression coverage that bootstrap coalesces duplicate configure paths and account switches only refresh the audit tracker label.

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS' -only-testing:whitenoise-macTests/whitenoise_macTests/observabilityRuntimeConfigurationSkipsUnchangedRequests` (not run locally: `xcodebuild` is not installed on this Linux worker)

Closes #21


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for observability configuration behavior during account switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->