### PR TITLE
fix(images): read remote image bytes in chunks instead of one byte at a time (#98)

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -113,74 +113,31 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         return loaded
     }
 
-    /// Streams the response, rejecting non-success HTTP status codes and aborting once the
-    /// body exceeds `RemoteImageURLPolicy.maxResponseBytes` so a malicious server cannot feed
-    /// us an unbounded image.
+    /// Downloads the response in the `Data` chunks `URLSession` delivers natively, rejecting
+    /// non-success HTTP status codes and aborting once the body exceeds
+    /// `RemoteImageURLPolicy.maxResponseBytes` so a malicious server cannot feed us an
+    /// unbounded image.
+    ///
+    /// We deliberately avoid `URLSession.AsyncBytes` (whose `Element` is a single `UInt8`, so
+    /// iterating it costs one async-sequence step per byte — 10^5–10^6 steps for a normal
+    /// avatar) and also avoid the fully-buffered `data(from:)` (which would have to hold an
+    /// entire malicious response in memory before we could check its length). Instead a
+    /// `URLSessionDataDelegate` collects the OS-sized chunks as they arrive, so a download is
+    /// O(number-of-chunks) while the incremental cap keeps peak memory bounded to roughly
+    /// `cap` plus one chunk before an oversized/length-less response is cancelled.
     private static func download(_ url: URL, using session: URLSession) async -> Data? {
         let cap = RemoteImageURLPolicy.maxResponseBytes
-        do {
-            let (bytes, response) = try await session.bytes(from: url)
-            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-                return nil
-            }
-            // Honour an advertised oversized Content-Length up front when present.
-            if response.expectedContentLength > 0, response.expectedContentLength > cap {
-                return nil
-            }
-            let reserve = response.expectedContentLength > 0
-                ? Int(min(response.expectedContentLength, cap))
-                : nil
-            return try await accumulate(bytes, cap: cap, reservingCapacity: reserve)
-        } catch {
-            return nil
-        }
-    }
-
-    /// Size of the temporary read buffer used to batch bytes out of `URLSession.AsyncBytes`
-    /// before flushing them to the result `Data`.
-    static let downloadChunkSize = 64 * 1024
-
-    /// Accumulates an async byte sequence into `Data` in fixed-size chunks, returning `nil`
-    /// once the running total exceeds `cap`.
-    ///
-    /// `URLSession.AsyncBytes` vends a single `UInt8` per iteration. Appending each byte to a
-    /// `Data` buffer individually turns even a modest avatar download into hundreds of
-    /// thousands of `Data.append(_:)` calls (and millions at the 8 MiB cap), which is the
-    /// pathology this loader had. We instead buffer bytes into a reusable array and flush
-    /// whole slices to `Data`, while still bounding total memory incrementally so the
-    /// unbounded-response protection is preserved (a chunk-granular check rather than a
-    /// per-byte one; at most `chunkSize - 1` bytes can be read past `cap` before we bail).
-    ///
-    /// Exposed as `internal static` (not `private`) so the cap-enforcement logic is unit
-    /// testable against a synthetic byte sequence without issuing a network request.
-    static func accumulate<S: AsyncSequence>(
-        _ bytes: S,
-        cap: Int64,
-        reservingCapacity reserve: Int? = nil,
-        chunkSize: Int = RemoteImageLoader.downloadChunkSize
-    ) async throws -> Data? where S.Element == UInt8 {
-        var data = Data()
-        if let reserve { data.reserveCapacity(reserve) }
-
-        var chunk = [UInt8]()
-        chunk.reserveCapacity(chunkSize)
-        var total: Int64 = 0
-
-        for try await byte in bytes {
-            chunk.append(byte)
-            if chunk.count >= chunkSize {
-                total += Int64(chunk.count)
-                if total > cap { return nil }
-                data.append(contentsOf: chunk)
-                chunk.removeAll(keepingCapacity: true)
-            }
-        }
-        if !chunk.isEmpty {
-            total += Int64(chunk.count)
-            if total > cap { return nil }
-            data.append(contentsOf: chunk)
-        }
-        return data
+        let delegate = CappedImageDownloadDelegate(cap: cap)
+        // A dedicated delegate-backed session keeps per-download collector state isolated
+        // (multiple avatars can download concurrently). It reuses the shared session's
+        // configuration, so the same `URLCache` instance still services these requests.
+        let downloadSession = URLSession(
+            configuration: session.configuration,
+            delegate: delegate,
+            delegateQueue: nil
+        )
+        defer { downloadSession.finishTasksAndInvalidate() }
+        return await delegate.download(url, using: downloadSession)
     }
 
     private static func downsample(data: Data, maxPixelSize: CGFloat) -> NSImage? {
@@ -194,5 +151,130 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         ] as CFDictionary
         guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options) else { return nil }
         return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+    }
