### PR TITLE
test: cover chat info toolbar action

### DIFF
--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2925,6 +2925,31 @@ struct whitenoise_macTests {
         #expect(!state.isGroupImagePickerPresented)
     }
 
+    @Test func conversationHeaderChatInfoButtonOpensGroupDetailsSheet() throws {
+        // The header is a private SwiftUI view, so this source-shape regression
+        // guards the user-facing toolbar affordance directly: the info button
+        // must remain wired to the group details sheet instead of an empty action.
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let projectRootURL = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let messengerShellURL = projectRootURL
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessengerShellView.swift")
+        let source = try String(contentsOf: messengerShellURL, encoding: .utf8)
+        let headerStart = try #require(source.range(of: "private struct ConversationHeader: View {"))
+        let headerEnd = try #require(source.range(of: "private struct GroupDetailsSheet: View {"))
+        let headerSource = String(source[headerStart.lowerBound..<headerEnd.lowerBound])
+
+        #expect(headerSource.contains("Task { await workspace.showGroupDetails(for: chat) }"))
+        #expect(headerSource.contains("Image(systemName: \"info.circle\")"))
+        #expect(headerSource.contains(".sheet(isPresented: $workspace.isGroupDetailsPresented)"))
+        #expect(headerSource.contains("GroupDetailsSheet(chat: chat)"))
+        #expect(!headerSource.contains("Button {} label: {\n                        Image(systemName: \"info.circle"))
+        #expect(!headerSource.contains("Button {} label: {\n                        Image(systemName: \"info.circle.fill"))
+    }
+
     @MainActor
     @Test func groupDetailsProfileSaveAndInviteUseBindings() async throws {
         let account = desktopAccount()


### PR DESCRIPTION
## Summary
- confirms the conversation header info control is wired to `showGroupDetails(for:)`
- adds source-shape regression coverage for the group details sheet presentation
- guards against reintroducing the empty `Button {}` chat-info affordance from #5

## Test Plan
- `python3` source-shape regression assertions
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS'` skipped: `xcodebuild` is unavailable on this Linux worker

Closes #5


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->