### PR TITLE
fix: refresh system language changes live

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -37,14 +37,14 @@ struct ContentView: View {
                     for: NSLocale.currentLocaleDidChangeNotification
                 )
             ) { _ in
-                workspace.handleSystemLocaleChange()
+                workspace.refreshSystemLanguageIfNeeded()
             }
             .onReceive(
                 NotificationCenter.default.publisher(
                     for: NSApplication.didBecomeActiveNotification
                 )
             ) { _ in
-                workspace.handleSystemLocaleChange()
+                workspace.refreshSystemLanguageIfNeeded()
                 // The app just regained focus. Flush any read-marking that was deferred
                 // while it was in the background so the selected chat clears its unread
                 // state now that the user may be looking at it again.

--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -34,9 +34,17 @@ struct ContentView: View {
             }
             .onReceive(
                 NotificationCenter.default.publisher(
+                    for: NSLocale.currentLocaleDidChangeNotification
+                )
+            ) { _ in
+                workspace.handleSystemLocaleChange()
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
                     for: NSApplication.didBecomeActiveNotification
                 )
             ) { _ in
+                workspace.handleSystemLocaleChange()
                 // The app just regained focus. Flush any read-marking that was deferred
                 // while it was in the background so the selected chat clears its unread
                 // state now that the user may be looking at it again.

--- a/whitenoise-mac/Core/AppLanguage.swift
+++ b/whitenoise-mac/Core/AppLanguage.swift
@@ -89,6 +89,10 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         return .autoupdatingCurrent
     }
 
+    static func currentSystemLocaleIdentifier() -> String {
+        systemLocale().identifier
+    }
+
     static func resolved(rawValue: String?) -> AppLanguage {
         rawValue.flatMap(AppLanguage.init(rawValue:)) ?? .system
     }

--- a/whitenoise-mac/Core/AppLanguage.swift
+++ b/whitenoise-mac/Core/AppLanguage.swift
@@ -39,12 +39,17 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     // re-evaluate frequently, per-message mapping) on the main thread. Resolving
     // it must not read `UserDefaults` or allocate a `Locale` on every call. We
     // cache the resolved locale in memory and only recompute it when the stored
-    // language preference actually changes. `refreshCachedLocale()` is invoked
-    // from `WorkspaceState.languagePreference` (the only production writer of
-    // `storageKey`) so the cache stays correct, while the common-case read is an
-    // allocation-free in-memory lookup. The unfair lock keeps the cache safe if
-    // `currentLocale` is ever touched off the main thread.
+    // language preference or effective system locale changes. The unfair lock
+    // keeps the cache safe if `currentLocale` is ever touched off the main thread.
     private static let cachedLocale = OSAllocatedUnfairLock<Locale?>(initialState: nil)
