### PR TITLE
fix: reset audio playback after completion

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2811,6 +2811,16 @@ private struct MessageAttachmentStatusRow: View {
     }
 }
 
+@MainActor
+private final class MessageAudioPlayerDelegate: NSObject, AVAudioPlayerDelegate {
+    var onDidFinishPlaying: (() -> Void)?
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        player.currentTime = 0
+        onDidFinishPlaying?()
+    }
+}
+
 private struct MessageAudioAttachmentPlayer: View {
     let download: MessageMediaDownload
     let fallbackFileName: String
@@ -2820,13 +2830,14 @@ private struct MessageAudioAttachmentPlayer: View {
     @State private var playbackProgress: CGFloat = 0
     @State private var metadata: MediaWaveformAnalyzer.Metadata?
     @State private var playbackMonitor: Task<Void, Never>?
+    @State private var audioPlayerDelegate = MessageAudioPlayerDelegate()
 
     var body: some View {
         HStack(spacing: 10) {
             Button {
                 togglePlayback()
             } label: {
-                Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                Image(systemName: isPlaying ? "stop.fill" : "play.fill")
                     .font(.system(size: 13, weight: .bold))
                     .frame(width: 30, height: 30)
                     .background {
@@ -2835,7 +2846,7 @@ private struct MessageAudioAttachmentPlayer: View {
                     }
             }
             .buttonStyle(.plain)
-            .help(isPlaying ? L10n.string("Pause") : L10n.string("Play"))
+            .help(isPlaying ? L10n.string("Stop") : L10n.string("Play"))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(download.fileName.nilIfBlank ?? fallbackFileName)
@@ -2900,37 +2911,42 @@ private struct MessageAudioAttachmentPlayer: View {
             if player == nil {
                 player = try AVAudioPlayer(data: download.data)
                 player?.prepareToPlay()
+                player?.delegate = audioPlayerDelegate
             }
+            audioPlayerDelegate.onDidFinishPlaying = handlePlaybackFinished
             player?.play()
             isPlaying = true
             updatePlaybackProgress()
-            monitorPlayback()
+            monitorPlaybackProgress()
         } catch {
             isPlaying = false
         }
     }
 
     private func stopPlayback() {
-        playbackMonitor?.cancel()
-        playbackMonitor = nil
+        audioPlayerDelegate.onDidFinishPlaying = nil
         player?.stop()
         player?.currentTime = 0
+        finishPlayback()
+    }
+
+    private func handlePlaybackFinished() {
+        finishPlayback()
+    }
+
+    private func finishPlayback() {
+        playbackMonitor?.cancel()
+        playbackMonitor = nil
         isPlaying = false
         playbackProgress = 0
     }
 
-    private func monitorPlayback() {
+    private func monitorPlaybackProgress() {
         playbackMonitor?.cancel()
         playbackMonitor = Task { @MainActor in
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 200_000_000)
-                guard player?.isPlaying == true else {
-                    player?.currentTime = 0
-                    isPlaying = false
-                    playbackProgress = 0
-                    break
-                }
+            while !Task.isCancelled, isPlaying {
                 updatePlaybackProgress()
+                try? await Task.sleep(nanoseconds: 200_000_000)
             }
         }
     }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2925,6 +2925,7 @@ private struct MessageAudioAttachmentPlayer: View {
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 200_000_000)
                 guard player?.isPlaying == true else {
+                    player?.currentTime = 0
                     isPlaying = false
                     playbackProgress = 0
                     break


### PR DESCRIPTION
## Summary
- Reset `AVAudioPlayer.currentTime` when audio attachment playback naturally reaches a non-playing state.
- Keep the existing playback progress reset so the waveform/play button returns to the beginning for replay.

## Verification
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' -- .`
- Not run: `xcrun swift-format lint`, `xcodebuild test`, `xcodebuild build`, `xcodebuild analyze` (Xcode/macOS toolchain is unavailable on this Linux worker: `xcodebuild`, `xcrun`, `swift`, `swift-format`, `plutil`, and `/usr/libexec/PlistBuddy` are missing).

Closes #118


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/124">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed audio message attachment playback to properly reset the playback position to the beginning when playback ends or is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->