### PR TITLE
fix: fail transcript export on empty history page

### DIFF
--- a/whitenoise-mac/Core/ConversationTranscriptExport.swift
+++ b/whitenoise-mac/Core/ConversationTranscriptExport.swift
@@ -7,6 +7,22 @@ import MarmotKit
 nonisolated enum ConversationTranscriptExport {
     static let pageLimit: UInt32 = 200
 
+    enum ExportError: LocalizedError {
+        /// The FFI reported more history exists (`hasMoreBefore == true`) but returned an
+        /// empty page, so the `before` cursor cannot advance. Surfacing this prevents
+        /// silently truncating the transcript (issue #139).
+        case emptyPageWithMoreHistory
+
+        var errorDescription: String? {
+            switch self {
+            case .emptyPageWithMoreHistory:
+                return
+                    "Transcript export stopped early: the timeline reported more history but returned an empty page, "
+                    + "so older messages could not be loaded."
+            }
+        }
+    }
+
     struct Document: Encodable {
         var v: Int = 1
         var exportedAt: String
@@ -89,8 +105,13 @@ nonisolated enum ConversationTranscriptExport {
                 collectedById[message.messageIdHex] = message
             }
 
+            guard page.hasMoreBefore else { break }
             let orderedPage = sortChronologically(page.messages)
-            guard page.hasMoreBefore, let oldest = orderedPage.first else { break }
+            guard let oldest = orderedPage.first else {
+                // `hasMoreBefore` is true but the page is empty, so the `before` cursor
+                // cannot advance. Fail loudly instead of silently truncating history (#139).
+                throw ExportError.emptyPageWithMoreHistory
+            }
             let nextBefore = oldest.timelineAt
             let nextBeforeMessageId = oldest.messageIdHex
             guard nextBefore != before || nextBeforeMessageId != beforeMessageId else { break }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3337,6 +3337,57 @@ struct whitenoise_macTests {
         #expect((json["events"] as? [[String: Any]])?.count == 2)
     }
 
+    @Test func conversationTranscriptExportFailsWhenEmptyPageReportsMoreHistory() throws {
+        // Regression for #139: an empty page returned with `hasMoreBefore == true` cannot
+        // advance the `before` cursor, so the export must fail loudly rather than silently
+        // truncating older history. The first page returns one message with more before it,
+        // then the second page comes back empty while still claiming more history exists.
+        let runtime = FakeMarmotRuntime(accounts: [desktopAccount()])
+        let firstId = String(repeating: "1", count: 64)
+        runtime.timelineMessagesHandler = { query in
+            if query.before == nil {
+                return TimelinePageFfi(
+                    messages: [
+                        timelineMessage(
+                            id: firstId,
+                            groupIdHex: "group",
+                            sender: String(repeating: "a", count: 64),
+                            plaintext: "newest",
+                            recordedAt: 10
+                        )
+                    ],
+                    hasMoreBefore: true,
+                    hasMoreAfter: false
+                )
+            }
+            return TimelinePageFfi(messages: [], hasMoreBefore: true, hasMoreAfter: false)
+        }
+
+        #expect(throws: ConversationTranscriptExport.ExportError.self) {
+            try ConversationTranscriptExport.fetchAllMessages(
+                client: runtime,
+                accountRef: "Desktop Account",
+                groupIdHex: "group"
+            )
+        }
+    }
+
+    @Test func conversationTranscriptExportStopsCleanlyWhenEmptyPageHasNoMoreHistory() throws {
+        // The companion to the regression above: an empty page with `hasMoreBefore == false`
+        // is genuinely done and must terminate the loop without throwing.
+        let runtime = FakeMarmotRuntime(accounts: [desktopAccount()])
+        runtime.timelineMessagesHandler = { _ in
+            TimelinePageFfi(messages: [], hasMoreBefore: false, hasMoreAfter: false)
+        }
+
+        let messages = try ConversationTranscriptExport.fetchAllMessages(
+            client: runtime,
+            accountRef: "Desktop Account",
+            groupIdHex: "group"
+        )
+        #expect(messages.isEmpty)
+    }
+
     @MainActor
     @Test func directChatUsesOtherMemberProfileForTitleAndAvatar() async throws {
         let account = AccountSummaryFfi(


### PR DESCRIPTION
Closes #139

## Summary
- Split the transcript-export pagination stop condition so `hasMoreBefore == false` remains the normal completion path.
- Added `ConversationTranscriptExport.ExportError.emptyPageWithMoreHistory` and throw it when the FFI returns an empty page while still reporting older history, preventing silent partial exports.
- Added focused Swift Testing coverage for the empty-but-more regression and the empty-no-more completion case.

## Verification
- `git diff --check` ✅
- working-tree conflict-marker sweep on touched files ✅
- changed-file line-length check against `.swift-format` 120-char limit ✅
- GitHub `Static Analysis` ✅
- GitHub `PR Checks` ❌, rerun once and failed both times on `whitenoise_macTests.incrementalChatRowUpdateEnrichesDirectChatTitle()`.
  - The same failure is present on current `master` run 28115979319 and sibling PR #149, so this appears to be unrelated master CI drift rather than this transcript-export change.
  - The new transcript-export tests passed in GitHub CI before the unrelated failure.
- Local macOS checks could not run on this Linux worker: `xcrun`, `xcodebuild`, `swift`, and `swift-format` are unavailable. `scripts/ci/macos-sanity-checks.sh` was attempted and stopped at missing `xcodebuild`.

## Sensitive paths
None.
