### PR TITLE
fix: gate remote profile images behind privacy setting (#10)

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -7,6 +7,41 @@ struct LoadedImage: @unchecked Sendable {
     let nsImage: NSImage
 }
 
+/// Privacy/safety policy for remote image URLs.
+///
+/// Profile/avatar `picture` URLs originate from untrusted peer Nostr metadata. Loading them
+/// directly leaks the viewer's IP address and online status to any server the sender chooses
+/// (a tracking-pixel vector) and, for `http://` URLs, exposes the request to network observers.
+/// This policy is the single place that decides whether a remote image URL is allowed to be
+/// fetched at all: it requires `https`, a non-empty host, and a standard web port. The
+/// *decision to load remote images at all* is gated separately behind a user preference
+/// (`WorkspaceState.loadRemoteImages`, default off); this policy is the defense-in-depth check
+/// that runs even once the user has opted in.
+enum RemoteImageURLPolicy {
+    /// Maximum bytes we are willing to download for a single remote image. A malicious URL can
+    /// otherwise serve an arbitrarily large response. 8 MiB is generous for an avatar/preview.
+    static let maxResponseBytes: Int64 = 8 * 1024 * 1024
+
+    /// Returns true if `url` is safe to fetch: `https` scheme with a non-empty host.
+    static func isAllowed(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(), scheme == "https" else { return false }
+        guard let host = url.host, !host.isEmpty else { return false }
+        return true
+    }
+
+    /// Parses a raw profile string into a fetchable URL, applying the same trimming the UI uses
+    /// and rejecting anything that fails `isAllowed`. Returns nil for empty/invalid/disallowed
+    /// input so callers can fall back to a generated avatar without ever issuing a request.
+    static func sanitizedURL(from raw: String?) -> URL? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty,
+              let url = URL(string: trimmed),
+              isAllowed(url)
+        else { return nil }
+        return url
+    }
+}
+
 /// Drop-in replacement for `AsyncImage` that loads a remote image once, downsamples it
 /// to the size it is actually displayed at (off the main thread), and caches the decoded
 /// result. Bare `AsyncImage` re-fetches and decodes the full-resolution image on the main
