### PR TITLE
fix: cache L10n localized bundle to avoid per-call .lproj lookup

### DIFF
--- a/whitenoise-mac/Core/AppLanguage.swift
+++ b/whitenoise-mac/Core/AppLanguage.swift
@@ -59,10 +59,14 @@ enum AppLanguage: String, CaseIterable, Identifiable {
 
     /// Recompute the cached locale from the stored language preference. Call this
     /// whenever the preference changes so `currentLocale` remains an
-    /// allocation-free in-memory read in the common case.
+    /// allocation-free in-memory read in the common case. Also invalidates
+    /// `L10n`'s cached `.lproj` bundle, which is keyed on the same preference.
     static func refreshCachedLocale() {
         let locale = resolvedLocaleFromDefaults()
         cachedLocale.withLock { $0 = locale }
+        // The localized `.lproj` bundle is cached against this same preference,
+        // so invalidate it here too (the single shared invalidation point).
+        L10n.refreshCachedLocalizedBundle()
     }
 
     private static func resolvedLocaleFromDefaults() -> Locale {

--- a/whitenoise-mac/Core/L10n.swift
+++ b/whitenoise-mac/Core/L10n.swift
@@ -1,8 +1,27 @@
 import Foundation
+import os
 
 enum L10n {
+    // `string(_:)` is invoked from the same render hot paths as
+    // `AppLanguage.currentLocale` (SwiftUI view bodies that re-evaluate
+    // frequently, enum `label`/`title` computed properties, per-message
+    // mapping). Resolving the language-specific `.lproj` bundle must not stat
+    // the filesystem (`Bundle.main.path(forResource:ofType:)`) or allocate a
+    // fresh `Bundle(path:)` on every call. We cache the resolved bundle in
+    // memory and only recompute it when the stored language preference actually
+    // changes. The cache is cleared from `AppLanguage.refreshCachedLocale()`
+    // (the single invalidation point shared with the cached locale), so it stays
+    // correct while the common-case read is an allocation-free in-memory lookup.
+    //
+    // The outer optional distinguishes "not yet resolved" (`nil`) from "resolved,
+    // no matching `.lproj` bundle" (`.some(nil)`), so a genuine miss (e.g. the
+    // base/development language, which has no separate `.lproj`) is cached too
+    // and not re-statted on every call. The unfair lock keeps the cache safe if
+    // `string(_:)` is ever touched off the main thread.
+    private static let cachedLocalizedBundle = OSAllocatedUnfairLock<Bundle??>(initialState: nil)
+
     static func string(_ key: String) -> String {
-        if let localizedBundle = localizedBundle(for: AppLanguage.currentLocale) {
+        if let localizedBundle = currentLocalizedBundle() {
             let localized = localizedBundle.localizedString(forKey: key, value: nil, table: nil)
             if localized != key {
                 return localized
@@ -10,6 +29,24 @@ enum L10n {
         }
 
         return Bundle.main.localizedString(forKey: key, value: key, table: nil)
+    }
+
+    /// Clear the cached localized bundle so the next `string(_:)` call re-resolves
+    /// it for the current language preference. Called from
+    /// `AppLanguage.refreshCachedLocale()` whenever the preference changes.
+    static func refreshCachedLocalizedBundle() {
+        cachedLocalizedBundle.withLock { $0 = nil }
+    }
+
+    private static func currentLocalizedBundle() -> Bundle? {
+        cachedLocalizedBundle.withLock { cache in
+            if let cache {
+                return cache
+            }
+            let bundle = localizedBundle(for: AppLanguage.currentLocale)
+            cache = .some(bundle)
+            return bundle
+        }
     }
 
     private static func localizedBundle(for locale: Locale) -> Bundle? {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -583,6 +583,43 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func localizedStringUsesSelectedAppLanguage() async throws {
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
+
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
+        #expect(L10n.string("Save") == "Guardar")
+    }
+
+    @MainActor
+    @Test func localizedStringBundleCacheInvalidatesOnLanguageChange() async throws {
+        // Regression for the residual half of #28 (#117): `L10n.string` caches the
+        // resolved `.lproj` bundle to avoid a per-call filesystem stat + `Bundle`
+        // allocation. The cache must be invalidated by `refreshCachedLocale()` when
+        // the language preference changes, otherwise a stale bundle keeps serving
+        // the previous language. Switch between two non-source languages and assert
+        // each read reflects the current preference.
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
+
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
+        // Prime the cache while Spanish is selected.
+        #expect(L10n.string("Save") == "Guardar")
+
+        UserDefaults.standard.set(AppLanguage.german.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
+        // The cache must have been cleared, so this resolves the German bundle.
+        #expect(L10n.string("Save") == "Speichern")
+
+        // And back again, confirming the cache tracks the preference in both directions.
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
+        #expect(L10n.string("Save") == "Guardar")
+    }
+
+    @MainActor
     @Test func projectedChatRowTimestampUsesLastMessageTime() async throws {
         let lastMessageAt: UInt64 = 1_700_000_000
         let projectionRefreshedAt: UInt64 = 1_800_000_000


### PR DESCRIPTION
Closes #117

## Summary

`L10n.string(_:)` is invoked from SwiftUI view bodies, enum `label`/`title` computed properties, and the per-message mapping layer — render hot paths SwiftUI re-evaluates frequently. #28 cached the resolved `Locale`, but the language-specific `.lproj` `Bundle` was still resolved from scratch on **every** call:

1. a fresh `candidates` array (string splitting/allocation),
2. a `Bundle.main.path(forResource:ofType:)` filesystem stat per candidate, and
3. a `Bundle(path:)` allocation,

all on the main thread during rendering. This was the residual half of #28 — one layer down from the locale cache.

## Fix

Cache the resolved `Bundle` in an `OSAllocatedUnfairLock`, mirroring the existing `AppLanguage.cachedLocale` pattern:

- `L10n.cachedLocalizedBundle: OSAllocatedUnfairLock<Bundle??>` — populated on first use, read lock-protected. The **double** optional distinguishes "not yet resolved" (`nil`) from "resolved, no matching `.lproj`" (`.some(nil)`), so a genuine miss (e.g. the base/development language) is memoized too and never re-statted.
- Invalidated by `L10n.refreshCachedLocalizedBundle()`, called from `AppLanguage.refreshCachedLocale()` — the **single shared invalidation point** already wired to `WorkspaceState.languagePreference` (the only production writer of the language key) and to the test harness (`restoreDefault`). So the bundle cache tracks the preference exactly like the locale cache.

Common-case read is now an allocation-free, stat-free in-memory lookup. The original candidate-resolution logic is unchanged — just memoized.

## Verification

This is a macOS/Xcode project; it does not build on the Linux box this fix was authored on (no Swift/Xcode toolchain, no GitHub Actions CI — CodeRabbit only), so it was verified by static review:

- Confirmed `Bundle` conforms to `Sendable` in the current SDK, so `OSAllocatedUnfairLock<Bundle??>(initialState:)` (which requires `State: Sendable`) is valid.
- Actor-isolation context is unchanged from the original (`AppLanguage.currentLocale` access stays in the same default-MainActor context, now inside the lock closure).
- Test target is hosted in `White Noise.app` (`TEST_HOST`/`BUNDLE_LOADER` set), so `Bundle.main` at test runtime is the app bundle containing the compiled `Localizable.xcstrings` → `.lproj` resources the new tests resolve against.

Added regression tests (Swift Testing):
- `localizedStringUsesSelectedAppLanguage` — `L10n.string("Save") == "Guardar"` under Spanish.
- `localizedStringBundleCacheInvalidatesOnLanguageChange` — primes the cache (es → "Guardar"), switches to German ("Speichern"), then back ("Guardar"), proving the cache invalidates on language change rather than serving a stale bundle.

## Sensitive paths

None. (Repo sensitive paths: `RemoteImageLoader.swift`, `MarmotClient.swift`, `MarmotKit/**`, `*.entitlements`, `AppSecrets*` — none touched.)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/122">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->