### PR TITLE
fix: coalesce remote image loads

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -79,12 +79,51 @@ struct DownsampledAsyncImage<Content: View, Placeholder: View>: View {
 }
 
 /// Shared image cache + downsampling pipeline. `NSCache` is thread-safe, so this needs no
-/// actor; the heavy decode/resize runs in a detached task off the main thread.
+/// actor for decoded-image storage; in-flight work is coordinated by `RemoteImageLoadRegistry`
+/// so concurrent views that need the same URL/size await one download and decode.
+private actor RemoteImageLoadRegistry {
+    private var tasks: [String: Task<LoadedImage?, Never>] = [:]
+
+    func task(
+        for key: String,
+        create: @Sendable () -> Task<LoadedImage?, Never>
+    ) -> (task: Task<LoadedImage?, Never>, owner: Bool) {
+        if let task = tasks[key] {
+            return (task, false)
+        }
+        let task = create()
+        tasks[key] = task
+        return (task, true)
+    }
+
+    func removeTask(for key: String) {
+        tasks[key] = nil
+    }
+}
+
 nonisolated final class RemoteImageLoader: @unchecked Sendable {
     static let shared = RemoteImageLoader()
+    static let defaultDecodedCacheCountLimit = 512
+    static let defaultDecodedCacheTotalCostLimit = 64 * 1024 * 1024
 
     private let cache = NSCache<NSString, NSImage>()
-    private let session: URLSession = {
+    private let inFlight = RemoteImageLoadRegistry()
+    private let session: URLSession
+
+    var decodedCacheCountLimit: Int { cache.countLimit }
+    var decodedCacheTotalCostLimit: Int { cache.totalCostLimit }
+
+    init(
+        session: URLSession = RemoteImageLoader.makeSession(),
+        cacheCountLimit: Int = RemoteImageLoader.defaultDecodedCacheCountLimit,
+        cacheTotalCostLimit: Int = RemoteImageLoader.defaultDecodedCacheTotalCostLimit
+    ) {
+        self.session = session
+        cache.countLimit = cacheCountLimit
+        cache.totalCostLimit = cacheTotalCostLimit
+    }
+
+    private static func makeSession() -> URLSession {
         let config = URLSessionConfiguration.default
         config.urlCache = URLCache(
             memoryCapacity: 16 * 1024 * 1024,
@@ -92,24 +131,47 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         )
         config.requestCachePolicy = .returnCacheDataElseLoad
         return URLSession(configuration: config)
-    }()
+    }
 
     func image(for url: URL, maxPixelSize: CGFloat) async -> LoadedImage? {
         // Defense-in-depth: never fetch a URL that fails the policy, even if a caller forgot
         // to sanitize. This is the network chokepoint for all remote image loads.
         guard RemoteImageURLPolicy.isAllowed(url) else { return nil }
 
-        let key = "\(url.absoluteString)|\(Int(maxPixelSize))" as NSString
+        let key = Self.cacheKey(for: url, maxPixelSize: maxPixelSize)
+        if let cached = cache.object(forKey: key as NSString) {
+            return LoadedImage(nsImage: cached)
+        }
+
+        let (task, owner) = await inFlight.task(for: key) { [self] in
+            Task { [self] in
+                await loadImage(for: url, cacheKey: key, maxPixelSize: maxPixelSize)
+            }
+        }
+        let loaded = await task.value
+        if owner {
+            await inFlight.removeTask(for: key)
+        }
+        return loaded
+    }
+
+    private static func cacheKey(for url: URL, maxPixelSize: CGFloat) -> String {
+        "\(url.absoluteString)|\(Int(maxPixelSize))"
+    }
+
+    private func loadImage(for url: URL, cacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
+        let key = cacheKey as NSString
         if let cached = cache.object(forKey: key) {
             return LoadedImage(nsImage: cached)
         }
+
         guard let data = await Self.download(url, using: session) else { return nil }
         let pixelSize = maxPixelSize
         let loaded = await Task.detached(priority: .utility) {
             Self.downsample(data: data, maxPixelSize: pixelSize).map(LoadedImage.init)
         }.value
         guard let loaded else { return nil }
-        cache.setObject(loaded.nsImage, forKey: key)
+        cache.setObject(loaded.nsImage, forKey: key, cost: Self.decodedCost(for: loaded.nsImage))
         return loaded
     }
 
@@ -152,5 +214,15 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         ] as CFDictionary
         guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options) else { return nil }
         return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+    }
