### PR TITLE
fix: clear media downloads on account removal

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -917,6 +917,7 @@ final class WorkspaceState {
                 messagesByChat.removeAll()
                 messageLookupByChat.removeAll()
                 messageIDsByChat.removeAll()
+                mediaDownloads.removeAll()
                 peerProfileFFICache.removeAll()
                 clearGroupMemberCache()
                 timelinePagingByChat.removeAll()


### PR DESCRIPTION
Closes #141

## Summary
- Clear `mediaDownloads` when `removeAccount(_:)` resets the active account state.
- This wipes decrypted attachment plaintext cached for a removed account before the last-account early return or surviving-account reselection path.
- Matches the surrounding cache-clearing behavior and the full-wipe `resetToNewInstallState` path.

## Verification
- `git diff --check` — passed.
- Inspected `.github/workflows/mac-ci.yml`; CI requires macOS/Xcode (`xcrun`, `xcodebuild`).
- Confirmed this Linux host lacks `xcrun`, `xcodebuild`, `swift`, and `swift-format`, so macOS CI commands could not be run locally.

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState.swift` — account-removal state cleanup for decrypted media plaintext cache.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/149">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing an account now also removes leftover media download state when the active session is reset, helping prevent stale attachment data from appearing after account removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->