### PR TITLE
fix: bound media JSON attachment traversal

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -390,6 +390,8 @@ private nonisolated enum MessageMediaParser {
             var output: [MediaAttachmentReferenceFfi] = []
 
             if let imeta = dictionary["imeta"] {
+                // Safe without its own depth counter because the raw JSON pre-scan rejects
+                // any object graph deeper than maxMediaJSONTraversalDepth before parsing.
                 output.append(
                     contentsOf: references(
                         fromIMetaValue: imeta,

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -349,6 +349,8 @@ private enum MarmotTimelineKind {
 }
 
 private nonisolated enum MessageMediaParser {
+    private static let maxMediaJSONTraversalDepth = 32
+
     static func attachments(
         mediaJson: String?,
         tags: [MessageTagFfi],
@@ -370,14 +372,20 @@ private nonisolated enum MessageMediaParser {
 
     private static func references(fromMediaJson mediaJson: String?) -> [MediaAttachmentReferenceFfi] {
         guard let mediaJson,
+              !mediaJSONNestingExceedsLimit(mediaJson, maxDepth: maxMediaJSONTraversalDepth),
               let data = mediaJson.data(using: .utf8),
               let root = try? JSONSerialization.jsonObject(with: data)
         else { return [] }
 
-        return references(fromJSONObject: root)
+        return references(fromJSONObject: root, remainingDepth: maxMediaJSONTraversalDepth)
     }
 
-    private static func references(fromJSONObject value: Any) -> [MediaAttachmentReferenceFfi] {
+    private static func references(
+        fromJSONObject value: Any,
+        remainingDepth: Int
+    ) -> [MediaAttachmentReferenceFfi] {
+        guard remainingDepth >= 0 else { return [] }
+
         if let dictionary = value as? [String: Any] {
             var output: [MediaAttachmentReferenceFfi] = []
 
@@ -390,7 +398,7 @@ private nonisolated enum MessageMediaParser {
                 )
             }
             if let media = dictionary["media"] {
-                output.append(contentsOf: references(fromJSONObject: media))
+                output.append(contentsOf: references(fromJSONObject: media, remainingDepth: remainingDepth - 1))
             }
             if let direct = reference(fromJSONObject: dictionary) {
                 output.append(direct)
@@ -403,10 +411,45 @@ private nonisolated enum MessageMediaParser {
             if let tagReferences = references(fromIMetaArray: array, sourceEpoch: nil), !tagReferences.isEmpty {
                 return tagReferences
             }
-            return array.flatMap(references(fromJSONObject:))
+            return array.flatMap { references(fromJSONObject: $0, remainingDepth: remainingDepth - 1) }
         }
 
         return []
+    }
+
+    private static func mediaJSONNestingExceedsLimit(_ json: String, maxDepth: Int) -> Bool {
+        var depth = 0
+        var isInsideString = false
+        var isEscaped = false
+
+        for scalar in json.unicodeScalars {
+            if isInsideString {
+                if isEscaped {
+                    isEscaped = false
+                } else if scalar.value == 0x5C { // \\
+                    isEscaped = true
+                } else if scalar.value == 0x22 { // "
+                    isInsideString = false
+                }
+                continue
+            }
+
+            switch scalar.value {
+            case 0x22: // "
+                isInsideString = true
+            case 0x7B, 0x5B: // { or [
+                depth += 1
+                if depth > maxDepth {
+                    return true
+                }
+            case 0x7D, 0x5D: // } or ]
+                depth = max(0, depth - 1)
+            default:
+                continue
+            }
+        }
+
+        return false
     }
 
     private static func references(fromIMetaValue value: Any, sourceEpoch: UInt64?) -> [MediaAttachmentReferenceFfi] {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -876,6 +876,45 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func boundedNestedMediaJSONStillProducesAttachments() async throws {
+        // Base helper shape is object + imeta array + tag array, so 29 wrappers
+        // reaches the current raw nesting limit of 32 without exceeding it.
+        let reference = mediaAttachmentReference(
+            mediaType: "image/png",
+            fileName: "bounded-[literal-{brackets}].png"
+        )
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "bounded-media-objects",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_002,
+                    mediaJson: mediaJson(for: reference, mediaObjectDepth: 29)
+                ),
+                timelineMessage(
+                    id: "bounded-media-arrays",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_003,
+                    mediaJson: mediaJson(for: reference, arrayDepth: 29)
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+
+        #expect(messages.count == 2)
+        #expect(messages.allSatisfy { $0.body.isEmpty })
+        #expect(messages.allSatisfy { $0.mediaAttachments.count == 1 })
+        #expect(messages.allSatisfy { $0.mediaAttachments.first?.reference.fileName == reference.fileName })
+    }
+
+    @MainActor
     @Test func workspaceDownloadsMediaAttachmentAndCachesResult() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -840,6 +840,42 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func deeplyNestedMediaJSONDoesNotProduceAttachments() async throws {
+        // Regression for whitenoise-mac#120: mediaJson is decrypted peer content.
+        // Overly deep objects/arrays must be ignored instead of recursively walking
+        // attacker-controlled nesting on the timeline mapping path.
+        let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "nested.png")
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "deep-media-objects",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJson(for: reference, mediaObjectDepth: 40)
+                ),
+                timelineMessage(
+                    id: "deep-media-arrays",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_001,
+                    mediaJson: mediaJson(for: reference, arrayDepth: 40)
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+
+        #expect(messages.count == 2)
+        #expect(messages.allSatisfy { $0.mediaAttachments.isEmpty })
+        #expect(messages.allSatisfy { $0.body == "Unsupported message" })
+    }
+
+    @MainActor
     @Test func workspaceDownloadsMediaAttachmentAndCachesResult() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -7809,7 +7845,27 @@ private func mediaAttachmentReference(
 
 private func mediaJson(for reference: MediaAttachmentReferenceFfi) -> String {
     let tag = mediaIMetaTag(for: reference).values
-    let data = try! JSONSerialization.data(withJSONObject: ["imeta": [tag]], options: [.sortedKeys])
+    return mediaJSONString(fromJSONObject: ["imeta": [tag]])
+}
+
+private func mediaJson(for reference: MediaAttachmentReferenceFfi, mediaObjectDepth depth: Int) -> String {
+    var object: [String: Any] = ["imeta": [mediaIMetaTag(for: reference).values]]
+    for _ in 0..<depth {
+        object = ["media": object]
+    }
+    return mediaJSONString(fromJSONObject: object)
+}
+
+private func mediaJson(for reference: MediaAttachmentReferenceFfi, arrayDepth depth: Int) -> String {
+    var object: Any = ["imeta": [mediaIMetaTag(for: reference).values]]
+    for _ in 0..<depth {
+        object = [object]
+    }
+    return mediaJSONString(fromJSONObject: object)
+}
+
+private func mediaJSONString(fromJSONObject object: Any) -> String {
+    let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
     return String(data: data, encoding: .utf8)!
 }
 


### PR DESCRIPTION
## Summary
- bounds media JSON attachment traversal to depth 32 before and after JSONSerialization
- rejects overly nested object/array payloads before walking peer-controlled mediaJson
- adds regression coverage for deeply nested media object and array payloads

## Test plan
- `git diff --check`
- `python3` smoke test of the JSON nesting scanner logic (shallow payload false; object depth 40 true; array depth 40 true; brackets inside strings false)
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS' -only-testing:whitenoise-macTests/whitenoise_macTests/deeplyNestedMediaJSONDoesNotProduceAttachments` (blocked locally: `xcodebuild: command not found` on this Linux worker)

Closes #120


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/123">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to limit how deeply nested media JSON is traversed during timeline mapping, preventing excessive recursion on attacker-controlled payloads.
  * Deeply nested/invalid media JSON now results in a safe fallback body and no unintended media attachments.
  * Moderately nested media JSON still extracts expected attachments.

* **Tests**
  * Added regression tests covering deep-nesting behavior (ensuring no attachments and correct fallback) and near-limit behavior (ensuring attachments are still produced).
  * Enhanced test media JSON generation helpers to support controlled nesting depths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->