### PR TITLE
fix: teardown notification-driven account switches

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -682,19 +682,7 @@ final class WorkspaceState {
     }
 
     private func switchActiveAccount(_ account: AccountItem, finalSelection: WorkspaceSelection?) {
-        stopTimelineListener()
-        clearEnteredLoginIdentity()
-        activeAccountId = account.id
-        UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
-        searchText = ""
-        closeNewChatComposer()
-        pruneMessageCache(keeping: nil)
-        // Lookup caches are scoped to the active account's view (directory display names and
-        // group membership visibility can differ per account); drop them on switch so the new
-        // account does not inherit stale cross-account entries (whitenoise-mac#8/#9).
-        peerProfileFFICache.removeAll()
-        clearGroupMemberCache()
-        refreshObservabilityRuntime()
+        prepareForActiveAccountSwitch(to: account, preservingMessageCacheFor: nil)
         selection = finalSelection
         if case let .chat(chatId)? = finalSelection {
             beginTimelineInitialLoadIfNeeded(groupIdHex: chatId)
@@ -705,6 +693,26 @@ final class WorkspaceState {
                 await loadMessages(groupIdHex: selectedChat.id)
             }
         }
+    }
+
+    private func prepareForActiveAccountSwitch(
+        to account: AccountItem,
+        preservingMessageCacheFor groupIdHex: String?
+    ) {
+        stopTimelineListener()
+        stopChatListListener()
+        clearEnteredLoginIdentity()
+        activeAccountId = account.id
+        UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
+        searchText = ""
+        closeNewChatComposer()
+        pruneMessageCache(keeping: groupIdHex)
+        // Lookup caches are scoped to the active account's view (directory display names and
+        // group membership visibility can differ per account); drop them on switch so the new
+        // account does not inherit stale cross-account entries (whitenoise-mac#8/#9).
+        peerProfileFFICache.removeAll()
+        clearGroupMemberCache()
+        refreshObservabilityRuntime()
     }
 
     private func activateReadyState() async throws {
@@ -2143,15 +2151,20 @@ final class WorkspaceState {
     func handleNotificationResponse(_ userInfo: [String: String]) {
         guard let groupIdHex = userInfo["groupIdHex"] else { return }
 
-        if let account = notificationAccount(from: userInfo) {
-            activeAccountId = account.id
-            UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
+        let switchedAccounts: Bool
+        if let account = notificationAccount(from: userInfo), activeAccountId != account.id {
+            prepareForActiveAccountSwitch(to: account, preservingMessageCacheFor: groupIdHex)
+            switchedAccounts = true
+        } else {
+            switchedAccounts = false
         }
 
         selection = .chat(groupIdHex)
         isChatListVisible = true
-        closeNewChatComposer()
-        pruneMessageCache(keeping: groupIdHex)
+        if !switchedAccounts {
+            closeNewChatComposer()
+            pruneMessageCache(keeping: groupIdHex)
+        }
         NSApplication.shared.activate(ignoringOtherApps: true)
         beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
 
@@ -3317,12 +3330,14 @@ final class WorkspaceState {
     }
 
     private func notificationAccount(from userInfo: [String: String]) -> AccountItem? {
-        let accountIdHex = userInfo["accountIdHex"]
-        let accountRef = userInfo["accountRef"]
+        if let accountIdHex = userInfo["accountIdHex"],
+           let account = accounts.first(where: { $0.accountIdHex == accountIdHex }) {
+            return account
+        }
+
+        guard let accountRef = userInfo["accountRef"] else { return nil }
         return accounts.first { account in
-            account.accountIdHex == accountIdHex
-                || account.accountRef == accountRef
-                || account.id == accountRef
+            account.accountRef == accountRef || account.id == accountRef
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -695,6 +695,9 @@ final class WorkspaceState {
         }
     }
 
+    /// Performs all account-scoped teardown before any chat or message reloads run.
+    /// Keeping listener stops, cache pruning, peer-profile invalidation, and
+    /// observability refresh together prevents reloads from seeing stale account state.
     private func prepareForActiveAccountSwitch(
         to account: AccountItem,
         preservingMessageCacheFor groupIdHex: String?

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4452,6 +4452,175 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func notificationResponseAccountSwitchRefreshesObservabilityAccountLabel() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.removeObject(forKey: "whitenoise.mac.activeAccountId")
+
+        let primary = AccountSummaryFfi(
+            label: "primary-account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "secondary-account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        runtime.installProfile(
+            accountIdHex: primary.accountIdHex,
+            profile: UserProfileMetadataFfi(
+                name: "primary",
+                displayName: "Primary Account",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installProfile(
+            accountIdHex: secondary.accountIdHex,
+            profile: UserProfileMetadataFfi(
+                name: "secondary",
+                displayName: "Secondary Account",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(
+            telemetryBuildConfigProvider: {
+                telemetryBuildConfig(
+                    telemetryToken: "otlp-token",
+                    auditToken: "audit-token",
+                    environment: "production"
+                )
+            },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(runtime.auditLogTrackerConfig?.source.accountLabel == "Primary Account")
+
+        // accountIdHex is the canonical account identifier; accountRef/label can be stale if
+        // the account was renamed after the notification was delivered.
+        state.handleNotificationResponse([
+            "groupIdHex": "direct-group",
+            "accountIdHex": secondary.accountIdHex,
+            "accountRef": primary.label
+        ])
+        let didRefreshAccountLabel = await waitFor {
+            runtime.auditLogTrackerConfig?.source.accountLabel == "Secondary Account"
+        }
+
+        #expect(didRefreshAccountLabel)
+        #expect(runtime.telemetryInstallIdCallCount == 1)
+        #expect(runtime.relayTelemetryRuntimeConfigSetCallCount == 1)
+        #expect(runtime.auditLogTrackerConfigSetCallCount == 2)
+    }
+
+    @MainActor
+    @Test func notificationResponseAccountSwitchClearsPeerProfileFFICache() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.removeObject(forKey: "whitenoise.mac.activeAccountId")
+
+        let primary = AccountSummaryFfi(
+            label: "primary-account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "secondary-account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            running: true
+        )
+        let senderId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        runtime.installProfile(
+            accountIdHex: primary.accountIdHex,
+            profile: UserProfileMetadataFfi(
+                name: "primary",
+                displayName: "Primary Account",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installProfile(
+            accountIdHex: secondary.accountIdHex,
+            profile: UserProfileMetadataFfi(
+                name: "secondary",
+                displayName: "Secondary Account",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: primary.accountIdHex,
+            otherAccountIdHex: senderId,
+            otherDisplayName: "Group Alias",
+            otherProfile: UserProfileMetadataFfi(
+                name: "sender-primary",
+                displayName: "Primary Alias",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages([
+            appMessage(
+                id: "initial",
+                groupIdHex: "direct-group",
+                sender: senderId,
+                plaintext: "Initial message",
+                kind: 9,
+                recordedAt: 1_700_000_000
+            )
+        ], groupIdHex: "direct-group")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.messagesByChat["direct-group"]?.first?.senderName == "Primary Alias")
+        let baselineProfileCalls = runtime.userProfileCallCount
+
+        runtime.installProfile(
+            accountIdHex: senderId,
+            profile: UserProfileMetadataFfi(
+                name: "sender-secondary",
+                displayName: "Secondary Alias",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+
+        state.handleNotificationResponse([
+            "groupIdHex": "direct-group",
+            "accountIdHex": secondary.accountIdHex,
+            "accountRef": secondary.label
+        ])
+        let didResolveWithSecondaryProfile = await waitFor {
+            state.messagesByChat["direct-group"]?.first?.senderName == "Secondary Alias"
+        }
+
+        #expect(didResolveWithSecondaryProfile)
+        #expect(runtime.userProfileCallCount > baselineProfileCalls)
+    }
+
+    @MainActor
     @Test func enablingPrivacySecurityTogglesRequireConfiguredTokens() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
## Summary
- Route notification-driven account switches through the same teardown path as manual account switches.
- Stop stale chat/timeline listeners, clear peer profile FFI cache, and refresh observability runtime metadata when a notification selects another account.
- Resolve notification accounts by canonical accountIdHex before falling back to accountRef/label.
- Add Swift Testing coverage for observability label refresh and peer profile cache invalidation on notification-driven switches.

Closes #99

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -only-testing:whitenoise-macTests/whitenoise_macTests/notificationResponseAccountSwitchRefreshesObservabilityAccountLabel -only-testing:whitenoise-macTests/whitenoise_macTests/notificationResponseAccountSwitchClearsPeerProfileFFICache` (not run locally: `xcodebuild` is not installed on this Linux worker)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->