### PR TITLE
fix: read notification settings once per active-account update (#111)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -2155,11 +2155,20 @@ final class WorkspaceState {
         guard !update.isFromSelf else { return }
         guard !deliveredNotificationKeys.contains(update.notificationKey) else { return }
 
-        // Keep the published settings snapshot in sync for the active account.
-        // This is an explicit step rather than a side effect of the guard below.
-        await syncNotificationSettingsIfActive(for: update)
+        // Read the account's notification settings exactly once over the FFI
+        // boundary, then reuse the snapshot for both responsibilities below:
+        //   1. Keep the published `notificationSettings` snapshot in sync when
+        //      the update targets the active account.
+        //   2. Gate notification delivery on `localNotificationsEnabled`.
+        // A failed read (`nil`) suppresses delivery and leaves the published
+        // snapshot untouched, matching the prior early-return-on-error behavior.
+        guard let settings = await fetchNotificationSettings(for: update) else { return }
 
-        guard await localNotificationsEnabled(for: update) else { return }
+        if activeAccount?.accountIdHex == update.accountIdHex {
+            notificationSettings = NotificationSettingsSnapshot(settings: settings)
+        }
+
+        guard settings.localNotificationsEnabled else { return }
 
         if selectedChat?.id == update.groupIdHex, selectedConversationIsVisible() {
             return
@@ -3228,37 +3237,20 @@ final class WorkspaceState {
         }
     }
 
-    /// Pure predicate: reports whether local notifications are enabled for the
-    /// account targeted by `update`. Has no side effects — callers that also need
-    /// to refresh the published `notificationSettings` snapshot must invoke
-    /// `syncNotificationSettingsIfActive(for:)` explicitly.
-    private func localNotificationsEnabled(for update: NotificationUpdateFfi) async -> Bool {
-        guard let client else { return false }
+    /// Reads the notification settings for the account targeted by `update` over
+    /// the off-main FFI boundary. Returns `nil` when there is no client or the
+    /// read fails, so callers can suppress delivery without mutating UI state.
+    ///
+    /// This is intentionally side-effect free: refreshing the published
+    /// `notificationSettings` snapshot for the active account is the caller's
+    /// responsibility (see `handleNotificationUpdate(_:)`), which lets a single
+    /// fetch serve both the active-account sync and the delivery gate.
+    private func fetchNotificationSettings(for update: NotificationUpdateFfi) async -> NotificationSettingsFfi? {
+        guard let client else { return nil }
         let accountRef = update.accountRef
-        guard let settings = try? await runOffMain({
+        return try? await runOffMain({
             try client.notificationSettings(accountRef: accountRef)
-        }) else {
-            return false
-        }
-
-        return settings.localNotificationsEnabled
-    }
-
-    /// Refreshes the published `notificationSettings` snapshot when `update`
-    /// targets the active account. Kept separate from
-    /// `localNotificationsEnabled(for:)` so that evaluating the predicate does
-    /// not mutate UI state as a hidden side effect.
-    private func syncNotificationSettingsIfActive(for update: NotificationUpdateFfi) async {
-        guard activeAccount?.accountIdHex == update.accountIdHex else { return }
-        guard let client else { return }
-        let accountRef = update.accountRef
-        guard let settings = try? await runOffMain({
-            try client.notificationSettings(accountRef: accountRef)
-        }) else {
-            return
-        }
-
-        notificationSettings = NotificationSettingsSnapshot(settings: settings)
+        })
     }
 
     private func handleNotificationPermissionError(_ error: Error) async {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5013,6 +5013,51 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func incomingNotificationReadsSettingsOnceForActiveAccount() async throws {
+        // Issue #111: `handleNotificationUpdate(_:)` previously read the account's
+        // notification settings twice over the FFI boundary for the active account
+        // — once to sync the published snapshot and once to gate delivery. The two
+        // responsibilities now share a single `notificationSettings(accountRef:)`
+        // read.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: true)
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        // Ignore any `notificationSettings` reads performed during bootstrap; only
+        // the handler's own reads are under test.
+        runtime.clearSyncCallThreadRecords()
+
+        await state.handleNotificationUpdate(notificationUpdate(
+            account: account,
+            notificationKey: "notice-1",
+            groupIdHex: "direct-group",
+            senderName: "Alice",
+            previewText: "See you there."
+        ))
+
+        // Exactly one FFI read for the active-account path (was two before the fix),
+        // and it still runs off the main thread.
+        let reads = runtime.syncCallThreadRecord("notificationSettings")
+        #expect(reads.count == 1)
+        #expect(reads.allSatisfy { !$0 })
+        // The single read still drives both the published snapshot and delivery.
+        #expect(state.notificationSettings.localNotificationsEnabled)
+        #expect(notificationCenter.postedRequests.count == 1)
+    }
+
+    @MainActor
     @Test func senderOnlyPreviewModeOmitsDecryptedMessageBody() async throws {
         // Issue #30: notification body must never leak decrypted plaintext when
         // the user opts into sender-only previews. DM => body is generic, group


### PR DESCRIPTION
## Summary

`handleNotificationUpdate(_:)` read the active account's notification settings **twice** over the off-main FFI boundary for every inbound notification update targeting the active account:

1. `syncNotificationSettingsIfActive(for:)` — refreshed the published `notificationSettings` snapshot (active account only).
2. `localNotificationsEnabled(for:)` — gated delivery.

Both issued the same blocking `client.notificationSettings(accountRef:)` read with the same `accountRef`. The first snapshot already contained the `localNotificationsEnabled` flag the second re-fetched.

## Fix

Collapse the two helpers into a single side-effect-free `fetchNotificationSettings(for:) -> NotificationSettingsFfi?` and call it once at the top of the handler. The active-account snapshot sync and the delivery gate now share one read.

**Behavior preserved:**
- A failed read (`nil`) suppresses delivery and leaves the published snapshot untouched (matches the prior early-return-on-error in both helpers).
- The published `notificationSettings` snapshot is still refreshed **only** for the active account.
- The sync happens before the delivery gate, matching the original ordering.
- Non-active-account path already did exactly one read; that's unchanged.

Net effect: active-account path drops from two identical FFI/DB reads to one. Non-active path unchanged.

## Test plan

- [x] Adds `incomingNotificationReadsSettingsOnceForActiveAccount` regression test: asserts exactly **one** off-main `notificationSettings` FFI read per active-account update (was two), the published snapshot is still populated, and the local notification is still posted.
- [x] Existing notification tests (`incomingNotificationPostsLocalAlertWhenEnabledAndInactive`, `notificationDeliveryFailureRoutesToBackgroundStatusNotLastError`, `senderOnlyPreviewModeOmitsDecryptedMessageBody`) exercise the unchanged delivery behavior through the same handler.

> No Swift toolchain / GitHub Actions CI in this repo; verified by hand (types, control flow, behavior equivalence) — relies on CodeRabbit + reviewer.

Closes #111


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized notification handling to reduce redundant system calls and improve performance.

* **Tests**
  * Added test coverage to verify notification delivery behavior and settings synchronization work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->