### PR TITLE
fix: mark copied message/transcript/key content as concealed on the pasteboard

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -284,7 +284,7 @@ final class WorkspaceState {
     private let localNotificationCenter: any LocalNotificationCenter
     private let appActivityProvider: @MainActor () -> Bool
     private let conversationWindowVisibilityProvider: @MainActor () -> Bool
-    private let copyTextHandler: @MainActor (String) -> Void
+    private let copyTextHandler: @MainActor (String, Bool) -> Void
     private let telemetryBuildConfigProvider: @MainActor () -> TelemetryBuildConfig
     private let groupImageSearchClient: any GroupImageSearchClient
     /// Injectable clock for peer-profile cache TTL decisions, so tests can drive cache
@@ -453,7 +453,7 @@ final class WorkspaceState {
         conversationWindowVisibilityProvider: @escaping @MainActor () -> Bool = {
             WorkspaceState.defaultConversationWindowVisibilityProvider()
         },
-        copyTextHandler: @escaping @MainActor (String) -> Void = WorkspaceState.copyToGeneralPasteboard,
+        copyTextHandler: @escaping @MainActor (String, Bool) -> Void = WorkspaceState.copyToGeneralPasteboard,
         telemetryBuildConfigProvider: @escaping @MainActor () -> TelemetryBuildConfig = { TelemetryBuildConfig.current() },
         groupImageSearchClient: (any GroupImageSearchClient)? = nil,
         nowProvider: @escaping @MainActor () -> Date = { Date() },
@@ -1566,8 +1566,16 @@ final class WorkspaceState {
         copyText(message.body)
     }
 
-    func copyText(_ text: String) {
-        copyTextHandler(text)
+    /// Copies `text` to the system pasteboard.
+    ///
+    /// Every value copied from this app is private-messenger content — decrypted message
+    /// bodies, full conversation transcripts, and Nostr identity keys — so copies default to
+    /// `concealed`. A concealed copy additionally carries the `org.nspasteboard.ConcealedType`
+    /// marker (see `copyToGeneralPasteboard`), which clipboard-history managers honor to avoid
+    /// persisting the value and which discourages Universal Clipboard (Handoff) from syncing it
+    /// to the user's other devices.
+    func copyText(_ text: String, concealed: Bool = true) {
+        copyTextHandler(text, concealed)
     }
 
     /// The bech32 `npub` form of a hex public key — the canonical, user-facing way to show
@@ -2224,9 +2232,20 @@ final class WorkspaceState {
         phase = .onboarding
     }
 
-    private static func copyToGeneralPasteboard(_ text: String) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
+    /// The community-convention pasteboard type (https://nspasteboard.org) that privacy-aware
+    /// clipboard managers check for to treat an item as transient: they skip persisting it to
+    /// clipboard history, and it also discourages Universal Clipboard / Handoff from broadcasting
+    /// the item to the user's other Apple devices.
+    static let concealedPasteboardType = NSPasteboard.PasteboardType("org.nspasteboard.ConcealedType")
+
+    private static func copyToGeneralPasteboard(_ text: String, concealed: Bool) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        if concealed {
+            // Non-destructive: apps that don't recognise the concealed type still read `.string`.
+            pasteboard.setString(text, forType: Self.concealedPasteboardType)
+        }
     }
 
     private var telemetryBuildConfig: TelemetryBuildConfig {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2578,7 +2578,8 @@ struct whitenoise_macTests {
     @MainActor
     @Test func copyingMessageTextUsesConfiguredClipboardWriter() async throws {
         var copiedText = ""
-        let state = WorkspaceState(copyTextHandler: { copiedText = $0 })
+        var copiedConcealed = false
+        let state = WorkspaceState(copyTextHandler: { copiedText = $0; copiedConcealed = $1 })
 
         state.copyText(of: MessageItem(
             id: "message",
@@ -2589,12 +2590,25 @@ struct whitenoise_macTests {
         ))
 
         #expect(copiedText == "Copy this")
+        // Decrypted message bodies are private content and must be marked concealed so
+        // clipboard managers / Universal Clipboard treat them as transient.
+        #expect(copiedConcealed)
+    }
+
+    @MainActor
+    @Test func copyingTextDefaultsToConcealed() async throws {
+        var copiedConcealed = false
+        let state = WorkspaceState(copyTextHandler: { _, concealed in copiedConcealed = concealed })
+
+        state.copyText("anything-copied-from-this-app")
+
+        #expect(copiedConcealed)
     }
 
     @MainActor
     @Test func deletedAndFailedMessageTextDoesNotCopyPlaceholder() async throws {
         var copiedText = "initial"
-        let state = WorkspaceState(copyTextHandler: { copiedText = $0 })
+        let state = WorkspaceState(copyTextHandler: { text, _ in copiedText = text })
         let sentAt = Date(timeIntervalSince1970: 1_700_000_000)
 
         state.copyText(of: MessageItem(
@@ -2620,7 +2634,7 @@ struct whitenoise_macTests {
     @MainActor
     @Test func copyingPlainSettingsTextUsesConfiguredClipboardWriter() async throws {
         var copiedText = ""
-        let state = WorkspaceState(copyTextHandler: { copiedText = $0 })
+        let state = WorkspaceState(copyTextHandler: { text, _ in copiedText = text })
 
         state.copyText("public-key-value")
 
@@ -3256,7 +3270,7 @@ struct whitenoise_macTests {
 
         var copiedText = ""
         let state = WorkspaceState(
-            copyTextHandler: { copiedText = $0 },
+            copyTextHandler: { text, _ in copiedText = text },
             clientFactory: { runtime }
         )
 


### PR DESCRIPTION
## Summary

Hardens all copy actions so decrypted, end-to-end-encrypted content isn't left unmarked on the system-wide pasteboard. Closes #80.

Every copy in the app routes through `WorkspaceState`'s single pasteboard primitive (`copyToGeneralPasteboard`). It previously wrote only `.string` to `NSPasteboard.general`. It now *also* sets the `org.nspasteboard.ConcealedType` pasteboard type — the [nspasteboard.org](https://nspasteboard.org) community convention.

This covers all the sensitive sinks called out in the issue:
- Decrypted message bodies (`copyText(of:)`)
- Full conversation transcript JSON (`copySelectedGroupTranscriptJSON()`)
- npub / key-package / group diagnostics (`CopyableKeyLabel`, diagnostics rows)

### Effect
- Privacy-aware **clipboard-history managers** honor the concealed type and skip persisting the value.
- It **discourages Universal Clipboard / Handoff** from broadcasting the item to the user's other Apple devices.
- **Non-destructive:** the plain `.string` representation is still written, so apps that don't recognise the concealed type paste normally.

`copyText(_:concealed:)` defaults to `concealed = true` because every value copied from this app is private-messenger content; no call sites needed to opt in individually.

## Test plan
- [x] Updated `copyTextHandler` test closures to the new `(String, Bool)` signature.
- [x] `copyingMessageTextUsesConfiguredClipboardWriter` now also asserts the copy is concealed.
- [x] Added `copyingTextDefaultsToConcealed`.
- [ ] CI (macOS build + `swift test`) — no local Swift toolchain on the fixer host (Linux); relying on CI.

## Notes
- Severity is LOW (all copies are user-initiated; this is hardening, not an exploitable defect).
- The fix's sole new pasteboard write is the concealed marker; no entitlements, crypto, MLS, or key-handling code is touched.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/100">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->