### PR TITLE
fix: invalidate peer/sender profile cache with TTL and on account switch (#8)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -280,6 +280,9 @@ final class WorkspaceState {
     private let copyTextHandler: @MainActor (String) -> Void
     private let telemetryBuildConfigProvider: @MainActor () -> TelemetryBuildConfig
     private let groupImageSearchClient: any GroupImageSearchClient
+    /// Injectable clock for peer-profile cache TTL decisions, so tests can drive cache
+    /// expiry deterministically (whitenoise-mac#8). Defaults to the system clock.
+    private let nowProvider: @MainActor () -> Date
     private var client: (any MarmotRuntime)?
     private var notificationTask: Task<Void, Never>?
     private var chatListTask: Task<Void, Never>?
@@ -330,8 +333,21 @@ final class WorkspaceState {
     private var newChatLookupGeneration = 0
     /// Raw per-sender FFI lookups (userProfile + directory displayName), cached so that
     /// scrolling back through history does not re-resolve the same senders from Rust on
-    /// every page. Keyed by sender accountIdHex; invalidated when a peer profile refreshes.
-    private var peerProfileFFICache: [String: ResolvedPeerFFI] = [:]
+    /// every page. Keyed by sender accountIdHex.
+    ///
+    /// Entries carry the resolution timestamp and whether the lookup produced a usable
+    /// profile (display name or picture). This prevents the cache from acting as a
+    /// permanent "seen" flag (whitenoise-mac#8): complete entries expire after
+    /// `peerProfileCacheTTL` so a contact's later name/avatar change is eventually
+    /// picked up within a session, and incomplete entries (relay not yet propagated, or
+    /// a failed/empty lookup) are always re-resolved so a contact is never pinned to a
+    /// fallback name/avatar for the life of the process. The cache is also account-scoped
+    /// and cleared on account switch.
+    private var peerProfileFFICache: [String: CachedPeerProfile] = [:]
+
+    /// How long a *complete* peer-profile lookup is trusted before it is re-resolved
+    /// from the Rust store. Incomplete lookups ignore the TTL and re-resolve every pass.
+    private static let peerProfileCacheTTL: TimeInterval = 300
 
     private static let activeAccountKey = "whitenoise.mac.activeAccountId"
     private static let developerModeKey = "whitenoise.mac.developerMode"
@@ -358,6 +374,28 @@ final class WorkspaceState {
         var profileName: String?
         var profilePicture: String?
         var directoryDisplayName: String?
+
+        /// A lookup is "complete" once it yields a usable display name or picture. An
+        /// incomplete lookup means the relay has not propagated the profile yet (or the
+        /// lookup failed), and must not be trusted as a terminal answer.
+        var isComplete: Bool {
+            firstNonBlank([profileDisplayName, profileName, directoryDisplayName]) != nil
+                || profilePicture?.nilIfBlank != nil
+        }
+    }
+
+    /// A `ResolvedPeerFFI` plus the time it was resolved, so the cache can apply a TTL to
+    /// complete lookups and always re-resolve incomplete ones (whitenoise-mac#8).
+    struct CachedPeerProfile: Sendable {
+        var resolved: ResolvedPeerFFI
+        var resolvedAt: Date
+
+        /// Whether this entry may be reused without re-resolving from the Rust store.
+        /// Incomplete lookups are never reused; complete lookups are reused until the TTL
+        /// elapses so later name/avatar changes are eventually picked up within a session.
+        func isFresh(now: Date, ttl: TimeInterval) -> Bool {
+            resolved.isComplete && now.timeIntervalSince(resolvedAt) < ttl
+        }
     }
 
     /// Runs a blocking FFI closure off the main thread and resumes on the caller's actor.
@@ -385,6 +423,7 @@ final class WorkspaceState {
         copyTextHandler: @escaping @MainActor (String) -> Void = WorkspaceState.copyToGeneralPasteboard,
         telemetryBuildConfigProvider: @escaping @MainActor () -> TelemetryBuildConfig = { TelemetryBuildConfig.current() },
         groupImageSearchClient: (any GroupImageSearchClient)? = nil,
+        nowProvider: @escaping @MainActor () -> Date = { Date() },
         clientFactory: @escaping @MainActor () throws -> any MarmotRuntime = { try MarmotClient() }
     ) {
         self.accounts = accounts
@@ -400,6 +439,7 @@ final class WorkspaceState {
         self.copyTextHandler = copyTextHandler
         self.telemetryBuildConfigProvider = telemetryBuildConfigProvider
         self.groupImageSearchClient = groupImageSearchClient ?? OpenverseGroupImageSearchClient()
+        self.nowProvider = nowProvider
         self.clientFactory = clientFactory
         self.developerMode = UserDefaults.standard.bool(forKey: Self.developerModeKey)
         self.streamingDebugMode = UserDefaults.standard.bool(forKey: Self.streamingDebugModeKey)
@@ -595,6 +635,10 @@ final class WorkspaceState {
         searchText = ""
         closeNewChatComposer()
         pruneMessageCache(keeping: nil)
+        // Peer-profile lookups are scoped to the active account's view (directory display
+        // names can differ per account); drop them on switch so the new account does not
+        // inherit stale cross-account entries (whitenoise-mac#8).
+        peerProfileFFICache.removeAll()
         refreshObservabilityRuntime()
         selection = finalSelection
         if case let .chat(chatId)? = finalSelection {
@@ -3103,10 +3147,18 @@ final class WorkspaceState {
             .filter { !$0.isEmpty }
         )
 
-        // Resolve any senders we have not seen before in a single off-main FFI batch,
-        // then cache the raw lookups so repeated scroll-up pages skip Rust entirely.
-        let unresolvedIds = senderIds.filter {
-            $0 != activeAccount.accountIdHex && peerProfileFFICache[$0] == nil
+        // Resolve any senders whose cached lookup is missing, incomplete, or stale in a
+        // single off-main FFI batch, then cache the raw lookups (timestamped) so repeated
+        // scroll-up pages skip Rust entirely. Incomplete lookups (relay not yet
+        // propagated, or a failed lookup) are always re-resolved so a contact is never
+        // pinned to a fallback name/avatar for the life of the process; complete lookups
+        // are re-resolved once the TTL elapses so later name/avatar changes are picked up
+        // within a session (whitenoise-mac#8).
+        let now = nowProvider()
+        let unresolvedIds = senderIds.filter { senderId in
+            guard senderId != activeAccount.accountIdHex else { return false }
+            guard let cached = peerProfileFFICache[senderId] else { return true }
+            return !cached.isFresh(now: now, ttl: Self.peerProfileCacheTTL)
         }
         if !unresolvedIds.isEmpty {
             let resolved = (try? await runOffMain { () -> [String: ResolvedPeerFFI] in
@@ -3123,7 +3175,7 @@ final class WorkspaceState {
                 return output
             }) ?? [:]
             for (senderId, value) in resolved {
-                peerProfileFFICache[senderId] = value
+                peerProfileFFICache[senderId] = CachedPeerProfile(resolved: value, resolvedAt: now)
             }
         }
 
@@ -3138,7 +3190,7 @@ final class WorkspaceState {
                 continue
             }
 
-            let resolved = peerProfileFFICache[senderId]
+            let resolved = peerProfileFFICache[senderId]?.resolved
             profiles[senderId] = ChatPeerProfile(
                 accountIdHex: senderId,
                 displayName: firstNonBlank([

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -3174,8 +3174,20 @@ final class WorkspaceState {
                 }
                 return output
             }) ?? [:]
-            for (senderId, value) in resolved {
-                peerProfileFFICache[senderId] = CachedPeerProfile(resolved: value, resolvedAt: now)
+            // The off-main resolution above suspends this actor. If the user switched
+            // accounts while the batch was in flight, `selectAccount`/
+            // `selectAccountFromSettings` already cleared `peerProfileFFICache` for the
+            // newly selected account. Writing these now-stale, account-scoped lookups
+            // would repopulate the cache with the *previous* account's directory/profile
+            // entries and leak them into the new account until TTL expiry, undercutting
+            // the account-scoped invalidation this code path relies on. Only commit the
+            // results if we are still resolving for the same active account; otherwise
+            // drop them — the caller re-checks `activeAccountId` after this await and
+            // discards the stale window anyway (whitenoise-mac#8).
+            if activeAccountId == activeAccount.id {
+                for (senderId, value) in resolved {
+                    peerProfileFFICache[senderId] = CachedPeerProfile(resolved: value, resolvedAt: now)
+                }
             }
         }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2057,6 +2057,164 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func incompletePeerProfileLookupIsNotPinnedForTheSession() async throws {
+        // Regression for #8: an incomplete first sender-profile lookup (relay has not
+        // propagated the profile yet, or the lookup failed) must not be cached as a
+        // terminal answer. A later pass that has the data available must re-resolve and
+        // pick up the real name instead of leaving the contact pinned to its hex fallback.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        // Blank group-member display name so the only name source is the profile lookup,
+        // and mark alice's profile as not-yet-available for the first pass.
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "",
+            otherProfile: UserProfileMetadataFfi(
+                name: nil,
+                displayName: nil,
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.accountIdsMissingProfiles.insert(aliceId)
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<150).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+
+        let firstPass = state.messagesByChat["direct-group"] ?? []
+        let firstAliceName = firstPass.first?.senderName
+        // The relay had not propagated the profile, so the contact falls back to a
+        // shortened hex id rather than a real display name.
+        #expect(firstAliceName != "Alice Cooper")
+        #expect(firstAliceName == DisplayText.short(aliceId))
+
+        // The profile becomes available; a subsequent render must re-resolve it.
+        runtime.accountIdsMissingProfiles.remove(aliceId)
+        runtime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Cooper",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        await state.loadOlderMessages(groupIdHex: "direct-group")
+
+        let secondPass = state.messagesByChat["direct-group"] ?? []
+        #expect(secondPass.first?.senderName == "Alice Cooper")
+    }
+
+    @MainActor
+    @Test func completePeerProfileIsRefreshedAfterCacheTTLExpires() async throws {
+        // Regression for #8: a complete sender-profile lookup is cached, but the cache is
+        // not a permanent "seen" flag. Once the TTL elapses the profile is re-resolved so
+        // a contact's later display-name change is picked up within the same session.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "",
+            otherProfile: UserProfileMetadataFfi(
+                name: nil,
+                displayName: nil,
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<350).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        // Drive the cache clock from the test so TTL expiry is deterministic.
+        let clock = MutableClock(now: Date(timeIntervalSince1970: 2_000_000_000))
+        let state = WorkspaceState(nowProvider: { clock.now }, clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        #expect(state.messagesByChat["direct-group"]?.first?.senderName == "Alice")
+
+        // Alice renames herself. A render inside the TTL keeps the cached name.
+        runtime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Renamed",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        clock.now = clock.now.addingTimeInterval(60)
+        await state.loadOlderMessages(groupIdHex: "direct-group")
+        #expect(state.messagesByChat["direct-group"]?.first?.senderName == "Alice")
+
+        // Once the TTL elapses, the next render re-resolves and reflects the new name.
+        clock.now = clock.now.addingTimeInterval(600)
+        await state.loadOlderMessages(groupIdHex: "direct-group")
+        #expect(state.messagesByChat["direct-group"]?.first?.senderName == "Alice Renamed")
+    }
+
+    @MainActor
     @Test func messageActionsDoNotRestartLiveSubscriptions() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -6146,6 +6304,15 @@ private func groupDetailsFixture(
             )
         ]
     )
+}
+
+/// A trivial mutable clock for driving time-dependent cache behaviour deterministically
+/// in tests (whitenoise-mac#8). `@MainActor` so it matches `WorkspaceState`'s isolation
+/// when injected via `nowProvider`.
+@MainActor
+private final class MutableClock {
+    var now: Date
+    init(now: Date) { self.now = now }
 }
 
 private func directGroup() -> AppGroupRecordFfi {


### PR DESCRIPTION
## Summary

Fixes #8. Peer/sender profiles were resolved at most once per session and never invalidated.

The issue was originally filed against `profileRefreshAccountIds`, which a later refactor replaced with `peerProfileFFICache` (the Swift-layer cache populated by `messageSenderProfiles`). The same defect carried over: the cache was keyed only on *presence*, so:

- An **incomplete** first lookup (relay had not yet propagated the profile, or the lookup failed) was cached as terminal, permanently pinning the contact to its truncated-hex/fallback name for the life of the process.
- A contact's later **display-name / avatar change** was never picked up within a session (no TTL).
- The cache **survived account switches** (`selectAccount` / `selectAccountFromSettings` cleared everything else but not this).

## Fix

Replace the raw cached value with a timestamped `CachedPeerProfile` that records whether the lookup produced a usable name/picture (`isComplete`):

- **Incomplete lookups are never reused** — re-resolved on every subsequent pass, so a contact is no longer pinned to a fallback once the real profile arrives.
- **Complete lookups are reused until a 5-minute TTL elapses**, then re-resolved so later name/avatar changes appear within the same session.
- The cache is **cleared on account switch** (it is account-scoped — directory display names can differ per account).

`directPeerProfile` (direct-chat header) already re-resolves on every call and is unchanged. An injectable `nowProvider` clock is added so TTL behaviour is deterministically testable.

## Test plan

Two regression tests added to `whitenoise-macTests`:

- `incompletePeerProfileLookupIsNotPinnedForTheSession` — first lookup with the profile unavailable renders the hex fallback; once the profile becomes available a later render re-resolves to the real name.
- `completePeerProfileIsRefreshedAfterCacheTTLExpires` — a complete lookup is cached, a rename inside the TTL keeps the cached name, and a render after the TTL elapses reflects the new name. Uses an injected mutable clock.

Verified locally by inspection only — no Swift toolchain on the build host (macOS/Xcode project). Needs an Xcode build + test run on a macOS reviewer/CI to confirm.

Closes #8

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->