### PR TITLE
fix: debounce and cancel new-chat recipient lookups (#2)

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -903,8 +903,14 @@ private struct NewChatColumnView: View {
                             .onSubmit {
                                 Task { await workspace.resolveNewChatQuery() }
                             }
-                            .onChange(of: workspace.newChatQuery) { _, _ in
-                                Task { await workspace.resolveNewChatQueryIfReady() }
+                            .task(id: workspace.newChatQuery) {
+                                // Debounce keystrokes and let `.task(id:)` cancel the
+                                // pending lookup when the query changes again, so a
+                                // flurry of edits no longer spawns overlapping,
+                                // untracked tasks that race to write composer state.
+                                try? await Task.sleep(nanoseconds: 250_000_000)
+                                guard !Task.isCancelled else { return }
+                                await workspace.resolveNewChatQueryIfReady()
                             }
                             .padding(.horizontal, 10)
                             .padding(.vertical, 9)


### PR DESCRIPTION
## Summary

Closes #2.

The new-chat public-key field started an **untracked `Task` on every `newChatQuery` change** with no debounce, id, or cancellation, so rapid typing/pasting could leave overlapping lookups racing to write composer state.

## What was already fixed

The model-side state-overwrite race the issue describes (evidence bullets 2–4) was **already resolved in master** by commit `0fcd0ea` ("Guard new chat lookups against stale completions", Jun 8):

- `WorkspaceState.resolveNewChatQuery()` now takes a `newChatLookupGeneration` token and guards `newChatRecipient`, `lastError`, and `isResolvingNewChat` with `isCurrentNewChatLookup(generation:query:)` before every mutation.
- A regression test `staleNewChatRecipientLookupDoesNotReplaceCurrentResult` exercises overlapping slow/fast lookups.

So a stale completion can no longer overwrite newer result/error/loading state.

## What this PR fixes

The one remaining gap — evidence bullet 1, the issue's own suggested fix:

- `whitenoise-mac/Views/MessengerShellView.swift`: replace the per-keystroke `.onChange { Task { … } }` with `.task(id: workspace.newChatQuery)`. SwiftUI cancels and restarts that task whenever the query changes, so we no longer fan out into untracked overlapping tasks.
- Add a 250ms debounce + explicit `Task.isCancelled` guard so a flurry of edits collapses into a single lookup.
- The Enter (`.onSubmit`) path still resolves immediately.

## Test plan

- macOS Xcode project; no local `xcodebuild`/CI on the build host. Change is a surgical SwiftUI view-modifier swap; verified by source inspection.
- Existing model-level guard test (`staleNewChatRecipientLookupDoesNotReplaceCurrentResult`) continues to cover the completion-ordering invariant.

## Sensitive paths

None touched. (Changed file is a SwiftUI view; no MarmotKit/crypto/auth/entitlements.)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->