### PR TITLE
fix: re-check pendingAppendAnchorId in bottom sentinel reset (#119)

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -664,6 +664,7 @@ private struct ConversationView: View {
                                             try? await Task.sleep(nanoseconds: 300_000_000)
                                             guard !Task.isCancelled else { return }
                                             await MainActor.run {
+                                                guard pendingAppendAnchorId == nil else { return }
                                                 didRequestNewerForVisibleBottomSentinel = false
                                             }
                                         }


### PR DESCRIPTION
Closes #119

## Summary

The forward (newer-page) and backward (older-page) pagination sentinels in `ConversationView` use the same deferred-reset pattern for their dedup flag, but the bottom sentinel dropped a guard the top sentinel keeps.

- **Top sentinel** (`hasMoreBefore`, line 627-629): re-checks `guard pendingPrependAnchorId == nil` *inside* the delayed `MainActor.run` before clearing `didRequestOlderForVisibleTopSentinel`.
- **Bottom sentinel** (`hasMoreAfter`, before this fix): cleared `didRequestNewerForVisibleBottomSentinel` after the 300 ms delay with **no** equivalent re-check.

Between the outer `onDisappear` guard and the delayed `MainActor.run` (300 ms later), a new forward-page load can set `pendingAppendAnchorId` (sentinel re-appears → `onAppear`). The bottom path then cleared the dedup flag while that append was still in flight, re-opening the `onAppear` guard and permitting a redundant `loadNewerMessages` for the same anchor.

## Fix

One-line addition — mirror the top sentinel:

```swift
await MainActor.run {
    guard pendingAppendAnchorId == nil else { return }   // ← added
    didRequestNewerForVisibleBottomSentinel = false
}
```

The two sentinel `onDisappear` blocks are now structurally identical.

## Impact

LOW. At worst a duplicate forward-pagination FFI request and an extra timeline-window apply for the same anchor; the runtime returns an authoritative deduped/capped window, so it never corrupted the transcript — it was wasted work and a subtle inconsistency with the (correct) top sentinel.

## Verification

- `git diff` reviewed: 1 file, 1 insertion. Surgical, no scope creep.
- Confirmed `pendingAppendAnchorId` is the `@State` var on the same `ConversationView` struct, read on `MainActor` exactly as the top sentinel reads `pendingPrependAnchorId`.
- No compile/CI available on the build host: whitenoise-mac is a macOS-only Xcode/SwiftUI app, this Linux box has no Swift toolchain, and the repo has no GitHub Actions CI. The existing `whitenoise-macTests` exercise the model-level `loadNewerMessages`/`MessageItem.timeline`, not the private View's sentinel-reset Tasks. The change is a copy of the already-shipping, already-correct top-sentinel pattern 40 lines above.

## Sensitive paths

None. `MessengerShellView.swift` is not in the repo's sensitive-path set.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/121">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->