### PR TITLE
fix: coalesce overlapping settings loads (#4)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -301,6 +301,13 @@ final class WorkspaceState {
     /// request for a different account cancels the now-stale load so it cannot clobber fresher state.
     private var settingsLoadTask: Task<Void, Never>?
     private var settingsLoadAccountId: String?
+    /// Monotonic token identifying the most recently started settings load. `performSettingsLoad`
+    /// captures the value at launch and only clears `isLoadingSettings` in its `defer` if it is
+    /// still the current generation — i.e. no newer load has superseded it. This distinguishes
+    /// "superseded by a newer load" (must NOT dismiss the spinner the newer load owns) from
+    /// "cancelled with no replacement" (the active account was cleared, so the spinner MUST be
+    /// dismissed instead of left stuck). See `loadSettingsData` / issue #4.
+    private var settingsLoadGeneration: UInt64 = 0
     private var timelineTask: Task<Void, Never>?
     private var timelineTaskGroupId: String?
     /// The live timeline subscription for the open conversation. It owns the
@@ -856,9 +863,14 @@ final class WorkspaceState {
     func loadSettingsData() async {
         guard let activeAccount else {
             // No active account: cancel any in-flight load and reset to defaults synchronously.
+            // The cancelled task may be suspended mid-flight; its `defer` will see a newer
+            // generation (bumped below) and decline to touch `isLoadingSettings`, so this path
+            // owns clearing the spinner — otherwise it would stay stuck `true` forever (issue #4).
             settingsLoadTask?.cancel()
             settingsLoadTask = nil
             settingsLoadAccountId = nil
+            settingsLoadGeneration &+= 1
+            isLoadingSettings = false
             profileDraft = ProfileDraft()
             relaySettings = .defaults
             relayDraft = relaySettings.relays(for: selectedRelaySection)
@@ -879,8 +891,10 @@ final class WorkspaceState {
         // A request for a different account supersedes the stale in-flight load.
         settingsLoadTask?.cancel()
 
+        settingsLoadGeneration &+= 1
+        let generation = settingsLoadGeneration
         let task = Task { [weak self] in
-            await self?.performSettingsLoad(accountId: accountId)
+            await self?.performSettingsLoad(accountId: accountId, generation: generation)
         }
         settingsLoadTask = task
         settingsLoadAccountId = accountId
@@ -896,14 +910,22 @@ final class WorkspaceState {
 
     /// Performs the actual settings fetches for `accountId`. Guarded so that if the active account
     /// changes (or the task is canceled) mid-flight, no stale results are written to the UI.
-    private func performSettingsLoad(accountId: String) async {
+    ///
+    /// `generation` is the monotonic token assigned when this load was started. The `defer` clears
+    /// `isLoadingSettings` only while this is still the current generation. If a newer load has
+    /// since superseded this one, that newer load owns the spinner and we must not dismiss it; if
+    /// instead the load was cancelled with no replacement (active account cleared), the
+    /// no-active-account branch in `loadSettingsData()` has already cleared the spinner. Keying on
+    /// the generation rather than `activeAccountId` also handles a rapid A→B→A switch, where the
+    /// account id alone would spuriously match.
+    private func performSettingsLoad(accountId: String, generation: UInt64) async {
         guard let client, let activeAccount, activeAccount.id == accountId else { return }
 
         isLoadingSettings = true
         defer {
             // Only the still-current owner clears the loading flag, so a superseded stale load
             // cannot prematurely dismiss the spinner for the newer account's load.
-            if activeAccountId == accountId {
+            if settingsLoadGeneration == generation {
                 isLoadingSettings = false
             }
         }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -292,6 +292,15 @@ final class WorkspaceState {
     /// are process-monotonic and never reused, so a stale canceled task can never match a future
     /// task's token and drop its tracking slot. See `ChatListRowEnrichmentTracker`.
     private var chatListRowEnrichment = ChatListRowEnrichmentTracker()
+    /// Single-owner coalescing for the aggregate settings load (issue #4). `loadSettingsData()`
+    /// is invoked from more than one entry point — the settings view's `.task(id: activeAccountId)`
+    /// and explicit reloads (e.g. after removing the active account) — which can otherwise issue
+    /// overlapping profile / relay / notification / privacy fetches for the same account. The
+    /// in-flight task is tracked here keyed by `settingsLoadAccountId`: a concurrent request for the
+    /// same account awaits the existing task (coalesces) instead of starting a duplicate, and a
+    /// request for a different account cancels the now-stale load so it cannot clobber fresher state.
+    private var settingsLoadTask: Task<Void, Never>?
+    private var settingsLoadAccountId: String?
     private var timelineTask: Task<Void, Never>?
     private var timelineTaskGroupId: String?
     /// The live timeline subscription for the open conversation. It owns the
@@ -829,8 +838,27 @@ final class WorkspaceState {
         }
     }
 
+    /// Loads the aggregate settings snapshot (profile, relays, notifications, privacy/security)
+    /// for the active account.
+    ///
+    /// Settings loading is driven from more than one entry point — the settings view's
+    /// `.task(id: workspace.activeAccountId)` and explicit reloads after account mutations (e.g.
+    /// `removeAccount`, which changes `activeAccountId` *and* calls this directly). Without
+    /// coalescing those paths can issue two overlapping loads for the same account, doubling the
+    /// profile/relay/notification/privacy work and racing each other to write UI state. This
+    /// method therefore enforces a single owner per account:
+    ///
+    /// - A concurrent call for the account already loading awaits the in-flight task (coalesces)
+    ///   instead of starting a duplicate.
+    /// - A call for a *different* account cancels the now-stale load — and the stale task, on
+    ///   resuming, sees `activeAccountId` no longer matches and abandons its writes — so a slower
+    ///   older load can never clobber the fresher account's UI state.
     func loadSettingsData() async {
-        guard let client, let activeAccount else {
+        guard let activeAccount else {
+            // No active account: cancel any in-flight load and reset to defaults synchronously.
+            settingsLoadTask?.cancel()
+            settingsLoadTask = nil
+            settingsLoadAccountId = nil
             profileDraft = ProfileDraft()
             relaySettings = .defaults
             relayDraft = relaySettings.relays(for: selectedRelaySection)
@@ -840,8 +868,45 @@ final class WorkspaceState {
             return
         }
 
+        let accountId = activeAccount.id
+
+        // Coalesce: a request for the account already loading joins the in-flight task.
+        if let existing = settingsLoadTask, settingsLoadAccountId == accountId {
+            await existing.value
+            return
+        }
+
+        // A request for a different account supersedes the stale in-flight load.
+        settingsLoadTask?.cancel()
+
+        let task = Task { [weak self] in
+            await self?.performSettingsLoad(accountId: accountId)
+        }
+        settingsLoadTask = task
+        settingsLoadAccountId = accountId
+
+        await task.value
+
+        // Only clear ownership if no newer load has since taken over this slot.
+        if settingsLoadTask == task {
+            settingsLoadTask = nil
+            settingsLoadAccountId = nil
+        }
+    }
+
+    /// Performs the actual settings fetches for `accountId`. Guarded so that if the active account
+    /// changes (or the task is canceled) mid-flight, no stale results are written to the UI.
+    private func performSettingsLoad(accountId: String) async {
+        guard let client, let activeAccount, activeAccount.id == accountId else { return }
+
         isLoadingSettings = true
-        defer { isLoadingSettings = false }
+        defer {
+            // Only the still-current owner clears the loading flag, so a superseded stale load
+            // cannot prematurely dismiss the spinner for the newer account's load.
+            if activeAccountId == accountId {
+                isLoadingSettings = false
+            }
+        }
 
         do {
             let profile = try client.userProfile(accountIdHex: activeAccount.accountIdHex)
@@ -869,6 +934,8 @@ final class WorkspaceState {
         }
 
         await refreshNotificationAuthorizationStatus()
+        // The active account may have changed during the await above; abandon stale writes.
+        guard !Task.isCancelled, activeAccountId == accountId else { return }
         loadNotificationSettings()
         await loadPrivacySecuritySettings()
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3597,6 +3597,55 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func cancellingInFlightSettingsLoadWithNoActiveAccountClearsSpinner() async throws {
+        // Issue #4 (adversarial-review blocking finding): a settings load that is cancelled
+        // *without* a replacement load starting must not leave `isLoadingSettings` stuck `true`.
+        // Repro: hold a load suspended mid-flight (at `refreshNotificationAuthorizationStatus()`),
+        // clear the active account (as account removal of the last account does), then let the
+        // stale load resume. The resumed task must NOT own the spinner (a newer generation has
+        // superseded it); the no-active-account reset path owns clearing it.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let gate = GatedLocalNotificationCenter()
+        let state = WorkspaceState(
+            localNotificationCenter: gate,
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+
+        // Arm the gate so the next settings load suspends inside refreshNotificationAuthorizationStatus().
+        gate.gateEnabled = true
+        async let inflight: Void = state.loadSettingsData()
+
+        // Spin the main actor until the suspended load has set the spinner and reached the gate.
+        while !(state.isLoadingSettings && gate.didReachGate) {
+            await Task.yield()
+        }
+        #expect(state.isLoadingSettings)
+
+        // Clear the active account with no replacement load — the no-active-account branch of
+        // loadSettingsData() runs synchronously, cancels the in-flight task, and resets to defaults.
+        state.activeAccountId = nil
+        await state.loadSettingsData()
+
+        // The spinner must already be cleared by the reset path, even before the stale load resumes.
+        #expect(state.isLoadingSettings == false)
+
+        // Release the gate so the stale load resumes; its defer must see the bumped generation and
+        // leave the (already-false) spinner untouched rather than resurrecting it.
+        gate.releaseGate()
+        _ = await inflight
+
+        #expect(state.isLoadingSettings == false)
+    }
+
+    @MainActor
     @Test func settingsLoadShowsNotificationPreference() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -5536,6 +5585,44 @@ private final class FakeLocalNotificationCenter: LocalNotificationCenter {
 
     func simulateResponse(_ userInfo: [String: String]) {
         responseHandler?(userInfo)
+    }
+}
+
+/// A notification center whose `authorizationStatus()` can be suspended on demand, used to hold a
+/// settings load at its `await refreshNotificationAuthorizationStatus()` point so a test can mutate
+/// state (e.g. clear the active account) before the load resumes. Issue #4 regression support.
+@MainActor
+private final class GatedLocalNotificationCenter: LocalNotificationCenter {
+    /// When false, `authorizationStatus()` returns immediately (e.g. during `bootstrap()`); when
+    /// true, it suspends on the first call until `releaseGate()` is invoked.
+    var gateEnabled = false
+    private(set) var didReachGate = false
+    private var gateContinuation: CheckedContinuation<Void, Never>?
+    private var responseHandler: (@MainActor ([String: String]) -> Void)?
+
+    func authorizationStatus() async -> LocalNotificationAuthorizationStatus {
+        if gateEnabled {
+            didReachGate = true
+            await withCheckedContinuation { continuation in
+                gateContinuation = continuation
+            }
+        }
+        return .authorized
+    }
+
+    func releaseGate() {
+        gateContinuation?.resume()
+        gateContinuation = nil
+    }
+
+    func requestAuthorization() async throws -> LocalNotificationAuthorizationStatus {
+        .authorized
+    }
+
+    func post(_ notification: LocalNotificationRequest) async throws {}
+
+    func setResponseHandler(_ handler: @escaping @MainActor ([String: String]) -> Void) {
+        responseHandler = handler
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3545,6 +3545,58 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func concurrentSettingsLoadsForSameAccountCoalesce() async throws {
+        // Issue #4: settings loading is driven from more than one entry point (the settings
+        // view's `.task(id: activeAccountId)` and explicit reloads), so two overlapping
+        // `loadSettingsData()` calls for the same account must coalesce onto a single in-flight
+        // load rather than duplicating the per-account profile / relay fetches.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let baselineProfileCalls = runtime.userProfileCallCount
+        let baselineRelayCalls = runtime.accountRelayListsCallCount
+
+        // Two concurrent loads for the same active account. The first to run installs the
+        // in-flight task before suspending; the second observes it and awaits the same task.
+        async let first: Void = state.loadSettingsData()
+        async let second: Void = state.loadSettingsData()
+        _ = await (first, second)
+
+        // Exactly one additional profile + relay fetch despite two concurrent callers.
+        #expect(runtime.userProfileCallCount == baselineProfileCalls + 1)
+        #expect(runtime.accountRelayListsCallCount == baselineRelayCalls + 1)
+        #expect(state.isLoadingSettings == false)
+    }
+
+    @MainActor
+    @Test func sequentialSettingsLoadsForSameAccountStillReload() async throws {
+        // Coalescing must not turn a later, intentionally-sequential reload into a no-op: once a
+        // load has finished, a fresh `loadSettingsData()` performs a new fetch.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadSettingsData()
+        let afterFirst = runtime.userProfileCallCount
+        await state.loadSettingsData()
+
+        #expect(runtime.userProfileCallCount == afterFirst + 1)
+    }
+
+    @MainActor
     @Test func settingsLoadShowsNotificationPreference() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -4470,6 +4522,11 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var refreshedProfileIds: [String] = []
     private(set) var markedReadMessageIds: [String] = []
     private(set) var accountKeyPackagesCallCount = 0
+    /// Number of times `userProfile` was queried — used to assert settings-load coalescing
+    /// (issue #4 regression): overlapping `loadSettingsData()` calls for the same account must
+    /// not duplicate the per-account profile fetch.
+    private(set) var userProfileCallCount = 0
+    private(set) var accountRelayListsCallCount = 0
     /// Per-group call count for `groupDetails`, used to assert chat-list enrichment runs
     /// through the incremental per-row path (issue #40 regression).
     private(set) var groupDetailsCallCounts: [String: Int] = [:]
@@ -4548,6 +4605,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func userProfile(accountIdHex: String) throws -> UserProfileMetadataFfi? {
+        userProfileCallCount += 1
         guard !accountIdsMissingProfiles.contains(accountIdHex) else { return nil }
         return profilesByAccountId[accountIdHex] ?? profile
     }
@@ -4712,7 +4770,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func accountRelayLists(accountRef: String) throws -> AccountRelayListsFfi {
-        relayLists
+        accountRelayListsCallCount += 1
+        return relayLists
     }
 
     func accountKeyPackages(accountRef: String, bootstrapRelays: [String]) async throws -> [AccountKeyPackageFfi] {


### PR DESCRIPTION
## Summary

Fixes #4 — duplicate Marmot loads when opening settings / key packages.

When this issue was filed it cited three overlapping load paths. Two of them have since been removed by intervening refactors (PRs #70, #84):

- `showSettings` / `selectAccountFromSettings` **no longer** eagerly start `Task { await loadSettingsData() }` — they only reload chats. The settings view's `.task(id: activeAccountId)` is now the single owner of settings loading.
- `loadSettingsData()` **no longer** calls `loadKeyPackages()`; key packages are loaded only from the Key Packages page's `.task`. The existing `settingsLoadDoesNotFetchKeyPackages` test guards this.

What remained unaddressed is the issue's third ask: **request coalescing / cancellation**. `loadSettingsData()` had no guard, so it could still run twice concurrently for the same account — e.g. the settings view `.task` firing while `removeAccount` (which changes `activeAccountId` *and* calls `loadSettingsData()` directly) reloads — duplicating the profile, relay, notification, and privacy/security fetches, and letting a slower older load clobber fresher UI state after an account switch.

## Fix

`loadSettingsData()` now enforces a single owner per account:

- The in-flight load is tracked as a `Task` keyed by account id.
- A concurrent call for the **same** account awaits the existing task (coalesces) instead of starting a duplicate.
- A call for a **different** account cancels the now-stale load; the stale task abandons its writes once it observes `activeAccountId` no longer matches, so it cannot overwrite the newer account's state.
- The loading-spinner flag is only cleared by the still-current owner, so a superseded stale load can't prematurely dismiss the spinner.

## Tests

- `concurrentSettingsLoadsForSameAccountCoalesce` — two overlapping loads ⇒ exactly one profile + relay fetch.
- `sequentialSettingsLoadsForSameAccountStillReload` — coalescing doesn't turn a later, intentional reload into a no-op.

## Notes

- macOS-only Xcode project; no Swift toolchain on the build host, so tests are validated by inspection here and run on macOS / via review CI.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->