### PR TITLE
fix: isolate media download state observation

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import AppKit
+import Combine
 import Foundation
 import MarmotKit
 import Observation

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -85,6 +85,16 @@ struct ChatListRowEnrichmentTracker {
 }
 
 @MainActor
+final class MediaDownloadStateStore: ObservableObject {
+    @Published private(set) var state: MediaDownloadState = .idle
+
+    func update(_ newState: MediaDownloadState) {
+        guard state != newState else { return }
+        state = newState
+    }
+}
+
+@MainActor
 @Observable
 final class WorkspaceState {
     enum Phase: Equatable {
@@ -115,7 +125,7 @@ final class WorkspaceState {
     private(set) var accounts: [AccountItem]
     private(set) var chatsByAccount: [String: [ChatItem]]
     private(set) var messagesByChat: [String: [MessageItem]]
-    private(set) var mediaDownloads: [String: MediaDownloadState] = [:]
+    @ObservationIgnored private var mediaDownloads: [String: MediaDownloadStateStore] = [:]
     /// Error for the user-initiated action on the *current* screen. Rendered by form
     /// surfaces (login, settings, new-chat composer). Must never be written by
     /// background tasks — see `backgroundStatus`.
@@ -1686,27 +1696,35 @@ final class WorkspaceState {
     }
 
     func mediaDownloadState(for message: MessageItem, attachment: MessageMediaAttachment) -> MediaDownloadState {
-        mediaDownloads[mediaDownloadKey(message: message, attachment: attachment)] ?? .idle
+        mediaDownloadStateStore(for: message, attachment: attachment).state
+    }
+
+    func mediaDownloadStateStore(
+        for message: MessageItem,
+        attachment: MessageMediaAttachment
+    ) -> MediaDownloadStateStore {
+        mediaDownloadStateStore(forKey: mediaDownloadKey(message: message, attachment: attachment))
     }
 
     func loadMediaAttachment(_ attachment: MessageMediaAttachment, for message: MessageItem) async {
         let key = mediaDownloadKey(message: message, attachment: attachment)
-        if case .loaded = mediaDownloads[key] {
+        let stateStore = mediaDownloadStateStore(forKey: key)
+        if case .loaded = stateStore.state {
             return
         }
-        if case .loading = mediaDownloads[key] {
+        if case .loading = stateStore.state {
             return
         }
 
         guard let client, let activeAccount, !message.groupIdHex.isEmpty else {
-            mediaDownloads[key] = .failed(L10n.string("Attachment unavailable"))
+            stateStore.update(.failed(L10n.string("Attachment unavailable")))
             return
         }
 
         let accountId = activeAccount.id
         let accountRef = activeAccount.accountRef
         let groupIdHex = message.groupIdHex
-        mediaDownloads[key] = .loading
+        stateStore.update(.loading)
 
         do {
             let reference = try await resolvedMediaReference(
@@ -1721,18 +1739,27 @@ final class WorkspaceState {
                 reference: reference
             )
             guard activeAccountId == accountId else { return }
-            mediaDownloads[key] = .loaded(
+            stateStore.update(.loaded(
                 MessageMediaDownload(
                     data: download.plaintext,
                     fileName: download.fileName,
                     mediaType: download.mediaType,
                     sizeBytes: download.sizeBytes
                 )
-            )
+            ))
         } catch {
             guard activeAccountId == accountId else { return }
-            mediaDownloads[key] = .failed(error.localizedDescription)
+            stateStore.update(.failed(error.localizedDescription))
         }
+    }
+
+    private func mediaDownloadStateStore(forKey key: String) -> MediaDownloadStateStore {
+        if let store = mediaDownloads[key] {
+            return store
+        }
+        let store = MediaDownloadStateStore()
+        mediaDownloads[key] = store
+        return store
     }
 
     /// Copies `text` to the system pasteboard.
@@ -2705,7 +2732,7 @@ final class WorkspaceState {
         accounts = []
         chatsByAccount = [:]
         messagesByChat = [:]
-        mediaDownloads = [:]
+        resetMediaDownloadStateStores()
         messageLookupByChat = [:]
         messageIDsByChat = [:]
         peerProfileFFICache.removeAll()
@@ -3510,14 +3537,23 @@ final class WorkspaceState {
 
     private func pruneMediaDownloadCache(keeping groupIdHex: String?) {
         guard let activeAccountId, let groupIdHex else {
-            mediaDownloads = [:]
+            resetMediaDownloadStateStores()
             return
         }
 
         let prefix = [activeAccountId, groupIdHex, ""].joined(separator: "\u{1F}")
-        mediaDownloads = mediaDownloads.filter { key, _ in
-            key.hasPrefix(prefix)
+        let removedKeys = mediaDownloads.keys.filter { !$0.hasPrefix(prefix) }
+        for key in removedKeys {
+            mediaDownloads[key]?.update(.idle)
+            mediaDownloads[key] = nil
         }
+    }
+
+    private func resetMediaDownloadStateStores() {
+        for store in mediaDownloads.values {
+            store.update(.idle)
+        }
+        mediaDownloads.removeAll()
     }
 
     private func resolvedMediaReference(

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1739,20 +1739,25 @@ final class WorkspaceState {
                 reference: reference
             )
             guard activeAccountId == accountId else { return }
-            stateStore.update(.loaded(
-                MessageMediaDownload(
-                    data: download.plaintext,
-                    fileName: download.fileName,
-                    mediaType: download.mediaType,
-                    sizeBytes: download.sizeBytes
+            stateStore.update(
+                .loaded(
+                    MessageMediaDownload(
+                        data: download.plaintext,
+                        fileName: download.fileName,
+                        mediaType: download.mediaType,
+                        sizeBytes: download.sizeBytes
+                    )
                 )
-            ))
+            )
         } catch {
             guard activeAccountId == accountId else { return }
             stateStore.update(.failed(error.localizedDescription))
         }
     }
 
+    /// Lazily allocates per-attachment stores from SwiftUI body lookup without observing the
+    /// backing dictionary; `mediaDownloads` is `@ObservationIgnored`, and pruning bounds it to
+    /// the active conversation.
     private func mediaDownloadStateStore(forKey key: String) -> MediaDownloadStateStore {
         if let store = mediaDownloads[key] {
             return store
@@ -3544,6 +3549,7 @@ final class WorkspaceState {
         let prefix = [activeAccountId, groupIdHex, ""].joined(separator: "\u{1F}")
         let removedKeys = mediaDownloads.keys.filter { !$0.hasPrefix(prefix) }
         for key in removedKeys {
+            // Notify any lingering per-attachment observers before dropping the store.
             mediaDownloads[key]?.update(.idle)
             mediaDownloads[key] = nil
         }
@@ -3551,6 +3557,7 @@ final class WorkspaceState {
 
     private func resetMediaDownloadStateStores() {
         for store in mediaDownloads.values {
+            // Notify any lingering per-attachment observers before clearing the cache.
             store.update(.idle)
         }
         mediaDownloads.removeAll()

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2303,6 +2303,7 @@ private struct MessageBubble: View {
 
                 ForEach(nonvisualMediaAttachments) { attachment in
                     MessageMediaAttachmentView(
+                        downloadState: workspace.mediaDownloadStateStore(for: message, attachment: attachment),
                         message: message,
                         attachment: attachment,
                         isOutgoing: message.isOutgoing
@@ -2469,6 +2470,7 @@ private struct MessageImageGalleryPresentation: Identifiable, Equatable {
 }
 
 private struct MessageVisualMediaGrid: View {
+    @Environment(WorkspaceState.self) private var workspace
     let message: MessageItem
     let attachments: [MessageMediaAttachment]
     let isOutgoing: Bool
@@ -2528,6 +2530,7 @@ private struct MessageVisualMediaGrid: View {
     private func tile(at index: Int) -> some View {
         if index < visibleAttachments.count {
             MessageVisualMediaTile(
+                downloadState: workspace.mediaDownloadStateStore(for: message, attachment: visibleAttachments[index]),
                 message: message,
                 attachment: visibleAttachments[index],
                 isOutgoing: isOutgoing,
@@ -2544,6 +2547,7 @@ private struct MessageVisualMediaGrid: View {
 
 private struct MessageVisualMediaTile: View {
     @Environment(WorkspaceState.self) private var workspace
+    @ObservedObject var downloadState: MediaDownloadStateStore
     let message: MessageItem
     let attachment: MessageMediaAttachment
     let isOutgoing: Bool
@@ -2579,7 +2583,7 @@ private struct MessageVisualMediaTile: View {
 
     @ViewBuilder
     private var content: some View {
-        switch workspace.mediaDownloadState(for: message, attachment: attachment) {
+        switch downloadState.state {
         case .idle, .loading:
             placeholder(systemImage: attachment.kind == .video ? "play.rectangle" : "photo", isLoading: true)
         case .failed:
@@ -2627,13 +2631,14 @@ private struct MessageVisualMediaTile: View {
 
 private struct MessageMediaAttachmentView: View {
     @Environment(WorkspaceState.self) private var workspace
+    @ObservedObject var downloadState: MediaDownloadStateStore
     let message: MessageItem
     let attachment: MessageMediaAttachment
     let isOutgoing: Bool
 
     var body: some View {
         Group {
-            switch workspace.mediaDownloadState(for: message, attachment: attachment) {
+            switch downloadState.state {
             case .idle, .loading:
                 MessageAttachmentStatusRow(
                     systemImage: "arrow.down.circle",
@@ -3196,36 +3201,11 @@ private struct MessageImageGalleryOverlay: View {
 
     @ViewBuilder
     private var imageContent: some View {
-        switch workspace.mediaDownloadState(for: presentation.message, attachment: selectedAttachment) {
-        case .idle, .loading:
-            ProgressView()
-                .controlSize(.regular)
-                .tint(.white)
-        case .failed:
-            VStack(spacing: 10) {
-                Image(systemName: "exclamationmark.triangle")
-                    .font(.title2)
-                Text("Image unavailable")
-                    .font(.callout.weight(.semibold))
-                Button {
-                    Task { await workspace.loadMediaAttachment(selectedAttachment, for: presentation.message) }
-                } label: {
-                    Label("Retry", systemImage: "arrow.clockwise")
-                }
-            }
-            .foregroundStyle(.white)
-        case .loaded(let download):
-            if let image = NSImage(data: download.data) {
-                Image(nsImage: image)
-                    .resizable()
-                    .scaledToFit()
-                    .accessibilityLabel(selectedAttachment.fileName)
-            } else {
-                Text("Image unavailable")
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(.white)
-            }
-        }
+        MessageImageGalleryContent(
+            downloadState: workspace.mediaDownloadStateStore(for: presentation.message, attachment: selectedAttachment),
+            message: presentation.message,
+            attachment: selectedAttachment
+        )
     }
 
     private func navigationButton(
@@ -3243,6 +3223,46 @@ private struct MessageImageGalleryOverlay: View {
         .foregroundStyle(.white.opacity(isEnabled ? 0.96 : 0.28))
         .disabled(!isEnabled)
         .help(systemName == "chevron.left" ? "Previous image" : "Next image")
+    }
+}
+
+private struct MessageImageGalleryContent: View {
+    @Environment(WorkspaceState.self) private var workspace
+    @ObservedObject var downloadState: MediaDownloadStateStore
+    let message: MessageItem
+    let attachment: MessageMediaAttachment
+
+    var body: some View {
+        switch downloadState.state {
+        case .idle, .loading:
+            ProgressView()
+                .controlSize(.regular)
+                .tint(.white)
+        case .failed:
+            VStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.title2)
+                Text("Image unavailable")
+                    .font(.callout.weight(.semibold))
+                Button {
+                    Task { await workspace.loadMediaAttachment(attachment, for: message) }
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                }
+            }
+            .foregroundStyle(.white)
+        case .loaded(let download):
+            if let image = NSImage(data: download.data) {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .accessibilityLabel(attachment.fileName)
+            } else {
+                Text("Image unavailable")
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(.white)
+            }
+        }
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -8,11 +8,29 @@
 import Darwin
 import Foundation
 import MarmotKit
+import Observation
 import SwiftUI
 import Testing
 import UserNotifications
 
 @testable import whitenoise_mac
+
+private final class ObservationInvalidationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var invalidated = false
+
+    func markInvalidated() {
+        lock.lock()
+        invalidated = true
+        lock.unlock()
+    }
+
+    var value: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return invalidated
+    }
+}
 
 @Suite(.serialized)
 struct whitenoise_macTests {
@@ -1090,6 +1108,65 @@ struct whitenoise_macTests {
 
         #expect(runtime.listMediaCallCount == 1)
         #expect(runtime.downloadMediaCallCount == 1)
+    }
+
+    @MainActor
+    @Test func mediaDownloadStateStoresDoNotInvalidateWorkspaceObservationForUnrelatedDownloads() async throws {
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+        let firstReference = mediaAttachmentReference(mediaType: "image/png", fileName: "first.png")
+        let secondReference = mediaAttachmentReference(mediaType: "image/png", fileName: "second.png")
+        let firstMessage = MessageItem(
+            id: "first-media-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "first-media-message#0#\(firstReference.plaintextSha256)",
+                    reference: firstReference
+                )
+            ]
+        )
+        let secondMessage = MessageItem(
+            id: "second-media-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_001),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "second-media-message#0#\(secondReference.plaintextSha256)",
+                    reference: secondReference
+                )
+            ]
+        )
+        let firstAttachment = try #require(firstMessage.mediaAttachments.first)
+        let secondAttachment = try #require(secondMessage.mediaAttachments.first)
+        let firstStore = state.mediaDownloadStateStore(for: firstMessage, attachment: firstAttachment)
+        let sameFirstStore = state.mediaDownloadStateStore(for: firstMessage, attachment: firstAttachment)
+        let secondStore = state.mediaDownloadStateStore(for: secondMessage, attachment: secondAttachment)
+
+        #expect(firstStore === sameFirstStore)
+        #expect(firstStore !== secondStore)
+
+        let workspaceInvalidated = ObservationInvalidationFlag()
+        withObservationTracking {
+            _ = state.mediaDownloadStateStore(for: firstMessage, attachment: firstAttachment)
+        } onChange: {
+            workspaceInvalidated.markInvalidated()
+        }
+
+        await state.loadMediaAttachment(secondAttachment, for: secondMessage)
+
+        #expect(!workspaceInvalidated.value)
+        #expect(firstStore.state == .idle)
+        guard case .failed = secondStore.state else {
+            Issue.record("Expected the unrelated download store to receive the failed state")
+            return
+        }
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5,6 +5,7 @@
 //  Created by Jeff Gardner on 26/05/2026.
 //
 
+import Combine
 import Darwin
 import Foundation
 import MarmotKit
@@ -1112,9 +1113,92 @@ struct whitenoise_macTests {
 
     @MainActor
     @Test func mediaDownloadStateStoresDoNotInvalidateWorkspaceObservationForUnrelatedDownloads() async throws {
-        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
-        let firstReference = mediaAttachmentReference(mediaType: "image/png", fileName: "first.png")
-        let secondReference = mediaAttachmentReference(mediaType: "image/png", fileName: "second.png")
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: false
+        )
+        let firstReference = mediaAttachmentReference(
+            sourceEpoch: 0,
+            mediaType: "image/png",
+            fileName: "first.png",
+            ciphertextSha256: String(repeating: "1", count: 64),
+            plaintextSha256: String(repeating: "2", count: 64)
+        )
+        let firstDownloadReference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "image/png",
+            fileName: "first.png",
+            ciphertextSha256: firstReference.ciphertextSha256,
+            plaintextSha256: firstReference.plaintextSha256
+        )
+        let secondReference = mediaAttachmentReference(
+            sourceEpoch: 0,
+            mediaType: "image/png",
+            fileName: "second.png",
+            ciphertextSha256: String(repeating: "3", count: 64),
+            plaintextSha256: String(repeating: "4", count: 64)
+        )
+        let secondDownloadReference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "image/png",
+            fileName: "second.png",
+            ciphertextSha256: secondReference.ciphertextSha256,
+            plaintextSha256: secondReference.plaintextSha256
+        )
+        let secondDownload = MediaDownloadResultFfi(
+            plaintext: Data([0x10, 0x20, 0x30, 0x40]),
+            fileName: "second.png",
+            mediaType: "image/png",
+            sizeBytes: 4
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        func mediaRecord(
+            messageId: String,
+            reference: MediaAttachmentReferenceFfi,
+            recordedAt: UInt64
+        ) -> MediaRecordFfi {
+            MediaRecordFfi(
+                messageIdHex: messageId,
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: reference,
+                caption: nil,
+                recordedAt: recordedAt,
+                receivedAt: recordedAt
+            )
+        }
+        runtime.installMediaRecord(
+            mediaRecord(
+                messageId: "first-media-message",
+                reference: firstDownloadReference,
+                recordedAt: 1_700_000_000
+            ),
+            download: MediaDownloadResultFfi(
+                plaintext: Data([0x01, 0x02, 0x03, 0x04]),
+                fileName: "first.png",
+                mediaType: "image/png",
+                sizeBytes: 4
+            )
+        )
+        runtime.installMediaRecord(
+            mediaRecord(
+                messageId: "second-media-message",
+                reference: secondDownloadReference,
+                recordedAt: 1_700_000_001
+            ),
+            download: secondDownload
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
         let firstMessage = MessageItem(
             id: "first-media-message",
             groupIdHex: "group",
@@ -1159,14 +1243,24 @@ struct whitenoise_macTests {
             workspaceInvalidated.markInvalidated()
         }
 
+        let firstStoreInvalidated = ObservationInvalidationFlag()
+        let firstStoreCancellable = firstStore.objectWillChange.sink { _ in
+            firstStoreInvalidated.markInvalidated()
+        }
+
         await state.loadMediaAttachment(secondAttachment, for: secondMessage)
 
+        withExtendedLifetime(firstStoreCancellable) {}
         #expect(!workspaceInvalidated.value)
+        #expect(!firstStoreInvalidated.value)
         #expect(firstStore.state == .idle)
-        guard case .failed = secondStore.state else {
-            Issue.record("Expected the unrelated download store to receive the failed state")
+        #expect(runtime.listMediaCallCount == 1)
+        #expect(runtime.downloadMediaCallCount == 1)
+        guard case .loaded(let loaded) = secondStore.state else {
+            Issue.record("Expected the unrelated download store to receive the loaded state")
             return
         }
+        #expect(loaded.data == secondDownload.plaintext)
     }
 
     @MainActor
@@ -8447,15 +8541,18 @@ private func encryptedMediaComponent() -> AppGroupEncryptedMediaComponentFfi {
 private func mediaAttachmentReference(
     sourceEpoch: UInt64 = 0,
     mediaType: String,
-    fileName: String
+    fileName: String,
+    ciphertextSha256: String = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    plaintextSha256: String = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    nonceHex: String = "cccccccccccccccccccccccc"
 ) -> MediaAttachmentReferenceFfi {
     MediaAttachmentReferenceFfi(
         locators: [
             MediaLocatorFfi(kind: "blossom", value: "https://blob.example/\(fileName)")
         ],
-        ciphertextSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        plaintextSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        nonceHex: "cccccccccccccccccccccccc",
+        ciphertextSha256: ciphertextSha256,
+        plaintextSha256: plaintextSha256,
+        nonceHex: nonceHex,
         fileName: fileName,
         mediaType: mediaType,
         version: "marmot.encrypted-media.v1",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4041,13 +4041,17 @@ struct whitenoise_macTests {
             return
         }
 
-        // Hold a load in-flight at the gate, then close group details before it completes.
+        await state.showGroupDetails(for: groupChat)
+        #expect(state.isGroupDetailsPresented)
+        #expect(state.groupDetailsSnapshot?.name == "Test Group")
+
+        // Hold a reload in-flight at the gate, then close group details before it completes.
+        // Opening first avoids the chat-list enrichment task racing to consume the test gate.
         runtime.groupDetailsGateEnabled = true
-        async let inflight: Void = state.showGroupDetails(for: groupChat)
+        async let inflight: Void = state.reloadSelectedGroupDetails()
         while !(state.isLoadingGroupDetails && runtime.didReachGroupDetailsGate) {
             await Task.yield()
         }
-        #expect(state.isGroupDetailsPresented)
 
         state.closeGroupDetails()
         #expect(!state.isGroupDetailsPresented)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1158,7 +1158,6 @@ struct whitenoise_macTests {
             sizeBytes: 4
         )
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installGroup(messageGroup())
         func mediaRecord(
             messageId: String,
             reference: MediaAttachmentReferenceFfi,
@@ -1261,6 +1260,7 @@ struct whitenoise_macTests {
             return
         }
         #expect(loaded.data == secondDownload.plaintext)
+        await state.deleteAllData()
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Replace the shared observed `mediaDownloads` value dictionary with ignored per-attachment `MediaDownloadStateStore` objects.
- Pass each attachment's store into visual tiles, file/audio rows, and the gallery overlay so only the matching attachment view observes state changes.
- Add a regression test that verifies unrelated media state changes do not invalidate WorkspaceState observation.

## Test Plan
- `git diff --check`
- `xcodebuild -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS' test` (not run: `xcodebuild` is not installed on this Linux worker)

Closes #144


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/148">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->