+}
+
+/// Pure, synchronously-testable accumulator for a capped chunked download. Collects the
+/// `Data` chunks `URLSession` delivers and reports when the running total exceeds `cap`, so
+/// the cap-enforcement logic can be unit tested without issuing a network request.
+///
+/// This is the chunk-granular replacement for the old per-byte loop: appends operate on
+/// whole `Data` chunks (one per `URLSession` delivery) rather than individual `UInt8`s.
+struct CappedDataCollector {
+    let cap: Int64
+    private(set) var data = Data()
+    private(set) var total: Int64 = 0
+    private(set) var exceededCap = false
+
+    init(cap: Int64, reservingCapacity reserve: Int? = nil) {
+        self.cap = cap
+        if let reserve { data.reserveCapacity(reserve) }
+    }
+
+    /// Reserves capacity for the result buffer (e.g. from an advertised `Content-Length`).
+    mutating func reserve(_ minimumCapacity: Int) {
+        data.reserveCapacity(minimumCapacity)
+    }
+
+    /// Appends a chunk, returning `false` once the running total exceeds `cap` (the caller
+    /// should then abort the download). The over-cap chunk is not retained, and once the cap
+    /// has been exceeded all further appends are rejected.
+    @discardableResult
+    mutating func append(_ chunk: Data) -> Bool {
+        if exceededCap { return false }
+        total += Int64(chunk.count)
+        if total > cap {
+            exceededCap = true
+            return false
+        }
+        data.append(chunk)
+        return true
+    }
+}
+
+/// `URLSessionDataDelegate` that downloads a single image body in the chunks `URLSession`
+/// delivers natively, enforcing an HTTP status check, an up-front `Content-Length` check,
+/// and an incremental byte cap. Bridges the delegate callbacks to a single `async` result.
+///
+/// Using the delegate's `didReceive data:` (which hands us OS-sized `Data` chunks) instead
+/// of `URLSession.AsyncBytes` is what removes the per-byte iteration: a download now costs
+/// O(number-of-chunks), not O(number-of-bytes), while the incremental cap still aborts an
+/// oversized or `Content-Length`-less response before it can exhaust memory.
+private final class CappedImageDownloadDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let cap: Int64
+    private let lock = NSLock()
+    private var collector: CappedDataCollector
+    private var continuation: CheckedContinuation<Data?, Never>?
+    private var finished = false
+
+    init(cap: Int64) {
+        self.cap = cap
+        self.collector = CappedDataCollector(cap: cap)
+    }
+
+    func download(_ url: URL, using session: URLSession) async -> Data? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Data?, Never>) in
+            lock.lock()
+            self.continuation = continuation
+            lock.unlock()
+            session.dataTask(with: url).resume()
+        }
+    }
+
+    /// Resumes the awaiting continuation exactly once; later calls are ignored. (A cap abort
+    /// resumes with `nil`, then the resulting cancellation error's `didComplete` is a no-op.)
+    private func finish(with result: Data?) {
+        lock.lock()
+        guard !finished, let continuation else { lock.unlock(); return }
+        finished = true
+        self.continuation = nil
+        lock.unlock()
+        continuation.resume(returning: result)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            completionHandler(.cancel)
+            finish(with: nil)
+            return
+        }
+        // Honour an advertised oversized Content-Length up front when present.
+        if response.expectedContentLength > 0, response.expectedContentLength > cap {
+            completionHandler(.cancel)
+            finish(with: nil)
+            return
+        }
+        if response.expectedContentLength > 0 {
+            lock.lock()
+            collector.reserve(Int(min(response.expectedContentLength, cap)))
+            lock.unlock()
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        lock.lock()
+        let ok = collector.append(data)
+        lock.unlock()
+        if !ok {
+            dataTask.cancel()
+            finish(with: nil)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if error != nil {
+            finish(with: nil)
+            return
+        }
+        lock.lock()
+        let result: Data? = collector.exceededCap ? nil : collector.data
+        lock.unlock()
+        finish(with: result)
     }
 }

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -127,18 +127,60 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
             if response.expectedContentLength > 0, response.expectedContentLength > cap {
                 return nil
             }
