### PR TITLE
fix: guard searchGroupImages() against stale/out-of-order results (#110)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -346,6 +346,15 @@ final class WorkspaceState {
     private var deliveredNotificationKeys = Set<String>()
     private var deliveredNotificationKeyOrder: [String] = []
     private var newChatLookupGeneration = 0
+    /// Monotonic token identifying the most recently started group-image (Openverse) search.
+    /// `searchGroupImages` captures the value before its `await` and only commits results /
+    /// clears `isSearchingGroupImages` while it is still current — i.e. no newer search has
+    /// superseded it and the picker is still on screen for the same query. This makes the
+    /// search last-request-wins (a slow earlier search cannot overwrite a newer one) and
+    /// prevents a search resolving after the picker is dismissed/reopened from repopulating
+    /// `groupImageResults`. Mirrors the new-chat lookup / settings-load generation guards
+    /// (issues #2, #4). See `searchGroupImages` / issue #110.
+    private var groupImageSearchGeneration = 0
     /// Raw per-sender FFI lookups (userProfile + directory displayName), cached so that
     /// scrolling back through history does not re-resolve the same senders from Rust on
     /// every page. Keyed by sender accountIdHex.
@@ -1895,6 +1904,7 @@ final class WorkspaceState {
         guard !chat.isDirect else { return }
         lastError = nil
         closeGroupDetails()
+        invalidateGroupImageSearch()
         groupImageSearchQuery = ""
         groupImageResults = []
         isGroupImagePickerPresented = true
@@ -1902,8 +1912,8 @@ final class WorkspaceState {
 
     func closeGroupImagePicker() {
         isGroupImagePickerPresented = false
+        invalidateGroupImageSearch()
         groupImageResults = []
-        isSearchingGroupImages = false
         isSavingGroupImage = false
     }
 
@@ -1915,17 +1925,31 @@ final class WorkspaceState {
     func searchGroupImages() async {
         let query = groupImageSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {
+            invalidateGroupImageSearch()
             groupImageResults = []
             return
         }
 
         lastError = nil
+        let searchGeneration = beginGroupImageSearch()
         isSearchingGroupImages = true
-        defer { isSearchingGroupImages = false }
+        defer {
+            // Only clear the spinner if this search is still the current one. A newer search
+            // (which bumped the generation) owns `isSearchingGroupImages` and must not have it
+            // cleared out from under it by this stale completion.
+            if isCurrentGroupImageSearch(generation: searchGeneration, query: query) {
+                isSearchingGroupImages = false
+            }
+        }
 
         do {
-            groupImageResults = try await groupImageSearchClient.searchImages(query: query)
+            let results = try await groupImageSearchClient.searchImages(query: query)
+            // Drop results if a newer search superseded this one, the query was edited, or the
+            // picker was dismissed/reopened while the request was in flight.
+            guard isCurrentGroupImageSearch(generation: searchGeneration, query: query) else { return }
+            groupImageResults = results
         } catch {
+            guard isCurrentGroupImageSearch(generation: searchGeneration, query: query) else { return }
             groupImageResults = []
             lastError = error.localizedDescription
         }
@@ -2267,7 +2291,7 @@ final class WorkspaceState {
         isGroupImagePickerPresented = false
         groupImageSearchQuery = ""
         groupImageResults = []
-        isSearchingGroupImages = false
+        invalidateGroupImageSearch()
         isSavingGroupImage = false
         isGroupDetailsPresented = false
         groupDetailsSnapshot = nil
@@ -3365,6 +3389,26 @@ final class WorkspaceState {
     private func isCurrentNewChatLookup(generation: Int, query: String) -> Bool {
         newChatLookupGeneration == generation
             && newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
+    }
+
+    private func beginGroupImageSearch() -> Int {
+        groupImageSearchGeneration += 1
+        return groupImageSearchGeneration
+    }
+
+    private func invalidateGroupImageSearch() {
+        groupImageSearchGeneration += 1
+        isSearchingGroupImages = false
+    }
+
+    /// True only if `generation` is still the latest group-image search, the picker is still
+    /// presented, and the live (trimmed) query still equals the one this search was issued for.
+    /// Any of: a newer search, a dismissed/reopened picker, or an edited query invalidates the
+    /// in-flight result so it cannot overwrite current UI state.
+    private func isCurrentGroupImageSearch(generation: Int, query: String) -> Bool {
+        groupImageSearchGeneration == generation
+            && isGroupImagePickerPresented
+            && groupImageSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
     }
 
     private func insertCreatedChatIfNeeded(groupIdHex: String, title: String, avatarSeed: String, pictureURL: String?) {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1934,10 +1934,14 @@ final class WorkspaceState {
         let searchGeneration = beginGroupImageSearch()
         isSearchingGroupImages = true
         defer {
-            // Only clear the spinner if this search is still the current one. A newer search
-            // (which bumped the generation) owns `isSearchingGroupImages` and must not have it
-            // cleared out from under it by this stale completion.
-            if isCurrentGroupImageSearch(generation: searchGeneration, query: query) {
+            // Spinner ownership is keyed on the generation ALONE, independent of the stricter
+            // picker/query guard used for committing results. Only a newer search or an
+            // `invalidateGroupImageSearch` (both bump the generation, and each sets the spinner
+            // state itself) supersedes this one's ownership of `isSearchingGroupImages`. Editing
+            // the query mid-flight without resubmitting must NOT strand the spinner at `true`
+            // (which would disable the Search button forever), so it is deliberately not part of
+            // this check — see issue #110 adversarial review.
+            if ownsGroupImageSearch(generation: searchGeneration) {
                 isSearchingGroupImages = false
             }
         }
@@ -3401,12 +3405,22 @@ final class WorkspaceState {
         isSearchingGroupImages = false
     }
 
+    /// True while `generation` still owns the group-image search spinner — i.e. no newer
+    /// `beginGroupImageSearch` or `invalidateGroupImageSearch` has bumped the generation. This is
+    /// intentionally looser than `isCurrentGroupImageSearch`: it does NOT require the picker to be
+    /// presented or the live query to match, because spinner ownership must transfer cleanly even
+    /// when the user edits the query mid-flight without resubmitting (otherwise the spinner would
+    /// stay stuck `true` and disable the Search button — issue #110 review).
+    private func ownsGroupImageSearch(generation: Int) -> Bool {
+        groupImageSearchGeneration == generation
+    }
+
     /// True only if `generation` is still the latest group-image search, the picker is still
     /// presented, and the live (trimmed) query still equals the one this search was issued for.
     /// Any of: a newer search, a dismissed/reopened picker, or an edited query invalidates the
     /// in-flight result so it cannot overwrite current UI state.
     private func isCurrentGroupImageSearch(generation: Int, query: String) -> Bool {
-        groupImageSearchGeneration == generation
+        ownsGroupImageSearch(generation: generation)
             && isGroupImagePickerPresented
             && groupImageSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
     }


### PR DESCRIPTION
## Summary

`WorkspaceState.searchGroupImages()` committed the Openverse network results to `groupImageResults` **without checking the query was still current**, making it last-*completion*-wins rather than last-*request*-wins. Two searches issued in quick succession (e.g. via the text field's `onSubmit` Return key, which is not disabled during a search) could land out of order — the slower request overwriting the newer query's grid — and a search that resolved **after the picker was dismissed/reopened** repopulated a sheet the user had already left.

This mirrors the generation-token guard already used by `resolveNewChatQuery` (#2) and `performSettingsLoad` (#4); the group-image path was simply not covered.

## Changes

All in `whitenoise-mac/Core/WorkspaceState.swift`:

- Add a monotonic `groupImageSearchGeneration` and `beginGroupImageSearch()` / `invalidateGroupImageSearch()` / `isCurrentGroupImageSearch(generation:query:)` helpers. `isCurrentGroupImageSearch` additionally requires the picker still be presented and the live trimmed query still equal the one the search was issued for, so a dismissed or edited picker is never repopulated.
- `searchGroupImages()` captures the generation before the `await` and only commits `groupImageResults` (and only clears `isSearchingGroupImages` in its `defer`) while still current. A stale completion can no longer (a) overwrite a newer search's results, (b) repopulate a dismissed sheet, or (c) clear a spinner a newer search owns.
- Invalidate the in-flight search from `showGroupImagePicker()`, `closeGroupImagePicker()`, the empty-query early return, and the full state-reset teardown.

## Edge cases verified (by hand — Swift, no CI on this runner)

`WorkspaceState` is `@MainActor`-isolated, so all generation reads/writes around the `await` are race-free (the suspension resumes on the main actor) — identical safety to the existing `resolveNewChatQuery` guard.

1. **Out-of-order overwrite:** A (gen 1) → edit query → B (gen 2); A resolves → gen mismatch → dropped. B wins. ✓
2. **Dismissed-picker repopulation:** A in flight → `closeGroupImagePicker()` bumps gen + flips `isGroupImagePickerPresented` false → A dropped. ✓
3. **Reopened picker:** A in flight → close → `showGroupImagePicker()` invalidates again → A cannot land. ✓
4. **Empty-query clear:** clearing the field invalidates a prior in-flight non-empty search. ✓
5. **Spinner ownership:** A's stale `defer` does not clear the spinner a newer B owns; B's `defer` clears it when current — no stuck spinner, no premature clear. ✓

## Test plan

- [ ] Builds in Xcode (macOS — cannot build on the Linux CI runner)
- [ ] Manual: issue two rapid searches with different queries; confirm the grid shows the newer query's results regardless of completion order
- [ ] Manual: start a search, dismiss the picker before it resolves; confirm the grid stays empty

Closes #110

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/114">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->