+
+    private static func decodedCost(for image: NSImage) -> Int {
+        let representation = image.representations.first
+        let width = max(1, representation?.pixelsWide ?? Int(ceil(image.size.width)))
+        let height = max(1, representation?.pixelsHigh ?? Int(ceil(image.size.height)))
+        guard width <= Int.max / max(height, 1) / 4 else {
+            return defaultDecodedCacheTotalCostLimit
+        }
+        return width * height * 4
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3563,6 +3563,46 @@ struct whitenoise_macTests {
         #expect(sanitized?.absoluteString == "https://cdn.example/p.png")
     }
 
+    @Test func remoteImageLoaderCoalescesConcurrentLoadsForSameCacheKey() async throws {
+        RemoteImageURLProtocolStub.reset(data: Self.singlePixelPNG, responseDelay: 0.2)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RemoteImageURLProtocolStub.self]
+        config.urlCache = nil
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://example.com/avatar.png"))
+
+        async let first = loader.image(for: url, maxPixelSize: 32)
+        async let second = loader.image(for: url, maxPixelSize: 32)
+        async let third = loader.image(for: url, maxPixelSize: 32)
+
+        let results = await [first, second, third]
+
+        #expect(results.allSatisfy { $0 != nil })
+        #expect(RemoteImageURLProtocolStub.requestCount() == 1)
+    }
+
+    @Test func remoteImageLoaderUsesBoundedDecodedCache() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+
+        #expect(loader.decodedCacheCountLimit == RemoteImageLoader.defaultDecodedCacheCountLimit)
+        #expect(loader.decodedCacheTotalCostLimit == RemoteImageLoader.defaultDecodedCacheTotalCostLimit)
+        #expect(loader.decodedCacheCountLimit > 0)
+        #expect(loader.decodedCacheTotalCostLimit > 0)
+    }
+
+    private static let singlePixelPNG = Data([
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+        0x54, 0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0xF0,
+        0x1F, 0x00, 0x05, 0x00, 0x01, 0xFF, 0x89, 0x99,
+        0x3D, 0x1D, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+        0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+    ])
+
     @MainActor
     @Test func loadRemoteImagesDefaultsOffAndPersists() async throws {
         let defaults = UserDefaults.standard
@@ -6798,6 +6838,68 @@ private func notificationSettings(
         localNotificationsEnabled: localEnabled,
         nativePushEnabled: false
     )
+}
+
+private final class RemoteImageURLProtocolStub: URLProtocol {
+    private static let lock = NSLock()
+    private static var responseData = Data()
+    private static var delay: TimeInterval = 0
+    private static var requests = 0
+
+    static func reset(data: Data, responseDelay: TimeInterval) {
+        lock.lock()
+        responseData = data
+        delay = responseDelay
+        requests = 0
+        lock.unlock()
+    }
+
+    static func requestCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let (data, responseDelay) = Self.recordRequest()
+        let complete = { [weak self] in
+            guard let self, let url = self.request.url else { return }
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        }
+
+        if responseDelay > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + responseDelay) {
+                complete()
+            }
+        } else {
+            complete()
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func recordRequest() -> (Data, TimeInterval) {
+        lock.lock()
+        defer { lock.unlock() }
+        requests += 1
+        return (responseData, delay)
+    }
 }
 
 private func telemetryBuildConfig(


### PR DESCRIPTION
## Summary
- coalesce concurrent RemoteImageLoader requests by URL/max-pixel cache key through an in-flight task registry
- bound the decoded NSImage cache with count and total-cost limits
- cache decoded images with an estimated decoded byte cost

## Test Plan
- `git diff --check`
- attempted `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -only-testing:whitenoise-macTests/whitenoise_macTests/remoteImageLoaderCoalescesConcurrentLoadsForSameCacheKey` (blocked: xcodebuild unavailable on this Linux worker)

Closes #79


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/103">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable decoded-image cache limits (count and cost) via new initializer parameters with sensible defaults
  * Improved concurrent remote image loading through automatic deduplication to prevent redundant downloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->