+
+    #if DEBUG
+        private static let systemLocaleOverride = OSAllocatedUnfairLock<Locale?>(initialState: nil)
+
+        static func setSystemLocaleOverrideForTesting(_ locale: Locale?) {
+            systemLocaleOverride.withLock { $0 = locale }
+        }
+    #endif
 
     static var currentLocale: Locale {
         cachedLocale.withLock { cache in
@@ -71,7 +76,17 @@ enum AppLanguage: String, CaseIterable, Identifiable {
 
     private static func resolvedLocaleFromDefaults() -> Locale {
         let rawValue = UserDefaults.standard.string(forKey: storageKey)
-        return resolved(rawValue: rawValue).locale ?? .autoupdatingCurrent
+        let language = resolved(rawValue: rawValue)
+        return language.locale ?? systemLocale()
+    }
+
+    private static func systemLocale() -> Locale {
+        #if DEBUG
+            if let override = systemLocaleOverride.withLock({ $0 }) {
+                return override
+            }
+        #endif
+        return .autoupdatingCurrent
     }
 
     static func resolved(rawValue: String?) -> AppLanguage {

--- a/whitenoise-mac/Core/L10n.swift
+++ b/whitenoise-mac/Core/L10n.swift
@@ -8,10 +8,11 @@ enum L10n {
     // mapping). Resolving the language-specific `.lproj` bundle must not stat
     // the filesystem (`Bundle.main.path(forResource:ofType:)`) or allocate a
     // fresh `Bundle(path:)` on every call. We cache the resolved bundle in
-    // memory and only recompute it when the stored language preference actually
-    // changes. The cache is cleared from `AppLanguage.refreshCachedLocale()`
-    // (the single invalidation point shared with the cached locale), so it stays
-    // correct while the common-case read is an allocation-free in-memory lookup.
+    // memory and only recompute it when the stored language preference or
+    // effective system locale changes. The cache is cleared from
+    // `AppLanguage.refreshCachedLocale()` (the single invalidation point shared
+    // with the cached locale), so it stays correct while the common-case read is
+    // an allocation-free in-memory lookup.
     //
     // The outer optional distinguishes "not yet resolved" (`nil`) from "resolved,
     // no matching `.lproj` bundle" (`.some(nil)`), so a genuine miss (e.g. the
@@ -33,7 +34,8 @@ enum L10n {
 
     /// Clear the cached localized bundle so the next `string(_:)` call re-resolves
     /// it for the current language preference. Called from
-    /// `AppLanguage.refreshCachedLocale()` whenever the preference changes.
+    /// `AppLanguage.refreshCachedLocale()` whenever the preference or effective
+    /// system locale changes.
     static func refreshCachedLocalizedBundle() {
         cachedLocalizedBundle.withLock { $0 = nil }
     }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -679,6 +679,16 @@ final class WorkspaceState {
         languagePreference.locale ?? .autoupdatingCurrent
     }
 
+    func handleSystemLocaleChange() {
+        guard languagePreference == .system else { return }
+        // Assigning the existing value intentionally re-triggers the observable
+        // mutation and the `didSet` cache invalidation path. The UI reads
+        // `preferredLocale`, which depends on `languagePreference`, so this also
+        // gives SwiftUI a concrete state mutation to render against after macOS
+        // changes its effective language while the app is running.
+        languagePreference = .system
+    }
+
     func bootstrap() async {
         guard client == nil, case .bootstrapping = phase else { return }
         lastError = nil

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -211,9 +211,14 @@ final class WorkspaceState {
     var languagePreference: AppLanguage {
         didSet {
             UserDefaults.standard.set(languagePreference.rawValue, forKey: AppLanguage.storageKey)
+            if languagePreference == .system {
+                observedSystemLocaleIdentifier = AppLanguage.currentSystemLocaleIdentifier()
+            }
             AppLanguage.refreshCachedLocale()
         }
     }
+    private var observedSystemLocaleIdentifier = AppLanguage.currentSystemLocaleIdentifier()
+    private(set) var systemLocaleRefreshRevision = 0
     var isLoadingSettings = false
     var isSavingProfile = false
     var isRemovingAccount = false
@@ -676,17 +681,24 @@ final class WorkspaceState {
     }
 
     var preferredLocale: Locale {
-        languagePreference.locale ?? .autoupdatingCurrent
+        if let locale = languagePreference.locale {
+            return locale
+        }
+        _ = systemLocaleRefreshRevision
+        return AppLanguage.currentLocale
     }
 
-    func handleSystemLocaleChange() {
+    func refreshSystemLanguageIfNeeded() {
         guard languagePreference == .system else { return }
-        // Assigning the existing value intentionally re-triggers the observable
-        // mutation and the `didSet` cache invalidation path. The UI reads
-        // `preferredLocale`, which depends on `languagePreference`, so this also
-        // gives SwiftUI a concrete state mutation to render against after macOS
-        // changes its effective language while the app is running.
-        languagePreference = .system
+        let systemLocaleIdentifier = AppLanguage.currentSystemLocaleIdentifier()
+        guard systemLocaleIdentifier != observedSystemLocaleIdentifier else { return }
+
+        observedSystemLocaleIdentifier = systemLocaleIdentifier
+        AppLanguage.refreshCachedLocale()
+        // `preferredLocale` reads this revision so SwiftUI has a concrete
+        // observable mutation to re-render against after the system language
+        // changes without rewriting the stored in-app language preference.
+        systemLocaleRefreshRevision += 1
     }
 
     func bootstrap() async {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -622,6 +622,47 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func systemLocaleChangeInvalidatesLocalizedStringCacheWhenPreferenceIsSystem() async throws {
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer {
+            AppLanguage.setSystemLocaleOverrideForTesting(nil)
+            restoreDefault(previousLanguage, forKey: AppLanguage.storageKey)
+        }
+
+        UserDefaults.standard.removeObject(forKey: AppLanguage.storageKey)
+        AppLanguage.setSystemLocaleOverrideForTesting(Locale(identifier: AppLanguage.spanish.rawValue))
+        AppLanguage.refreshCachedLocale()
+        // Prime the system-preference cache while the effective system language is Spanish.
+        #expect(L10n.string("Save") == "Guardar")
+
+        AppLanguage.setSystemLocaleOverrideForTesting(Locale(identifier: AppLanguage.german.rawValue))
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+
+        state.handleSystemLocaleChange()
+
+        #expect(L10n.string("Save") == "Speichern")
+    }
+
+    @MainActor
+    @Test func systemLocaleChangeDoesNotOverrideSelectedAppLanguage() async throws {
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer {
+            AppLanguage.setSystemLocaleOverrideForTesting(nil)
+            restoreDefault(previousLanguage, forKey: AppLanguage.storageKey)
+        }
+
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.setSystemLocaleOverrideForTesting(Locale(identifier: AppLanguage.german.rawValue))
+        AppLanguage.refreshCachedLocale()
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+
+        state.handleSystemLocaleChange()
+
+        #expect(state.languagePreference == .spanish)
+        #expect(L10n.string("Save") == "Guardar")
+    }
+
+    @MainActor
     @Test func projectedChatRowTimestampUsesLastMessageTime() async throws {
         let lastMessageAt: UInt64 = 1_700_000_000
         let projectionRefreshedAt: UInt64 = 1_800_000_000

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -632,15 +632,19 @@ struct whitenoise_macTests {
         UserDefaults.standard.removeObject(forKey: AppLanguage.storageKey)
         AppLanguage.setSystemLocaleOverrideForTesting(Locale(identifier: AppLanguage.spanish.rawValue))
         AppLanguage.refreshCachedLocale()
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
         // Prime the system-preference cache while the effective system language is Spanish.
         #expect(L10n.string("Save") == "Guardar")
 
-        AppLanguage.setSystemLocaleOverrideForTesting(Locale(identifier: AppLanguage.german.rawValue))
-        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+        state.refreshSystemLanguageIfNeeded()
+        #expect(state.systemLocaleRefreshRevision == 0)
 
-        state.handleSystemLocaleChange()
+        AppLanguage.setSystemLocaleOverrideForTesting(Locale(identifier: AppLanguage.german.rawValue))
+
+        state.refreshSystemLanguageIfNeeded()
 
         #expect(L10n.string("Save") == "Speichern")
+        #expect(state.systemLocaleRefreshRevision == 1)
     }
 
     @MainActor
@@ -656,7 +660,7 @@ struct whitenoise_macTests {
         AppLanguage.refreshCachedLocale()
         let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
 
-        state.handleSystemLocaleChange()
+        state.refreshSystemLanguageIfNeeded()
 
         #expect(state.languagePreference == .spanish)
         #expect(L10n.string("Save") == "Guardar")


### PR DESCRIPTION
## Summary
- observe live macOS locale-change notifications from the root view
- refresh the cached app locale/localized bundle only when the in-app preference is System
- add regression coverage for system-locale cache invalidation and for preserving explicit language overrides

## Test Plan
- `git diff --check`
- changed Swift file line-length scan (<=120 chars)
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` (skipped locally: `xcrun` not installed on Linux worker)
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' -only-testing:whitenoise-macTests/whitenoise_macTests/systemLocaleChangeInvalidatesLocalizedStringCacheWhenPreferenceIsSystem CODE_SIGNING_ALLOWED=NO` (skipped locally: `xcodebuild` not installed on Linux worker)

Closes #140


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->