### PR TITLE
fix: remove PII from audit log upload source

### DIFF
--- a/whitenoise-mac/Core/TelemetryBuildConfig.swift
+++ b/whitenoise-mac/Core/TelemetryBuildConfig.swift
@@ -101,13 +101,13 @@ struct TelemetryBuildConfig: Equatable {
         )
     }
 
-    func auditTrackerConfig(accountLabel: String?) -> AuditLogTrackerConfigFfi {
+    func auditTrackerConfig(deviceLabel: String?) -> AuditLogTrackerConfigFfi {
         AuditLogTrackerConfigFfi(
             endpoint: nil,
             authorizationBearerToken: auditLogBearerToken,
             source: AuditLogUploadSourceFfi(
-                accountLabel: accountLabel,
-                deviceLabel: deviceModelIdentifier,
+                accountLabel: nil,
+                deviceLabel: deviceLabel.flatMap(Self.resolvedStringValue),
                 platform: "macOS",
                 appVersion: serviceVersion
             )

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -279,6 +279,7 @@ final class WorkspaceState {
     private let conversationWindowVisibilityProvider: @MainActor () -> Bool
     private let copyTextHandler: @MainActor (String) -> Void
     private let telemetryBuildConfigProvider: @MainActor () -> TelemetryBuildConfig
+    private let auditLogUploadDeviceLabelProvider: @MainActor () -> String
     private let groupImageSearchClient: any GroupImageSearchClient
     private var client: (any MarmotRuntime)?
     private var notificationTask: Task<Void, Never>?
@@ -339,6 +340,7 @@ final class WorkspaceState {
     private static let appearancePreferenceKey = "whitenoise.mac.appearancePreference"
     private static let notificationPreviewModeKey = "whitenoise.mac.notificationPreviewMode"
     private static let loadRemoteImagesKey = "whitenoise.mac.loadRemoteImages"
+    private static let auditLogUploadDeviceLabelKey = "whitenoise.mac.auditLogUploadDeviceLabel"
     private static let deliveredNotificationKeyLimit = 256
     private static let timelinePageLimit: UInt32 = 100
 
@@ -384,6 +386,7 @@ final class WorkspaceState {
         },
         copyTextHandler: @escaping @MainActor (String) -> Void = WorkspaceState.copyToGeneralPasteboard,
         telemetryBuildConfigProvider: @escaping @MainActor () -> TelemetryBuildConfig = { TelemetryBuildConfig.current() },
+        auditLogUploadDeviceLabelProvider: @escaping @MainActor () -> String = { WorkspaceState.auditLogUploadDeviceLabel() },
         groupImageSearchClient: (any GroupImageSearchClient)? = nil,
         clientFactory: @escaping @MainActor () throws -> any MarmotRuntime = { try MarmotClient() }
     ) {
@@ -399,6 +402,7 @@ final class WorkspaceState {
         self.conversationWindowVisibilityProvider = conversationWindowVisibilityProvider
         self.copyTextHandler = copyTextHandler
         self.telemetryBuildConfigProvider = telemetryBuildConfigProvider
+        self.auditLogUploadDeviceLabelProvider = auditLogUploadDeviceLabelProvider
         self.groupImageSearchClient = groupImageSearchClient ?? OpenverseGroupImageSearchClient()
         self.clientFactory = clientFactory
         self.developerMode = UserDefaults.standard.bool(forKey: Self.developerModeKey)
@@ -2119,6 +2123,17 @@ final class WorkspaceState {
         NSPasteboard.general.setString(text, forType: .string)
     }
 
+    private static func auditLogUploadDeviceLabel(defaults: UserDefaults = .standard) -> String {
+        if let stored = defaults.string(forKey: Self.auditLogUploadDeviceLabelKey)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !stored.isEmpty {
+            return stored
+        }
+
+        let generated = UUID().uuidString.lowercased()
+        defaults.set(generated, forKey: Self.auditLogUploadDeviceLabelKey)
+        return generated
+    }
+
     private var telemetryBuildConfig: TelemetryBuildConfig {
         telemetryBuildConfigProvider()
     }
@@ -2153,7 +2168,7 @@ final class WorkspaceState {
             config: config.runtimeConfig(installId: try client.telemetryInstallId())
         )
         _ = try client.setAuditLogTrackerConfig(
-            config: config.auditTrackerConfig(accountLabel: activeAccount?.displayName)
+            config: config.auditTrackerConfig(deviceLabel: auditLogUploadDeviceLabelProvider())
         )
         privacySecuritySettings.telemetryCredentialsAvailable = config.telemetryCredentialsAvailable
         privacySecuritySettings.auditLogCredentialsAvailable = config.auditLogCredentialsAvailable

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2787,6 +2787,10 @@ private struct PrivacySecuritySettingsView: View {
                 }
                 .disabled(workspace.isSavingPrivacySecurity)
 
+                Text("Audit log upload metadata includes only the platform (macOS), app version, and an opaque audit-log device ID. It does not include your Mac name or account display name.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 if workspace.isSavingPrivacySecurity {
                     HStack(spacing: 10) {
                         ProgressView()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3702,10 +3702,10 @@ struct whitenoise_macTests {
         #expect(runtimeConfig.resource?.osVersion == "Version 26.0")
         #expect(runtimeConfig.resource?.deviceModelIdentifier == "Mac15,3")
 
-        let auditConfig = config.auditTrackerConfig(accountLabel: "Desktop Account")
+        let auditConfig = config.auditTrackerConfig(deviceLabel: "audit-device-id")
         #expect(auditConfig.authorizationBearerToken == "audit-token")
-        #expect(auditConfig.source.accountLabel == "Desktop Account")
-        #expect(auditConfig.source.deviceLabel == "Mac15,3")
+        #expect(auditConfig.source.accountLabel == nil)
+        #expect(auditConfig.source.deviceLabel == "audit-device-id")
         #expect(auditConfig.source.platform == "macOS")
         #expect(auditConfig.source.appVersion == "2026.6+12")
     }
@@ -3769,6 +3769,7 @@ struct whitenoise_macTests {
                     environment: "production"
                 )
             },
+            auditLogUploadDeviceLabelProvider: { "audit-device-id" },
             clientFactory: { runtime }
         )
 
@@ -3790,7 +3791,8 @@ struct whitenoise_macTests {
         #expect(telemetryResource?.osVersion == ProcessInfo.processInfo.operatingSystemVersionString)
         #expect(telemetryResource?.deviceModelIdentifier == expectedDeviceModelIdentifier())
         #expect(runtime.auditLogTrackerConfig?.authorizationBearerToken == "audit-token")
-        #expect(runtime.auditLogTrackerConfig?.source.accountLabel == "Desktop Account")
+        #expect(runtime.auditLogTrackerConfig?.source.accountLabel == nil)
+        #expect(runtime.auditLogTrackerConfig?.source.deviceLabel == "audit-device-id")
 
         await state.setRelayTelemetryEnabled(false)
         await state.setAuditLoggingEnabled(true)


### PR DESCRIPTION
## Summary
- stop sending the account display name in audit-log upload source metadata
- replace the audit-log device label with a locally stable opaque ID instead of a Mac/device name
- disclose the audit-log upload metadata in Privacy and Security settings

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS'` (blocked locally: `xcodebuild: command not found` on this Linux worker)

Closes #15


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->