### PR TITLE
fix: restart ended subscription listeners

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -313,8 +313,9 @@ final class WorkspaceState {
     /// The live timeline subscription for the open conversation. It owns the
     /// authoritative, bounded, materialized window; scroll-back/forward pagination and
     /// live updates all flow through it (`paginateBackwards` / `paginateForwards` / `next`).
-    /// Kept alive for pagination independent of the listener task (which may finish if the
-    /// live stream ends), and cleared only when the conversation is torn down.
+    /// Kept alive for pagination independent of the listener task. The listener replaces
+    /// it after a recoverable stream end/reconnect, and it is cleared only when the
+    /// conversation is torn down.
     private var activeTimelineSubscription: TimelineMessagesSubscription?
     private var activeTimelineGroupId: String?
     private var messageLookupByChat: [String: [String: MessageItem]] = [:]
@@ -341,6 +342,21 @@ final class WorkspaceState {
     private static let loadRemoteImagesKey = "whitenoise.mac.loadRemoteImages"
     private static let deliveredNotificationKeyLimit = 256
     private static let timelinePageLimit: UInt32 = 100
+    /// Reconnect immediately once when a subscription stream ends, then use a capped
+    /// backoff if a broken stream keeps ending during startup. This avoids silent
+    /// listener death without tight-looping on an already-closed runtime channel.
+    private static let listenerReconnectDelaysNanoseconds: [UInt64] = [
+        0,
+        1_000_000_000,
+        2_000_000_000,
+        5_000_000_000,
+        10_000_000_000,
+    ]
+
+    private static func listenerReconnectDelayNanoseconds(forAttempt attempt: Int) -> UInt64 {
+        let index = min(max(attempt, 0), listenerReconnectDelaysNanoseconds.count - 1)
+        return listenerReconnectDelaysNanoseconds[index]
+    }
 
     /// Dedicated queue for blocking MarmotRuntime FFI calls. The Rust core runs
     /// synchronously (DB reads, MLS decryption); WorkspaceState is `@MainActor`, so
@@ -2146,6 +2162,15 @@ final class WorkspaceState {
         backgroundStatus = nil
     }
 
+    private func waitBeforeListenerReconnect(attempt: Int) async throws {
+        let delay = Self.listenerReconnectDelayNanoseconds(forAttempt: attempt)
+        guard delay > 0 else {
+            await Task.yield()
+            return
+        }
+        try await Task.sleep(nanoseconds: delay)
+    }
+
     private func configureObservabilityRuntime() async throws {
         guard let client else { return }
         let config = telemetryBuildConfig
@@ -2338,20 +2363,36 @@ final class WorkspaceState {
 
     private func runNotificationListener() async {
         guard let client else { return }
+        var reconnectAttempt = 0
 
-        do {
-            let subscription = try await client.subscribeNotifications()
-            while !Task.isCancelled {
-                guard let update = await subscription.next() else { break }
-                await handleNotificationUpdate(update)
+        while !Task.isCancelled {
+            do {
+                let subscription = try await client.subscribeNotifications()
+                while !Task.isCancelled {
+                    guard let update = await subscription.next() else { break }
+                    reconnectAttempt = 0
+                    await handleNotificationUpdate(update)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                setBackgroundStatus(error.localizedDescription)
             }
-        } catch is CancellationError {
-            return
-        } catch {
-            setBackgroundStatus(error.localizedDescription)
+
+            guard !Task.isCancelled else { break }
+            do {
+                try await waitBeforeListenerReconnect(attempt: reconnectAttempt)
+            } catch is CancellationError {
+                return
+            } catch {
+                setBackgroundStatus(error.localizedDescription)
+            }
+            reconnectAttempt += 1
         }
 
-        notificationTask = nil
+        if !Task.isCancelled {
+            notificationTask = nil
+        }
     }
 
     private func startChatListListener(
@@ -2384,30 +2425,49 @@ final class WorkspaceState {
         existingSubscription: ChatListSubscription? = nil
     ) async {
         guard let client else { return }
+        var reconnectAttempt = 0
+        var pendingSubscription = existingSubscription
 
-        do {
-            let subscription: ChatListSubscription
-            if let existingSubscription {
-                subscription = existingSubscription
-            } else {
-                subscription = try await client.subscribeChatList(
-                    accountRef: account.accountRef,
-                    includeArchived: false
-                )
-                await applyChatRows(subscription.snapshot(), account: account)
+        while !Task.isCancelled, activeAccountId == account.id {
+            do {
+                let subscription: ChatListSubscription
+                if let existing = pendingSubscription {
+                    subscription = existing
+                    pendingSubscription = nil
+                } else {
+                    subscription = try await client.subscribeChatList(
+                        accountRef: account.accountRef,
+                        includeArchived: false
+                    )
+                    guard activeAccountId == account.id, !Task.isCancelled else { break }
+                    await applyChatRows(subscription.snapshot(), account: account)
+                }
+
+                while !Task.isCancelled, activeAccountId == account.id {
+                    guard let update = await subscription.nextUpdate() else { break }
+                    guard !Task.isCancelled, activeAccountId == account.id else { break }
+                    reconnectAttempt = 0
+                    await applyChatListSubscriptionUpdate(update, account: account)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                if activeAccountId == account.id {
+                    setBackgroundStatus(error.localizedDescription)
+                }
             }
 
-            while !Task.isCancelled {
-                guard let update = await subscription.nextUpdate() else { break }
-                guard !Task.isCancelled else { break }
-                await applyChatListSubscriptionUpdate(update, account: account)
+            guard !Task.isCancelled, activeAccountId == account.id else { break }
+            do {
+                try await waitBeforeListenerReconnect(attempt: reconnectAttempt)
+            } catch is CancellationError {
+                return
+            } catch {
+                if activeAccountId == account.id {
+                    setBackgroundStatus(error.localizedDescription)
+                }
             }
-        } catch is CancellationError {
-            return
-        } catch {
-            if activeAccountId == account.id {
-                setBackgroundStatus(error.localizedDescription)
-            }
+            reconnectAttempt += 1
         }
 
         if chatListTaskAccountId == account.id && !Task.isCancelled {
@@ -2448,37 +2508,79 @@ final class WorkspaceState {
         existingSubscription: TimelineMessagesSubscription? = nil
     ) async {
         guard let client else { return }
+        var reconnectAttempt = 0
+        var pendingSubscription = existingSubscription
 
-        do {
-            let subscription: TimelineMessagesSubscription
-            if let existingSubscription {
-                subscription = existingSubscription
-            } else {
-                subscription = try await client.subscribeTimelineMessages(
-                    accountRef: account.accountRef,
-                    groupIdHex: groupIdHex,
-                    limit: Self.timelinePageLimit
-                )
+        while !Task.isCancelled,
+              activeAccountId == account.id,
+              selectedChat?.id == groupIdHex {
+            do {
+                let subscription: TimelineMessagesSubscription
+                if let existing = pendingSubscription {
+                    subscription = existing
+                    pendingSubscription = nil
+                } else {
+                    subscription = try await client.subscribeTimelineMessages(
+                        accountRef: account.accountRef,
+                        groupIdHex: groupIdHex,
+                        limit: Self.timelinePageLimit
+                    )
+                    guard activeAccountId == account.id,
+                          selectedChat?.id == groupIdHex,
+                          !Task.isCancelled
+                    else { break }
+                    activeTimelineSubscription = subscription
+                    activeTimelineGroupId = groupIdHex
+                    if let page = subscription.snapshot() {
+                        await applyTimelineWindow(
+                            page,
+                            groupIdHex: groupIdHex,
+                            account: account,
+                            client: client
+                        )
+                    }
+                }
+                // `next()` blocks for the next live change and returns the resulting
+                // authoritative window (ordering, dedup, head-anchoring while scrolled back,
+                // and the cap are all owned by the runtime), so we render it directly.
+                while !Task.isCancelled,
+                      activeAccountId == account.id,
+                      selectedChat?.id == groupIdHex {
+                    guard let page = await subscription.next() else { break }
+                    guard !Task.isCancelled,
+                          activeAccountId == account.id,
+                          selectedChat?.id == groupIdHex
+                    else { break }
+                    reconnectAttempt = 0
+                    await applyTimelineWindow(
+                        page,
+                        groupIdHex: groupIdHex,
+                        account: account,
+                        client: client
+                    )
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                if activeAccountId == account.id, selectedChat?.id == groupIdHex {
+                    setBackgroundStatus(error.localizedDescription)
+                }
             }
-            // `next()` blocks for the next live change and returns the resulting
-            // authoritative window (ordering, dedup, head-anchoring while scrolled back,
-            // and the cap are all owned by the runtime), so we render it directly.
-            while !Task.isCancelled {
-                guard let page = await subscription.next() else { break }
-                guard !Task.isCancelled else { break }
-                await applyTimelineWindow(
-                    page,
-                    groupIdHex: groupIdHex,
-                    account: account,
-                    client: client
-                )
+
+            guard !Task.isCancelled,
+                  activeAccountId == account.id,
+                  selectedChat?.id == groupIdHex
+            else { break }
+            do {
+                try await waitBeforeListenerReconnect(attempt: reconnectAttempt)
+            } catch is CancellationError {
+                return
+            } catch {
+                if activeAccountId == account.id, selectedChat?.id == groupIdHex {
+                    setBackgroundStatus(error.localizedDescription)
+                }
             }
-        } catch is CancellationError {
-            return
-        } catch {
-            if activeAccountId == account.id, selectedChat?.id == groupIdHex {
-                setBackgroundStatus(error.localizedDescription)
-            }
+            reconnectAttempt += 1
         }
 
         if timelineTaskGroupId == groupIdHex && !Task.isCancelled {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -2390,9 +2390,6 @@ final class WorkspaceState {
             reconnectAttempt += 1
         }
 
-        if !Task.isCancelled {
-            notificationTask = nil
-        }
     }
 
     private func startChatListListener(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3864,6 +3864,105 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func notificationListenerRestartsWhenStreamEnds() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationStreamEndsImmediately = true
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didRestart = await waitFor {
+            runtime.notificationSubscriptionCount >= 2
+        }
+
+        #expect(didRestart)
+    }
+
+    @MainActor
+    @Test func chatListListenerRestartsWhenUpdateStreamEnds() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.chatListStreamEndsAfterUpdates = true
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didRestart = await waitFor {
+            runtime.chatListSubscriptionCount >= 2
+        }
+
+        #expect(didRestart)
+    }
+
+    @MainActor
+    @Test func timelineListenerRestartsWhenLiveStreamEndsForSelectedChat() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages([
+            appMessage(
+                id: "initial",
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Initial message",
+                kind: 9,
+                recordedAt: 1_700_000_000
+            )
+        ], groupIdHex: "direct-group")
+        runtime.timelineStreamEndsAfterUpdates = true
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didRestart = await waitFor {
+            runtime.timelineSubscriptionCount >= 2
+        }
+
+        #expect(didRestart)
+    }
+
+    @MainActor
     @Test func notificationDeliveryFailureRoutesToBackgroundStatusNotLastError() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -4688,8 +4787,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// through the incremental per-row path (issue #40 regression).
     private(set) var groupDetailsCallCounts: [String: Int] = [:]
     private(set) var chatListSubscriptionCount = 0
+    private(set) var notificationSubscriptionCount = 0
     private(set) var timelineSubscriptionCount = 0
     private(set) var lastTimelineSubscription: FakeTimelineMessagesSubscription?
+    var chatListStreamEndsAfterUpdates = false
+    var notificationStreamEndsImmediately = false
+    var timelineStreamEndsAfterUpdates = false
     private(set) var timelineMessageQueries: [TimelineMessageQueryFfi] = []
     var profileRefreshDelaysByAccountId: [String: UInt64] = [:]
     var accountIdsMissingProfiles = Set<String>()
@@ -5247,7 +5350,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         chatListSubscriptionCount += 1
         return FakeChatListSubscription(
             rows: chatListRows(includeArchived: includeArchived),
-            updates: chatListUpdates
+            updates: chatListUpdates,
+            endsWhenExhausted: chatListStreamEndsAfterUpdates
         )
     }
 
@@ -5314,10 +5418,11 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func subscribeNotifications() async throws -> NotificationsSubscription {
+        notificationSubscriptionCount += 1
         if let subscribeNotificationsError {
             throw subscribeNotificationsError
         }
-        return FakeNotificationsSubscription()
+        return FakeNotificationsSubscription(endsImmediately: notificationStreamEndsImmediately)
     }
 
     func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi) throws -> TimelinePageFfi {
@@ -5352,7 +5457,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
             limit: Int(limit ?? 100),
             windowCap: 200,
             updates: groupIdHex.flatMap { timelineUpdatesByGroupId[$0] } ?? [],
-            updateDelayNanoseconds: timelineUpdateDelayNanoseconds
+            updateDelayNanoseconds: timelineUpdateDelayNanoseconds,
+            endsWhenExhausted: timelineStreamEndsAfterUpdates
         )
         lastTimelineSubscription = subscription
         return subscription
@@ -5458,19 +5564,37 @@ private struct ArchivedGroup: Equatable {
     let archived: Bool
 }
 
+private func awaitSubscriptionCancellation<T>() async -> T? {
+    while !Task.isCancelled {
+        do {
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+        } catch {
+            break
+        }
+    }
+    return nil
+}
+
 private final class FakeChatListSubscription: ChatListSubscription {
     private let rows: [ChatListRowFfi]
     private var updates: [ChatListSubscriptionUpdateFfi]
+    private let endsWhenExhausted: Bool
 
     required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.rows = []
         self.updates = []
+        self.endsWhenExhausted = true
         super.init(unsafeFromRawPointer: pointer)
     }
 
-    init(rows: [ChatListRowFfi], updates: [ChatListSubscriptionUpdateFfi] = []) {
+    init(
+        rows: [ChatListRowFfi],
+        updates: [ChatListSubscriptionUpdateFfi] = [],
+        endsWhenExhausted: Bool = false
+    ) {
         self.rows = rows
         self.updates = updates
+        self.endsWhenExhausted = endsWhenExhausted
         super.init(noPointer: NoPointer())
     }
 
@@ -5479,11 +5603,15 @@ private final class FakeChatListSubscription: ChatListSubscription {
     }
 
     override func next() async -> ChatListRowFfi? {
-        nil
+        if endsWhenExhausted { return nil }
+        return await awaitSubscriptionCancellation()
     }
 
     override func nextUpdate() async -> ChatListSubscriptionUpdateFfi? {
-        guard !updates.isEmpty else { return nil }
+        guard !updates.isEmpty else {
+            if endsWhenExhausted { return nil }
+            return await awaitSubscriptionCancellation()
+        }
         return updates.removeFirst()
     }
 }
@@ -5501,6 +5629,7 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
     private var hi: Int
     private var updates: [TimelineSubscriptionUpdateFfi]
     private let updateDelayNanoseconds: UInt64
+    private let endsWhenExhausted: Bool
     private(set) var paginateBackwardsCount = 0
     private(set) var paginateForwardsCount = 0
 
@@ -5512,6 +5641,7 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
         self.hi = 0
         self.updates = []
         self.updateDelayNanoseconds = 0
+        self.endsWhenExhausted = true
         super.init(unsafeFromRawPointer: pointer)
     }
 
@@ -5520,7 +5650,8 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
         limit: Int,
         windowCap: Int,
         updates: [TimelineSubscriptionUpdateFfi] = [],
-        updateDelayNanoseconds: UInt64 = 0
+        updateDelayNanoseconds: UInt64 = 0,
+        endsWhenExhausted: Bool = false
     ) {
         var page = TimelinePageFfi(messages: messages, hasMoreBefore: false, hasMoreAfter: false)
         page.sortCanonical()
@@ -5531,6 +5662,7 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
         self.lo = max(0, page.messages.count - max(1, limit))
         self.updates = updates
         self.updateDelayNanoseconds = updateDelayNanoseconds
+        self.endsWhenExhausted = endsWhenExhausted
         super.init(noPointer: NoPointer())
     }
 
@@ -5564,7 +5696,10 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
     }
 
     override func next() async -> TimelinePageFfi? {
-        guard !updates.isEmpty else { return nil }
+        guard !updates.isEmpty else {
+            if endsWhenExhausted { return nil }
+            return await awaitSubscriptionCancellation()
+        }
         if updateDelayNanoseconds > 0 {
             try? await Task.sleep(nanoseconds: updateDelayNanoseconds)
         }
@@ -5599,7 +5734,10 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
     }
 
     override func nextUpdate() async -> TimelineSubscriptionUpdateFfi? {
-        guard !updates.isEmpty else { return nil }
+        guard !updates.isEmpty else {
+            if endsWhenExhausted { return nil }
+            return await awaitSubscriptionCancellation()
+        }
         if updateDelayNanoseconds > 0 {
             try? await Task.sleep(nanoseconds: updateDelayNanoseconds)
         }
@@ -5735,16 +5873,21 @@ private final class GatedLocalNotificationCenter: LocalNotificationCenter {
 }
 
 private final class FakeNotificationsSubscription: NotificationsSubscription {
+    private let endsImmediately: Bool
+
     required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.endsImmediately = true
         super.init(unsafeFromRawPointer: pointer)
     }
 
-    init() {
+    init(endsImmediately: Bool = false) {
+        self.endsImmediately = endsImmediately
         super.init(noPointer: NoPointer())
     }
 
     override func next() async -> NotificationUpdateFfi? {
-        nil
+        if endsImmediately { return nil }
+        return await awaitSubscriptionCancellation()
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3881,6 +3881,7 @@ struct whitenoise_macTests {
         }
 
         #expect(didRestart)
+        await state.deleteAllData()
     }
 
     @MainActor
@@ -3915,6 +3916,7 @@ struct whitenoise_macTests {
         }
 
         #expect(didRestart)
+        await state.deleteAllData()
     }
 
     @MainActor
@@ -3960,6 +3962,7 @@ struct whitenoise_macTests {
         }
 
         #expect(didRestart)
+        await state.deleteAllData()
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Add bounded reconnect/backoff loops when notification, chat-list, or timeline subscription streams end unexpectedly.
- Keep reconnects cancellation-safe and gated by the active account / selected chat so stale listeners do not resubscribe after context changes.
- Extend listener fakes and add regression coverage for notification, chat-list, and timeline stream-end restarts.

Closes #13

## Test Plan
- `git diff --check`
- Attempted targeted Xcode test:
  - `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -only-testing:whitenoise-macTests/whitenoise_macTests/notificationListenerRestartsWhenStreamEnds`
  - blocked on this Linux host: `xcodebuild: command not found`

## Notes
- Swift/Xcode tooling is unavailable on this host (`xcodebuild`, `swift`, and `swift-format` missing), so compile/test verification needs to run in CI or on a Mac.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->