### PR TITLE
fix: accept camelCase sourceEpoch in imeta JSON

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -398,7 +398,7 @@ private nonisolated enum MessageMediaParser {
                 output.append(
                     contentsOf: references(
                         fromIMetaValue: imeta,
-                        sourceEpoch: unsignedInteger(dictionary["source_epoch"])
+                        sourceEpoch: unsignedInteger(dictionary["source_epoch"] ?? dictionary["sourceEpoch"])
                     )
                 )
             }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -945,6 +945,41 @@ struct whitenoise_macTests {
         #expect(!message.canCopyText)
     }
 
+    @MainActor
+    @Test func imetaInsideJSONReadsSourceEpochInBothSpellings() async throws {
+        // Regression for whitenoise-mac#137: the imeta-within-object branch must
+        // accept both snake_case `source_epoch` and camelCase `sourceEpoch` so a
+        // camelCase payload does not silently default the epoch to 0.
+        let reference = mediaAttachmentReference(sourceEpoch: 7, mediaType: "image/png", fileName: "photo.png")
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "snake-epoch",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJson(for: reference, sourceEpochKey: "source_epoch")
+                ),
+                timelineMessage(
+                    id: "camel-epoch",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_001,
+                    mediaJson: mediaJson(for: reference, sourceEpochKey: "sourceEpoch")
+                ),
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+
+        #expect(messages.count == 2)
+        #expect(messages.allSatisfy { $0.mediaAttachments.first?.reference.sourceEpoch == 7 })
+    }
+
     @Test func mediaGridPresentationUsesSquareFourTileLayout() {
         #expect(MessageMediaGridPresentation.visibleCount(totalCount: 6) == 4)
         #expect(MessageMediaGridPresentation.hiddenCount(totalCount: 6) == 2)
@@ -8569,6 +8604,11 @@ private func mediaAttachmentReference(
 private func mediaJson(for reference: MediaAttachmentReferenceFfi) -> String {
     let tag = mediaIMetaTag(for: reference).values
     return mediaJSONString(fromJSONObject: ["imeta": [tag]])
+}
+
+private func mediaJson(for reference: MediaAttachmentReferenceFfi, sourceEpochKey key: String) -> String {
+    let tag = mediaIMetaTag(for: reference).values
+    return mediaJSONString(fromJSONObject: ["imeta": [tag], key: NSNumber(value: reference.sourceEpoch)])
 }
 
 private func mediaJson(for reference: MediaAttachmentReferenceFfi, mediaObjectDepth depth: Int) -> String {


### PR DESCRIPTION
Closes #137

## Summary
- Accept camelCase `sourceEpoch` as well as snake_case `source_epoch` when parsing an `imeta` array embedded inside media JSON.
- Added a focused regression test that maps both spellings and asserts the parsed attachment keeps the non-zero source epoch.

## Verification
- `git diff --check` — passed.
- `python3` static line-length check for changed Swift files (120-column config) — passed.
- macOS/Xcode checks not run locally: this Linux host does not have `swift`, `xcodebuild`, `xcrun`, `swift-format`, or `swiftlint`. GitHub CI on `macos-26` will run the formatter, unit tests, release build smoke, and static analysis.

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/153">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->