### PR TITLE
fix: move sync FFI reads off main actor

### DIFF
--- a/whitenoise-mac/Core/MarmotConcurrency.swift
+++ b/whitenoise-mac/Core/MarmotConcurrency.swift
@@ -9,3 +9,12 @@ extension TimelineMessageQueryFfi: @retroactive @unchecked Sendable {}
 extension TimelinePageFfi: @retroactive @unchecked Sendable {}
 extension ChatListRowFfi: @retroactive @unchecked Sendable {}
 extension AppMessageRecordFfi: @retroactive @unchecked Sendable {}
+extension AccountSummaryFfi: @retroactive @unchecked Sendable {}
+extension UserProfileMetadataFfi: @retroactive @unchecked Sendable {}
+extension AccountRelayListsFfi: @retroactive @unchecked Sendable {}
+extension NotificationSettingsFfi: @retroactive @unchecked Sendable {}
+extension RelayTelemetrySettingsFfi: @retroactive @unchecked Sendable {}
+extension AuditLogSettingsFfi: @retroactive @unchecked Sendable {}
+extension AuditLogFileFfi: @retroactive @unchecked Sendable {}
+extension AuditLogTrackerConfigFfi: @retroactive @unchecked Sendable {}
+extension MemberRefFfi: @retroactive @unchecked Sendable {}

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -422,6 +422,15 @@ final class WorkspaceState {
         }
     }
 
