### PR TITLE
fix: preserve runtime timeline ordering

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -146,20 +146,21 @@ extension MessageItem {
         activeAccountIdHex: String?,
         senderProfiles: [String: ChatPeerProfile] = [:]
     ) -> [MessageItem] {
-        page.messages
-            .map { record in
-                MessageItem(
-                    record: record,
-                    activeAccountIdHex: activeAccountIdHex,
-                    senderProfiles: senderProfiles,
-                    reactions: MessageReaction.summarize(record.reactions, activeAccountIdHex: activeAccountIdHex),
-                    replyContext: MessageItem.replyContext(
-                        for: record.replyPreview,
-                        senderProfiles: senderProfiles
-                    )
+        // MarmotKit returns an authoritative timeline window. Keep that order
+        // intact: `timelineAt` is second-granular, and re-sorting in the client
+        // can reshuffle records that the runtime/database already tie-broke.
+        return page.messages.map { record in
+            MessageItem(
+                record: record,
+                activeAccountIdHex: activeAccountIdHex,
+                senderProfiles: senderProfiles,
+                reactions: MessageReaction.summarize(record.reactions, activeAccountIdHex: activeAccountIdHex),
+                replyContext: MessageItem.replyContext(
+                    for: record.replyPreview,
+                    senderProfiles: senderProfiles
                 )
-            }
-            .sorted { $0.sentAt < $1.sentAt }
+            )
+        }
     }
 
     fileprivate static func presentation(for kind: UInt64) -> MessagePresentation {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -701,6 +701,52 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func timelineMappingPreservesRuntimeWindowOrder() async throws {
+        // Regression for #7: the runtime page already carries the authoritative
+        // timeline order, including any hidden same-second tie-break from storage.
+        // The client mapper must not re-sort the page by second-granular
+        // `timelineAt`, or subscription refreshes can reshuffle colliding rows.
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "runtime-third",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "storage order 3",
+                    recordedAt: 1_700_000_001
+                ),
+                timelineMessage(
+                    id: "runtime-first",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "storage order 1",
+                    recordedAt: 1_700_000_000
+                ),
+                timelineMessage(
+                    id: "runtime-second",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "storage order 2",
+                    recordedAt: 1_700_000_000
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(
+            from: page,
+            activeAccountIdHex: "self"
+        )
+
+        #expect(messages.map(\.id) == [
+            "runtime-third",
+            "runtime-first",
+            "runtime-second"
+        ])
+    }
+
+    @MainActor
     @Test func chatListPreviewUsesSystemMessageText() async throws {
         let row = chatListRow(
             groupIdHex: "group",


### PR DESCRIPTION
## Summary
- preserve the authoritative MarmotKit timeline window order when mapping records into UI `MessageItem`s
- stop client-side re-sorting by second-granular `timelineAt`, which can reshuffle same-second messages after subscription refreshes
- add a regression test covering runtime-window order preservation

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -only-testing:whitenoise-macTests/whitenoise_macTests/timelineMappingPreservesRuntimeWindowOrder` (not run: `xcodebuild` is unavailable on this Linux worker)

Closes #7


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message timeline ordering to preserve the server's authoritative sequence instead of applying client-side reordering.

* **Tests**
  * Added test coverage for timeline order preservation, including same-timestamp message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->