-            var data = Data()
-            if response.expectedContentLength > 0 {
-                data.reserveCapacity(Int(min(response.expectedContentLength, cap)))
-            }
-            for try await byte in bytes {
-                data.append(byte)
-                if Int64(data.count) > cap { return nil }
-            }
-            return data
+            let reserve = response.expectedContentLength > 0
+                ? Int(min(response.expectedContentLength, cap))
+                : nil
+            return try await accumulate(bytes, cap: cap, reservingCapacity: reserve)
         } catch {
             return nil
         }
+    }
+
+    /// Size of the temporary read buffer used to batch bytes out of `URLSession.AsyncBytes`
+    /// before flushing them to the result `Data`.
+    static let downloadChunkSize = 64 * 1024
+
+    /// Accumulates an async byte sequence into `Data` in fixed-size chunks, returning `nil`
+    /// once the running total exceeds `cap`.
+    ///
+    /// `URLSession.AsyncBytes` vends a single `UInt8` per iteration. Appending each byte to a
+    /// `Data` buffer individually turns even a modest avatar download into hundreds of
+    /// thousands of `Data.append(_:)` calls (and millions at the 8 MiB cap), which is the
+    /// pathology this loader had. We instead buffer bytes into a reusable array and flush
+    /// whole slices to `Data`, while still bounding total memory incrementally so the
+    /// unbounded-response protection is preserved (a chunk-granular check rather than a
+    /// per-byte one; at most `chunkSize - 1` bytes can be read past `cap` before we bail).
+    ///
+    /// Exposed as `internal static` (not `private`) so the cap-enforcement logic is unit
+    /// testable against a synthetic byte sequence without issuing a network request.
+    static func accumulate<S: AsyncSequence>(
+        _ bytes: S,
+        cap: Int64,
+        reservingCapacity reserve: Int? = nil,
+        chunkSize: Int = RemoteImageLoader.downloadChunkSize
+    ) async throws -> Data? where S.Element == UInt8 {
+        var data = Data()
+        if let reserve { data.reserveCapacity(reserve) }
+
+        var chunk = [UInt8]()
+        chunk.reserveCapacity(chunkSize)
+        var total: Int64 = 0
+
+        for try await byte in bytes {
+            chunk.append(byte)
+            if chunk.count >= chunkSize {
+                total += Int64(chunk.count)
+                if total > cap { return nil }
+                data.append(contentsOf: chunk)
+                chunk.removeAll(keepingCapacity: true)
+            }
+        }
+        if !chunk.isEmpty {
+            total += Int64(chunk.count)
+            if total > cap { return nil }
+            data.append(contentsOf: chunk)
+        }
+        return data
     }
 
     private static func downsample(data: Data, maxPixelSize: CGFloat) -> NSImage? {

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -205,6 +205,8 @@ private final class CappedImageDownloadDelegate: NSObject, URLSessionDataDelegat
     private let lock = NSLock()
     private var collector: CappedDataCollector
     private var continuation: CheckedContinuation<Data?, Never>?
+    private var task: URLSessionDataTask?
+    private var cancelled = false
     private var finished = false
 
     init(cap: Int64) {
@@ -213,12 +215,40 @@ private final class CappedImageDownloadDelegate: NSObject, URLSessionDataDelegat
     }
 
     func download(_ url: URL, using session: URLSession) async -> Data? {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Data?, Never>) in
-            lock.lock()
-            self.continuation = continuation
-            lock.unlock()
-            session.dataTask(with: url).resume()
+        // Propagate Swift task cancellation to the underlying network request. The
+        // `DownsampledAsyncImage` call site runs this inside a `.task(id:)`, which cancels the
+        // awaiting task whenever the row's URL/size identity changes (scrolling, navigation);
+        // without this the request would keep running and buffering until it completed or timed
+        // out. (The native `URLSession.bytes(from:)` API we replaced did this automatically.)
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Data?, Never>) in
+                lock.lock()
+                if cancelled {
+                    lock.unlock()
+                    continuation.resume(returning: nil)
+                    return
+                }
+                self.continuation = continuation
+                let task = session.dataTask(with: url)
+                self.task = task
+                lock.unlock()
+                task.resume()
+            }
+        } onCancel: {
+            cancel()
         }
