### PR TITLE
Refactor account activation flow

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -553,13 +553,7 @@ final class WorkspaceState {
             try await bringRuntimeOnline(runtime)
             accounts = try runtime.listAccounts().map { accountItem(from: $0) }
             restoreOrSelectFirstAccount()
-            try await configureObservabilityRuntime()
-            phase = .ready
-            await refreshNotificationAuthorizationStatus()
-            loadNotificationSettings()
-            await loadPrivacySecuritySettings()
-            await reloadChats()
-            startNotificationListener()
+            try await activateReadyState()
         } catch {
             phase = .failed(error.localizedDescription)
             lastError = error.localizedDescription
@@ -567,6 +561,17 @@ final class WorkspaceState {
     }
 
     func selectAccount(_ account: AccountItem) {
+        switchActiveAccount(
+            account,
+            finalSelection: chatsByAccount[account.id]?.first.map { WorkspaceSelection.chat($0.id) }
+        )
+    }
+
+    func selectAccountFromSettings(_ account: AccountItem) {
+        switchActiveAccount(account, finalSelection: .settings(.accounts))
+    }
+
+    private func switchActiveAccount(_ account: AccountItem, finalSelection: WorkspaceSelection?) {
         stopTimelineListener()
         clearEnteredLoginIdentity()
         activeAccountId = account.id
@@ -575,10 +580,9 @@ final class WorkspaceState {
         closeNewChatComposer()
         pruneMessageCache(keeping: nil)
         refreshObservabilityRuntime()
-        let chatToLoad = activeChats.first
-        selection = chatToLoad.map { .chat($0.id) }
-        if let chatToLoad {
-            beginTimelineInitialLoadIfNeeded(groupIdHex: chatToLoad.id)
+        selection = finalSelection
+        if case let .chat(chatId)? = finalSelection {
+            beginTimelineInitialLoadIfNeeded(groupIdHex: chatId)
         }
         Task {
             await reloadChats()
@@ -588,19 +592,14 @@ final class WorkspaceState {
         }
     }
 
-    func selectAccountFromSettings(_ account: AccountItem) {
-        stopTimelineListener()
-        clearEnteredLoginIdentity()
-        activeAccountId = account.id
-        UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
-        searchText = ""
-        closeNewChatComposer()
-        pruneMessageCache(keeping: nil)
-        refreshObservabilityRuntime()
-        selection = .settings(.accounts)
-        Task {
-            await reloadChats()
-        }
+    private func activateReadyState() async throws {
+        phase = .ready
+        try await configureObservabilityRuntime()
+        await refreshNotificationAuthorizationStatus()
+        loadNotificationSettings()
+        await loadPrivacySecuritySettings()
+        await reloadChats()
+        startNotificationListener()
     }
 
     func selectChat(_ chat: ChatItem) {
@@ -671,13 +670,7 @@ final class WorkspaceState {
             try await bringRuntimeOnline(client)
             try refreshAccounts(preferred: summary)
             authenticationMode = .landing
-            phase = .ready
-            try await configureObservabilityRuntime()
-            await refreshNotificationAuthorizationStatus()
-            loadNotificationSettings()
-            await loadPrivacySecuritySettings()
-            await reloadChats()
-            startNotificationListener()
+            try await activateReadyState()
         } catch {
             lastError = error.localizedDescription
         }
@@ -707,13 +700,7 @@ final class WorkspaceState {
             try await bringRuntimeOnline(client)
             try refreshAccounts(preferred: summary)
             authenticationMode = .landing
-            phase = .ready
-            try await configureObservabilityRuntime()
-            await refreshNotificationAuthorizationStatus()
-            loadNotificationSettings()
-            await loadPrivacySecuritySettings()
-            await reloadChats()
-            startNotificationListener()
+            try await activateReadyState()
         } catch {
             lastError = error.localizedDescription
         }


### PR DESCRIPTION
## Summary
- Extract shared post-auth readiness setup into `activateReadyState()` for bootstrap, sign-up, and login.
- Extract common active-account switching into `switchActiveAccount(_:finalSelection:)` for main sidebar and settings account selection.

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS'` not run locally: `xcodebuild` is unavailable on this Linux worker.

Closes #19


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined authentication initialization sequences across bootstrap, sign-up, and login for improved consistency and reliability.
  * Optimized account switching logic to load chat data more efficiently when transitioning between accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->