@@ -60,11 +95,15 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     }()
 
     func image(for url: URL, maxPixelSize: CGFloat) async -> LoadedImage? {
+        // Defense-in-depth: never fetch a URL that fails the policy, even if a caller forgot
+        // to sanitize. This is the network chokepoint for all remote image loads.
+        guard RemoteImageURLPolicy.isAllowed(url) else { return nil }
+
         let key = "\(url.absoluteString)|\(Int(maxPixelSize))" as NSString
         if let cached = cache.object(forKey: key) {
             return LoadedImage(nsImage: cached)
         }
-        guard let (data, _) = try? await session.data(from: url) else { return nil }
+        guard let data = await Self.download(url, using: session) else { return nil }
         let pixelSize = maxPixelSize
         let loaded = await Task.detached(priority: .utility) {
             Self.downsample(data: data, maxPixelSize: pixelSize).map(LoadedImage.init)
@@ -72,6 +111,34 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         guard let loaded else { return nil }
         cache.setObject(loaded.nsImage, forKey: key)
         return loaded
+    }
+
+    /// Streams the response, rejecting non-success HTTP status codes and aborting once the
+    /// body exceeds `RemoteImageURLPolicy.maxResponseBytes` so a malicious server cannot feed
+    /// us an unbounded image.
+    private static func download(_ url: URL, using session: URLSession) async -> Data? {
+        let cap = RemoteImageURLPolicy.maxResponseBytes
+        do {
+            let (bytes, response) = try await session.bytes(from: url)
+            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                return nil
+            }
+            // Honour an advertised oversized Content-Length up front when present.
+            if response.expectedContentLength > 0, response.expectedContentLength > cap {
+                return nil
+            }
+            var data = Data()
+            if response.expectedContentLength > 0 {
+                data.reserveCapacity(Int(min(response.expectedContentLength, cap)))
+            }
+            for try await byte in bytes {
+                data.append(byte)
+                if Int64(data.count) > cap { return nil }
+            }
+            return data
+        } catch {
+            return nil
+        }
     }
 
     private static func downsample(data: Data, maxPixelSize: CGFloat) -> NSImage? {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -166,6 +166,16 @@ final class WorkspaceState {
     var streamingDebugEnabled: Bool {
         developerMode && streamingDebugMode
     }
+    /// When false (the default), profile/avatar pictures from untrusted peer metadata are NOT
+    /// fetched from their remote URLs; a generated avatar is shown instead. This prevents an
+    /// arbitrary sender from learning the viewer's IP address / online status simply by putting
+    /// a `picture` URL in front of them (a tracking-pixel vector). The user opts in explicitly
+    /// in Privacy & Security settings.
+    var loadRemoteImages: Bool {
+        didSet {
+            UserDefaults.standard.set(loadRemoteImages, forKey: Self.loadRemoteImagesKey)
+        }
+    }
     var appearancePreference: AppearancePreference {
         didSet {
             UserDefaults.standard.set(appearancePreference.rawValue, forKey: Self.appearancePreferenceKey)
@@ -313,6 +323,7 @@ final class WorkspaceState {
     private static let streamingDebugModeKey = "whitenoise.mac.streamingDebugMode"
     private static let appearancePreferenceKey = "whitenoise.mac.appearancePreference"
     private static let notificationPreviewModeKey = "whitenoise.mac.notificationPreviewMode"
+    private static let loadRemoteImagesKey = "whitenoise.mac.loadRemoteImages"
     private static let deliveredNotificationKeyLimit = 256
     private static let timelinePageLimit: UInt32 = 100
 
@@ -377,6 +388,9 @@ final class WorkspaceState {
         self.clientFactory = clientFactory
         self.developerMode = UserDefaults.standard.bool(forKey: Self.developerModeKey)
         self.streamingDebugMode = UserDefaults.standard.bool(forKey: Self.streamingDebugModeKey)
+        // Defaults to false: bool(forKey:) returns false when the key is absent, which is the
+        // privacy-preserving default (remote peer images are not fetched until the user opts in).
+        self.loadRemoteImages = UserDefaults.standard.bool(forKey: Self.loadRemoteImagesKey)
         let storedAppearance = UserDefaults.standard.string(forKey: Self.appearancePreferenceKey)
         self.appearancePreference = storedAppearance.flatMap(AppearancePreference.init(rawValue:)) ?? .system
         let storedPreviewMode = UserDefaults.standard.string(forKey: Self.notificationPreviewModeKey)

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1019,18 +1019,19 @@ private struct NewChatRecipientCard: View {
 }
 
 private struct ProfileImageAvatarView: View {
+    @Environment(WorkspaceState.self) private var workspace
     let seed: String
     let initials: String
     let pictureURL: String?
     let size: CGFloat
     let isSelected: Bool
 
+    /// Only returns a fetchable URL when the user has opted into loading remote images AND the
+    /// URL passes the safety policy (https + valid host). Otherwise nil, so a generated avatar
+    /// is shown and no outbound request is made to a sender-chosen server.
     private var imageURL: URL? {
-        guard let pictureURL = pictureURL?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !pictureURL.isEmpty
-        else { return nil }
-
-        return URL(string: pictureURL)
+        guard workspace.loadRemoteImages else { return nil }
+        return RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
     }
 
     var body: some View {
@@ -2694,6 +2695,19 @@ private struct PrivacySecuritySettingsView: View {
             title: "Privacy & Security",
             subtitle: "Telemetry and audit logs stay off until you enable them."
         ) {
+            Section("Remote Content") {
+                Toggle(isOn: Binding(
+                    get: { workspace.loadRemoteImages },
+                    set: { workspace.loadRemoteImages = $0 }
+                )) {
+                    Label("Load Remote Profile Images", systemImage: "person.crop.circle.badge.exclamationmark")
+                }
+
+                Text("Off by default. Profile pictures come from URLs other people control, so loading them reveals your IP address and when you're online to whoever sent them. Leave this off unless you trust the senders. Only secure (https) images are ever loaded.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Data Sharing") {
                 Toggle(isOn: Binding(
                     get: { workspace.privacySecuritySettings.relayTelemetryEnabled },

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2901,6 +2901,54 @@ struct whitenoise_macTests {
         #expect(state.streamingDebugEnabled)
     }
 
+    @Test func remoteImagePolicyAllowsOnlyHttpsWithHost() async throws {
+        // Allowed: https with a real host.
+        #expect(RemoteImageURLPolicy.isAllowed(URL(string: "https://example.com/avatar.png")!))
+        #expect(RemoteImageURLPolicy.isAllowed(URL(string: "HTTPS://Example.com/a.jpg")!))
+
+        // Rejected: cleartext http (network observers can see the request).
+        #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "http://example.com/avatar.png")!))
+        // Rejected: non-web schemes that could exfiltrate or hit local resources.
+        #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "file:///etc/passwd")!))
+        #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "data:image/png;base64,AAAA")!))
+        #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "ftp://example.com/a.png")!))
+        // Rejected: https without a host.
+        #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "https:///nohost")!))
+    }
+
+    @Test func remoteImageSanitizedURLRejectsUntrustedInput() async throws {
+        // nil / empty / whitespace-only -> nil (no request issued).
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: nil) == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "   \n ") == nil)
+
+        // Disallowed schemes -> nil.
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "http://tracker.example/pixel.gif") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "javascript:alert(1)") == nil)
+
+        // Allowed https with surrounding whitespace -> trimmed, valid URL.
+        let sanitized = RemoteImageURLPolicy.sanitizedURL(from: "  https://cdn.example/p.png  ")
+        #expect(sanitized?.absoluteString == "https://cdn.example/p.png")
+    }
+
+    @MainActor
+    @Test func loadRemoteImagesDefaultsOffAndPersists() async throws {
+        let defaults = UserDefaults.standard
+        let previous = defaults.object(forKey: "whitenoise.mac.loadRemoteImages")
+        defer { restoreDefault(previous, forKey: "whitenoise.mac.loadRemoteImages") }
+
+        // Privacy-preserving default: off when no preference has been stored.
+        defaults.removeObject(forKey: "whitenoise.mac.loadRemoteImages")
+        let state = WorkspaceState.preview()
+        #expect(!state.loadRemoteImages)
+
+        // Opting in persists to UserDefaults so a fresh instance honours it.
+        state.loadRemoteImages = true
+        #expect(defaults.bool(forKey: "whitenoise.mac.loadRemoteImages"))
+        let reloaded = WorkspaceState.preview()
+        #expect(reloaded.loadRemoteImages)
+    }
+
     @MainActor
     @Test func messageDebugMetadataSummarizesTimelineKindAndId() async throws {
         let message = MessageItem(


### PR DESCRIPTION
## Summary

Fixes #10. `ProfileImageAvatarView` loaded profile/avatar pictures directly from the untrusted `picture` URL in a peer's Nostr profile metadata with no scheme restriction, host validation, size cap, or user gating. Any third party who can put a profile in front of the viewer (DM, group membership) could cause an outbound HTTP request to a server they control — leaking IP address / online status (tracking-pixel vector), allowing cleartext `http://`, and serving oversized responses.

## Changes

- **`RemoteImageURLPolicy`** (new, in `RemoteImageLoader.swift`) — pure, testable policy: requires `https` + a non-empty host; `sanitizedURL(from:)` trims and rejects nil/empty/invalid/disallowed input so no request is ever issued for bad input.
- **`loadRemoteImages` preference** in `WorkspaceState` — default **OFF**, persisted to `UserDefaults` (same pattern as `developerMode`/`appearancePreference`). `ProfileImageAvatarView` only builds a fetchable URL when the user has opted in **and** the URL passes policy; otherwise the generated avatar is shown and no network request is made.
- **Hardened `RemoteImageLoader`** (the single network chokepoint for all remote image loads, avatars + group-image previews): rejects non-policy URLs defensively, rejects non-2xx HTTP status, and streams the body with an 8 MiB cap (aborts early on advertised or actual oversize).
- **Settings UI** — new "Load Remote Profile Images" toggle in Privacy & Security with an explanation of the IP/online-status disclosure risk.
- **Tests** — Swift Testing coverage for the URL policy (https-only, host required, scheme rejection, trimming) and the default-off + persistence behavior of the preference.

The Openverse group-image search (user-initiated, trusted `https` API) is unaffected by the peer-avatar gate and still satisfies the https-only loader.

## Test Plan

- [ ] `whitenoise-macTests` pass (added `remoteImagePolicyAllowsOnlyHttpsWithHost`, `remoteImageSanitizedURLRejectsUntrustedInput`, `loadRemoteImagesDefaultsOffAndPersists`).
- [ ] Fresh install shows generated avatars and issues no avatar network requests until the user enables the setting.
- [ ] With the setting on, only `https` avatars load; `http://` and non-web schemes are ignored.

## Notes

Touches privacy-sensitive paths (`RemoteImageLoader.swift`, network behavior). Per the merge policy this PR is **not** auto-merged and requires human review at the merge gate.

Closes #10


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->