### PR TITLE
fix: cache composer draft image thumbnails

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -941,11 +941,24 @@ private struct PendingMediaDraftTile: View {
     let attachment: PendingMediaAttachment
     let tileSize: CGSize
 
+    @State private var decodedImagePreview: NSImage?
+    @State private var decodedImageCacheKey: String?
+
+    private static let imagePreviewCache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 64
+        cache.totalCostLimit = 8 * 1024 * 1024
+        return cache
+    }()
+
     var body: some View {
         Group {
             switch attachment.kind {
             case .image:
                 imagePreview
+                    .task(id: imagePreviewTaskID) {
+                        await loadImagePreview()
+                    }
             case .audio:
                 audioPreview
             case .video, .file:
@@ -966,7 +979,7 @@ private struct PendingMediaDraftTile: View {
 
     @ViewBuilder
     private var imagePreview: some View {
-        if let image = NSImage(data: attachment.data) {
+        if let image = decodedImagePreview {
             Image(nsImage: image)
                 .resizable()
                 .scaledToFill()
@@ -974,6 +987,50 @@ private struct PendingMediaDraftTile: View {
         } else {
             iconPreview(systemName: attachment.kind.systemImageName)
         }
+    }
+
+    private var imagePreviewTaskID: String {
+        Self.cacheKey(for: attachment, maxPixelSize: imagePreviewMaxPixelSize)
+    }
+
+    private var imagePreviewMaxPixelSize: CGFloat {
+        ceil(max(tileSize.width, tileSize.height) * 2)
+    }
+
+    @MainActor
+    private func loadImagePreview() async {
+        let cacheKey = imagePreviewTaskID
+        if decodedImageCacheKey == cacheKey, decodedImagePreview != nil {
+            return
+        }
+        if let cached = Self.imagePreviewCache.object(forKey: cacheKey as NSString) {
+            decodedImageCacheKey = cacheKey
+            decodedImagePreview = cached
+            return
+        }
+
+        decodedImageCacheKey = cacheKey
+        decodedImagePreview = nil
+
+        let data = attachment.data
+        let maxPixelSize = imagePreviewMaxPixelSize
+        let decoded = await Task.detached(priority: .utility) {
+            PendingMediaDraftThumbnailDecoder.image(from: data, maxPixelSize: maxPixelSize)
+        }.value
+
+        guard decodedImageCacheKey == cacheKey else { return }
+        if let decoded {
+            Self.imagePreviewCache.setObject(
+                decoded,
+                forKey: cacheKey as NSString,
+                cost: PendingMediaDraftThumbnailDecoder.decodedCost(for: decoded)
+            )
+        }
+        decodedImagePreview = decoded
+    }
+
+    private static func cacheKey(for attachment: PendingMediaAttachment, maxPixelSize: CGFloat) -> String {
+        "\(attachment.id.uuidString)|\(attachment.data.count)|\(Int(maxPixelSize))"
     }
 
     private var audioPreview: some View {
@@ -1018,6 +1075,36 @@ private struct PendingMediaDraftTile: View {
         Image(systemName: systemName)
             .font(.system(size: 20, weight: .semibold))
             .foregroundStyle(.secondary)
+    }
+}
+
+enum PendingMediaDraftThumbnailDecoder {
+    static func image(from data: Data, maxPixelSize: CGFloat) -> NSImage? {
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+            return nil
+        }
+        let options =
+            [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceShouldCacheImmediately: true,
+                kCGImageSourceThumbnailMaxPixelSize: Int(max(1, maxPixelSize)),
+            ] as CFDictionary
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options) else {
+            return nil
+        }
+        return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+    }
+
+    static func decodedCost(for image: NSImage) -> Int {
+        let representation = image.representations.first
+        let width = max(1, representation?.pixelsWide ?? Int(ceil(image.size.width)))
+        let height = max(1, representation?.pixelsHigh ?? Int(ceil(image.size.height)))
+        guard width <= Int.max / max(height, 1) / 4 else {
+            return 8 * 1024 * 1024
+        }
+        return width * height * 4
     }
 }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -3,6 +3,7 @@ import AVKit
 import AppKit
 import CoreImage
 import CryptoKit
+import ImageIO
 import MarmotKit
 import SwiftUI
 import UniformTypeIdentifiers
@@ -944,10 +945,23 @@ private struct PendingMediaDraftTile: View {
     @State private var decodedImagePreview: NSImage?
     @State private var decodedImageCacheKey: String?
 
+    // The composer only shows a handful of draft tiles. Keep thumbnails bounded while allowing
+    // enough headroom for several ~148px previews and matching failed-decode entries.
+    private static let imagePreviewCacheCountLimit = 64
+    private static let failedImagePreviewCacheCountLimit = imagePreviewCacheCountLimit
+    private static let imagePreviewCacheTotalCostLimit =
+        PendingMediaDraftThumbnailDecoder.defaultDecodedCacheTotalCostLimit
+
     private static let imagePreviewCache: NSCache<NSString, NSImage> = {
         let cache = NSCache<NSString, NSImage>()
-        cache.countLimit = 64
-        cache.totalCostLimit = 8 * 1024 * 1024
+        cache.countLimit = imagePreviewCacheCountLimit
+        cache.totalCostLimit = imagePreviewCacheTotalCostLimit
+        return cache
+    }()
+
+    private static let failedImagePreviewCache: NSCache<NSString, NSNumber> = {
+        let cache = NSCache<NSString, NSNumber>()
+        cache.countLimit = failedImagePreviewCacheCountLimit
         return cache
     }()
 
@@ -1000,12 +1014,18 @@ private struct PendingMediaDraftTile: View {
     @MainActor
     private func loadImagePreview() async {
         let cacheKey = imagePreviewTaskID
-        if decodedImageCacheKey == cacheKey, decodedImagePreview != nil {
+        let nsCacheKey = cacheKey as NSString
+        if decodedImageCacheKey == cacheKey {
             return
         }
-        if let cached = Self.imagePreviewCache.object(forKey: cacheKey as NSString) {
+        if let cached = Self.imagePreviewCache.object(forKey: nsCacheKey) {
             decodedImageCacheKey = cacheKey
             decodedImagePreview = cached
+            return
+        }
+        if Self.failedImagePreviewCache.object(forKey: nsCacheKey) != nil {
+            decodedImageCacheKey = cacheKey
+            decodedImagePreview = nil
             return
         }
 
@@ -1020,11 +1040,14 @@ private struct PendingMediaDraftTile: View {
 
         guard decodedImageCacheKey == cacheKey else { return }
         if let decoded {
+            Self.failedImagePreviewCache.removeObject(forKey: nsCacheKey)
             Self.imagePreviewCache.setObject(
                 decoded,
-                forKey: cacheKey as NSString,
+                forKey: nsCacheKey,
                 cost: PendingMediaDraftThumbnailDecoder.decodedCost(for: decoded)
             )
+        } else {
+            Self.failedImagePreviewCache.setObject(NSNumber(value: true), forKey: nsCacheKey)
         }
         decodedImagePreview = decoded
     }
@@ -1079,6 +1102,8 @@ private struct PendingMediaDraftTile: View {
 }
 
 enum PendingMediaDraftThumbnailDecoder {
+    static let defaultDecodedCacheTotalCostLimit = 8 * 1024 * 1024
+
     static func image(from data: Data, maxPixelSize: CGFloat) -> NSImage? {
         let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
         guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
@@ -1102,7 +1127,7 @@ enum PendingMediaDraftThumbnailDecoder {
         let width = max(1, representation?.pixelsWide ?? Int(ceil(image.size.width)))
         let height = max(1, representation?.pixelsHigh ?? Int(ceil(image.size.height)))
         guard width <= Int.max / max(height, 1) / 4 else {
-            return 8 * 1024 * 1024
+            return defaultDecodedCacheTotalCostLimit
         }
         return width * height * 4
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4662,11 +4662,20 @@ struct whitenoise_macTests {
 
     @Test func pendingMediaDraftThumbnailDecoderDownsamplesLargeImage() async throws {
         let data = try Self.jpegData(width: 640, height: 480)
-        let image = try #require(PendingMediaDraftThumbnailDecoder.image(from: data, maxPixelSize: 74))
+        let productionTileMaxPixelSize = 148
+        let image = try #require(
+            PendingMediaDraftThumbnailDecoder.image(
+                from: data,
+                maxPixelSize: CGFloat(productionTileMaxPixelSize)
+            )
+        )
         let representation = try #require(image.representations.first)
 
-        #expect(max(representation.pixelsWide, representation.pixelsHigh) <= 74)
-        #expect(PendingMediaDraftThumbnailDecoder.decodedCost(for: image) <= 74 * 74 * 4)
+        #expect(max(representation.pixelsWide, representation.pixelsHigh) <= productionTileMaxPixelSize)
+        #expect(
+            PendingMediaDraftThumbnailDecoder.decodedCost(for: image)
+                <= productionTileMaxPixelSize * productionTileMaxPixelSize * 4
+        )
     }
 
     @Test func pendingMediaDraftThumbnailDecoderRejectsInvalidImageData() async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5,13 +5,16 @@
 //  Created by Jeff Gardner on 26/05/2026.
 //
 
+import AppKit
 import Combine
 import Darwin
 import Foundation
+import ImageIO
 import MarmotKit
 import Observation
 import SwiftUI
 import Testing
+import UniformTypeIdentifiers
 import UserNotifications
 
 @testable import whitenoise_mac
@@ -4657,6 +4660,24 @@ struct whitenoise_macTests {
         #expect(!collector.exceededCap)
     }
 
+    @Test func pendingMediaDraftThumbnailDecoderDownsamplesLargeImage() async throws {
+        let data = try Self.jpegData(width: 640, height: 480)
+        let image = try #require(PendingMediaDraftThumbnailDecoder.image(from: data, maxPixelSize: 74))
+        let representation = try #require(image.representations.first)
+
+        #expect(max(representation.pixelsWide, representation.pixelsHigh) <= 74)
+        #expect(PendingMediaDraftThumbnailDecoder.decodedCost(for: image) <= 74 * 74 * 4)
+    }
+
+    @Test func pendingMediaDraftThumbnailDecoderRejectsInvalidImageData() async throws {
+        let image = PendingMediaDraftThumbnailDecoder.image(
+            from: Data([0x00, 0x01, 0x02, 0x03]),
+            maxPixelSize: 74
+        )
+
+        #expect(image == nil)
+    }
+
     @Test func remoteImageSanitizedURLRejectsUntrustedInput() async throws {
         // nil / empty / whitespace-only -> nil (no request issued).
         #expect(RemoteImageURLPolicy.sanitizedURL(from: nil) == nil)
@@ -4711,6 +4732,40 @@ struct whitenoise_macTests {
         0x3D, 0x1D, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
         0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
     ])
+
+    private static func jpegData(width: Int, height: Int) throws -> Data {
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        let cgImage = pixels.withUnsafeMutableBytes { bytes -> CGImage? in
+            guard
+                let context = CGContext(
+                    data: bytes.baseAddress,
+                    width: width,
+                    height: height,
+                    bitsPerComponent: 8,
+                    bytesPerRow: bytesPerRow,
+                    space: colorSpace,
+                    bitmapInfo: bitmapInfo
+                )
+            else {
+                return nil
+            }
+            context.setFillColor(NSColor.systemBlue.cgColor)
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+            return context.makeImage()
+        }
+        let image = try #require(cgImage)
+        let data = NSMutableData()
+        let destination = try #require(
+            CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil)
+        )
+        CGImageDestinationAddImage(destination, image, nil)
+        #expect(CGImageDestinationFinalize(destination))
+        return data as Data
+    }
 
     @MainActor
     @Test func loadRemoteImagesDefaultsOffAndPersists() async throws {


### PR DESCRIPTION
## Summary
- replace composer draft image tile `NSImage(data:)` body decoding with an async downsampled thumbnail load
- cache decoded draft thumbnails by attachment id/data size/tile pixel size
- add regression coverage for thumbnail downsampling and invalid image data

## Verification
- `git diff --check`
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' HEAD -- .` (no matches)
- `scripts/ci/macos-sanity-checks.sh` (blocked on Linux: `xcodebuild: command not found`)
- `xcrun swift-format lint ...` (blocked on Linux: `xcrun` unavailable)

Closes #142


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/151">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->