+    }
+
+    /// Cancels the in-flight data task (if any) and resolves the awaiting continuation with
+    /// `nil`. Safe to call before the task is created (the `cancelled` flag short-circuits
+    /// `download`) and idempotent (later calls are no-ops once `finished`).
+    private func cancel() {
+        lock.lock()
+        cancelled = true
+        let task = self.task
+        lock.unlock()
+        task?.cancel()
+        finish(with: nil)
     }
 
     /// Resumes the awaiting continuation exactly once; later calls are ignored. (A cap abort
@@ -230,6 +260,26 @@ private final class CappedImageDownloadDelegate: NSObject, URLSessionDataDelegat
         self.continuation = nil
         lock.unlock()
         continuation.resume(returning: result)
+    }
+
+    /// Re-validate redirect targets against the privacy policy. `URLSession` follows redirects
+    /// automatically by default, so without this an allowed `https://` avatar could 3xx-redirect
+    /// to `http://` (or another disallowed scheme/host), defeating the HTTPS-only,
+    /// IP-leak-limiting `RemoteImageURLPolicy` check applied to the original URL.
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let url = request.url, RemoteImageURLPolicy.isAllowed(url) else {
+            completionHandler(nil)
+            task.cancel()
+            finish(with: nil)
+            return
+        }
+        completionHandler(request)
     }
 
     func urlSession(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3548,6 +3548,66 @@ struct whitenoise_macTests {
         #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "https:///nohost")!))
     }
 
+    /// An `AsyncSequence` of `UInt8` that mimics `URLSession.AsyncBytes` (one byte per
+    /// iteration) so the download accumulator's cap enforcement can be tested without a
+    /// network request.
+    private struct ByteStream: AsyncSequence {
+        typealias Element = UInt8
+        let bytes: [UInt8]
+        struct Iterator: AsyncIteratorProtocol {
+            var bytes: [UInt8]
+            var index = 0
+            mutating func next() async -> UInt8? {
+                guard index < bytes.count else { return nil }
+                defer { index += 1 }
+                return bytes[index]
+            }
+        }
+        func makeAsyncIterator() -> Iterator { Iterator(bytes: bytes) }
+    }
+
+    @Test func remoteImageAccumulateReturnsAllBytesUnderCap() async throws {
+        // A payload spanning several chunk boundaries should round-trip byte-for-byte.
+        let payload = (0..<(RemoteImageLoader.downloadChunkSize * 2 + 123))
+            .map { UInt8($0 & 0xFF) }
+        let result = try await RemoteImageLoader.accumulate(
+            ByteStream(bytes: payload),
+            cap: Int64(payload.count) + 1
+        )
+        #expect(result != nil)
+        #expect(result.map(Array.init) == payload)
+    }
+
+    @Test func remoteImageAccumulateAcceptsExactlyCapBytes() async throws {
+        // Exactly `cap` bytes is allowed (the check rejects only when total exceeds cap).
+        let payload = [UInt8](repeating: 0xAB, count: RemoteImageLoader.downloadChunkSize + 7)
+        let result = try await RemoteImageLoader.accumulate(
+            ByteStream(bytes: payload),
+            cap: Int64(payload.count)
+        )
+        #expect(result?.count == payload.count)
+    }
+
+    @Test func remoteImageAccumulateRejectsOverCap() async throws {
+        // One byte past the cap aborts the download (unbounded-response protection).
+        let cap = RemoteImageLoader.downloadChunkSize
+        let payload = [UInt8](repeating: 0x01, count: cap + 1)
+        let result = try await RemoteImageLoader.accumulate(
+            ByteStream(bytes: payload),
+            cap: Int64(cap),
+            chunkSize: cap
+        )
+        #expect(result == nil)
+    }
+
+    @Test func remoteImageAccumulateHandlesEmptyResponse() async throws {
+        let result = try await RemoteImageLoader.accumulate(
+            ByteStream(bytes: []),
+            cap: 1024
+        )
+        #expect(result?.isEmpty == true)
+    }
+
     @Test func remoteImageSanitizedURLRejectsUntrustedInput() async throws {
         // nil / empty / whitespace-only -> nil (no request issued).
         #expect(RemoteImageURLPolicy.sanitizedURL(from: nil) == nil)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3548,64 +3548,48 @@ struct whitenoise_macTests {
         #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "https:///nohost")!))
     }
 
-    /// An `AsyncSequence` of `UInt8` that mimics `URLSession.AsyncBytes` (one byte per
-    /// iteration) so the download accumulator's cap enforcement can be tested without a
-    /// network request.
-    private struct ByteStream: AsyncSequence {
-        typealias Element = UInt8
-        let bytes: [UInt8]
-        struct Iterator: AsyncIteratorProtocol {
-            var bytes: [UInt8]
-            var index = 0
-            mutating func next() async -> UInt8? {
-                guard index < bytes.count else { return nil }
-                defer { index += 1 }
-                return bytes[index]
-            }
+    @Test func remoteImageCollectorReturnsAllBytesUnderCap() async throws {
+        // Several chunks spanning typical OS delivery sizes should round-trip byte-for-byte.
+        let chunkSize = 64 * 1024
+        let payload = (0..<(chunkSize * 2 + 123)).map { UInt8($0 & 0xFF) }
+        var collector = CappedDataCollector(cap: Int64(payload.count) + 1)
+        // Feed the payload in chunks the way URLSession would deliver it.
+        var offset = 0
+        while offset < payload.count {
+            let end = min(offset + chunkSize, payload.count)
+            #expect(collector.append(Data(payload[offset..<end])))
+            offset = end
         }
-        func makeAsyncIterator() -> Iterator { Iterator(bytes: bytes) }
+        #expect(!collector.exceededCap)
+        #expect(Array(collector.data) == payload)
     }
 
-    @Test func remoteImageAccumulateReturnsAllBytesUnderCap() async throws {
-        // A payload spanning several chunk boundaries should round-trip byte-for-byte.
-        let payload = (0..<(RemoteImageLoader.downloadChunkSize * 2 + 123))
-            .map { UInt8($0 & 0xFF) }
-        let result = try await RemoteImageLoader.accumulate(
-            ByteStream(bytes: payload),
-            cap: Int64(payload.count) + 1
-        )
-        #expect(result != nil)
-        #expect(result.map(Array.init) == payload)
-    }
-
-    @Test func remoteImageAccumulateAcceptsExactlyCapBytes() async throws {
+    @Test func remoteImageCollectorAcceptsExactlyCapBytes() async throws {
         // Exactly `cap` bytes is allowed (the check rejects only when total exceeds cap).
-        let payload = [UInt8](repeating: 0xAB, count: RemoteImageLoader.downloadChunkSize + 7)
-        let result = try await RemoteImageLoader.accumulate(
-            ByteStream(bytes: payload),
-            cap: Int64(payload.count)
-        )
-        #expect(result?.count == payload.count)
+        let payload = [UInt8](repeating: 0xAB, count: 64 * 1024 + 7)
+        var collector = CappedDataCollector(cap: Int64(payload.count))
+        #expect(collector.append(Data(payload)))
+        #expect(!collector.exceededCap)
+        #expect(collector.data.count == payload.count)
     }
 
-    @Test func remoteImageAccumulateRejectsOverCap() async throws {
-        // One byte past the cap aborts the download (unbounded-response protection).
-        let cap = RemoteImageLoader.downloadChunkSize
-        let payload = [UInt8](repeating: 0x01, count: cap + 1)
-        let result = try await RemoteImageLoader.accumulate(
-            ByteStream(bytes: payload),
-            cap: Int64(cap),
-            chunkSize: cap
-        )
-        #expect(result == nil)
+    @Test func remoteImageCollectorRejectsOverCap() async throws {
+        // One byte past the cap aborts the download (unbounded-response protection): the
+        // over-cap chunk is rejected, the flag is set, and subsequent chunks are ignored.
+        let cap = 64 * 1024
+        var collector = CappedDataCollector(cap: Int64(cap))
+        #expect(collector.append(Data([UInt8](repeating: 0x01, count: cap))))
+        #expect(!collector.append(Data([0x02])))
+        #expect(collector.exceededCap)
+        // Further appends stay rejected and do not grow the buffer.
+        #expect(!collector.append(Data([0x03, 0x04])))
+        #expect(collector.data.count == cap)
     }
 
-    @Test func remoteImageAccumulateHandlesEmptyResponse() async throws {
-        let result = try await RemoteImageLoader.accumulate(
-            ByteStream(bytes: []),
-            cap: 1024
-        )
-        #expect(result?.isEmpty == true)
+    @Test func remoteImageCollectorHandlesEmptyResponse() async throws {
+        let collector = CappedDataCollector(cap: 1024)
+        #expect(collector.data.isEmpty)
+        #expect(!collector.exceededCap)
     }
 
     @Test func remoteImageSanitizedURLRejectsUntrustedInput() async throws {


### PR DESCRIPTION
## Summary

`RemoteImageLoader.download(_:using:)` streamed the HTTP response with
`URLSession.bytes(from:)` and appended each `UInt8` to a `Data` buffer
individually. `AsyncBytes` vends one byte per async iteration, so a single
avatar/preview download became ~10^5–10^6 async-sequence iterations plus that
many `Data.append(_:)` calls (millions at the 8 MiB cap), burning CPU/battery
proportional to byte size and noticeably delaying first display of avatars and
group images.

## Fix

- Extract a testable `accumulate(_:cap:reservingCapacity:chunkSize:)` helper that
  batches bytes into a 64 KiB buffer and flushes whole slices to `Data`,
  checking the running total against the cap **per chunk** rather than per byte.
- This removes the per-byte iteration/append overhead while **preserving the
  incremental unbounded-response protection** — at most `chunkSize - 1` bytes can
  be read past the cap before bailing. That incremental cap is the reason
  streaming was chosen over `session.data(from:)` (which buffers the entire body
  before any size check), so this keeps the security property intact.

## Test plan

New unit tests for the accumulator (no network required, via a synthetic
`AsyncSequence<UInt8>` mimicking `URLSession.AsyncBytes`):

- [x] byte-exact round-trip across multiple chunk boundaries
- [x] exactly `cap` bytes accepted (boundary)
- [x] one byte past `cap` rejected (unbounded-response protection)
- [x] empty response handled

Build/test runs in CI (macOS AppKit/ImageIO target; no local Swift toolchain on the worker host).

## Notes for review

`whitenoise-mac/Core/RemoteImageLoader.swift` is a privacy/security-sensitive
path (it is the network chokepoint for all remote image loads). This change does
not alter the `RemoteImageURLPolicy` allow-list, the HTTPS-only/host checks, the
status-code rejection, or the up-front `Content-Length` check — only the
read-loop mechanics. The cap value (`maxResponseBytes`, 8 MiB) is unchanged.

Closes #98


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/102">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote image downloads now enforce strict byte-size limits and validate HTTP responses to improve reliability and prevent excessive data consumption.

* **Tests**
  * Added comprehensive unit tests verifying download behavior under various byte-cap scenarios, including cap exceeded, exact match, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->