+    /// Raw output of the per-account bootstrap/settings FFI lookups.
+    struct ResolvedAccountFFI: Sendable {
+        var profileDisplayName: String?
+        var profileName: String?
+        var profilePicture: String?
+        var directoryDisplayName: String?
+        var npub: String?
+    }
+
     /// Runs a blocking FFI closure off the main thread and resumes on the caller's actor.
     nonisolated private func runOffMain<T>(
         _ work: @escaping @Sendable () throws -> T
@@ -621,8 +630,10 @@ final class WorkspaceState {
             let runtime = try clientFactory()
             client = runtime
             storageRootPath = runtime.storageRootPath
-            let summaries = try runtime.listAccounts()
-            accounts = summaries.map { accountItem(from: $0) }
+            let summaries = try await runOffMain {
+                try runtime.listAccounts()
+            }
+            accounts = try await accountItems(from: summaries, client: runtime)
             restoreOrSelectFirstAccount()
             try await configureObservabilityRuntime()
             if accounts.isEmpty {
@@ -631,7 +642,7 @@ final class WorkspaceState {
             }
 
             try await bringRuntimeOnline(runtime)
-            accounts = try runtime.listAccounts().map { accountItem(from: $0) }
+            accounts = try await accountItemsFromRuntime(client: runtime)
             restoreOrSelectFirstAccount()
             try await activateReadyState()
         } catch {
@@ -680,7 +691,7 @@ final class WorkspaceState {
         phase = .ready
         try await configureObservabilityRuntime()
         await refreshNotificationAuthorizationStatus()
-        loadNotificationSettings()
+        await loadNotificationSettings()
         await loadPrivacySecuritySettings()
         await reloadChats()
         startNotificationListener()
@@ -750,9 +761,9 @@ final class WorkspaceState {
                 defaultRelays: MarmotClient.seedRelays,
                 bootstrapRelays: MarmotClient.seedRelays
             )
-            try refreshAccounts(preferred: summary)
+            try await refreshAccounts(preferred: summary)
             try await bringRuntimeOnline(client)
-            try refreshAccounts(preferred: summary)
+            try await refreshAccounts(preferred: summary)
             authenticationMode = .landing
             try await activateReadyState()
         } catch {
@@ -780,9 +791,9 @@ final class WorkspaceState {
                 defaultRelays: MarmotClient.seedRelays,
                 bootstrapRelays: MarmotClient.seedRelays
             )
-            try refreshAccounts(preferred: summary)
+            try await refreshAccounts(preferred: summary)
             try await bringRuntimeOnline(client)
-            try refreshAccounts(preferred: summary)
+            try await refreshAccounts(preferred: summary)
             authenticationMode = .landing
             try await activateReadyState()
         } catch {
@@ -816,7 +827,7 @@ final class WorkspaceState {
             }
             try await client.removeAccount(accountRef: account.accountRef)
             clearComposerDrafts(forAccountId: removedAccountId)
-            accounts = try client.listAccounts().map { accountItem(from: $0) }
+            accounts = try await accountItemsFromRuntime(client: client)
             chatsByAccount[removedAccountId] = nil
 
             // `activeAccountId` may have changed during the await above — e.g. the user
@@ -986,23 +997,35 @@ final class WorkspaceState {
             }
         }
 
+        let accountIdHex = activeAccount.accountIdHex
+        let accountRef = activeAccount.accountRef
+        let fallbackName = activeAccount.displayName
+        let pictureURL = activeAccount.pictureURL
+
         do {
-            let profile = try client.userProfile(accountIdHex: activeAccount.accountIdHex)
-            profileDraft = ProfileDraft(profile: profile, fallbackName: activeAccount.displayName)
-            let displayName = profileDraft.primaryDisplayName(fallback: activeAccount.displayName)
+            let profile = try await runOffMain {
+                try client.userProfile(accountIdHex: accountIdHex)
+            }
+            profileDraft = ProfileDraft(profile: profile, fallbackName: fallbackName)
+            let displayName = profileDraft.primaryDisplayName(fallback: fallbackName)
             updateActiveAccountProfile(displayName: displayName, pictureURL: profileDraft.picture)
         } catch {
             lastError = error.localizedDescription
-            profileDraft = ProfileDraft(fallbackName: activeAccount.displayName)
-            if let displayName = client.displayName(accountIdHex: activeAccount.accountIdHex)?
+            profileDraft = ProfileDraft(fallbackName: fallbackName)
+            let displayName = (try? await runOffMain {
+                client.displayName(accountIdHex: accountIdHex)
+            }) ?? nil
+            if let displayName = displayName?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                 !displayName.isEmpty {
-                updateActiveAccountProfile(displayName: displayName, pictureURL: activeAccount.pictureURL)
+                updateActiveAccountProfile(displayName: displayName, pictureURL: pictureURL)
             }
         }
 
         do {
-            let lists = try client.accountRelayLists(accountRef: activeAccount.accountRef)
+            let lists = try await runOffMain {
+                try client.accountRelayLists(accountRef: accountRef)
+            }
             relaySettings = RelaySettingsSnapshot(lists: lists)
             relayDraft = relaySettings.relays(for: selectedRelaySection)
         } catch {
@@ -1014,7 +1037,7 @@ final class WorkspaceState {
         await refreshNotificationAuthorizationStatus()
         // The active account may have changed during the await above; abandon stale writes.
         guard !Task.isCancelled, activeAccountId == accountId else { return }
-        loadNotificationSettings()
+        await loadNotificationSettings()
         await loadPrivacySecuritySettings()
     }
 
@@ -1077,11 +1100,15 @@ final class WorkspaceState {
             }
         }
 
+        let accountRef = activeAccount.accountRef
+
         do {
-            let settings = try client.setLocalNotificationsEnabled(
-                accountRef: activeAccount.accountRef,
-                enabled: enabled
-            )
+            let settings = try await runOffMain {
+                try client.setLocalNotificationsEnabled(
+                    accountRef: accountRef,
+                    enabled: enabled
+                )
+            }
             notificationSettings = NotificationSettingsSnapshot(settings: settings)
         } catch {
             lastError = error.localizedDescription
@@ -1260,14 +1287,24 @@ final class WorkspaceState {
         }
 
         do {
-            let member = try client.normalizeMemberRef(memberRef: query)
+            let member = try await runOffMain {
+                try client.normalizeMemberRef(memberRef: query)
+            }
             try? await client.refreshProfile(accountIdHex: member.accountIdHex, relays: MarmotClient.seedRelays)
             peerProfileFFICache[member.accountIdHex] = nil
-            let profile = try? client.userProfile(accountIdHex: member.accountIdHex)
+            let resolved = try? await runOffMain { () -> ResolvedPeerFFI in
+                let profile = try? client.userProfile(accountIdHex: member.accountIdHex)
+                return ResolvedPeerFFI(
+                    profileDisplayName: profile?.displayName,
+                    profileName: profile?.name,
+                    profilePicture: profile?.picture,
+                    directoryDisplayName: client.displayName(accountIdHex: member.accountIdHex)
+                )
+            }
             let displayName = firstNonBlank([
-                profile?.displayName,
-                profile?.name,
-                client.displayName(accountIdHex: member.accountIdHex)
+                resolved?.profileDisplayName,
+                resolved?.profileName,
+                resolved?.directoryDisplayName
             ])
             let recipient = NewChatRecipient(
                 sourceQuery: query,
@@ -1275,7 +1312,7 @@ final class WorkspaceState {
                 accountIdHex: member.accountIdHex,
                 npub: member.npub,
                 displayName: displayName,
-                pictureURL: profile?.picture
+                pictureURL: resolved?.profilePicture
             )
             guard isCurrentNewChatLookup(generation: lookupGeneration, query: query) else {
                 return nil
@@ -1534,12 +1571,12 @@ final class WorkspaceState {
     }
 
     /// The bech32 `npub` form of a hex public key — the canonical, user-facing way to show
-    /// a Nostr public key. Falls back to the hex if conversion is unavailable. The
-    /// conversion is a pure in-memory bech32 encode, so it's cheap to call from view bodies.
+    /// a Nostr public key. Falls back to the hex until the account cache has been hydrated
+    /// off the main thread.
     func npub(forAccountIdHex accountIdHex: String) -> String {
         let trimmed = accountIdHex.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return trimmed }
-        return client?.npub(accountIdHex: trimmed) ?? trimmed
+        return accounts.first(where: { $0.accountIdHex == trimmed })?.npub ?? trimmed
     }
 
     func react(to message: MessageItem, emoji: String) async {
@@ -1701,7 +1738,9 @@ final class WorkspaceState {
         defer { isInvitingGroupMember = false }
 
         do {
-            let normalized = try client.normalizeMemberRef(memberRef: query)
+            let normalized = try await runOffMain {
+                try client.normalizeMemberRef(memberRef: query)
+            }
             let result = try await client.inviteMembersDetailed(
                 accountRef: activeAccount.accountRef,
                 groupIdHex: snapshot.groupIdHex,
@@ -2029,9 +2068,9 @@ final class WorkspaceState {
 
         // Keep the published settings snapshot in sync for the active account.
         // This is an explicit step rather than a side effect of the guard below.
-        syncNotificationSettingsIfActive(for: update)
+        await syncNotificationSettingsIfActive(for: update)
 
-        guard localNotificationsEnabled(for: update) else { return }
+        guard await localNotificationsEnabled(for: update) else { return }
 
         if selectedChat?.id == update.groupIdHex, selectedConversationIsVisible() {
             return
@@ -2082,10 +2121,11 @@ final class WorkspaceState {
         }
     }
 
-    private func refreshAccounts(preferred summary: AccountSummaryFfi) throws {
+    private func refreshAccounts(preferred summary: AccountSummaryFfi) async throws {
         guard let client else { return }
-        let preferredAccount = accountItem(from: summary)
-        var refreshed = try client.listAccounts().map { accountItem(from: $0) }
+        let preferredItems = try await accountItems(from: [summary], client: client)
+        let preferredAccount = preferredItems.first ?? Self.accountItem(from: summary, resolved: nil)
+        var refreshed = try await accountItemsFromRuntime(client: client)
         if !refreshed.contains(where: { $0.id == preferredAccount.id }) {
             refreshed.append(preferredAccount)
         }
@@ -2246,7 +2286,10 @@ final class WorkspaceState {
            cached.buildConfig == config {
             relayRuntimeConfig = cached.relayTelemetryRuntimeConfig
         } else {
-            relayRuntimeConfig = config.runtimeConfig(installId: try client.telemetryInstallId())
+            let installId = try await runOffMain {
+                try client.telemetryInstallId()
+            }
+            relayRuntimeConfig = config.runtimeConfig(installId: installId)
         }
         let auditTrackerConfig = config.auditTrackerConfig(accountLabel: accountLabel)
 
@@ -2254,7 +2297,9 @@ final class WorkspaceState {
             try await client.setRelayTelemetryRuntimeConfig(config: relayRuntimeConfig)
         }
         if observabilityRuntimeConfiguration?.auditLogTrackerConfig != auditTrackerConfig {
-            _ = try client.setAuditLogTrackerConfig(config: auditTrackerConfig)
+            _ = try await runOffMain {
+                try client.setAuditLogTrackerConfig(config: auditTrackerConfig)
+            }
         }
 
         observabilityRuntimeConfiguration = ObservabilityRuntimeConfiguration(
@@ -2267,14 +2312,17 @@ final class WorkspaceState {
         privacySecuritySettings.auditLogCredentialsAvailable = config.auditLogCredentialsAvailable
     }
 
-    private func loadNotificationSettings() {
+    private func loadNotificationSettings() async {
         guard let client, let activeAccount else {
             notificationSettings = .defaults
             return
         }
 
         do {
-            let settings = try client.notificationSettings(accountRef: activeAccount.accountRef)
+            let accountRef = activeAccount.accountRef
+            let settings = try await runOffMain {
+                try client.notificationSettings(accountRef: accountRef)
+            }
             notificationSettings = NotificationSettingsSnapshot(settings: settings)
         } catch {
             notificationSettings = .defaults
@@ -2290,8 +2338,12 @@ final class WorkspaceState {
 
         do {
             try await configureObservabilityRuntime()
-            let telemetry = try client.relayTelemetrySettings()
-            let auditLog = try client.auditLogSettings()
+            let (telemetry, auditLog) = try await runOffMain {
+                (
+                    try client.relayTelemetrySettings(),
+                    try client.auditLogSettings()
+                )
+            }
             let config = telemetryBuildConfig
             privacySecuritySettings = PrivacySecuritySettingsSnapshot(
                 relayTelemetryEnabled: telemetry.exportEnabled,
@@ -2322,7 +2374,9 @@ final class WorkspaceState {
 
         do {
             try await configureObservabilityRuntime()
-            let current = try client.relayTelemetrySettings()
+            let current = try await runOffMain {
+                try client.relayTelemetrySettings()
+            }
             let settings = RelayTelemetrySettingsFfi(
                 exportEnabled: enabled,
                 exportIntervalSeconds: current.exportIntervalSeconds
@@ -2369,7 +2423,9 @@ final class WorkspaceState {
         defer { isLoadingAuditLogFiles = false }
 
         do {
-            auditLogFiles = try client.auditLogFiles()
+            auditLogFiles = try await runOffMain {
+                try client.auditLogFiles()
+            }
         } catch {
             auditLogFiles = []
             lastError = error.localizedDescription
@@ -3046,9 +3102,12 @@ final class WorkspaceState {
     /// account targeted by `update`. Has no side effects — callers that also need
     /// to refresh the published `notificationSettings` snapshot must invoke
     /// `syncNotificationSettingsIfActive(for:)` explicitly.
-    private func localNotificationsEnabled(for update: NotificationUpdateFfi) -> Bool {
+    private func localNotificationsEnabled(for update: NotificationUpdateFfi) async -> Bool {
         guard let client else { return false }
-        guard let settings = try? client.notificationSettings(accountRef: update.accountRef) else {
+        let accountRef = update.accountRef
+        guard let settings = try? await runOffMain({
+            try client.notificationSettings(accountRef: accountRef)
+        }) else {
             return false
         }
 
@@ -3059,10 +3118,13 @@ final class WorkspaceState {
     /// targets the active account. Kept separate from
     /// `localNotificationsEnabled(for:)` so that evaluating the predicate does
     /// not mutate UI state as a hidden side effect.
-    private func syncNotificationSettingsIfActive(for update: NotificationUpdateFfi) {
+    private func syncNotificationSettingsIfActive(for update: NotificationUpdateFfi) async {
         guard activeAccount?.accountIdHex == update.accountIdHex else { return }
         guard let client else { return }
-        guard let settings = try? client.notificationSettings(accountRef: update.accountRef) else {
+        let accountRef = update.accountRef
+        guard let settings = try? await runOffMain({
+            try client.notificationSettings(accountRef: accountRef)
+        }) else {
             return
         }
 
@@ -3356,15 +3418,48 @@ final class WorkspaceState {
         return profiles
     }
 
-    private func accountItem(from summary: AccountSummaryFfi) -> AccountItem {
-        let base = AccountItem(summary: summary)
-        guard let client else { return base }
+    private func accountItemsFromRuntime(client: any MarmotRuntime) async throws -> [AccountItem] {
+        let summaries = try await runOffMain {
+            try client.listAccounts()
+        }
+        return try await accountItems(from: summaries, client: client)
+    }
 
+    private func accountItems(
+        from summaries: [AccountSummaryFfi],
+        client: any MarmotRuntime
+    ) async throws -> [AccountItem] {
+        try await runOffMain {
+            summaries.map { summary in
+                let resolved = Self.resolvedAccountFFI(from: summary, client: client)
+                return Self.accountItem(from: summary, resolved: resolved)
+            }
+        }
+    }
+
+    nonisolated private static func resolvedAccountFFI(
+        from summary: AccountSummaryFfi,
+        client: any MarmotRuntime
+    ) -> ResolvedAccountFFI {
         let profile = try? client.userProfile(accountIdHex: summary.accountIdHex)
+        return ResolvedAccountFFI(
+            profileDisplayName: profile?.displayName,
+            profileName: profile?.name,
+            profilePicture: profile?.picture,
+            directoryDisplayName: client.displayName(accountIdHex: summary.accountIdHex),
+            npub: client.npub(accountIdHex: summary.accountIdHex)
+        )
+    }
+
+    nonisolated private static func accountItem(
+        from summary: AccountSummaryFfi,
+        resolved: ResolvedAccountFFI?
+    ) -> AccountItem {
+        let base = AccountItem(summary: summary)
         let displayName = firstNonBlank([
-            profile?.displayName,
-            profile?.name,
-            client.displayName(accountIdHex: summary.accountIdHex)
+            resolved?.profileDisplayName,
+            resolved?.profileName,
+            resolved?.directoryDisplayName
         ]) ?? base.displayName
 
         return AccountItem(
@@ -3372,8 +3467,8 @@ final class WorkspaceState {
             accountRef: base.accountRef,
             displayName: displayName,
             accountIdHex: base.accountIdHex,
-            npub: client.npub(accountIdHex: base.accountIdHex),
-            pictureURL: profile?.picture,
+            npub: resolved?.npub,
+            pictureURL: resolved?.profilePicture,
             localSigning: base.localSigning,
             isRunning: base.isRunning
         )

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -998,9 +998,12 @@ private struct NewChatDetailsForm: View {
 }
 
 private struct NewChatRecipientCard: View {
+    @Environment(WorkspaceState.self) private var workspace
     let recipient: NewChatRecipient
 
     var body: some View {
+        let publicKey = recipient.npub.isEmpty ? recipient.accountIdHex : recipient.npub
+
         HStack(spacing: 12) {
             ProfileImageAvatarView(
                 seed: recipient.accountIdHex,
@@ -1014,7 +1017,24 @@ private struct NewChatRecipientCard: View {
                 Text(recipient.title)
                     .font(.system(size: 15, weight: .semibold))
                     .lineLimit(1)
-                CopyableKeyLabel(accountIdHex: recipient.accountIdHex)
+                HStack(spacing: 6) {
+                    Text(DisplayText.short(publicKey, head: 12, tail: 10))
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+
+                    Button {
+                        workspace.copyText(publicKey)
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 10))
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .help(L10n.string("Copy npub"))
+                }
             }
 
             Spacer()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -78,6 +78,81 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func bootstrapRunsSynchronousRuntimeReadsOffMainThread() async throws {
+        // Regression for #17: WorkspaceState is @MainActor, but blocking sync FFI reads
+        // (account listing/profile/name/npub plus settings probes) must not execute on
+        // the main thread during launch.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        runtime.clearSyncCallThreadRecords()
+        await state.bootstrap()
+
+        #expect(state.phase == .ready)
+        #expect(runtime.syncCallThreadRecord("listAccounts").count >= 2)
+        #expect(runtime.syncCallThreadRecord("listAccounts").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("userProfile").contains(false))
+        #expect(runtime.syncCallThreadRecord("userProfile").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("displayName").contains(false))
+        #expect(runtime.syncCallThreadRecord("displayName").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("npub").contains(false))
+        #expect(runtime.syncCallThreadRecord("npub").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("notificationSettings").contains(false))
+        #expect(runtime.syncCallThreadRecord("notificationSettings").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("telemetryInstallId").contains(false))
+        #expect(runtime.syncCallThreadRecord("telemetryInstallId").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("setAuditLogTrackerConfig").contains(false))
+        #expect(runtime.syncCallThreadRecord("setAuditLogTrackerConfig").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("relayTelemetrySettings").contains(false))
+        #expect(runtime.syncCallThreadRecord("relayTelemetrySettings").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("auditLogSettings").contains(false))
+        #expect(runtime.syncCallThreadRecord("auditLogSettings").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("auditLogFiles").contains(false))
+        #expect(runtime.syncCallThreadRecord("auditLogFiles").allSatisfy { !$0 })
+    }
+
+    @MainActor
+    @Test func loadSettingsDataRunsSynchronousRuntimeReadsOffMainThread() async throws {
+        // The Settings screen pulls profile, relay, notification, telemetry, and audit
+        // snapshots. Those are synchronous FFI reads and must not block the run loop.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        runtime.clearSyncCallThreadRecords()
+        await state.loadSettingsData()
+
+        #expect(runtime.syncCallThreadRecord("userProfile").contains(false))
+        #expect(runtime.syncCallThreadRecord("userProfile").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("accountRelayLists").contains(false))
+        #expect(runtime.syncCallThreadRecord("accountRelayLists").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("notificationSettings").contains(false))
+        #expect(runtime.syncCallThreadRecord("notificationSettings").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("telemetryInstallId").contains(false))
+        #expect(runtime.syncCallThreadRecord("telemetryInstallId").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("setAuditLogTrackerConfig").contains(false))
+        #expect(runtime.syncCallThreadRecord("setAuditLogTrackerConfig").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("relayTelemetrySettings").contains(false))
+        #expect(runtime.syncCallThreadRecord("relayTelemetrySettings").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("auditLogSettings").contains(false))
+        #expect(runtime.syncCallThreadRecord("auditLogSettings").allSatisfy { !$0 })
+        #expect(runtime.syncCallThreadRecord("auditLogFiles").contains(false))
+        #expect(runtime.syncCallThreadRecord("auditLogFiles").allSatisfy { !$0 })
+    }
+
+    @MainActor
     @Test func addingSecondAccountViaLoginBringsItOnlineWithoutRelaunch() async throws {
         // Regression for #74: the Settings → Add Account flow reuses login()/
         // signUp() while the runtime is already running. The new account must be
@@ -5100,6 +5175,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var profileRefreshDelaysByAccountId: [String: UInt64] = [:]
     var accountIdsMissingProfiles = Set<String>()
     var timelineMessagesHandler: ((TimelineMessageQueryFfi) -> TimelinePageFfi)?
+    private let syncCallThreadLock = NSLock()
+    private var syncCallThreads: [String: [Bool]] = [:]
     /// When set, `subscribeNotifications()` throws this error, simulating a background
     /// notification-listener failure for routing tests.
     var subscribeNotificationsError: Error?
@@ -5157,14 +5234,36 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func listAccounts() throws -> [AccountSummaryFfi] {
-        storedAccounts
+        recordSyncCall("listAccounts")
+        return storedAccounts
+    }
+
+    func clearSyncCallThreadRecords() {
+        syncCallThreadLock.lock()
+        syncCallThreads = [:]
+        syncCallThreadLock.unlock()
+    }
+
+    func syncCallThreadRecord(_ name: String) -> [Bool] {
+        syncCallThreadLock.lock()
+        let threads = syncCallThreads[name] ?? []
+        syncCallThreadLock.unlock()
+        return threads
+    }
+
+    private func recordSyncCall(_ name: String) {
+        syncCallThreadLock.lock()
+        syncCallThreads[name, default: []].append(Thread.isMainThread)
+        syncCallThreadLock.unlock()
     }
 
     func npub(accountIdHex: String) -> String? {
-        "npub1\(accountIdHex.prefix(12))"
+        recordSyncCall("npub")
+        return "npub1\(accountIdHex.prefix(12))"
     }
 
     func displayName(accountIdHex: String) -> String? {
+        recordSyncCall("displayName")
         guard !accountIdsMissingProfiles.contains(accountIdHex) else { return nil }
         let resolvedProfile = profilesByAccountId[accountIdHex] ?? profile
         return resolvedProfile.displayName ?? resolvedProfile.name
@@ -5172,11 +5271,13 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func userProfile(accountIdHex: String) throws -> UserProfileMetadataFfi? {
         userProfileCallCount += 1
+        recordSyncCall("userProfile")
         guard !accountIdsMissingProfiles.contains(accountIdHex) else { return nil }
         return profilesByAccountId[accountIdHex] ?? profile
     }
 
     func normalizeMemberRef(memberRef: String) throws -> MemberRefFfi {
+        recordSyncCall("normalizeMemberRef")
         if let member = normalizedMembersByRef[memberRef] {
             return member
         }
@@ -5337,6 +5438,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func accountRelayLists(accountRef: String) throws -> AccountRelayListsFfi {
         accountRelayListsCallCount += 1
+        recordSyncCall("accountRelayLists")
         return relayLists
     }
 
@@ -5347,11 +5449,13 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func auditLogFiles() throws -> [AuditLogFileFfi] {
-        storedAuditLogFiles
+        recordSyncCall("auditLogFiles")
+        return storedAuditLogFiles
     }
 
     func auditLogSettings() throws -> AuditLogSettingsFfi {
-        storedAuditLogSettings
+        recordSyncCall("auditLogSettings")
+        return storedAuditLogSettings
     }
 
     func deleteAuditLogFile(path: String) async throws -> AuditLogDeleteResultFfi {
@@ -5361,7 +5465,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func notificationSettings(accountRef: String) throws -> NotificationSettingsFfi {
-        notificationSettings
+        recordSyncCall("notificationSettings")
+        return notificationSettings
     }
 
     func postAuditLogTrackerUpdate() async throws -> AuditLogTrackerUpdateResultFfi {
@@ -5370,7 +5475,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func relayTelemetrySettings() throws -> RelayTelemetrySettingsFfi {
-        storedRelayTelemetrySettings
+        recordSyncCall("relayTelemetrySettings")
+        return storedRelayTelemetrySettings
     }
 
     func setAuditLogSettings(settings: AuditLogSettingsFfi) async throws -> AuditLogSettingsFfi {
@@ -5380,11 +5486,13 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func setAuditLogTrackerConfig(config: AuditLogTrackerConfigFfi) throws -> AuditLogTrackerConfigFfi {
         auditLogTrackerConfigSetCallCount += 1
+        recordSyncCall("setAuditLogTrackerConfig")
         auditLogTrackerConfig = config
         return config
     }
 
     func setLocalNotificationsEnabled(accountRef: String, enabled: Bool) throws -> NotificationSettingsFfi {
+        recordSyncCall("setLocalNotificationsEnabled")
         localNotificationsEnabledSet = enabled
         notificationSettings.localNotificationsEnabled = enabled
         return notificationSettings
@@ -5402,6 +5510,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func telemetryInstallId() throws -> String {
         telemetryInstallIdCallCount += 1
+        recordSyncCall("telemetryInstallId")
         return "test-install-id"
     }
 
@@ -5735,6 +5844,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi) throws -> TimelinePageFfi {
+        recordSyncCall("timelineMessages")
         timelineMessageQueries.append(query)
         if let timelineMessagesHandler {
             return timelineMessagesHandler(query)
@@ -5774,10 +5884,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func initializeChatReadState(accountRef: String, groupIdHex: String) throws -> ChatListRowFfi? {
-        groups.first(where: { $0.groupIdHex == groupIdHex }).map(chatListRow(for:))
+        recordSyncCall("initializeChatReadState")
+        return groups.first(where: { $0.groupIdHex == groupIdHex }).map(chatListRow(for:))
     }
 
     func markTimelineMessageRead(accountRef: String, groupIdHex: String, messageIdHex: String) throws -> ChatListRowFfi? {
+        recordSyncCall("markTimelineMessageRead")
         markedReadMessageIds.append(messageIdHex)
         return groups.first(where: { $0.groupIdHex == groupIdHex }).map(chatListRow(for:))
     }


### PR DESCRIPTION
## Summary
- route synchronous MarmotRuntime reads through WorkspaceState.runOffMain during bootstrap, account refresh, settings load, notification probes, and peer/profile resolution
- cache account npub/profile/name data from off-main account hydration so SwiftUI view bodies no longer call synchronous FFI
- add regression coverage that records FakeMarmotRuntime sync-call thread affinity for bootstrap and settings reads

## Test Plan
- `git diff --check`
- `xcodebuild` not run: unavailable on this Linux worker host

Closes #17


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the New Chat recipient selection interface to display the public key (npub format) with a convenient one-click copy button for improved user convenience.

* **Refactor**
  * Optimized internal architecture and data flow to move resource-intensive operations off the main thread, resulting in improved application responsiveness and smoother user experience.

* **Tests**
  * Added comprehensive regression test suite to verify proper concurrent operation handling and ensure main thread safety across critical application workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->