### PR TITLE
fix: reuse shared URLSession for remote image downloads (#108)

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -189,17 +189,13 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     /// `cap` plus one chunk before an oversized/length-less response is cancelled.
     private static func download(_ url: URL, using session: URLSession) async -> Data? {
         let cap = RemoteImageURLPolicy.maxResponseBytes
+        // A fresh per-download delegate keeps per-download collector state isolated (multiple
+        // avatars can download concurrently). The delegate is attached to the *task*, not a new
+        // session (see `CappedImageDownloadDelegate.download`), so every download runs on the
+        // shared `session` and reuses its connection pool + `URLCache` instead of paying a fresh
+        // DNS/TCP/TLS handshake and churning a throwaway `URLSession` per image.
         let delegate = CappedImageDownloadDelegate(cap: cap)
-        // A dedicated delegate-backed session keeps per-download collector state isolated
-        // (multiple avatars can download concurrently). It reuses the shared session's
-        // configuration, so the same `URLCache` instance still services these requests.
-        let downloadSession = URLSession(
-            configuration: session.configuration,
-            delegate: delegate,
-            delegateQueue: nil
-        )
-        defer { downloadSession.finishTasksAndInvalidate() }
-        return await delegate.download(url, using: downloadSession)
+        return await delegate.download(url, using: session)
     }
 
     private static func downsample(data: Data, maxPixelSize: CGFloat) -> NSImage? {
@@ -302,6 +298,10 @@ private final class CappedImageDownloadDelegate: NSObject, URLSessionDataDelegat
                 }
                 self.continuation = continuation
                 let task = session.dataTask(with: url)
+                // Attach *this* delegate per task (macOS 12+) rather than backing a throwaway
+                // per-download `URLSession`. This keeps per-download collector state isolated
+                // while letting the shared `session` reuse its connection pool across avatars.
+                task.delegate = self
                 self.task = task
                 lock.unlock()
                 task.resume()


### PR DESCRIPTION
## Summary

`RemoteImageLoader.download(_:using:)` constructed a **new `URLSession`** (`URLSession(configuration:delegate:delegateQueue:)`) for **every** image fetch — purely to attach the per-download `CappedImageDownloadDelegate` — then `finishTasksAndInvalidate()`d it. Each `URLSession` owns its own connection pool, so two avatars served by the *same* host/CDN never reused a TCP+TLS connection: every avatar paid a fresh DNS/TCP/TLS handshake, plus continuous session allocate/invalidate churn on every load. The long-lived shared `session` was used only as a configuration template, so its connection pool was never exercised.

The per-download isolation only requires a per-task **delegate**, not a per-task **session**.

## Fix

- Attach the `CappedImageDownloadDelegate` to the **data task** via the task-specific delegate API (`URLSessionTask.delegate`, available macOS 12+; this app targets 15.6).
- Run every download on the **shared** `session`, restoring connection-pool reuse and the shared `URLCache`.
- Drop the throwaway `URLSession` + `finishTasksAndInvalidate()` churn.

This preserves all prior behavior:
- **Per-download collector isolation** — each download still gets its own delegate/`CappedDataCollector`, so concurrent avatars don't share buffer state.
- **Chunked cap (#98)** — the task delegate still receives `urlSession(_:dataTask:didReceive data:)` per OS-sized chunk, so the incremental `maxResponseBytes` cap and `Content-Length` check are unchanged.
- **HTTPS-only redirect re-validation** — `willPerformHTTPRedirection` is a `URLSessionTaskDelegate` method delivered to the task-specific delegate, so the `RemoteImageURLPolicy` downgrade guard still runs.
- **Cancellation** — `task.cancel()` + continuation bridge are unchanged.

Distinct from #79 (identical-URL coalescing / `NSCache` limits) and from the now-fixed #98 (per-byte read loop). This issue is specifically the per-download `URLSession` lifecycle defeating connection reuse for *different* URLs.

## Test plan

- [ ] CI build (macOS) passes.
- [ ] `remoteImageLoaderCoalescesConcurrentLoadsForSameCacheKey` still passes — it injects a stubbed `URLProtocol` config on the shared session, which now (correctly) services the data task directly.
- [ ] `CappedDataCollector` cap/empty/exceeds unit tests unaffected (collector unchanged).

Local Swift compilation/tests not run: this is a macOS-only Xcode target and the fix machine is Linux. CI on macOS runners is the build/test gate.

Closes #108


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/109">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->