### PR TITLE
fix: guard concurrent group details loads

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -375,6 +375,18 @@ final class WorkspaceState {
     /// `groupImageResults`. Mirrors the new-chat lookup / settings-load generation guards
     /// (issues #2, #4). See `searchGroupImages` / issue #110.
     private var groupImageSearchGeneration = 0
+    /// Monotonic token identifying the most recently started group-details load. `loadGroupDetails`
+    /// captures the value on entry and only applies the fetched snapshot, clears
+    /// `isLoadingGroupDetails`, or reports errors while it is still current — i.e. no newer load or
+    /// `closeGroupDetails` has bumped the generation. This makes the load last-request-wins (a slow
+    /// earlier load cannot clobber a newer snapshot or prematurely drop the shared spinner) and
+    /// prevents a load resolving after group details are closed from repopulating closed UI state.
+    /// `loadGroupDetails` is reachable concurrently for the same group from `showGroupDetails`,
+    /// `reloadSelectedGroupDetails`, `saveGroupProfile`, member-mutation paths, and
+    /// `acceptGroupInvite`, and `applyGroupDetails` is completion-ordered, not request-ordered.
+    /// Mirrors the settings-load / group-image-search generation guards (issues #2, #4, #110).
+    /// See `loadGroupDetails` / issue #135.
+    private var groupDetailsLoadGeneration = 0
     /// Raw per-sender FFI lookups (userProfile + directory displayName), cached so that
     /// scrolling back through history does not re-resolve the same senders from Rust on
     /// every page. Keyed by sender accountIdHex.
@@ -1792,7 +1804,9 @@ final class WorkspaceState {
         groupProfileDraftName = ""
         groupProfileDraftDescription = ""
         groupInviteMemberQuery = ""
-        isLoadingGroupDetails = false
+        // Invalidate any in-flight load so a stale completion cannot repopulate closed details or
+        // resurrect the spinner; this also clears `isLoadingGroupDetails`. See issue #135.
+        invalidateGroupDetailsLoad()
         isSavingGroupProfile = false
         isInvitingGroupMember = false
         isAcceptingGroupInvite = false
@@ -2144,8 +2158,18 @@ final class WorkspaceState {
         guard let client, let activeAccount else { return }
         guard selectedChat?.id == groupIdHex else { return }
 
+        // Last-request-wins guard (issue #135): this method is reachable concurrently for the same
+        // group, and the FFI pair below is completion-ordered, not request-ordered. Capture the
+        // generation on entry; only the still-current load may apply its snapshot, clear the shared
+        // spinner, or report errors. A superseded load (a newer load started, or `closeGroupDetails`
+        // ran) leaves the spinner to its owner so it cannot drop it early or repopulate closed UI.
+        let generation = beginGroupDetailsLoad()
         isLoadingGroupDetails = true
-        defer { isLoadingGroupDetails = false }
+        defer {
+            if ownsGroupDetailsLoad(generation: generation) {
+                isLoadingGroupDetails = false
+            }
+        }
 
         do {
             let details = try await client.groupDetails(
@@ -2156,9 +2180,11 @@ final class WorkspaceState {
                 accountRef: activeAccount.accountRef,
                 groupIdHex: groupIdHex
             )
+            guard ownsGroupDetailsLoad(generation: generation) else { return }
             guard selectedChat?.id == groupIdHex else { return }
             applyGroupDetails(details, managementState: managementState)
         } catch {
+            guard ownsGroupDetailsLoad(generation: generation) else { return }
             lastError = error.localizedDescription
         }
     }
@@ -2702,7 +2728,9 @@ final class WorkspaceState {
         groupProfileDraftName = ""
         groupProfileDraftDescription = ""
         groupInviteMemberQuery = ""
-        isLoadingGroupDetails = false
+        // Invalidate any in-flight load so a stale completion cannot write into the reset state;
+        // this also clears `isLoadingGroupDetails`. See issue #135.
+        invalidateGroupDetailsLoad()
         isSavingGroupProfile = false
         isInvitingGroupMember = false
         isAcceptingGroupInvite = false
@@ -3860,6 +3888,25 @@ final class WorkspaceState {
     private func isCurrentNewChatLookup(generation: Int, query: String) -> Bool {
         newChatLookupGeneration == generation
             && newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
+    }
+
+    private func beginGroupDetailsLoad() -> Int {
+        groupDetailsLoadGeneration += 1
+        return groupDetailsLoadGeneration
+    }
+
+    /// Invalidate any in-flight group-details load so a stale completion cannot apply its snapshot,
+    /// clear the spinner, or report an error against closed/superseded UI state. Also clears the
+    /// (now-orphaned) spinner: the in-flight load, once superseded, declines to touch it.
+    private func invalidateGroupDetailsLoad() {
+        groupDetailsLoadGeneration += 1
+        isLoadingGroupDetails = false
+    }
+
+    /// True while `generation` still owns the group-details load — i.e. no newer `loadGroupDetails`
+    /// or `invalidateGroupDetailsLoad` (via `closeGroupDetails`) has bumped the generation.
+    private func ownsGroupDetailsLoad(generation: Int) -> Bool {
+        groupDetailsLoadGeneration == generation
     }
 
     private func beginGroupImageSearch() -> Int {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3760,6 +3760,94 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func staleGroupDetailsLoadDoesNotClobberNewerSnapshotOrDropSpinner() async throws {
+        // Issue #135: `loadGroupDetails` is reachable concurrently for the same group, and the FFI
+        // pair it awaits is completion-ordered, not request-ordered. An older, slower load must not
+        // overwrite a newer snapshot, must not report a stale error, and an older completion must
+        // not clear `isLoadingGroupDetails` while a newer load is still running.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        var olderDetails = groupDetailsFixture(selfAccountIdHex: account.accountIdHex)
+        olderDetails.group.name = "Older Snapshot"
+        runtime.installGroupDetails(olderDetails)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        guard let groupChat = state.activeChats.first else {
+            Issue.record("Expected a group chat")
+            return
+        }
+        await state.showGroupDetails(for: groupChat)
+        #expect(state.groupDetailsSnapshot?.name == "Older Snapshot")
+
+        // Arm the gate so the next `groupDetails` FFI call (the older load) suspends in-flight after
+        // capturing the older details.
+        runtime.groupDetailsGateEnabled = true
+        async let older: Void = state.reloadSelectedGroupDetails()
+        while !(state.isLoadingGroupDetails && runtime.didReachGroupDetailsGate) {
+            await Task.yield()
+        }
+        #expect(state.isLoadingGroupDetails)
+
+        // While the older load is held, install a newer snapshot and run a newer load to completion.
+        // The gate only holds the first call, so this newer load is not gated.
+        var newerDetails = groupDetailsFixture(selfAccountIdHex: account.accountIdHex)
+        newerDetails.group.name = "Newer Snapshot"
+        runtime.installGroupDetails(newerDetails)
+        await state.reloadSelectedGroupDetails()
+
+        // The newer load applied its snapshot and, owning the spinner, cleared it.
+        #expect(state.groupDetailsSnapshot?.name == "Newer Snapshot")
+        #expect(state.isLoadingGroupDetails == false)
+
+        // Release the older load. Its completion is now superseded, so it must neither overwrite the
+        // newer snapshot, report an error, nor resurrect the spinner.
+        runtime.releaseGroupDetailsGate()
+        _ = await older
+
+        #expect(state.groupDetailsSnapshot?.name == "Newer Snapshot")
+        #expect(state.isLoadingGroupDetails == false)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
+    @Test func closingGroupDetailsInvalidatesInFlightLoad() async throws {
+        // Issue #135: closing group details must invalidate any in-flight load so a stale completion
+        // cannot repopulate the closed snapshot or resurrect the shared spinner.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        guard let groupChat = state.activeChats.first else {
+            Issue.record("Expected a group chat")
+            return
+        }
+
+        // Hold a load in-flight at the gate, then close group details before it completes.
+        runtime.groupDetailsGateEnabled = true
+        async let inflight: Void = state.showGroupDetails(for: groupChat)
+        while !(state.isLoadingGroupDetails && runtime.didReachGroupDetailsGate) {
+            await Task.yield()
+        }
+        #expect(state.isGroupDetailsPresented)
+
+        state.closeGroupDetails()
+        #expect(!state.isGroupDetailsPresented)
+        #expect(state.isLoadingGroupDetails == false)
+        #expect(state.groupDetailsSnapshot == nil)
+
+        // Releasing the now-invalidated load must not repopulate the closed UI or set the spinner.
+        runtime.releaseGroupDetailsGate()
+        _ = await inflight
+
+        #expect(!state.isGroupDetailsPresented)
+        #expect(state.groupDetailsSnapshot == nil)
+        #expect(state.isLoadingGroupDetails == false)
+    }
+
+    @MainActor
     @Test func groupDetailsProfileSaveAndInviteUseBindings() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
@@ -6410,6 +6498,13 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var messageActionGateEnabled = false
     private(set) var didReachMessageActionGate = false
     private var messageActionGateContinuation: CheckedContinuation<Void, Never>?
+    /// Issue #135 last-request-wins-test support: when armed, the first `groupDetails` FFI call
+    /// suspends until `releaseGroupDetailsGate()` is invoked, holding the older `loadGroupDetails`
+    /// in-flight so a test can run a newer overlapping load to completion and then assert the stale
+    /// older completion does not clobber the newer snapshot or drop the shared spinner.
+    var groupDetailsGateEnabled = false
+    private(set) var didReachGroupDetailsGate = false
+    private var groupDetailsGateContinuation: CheckedContinuation<Void, Never>?
     private var profilesByAccountId: [String: UserProfileMetadataFfi] = [:]
     private var normalizedMembersByRef: [String: MemberRefFfi] = [:]
     private var groupDetailsById: [String: GroupDetailsFfi] = [:]
@@ -6865,13 +6960,31 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func groupDetails(accountRef: String, groupIdHex: String) async throws -> GroupDetailsFfi {
         groupDetailsCallCounts[groupIdHex, default: 0] += 1
+        // Snapshot the value *before* the gate so a held older load captures the older details and a
+        // later mutation cannot retroactively change what it returns (issue #135 last-request-wins).
+        let result: GroupDetailsFfi
         if let details = groupDetailsById[groupIdHex] {
-            return details
-        }
-        guard let group = groups.first(where: { $0.groupIdHex == groupIdHex }) else {
+            result = details
+        } else if let group = groups.first(where: { $0.groupIdHex == groupIdHex }) {
+            result = GroupDetailsFfi(group: group, members: [])
+        } else {
             throw FakeMarmotRuntimeError.unused
         }
-        return GroupDetailsFfi(group: group, members: [])
+        await passGroupDetailsGateIfArmed()
+        return result
+    }
+
+    private func passGroupDetailsGateIfArmed() async {
+        guard groupDetailsGateEnabled, groupDetailsGateContinuation == nil, !didReachGroupDetailsGate else { return }
+        didReachGroupDetailsGate = true
+        await withCheckedContinuation { continuation in
+            groupDetailsGateContinuation = continuation
+        }
+    }
+
+    func releaseGroupDetailsGate() {
+        groupDetailsGateContinuation?.resume()
+        groupDetailsGateContinuation = nil
     }
 
     func groupManagementState(accountRef: String, groupIdHex: String) async throws -> GroupManagementStateFfi {


### PR DESCRIPTION
Closes #135

## Summary
- Added a monotonic group-details load generation token in `WorkspaceState` so only the most recent `loadGroupDetails` call can apply its snapshot, clear `isLoadingGroupDetails`, or surface an error.
- Invalidated in-flight group-details loads when closing/resetting group details, preventing stale completions from repopulating closed UI.
- Added regression coverage for overlapping group-detail loads and closing the details sheet while a load is suspended.

## Verification
- GitHub Mac CI `PR Checks` — passed.
- GitHub Mac CI `Static Analysis` — passed.
- GitHub `CodeRabbit` status — passed, but the bot posted a rate-limit notice instead of a substantive review.
- `git diff --check` — passed.
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- . ':!*.xcuserstate'` — no conflict markers.
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed.
- Local `scripts/ci/macos-sanity-checks.sh` — blocked on Linux: `xcodebuild: command not found`.
- Swift/Xcode CI commands from `.github/workflows/mac-ci.yml` could not be run locally because `swift`, `swiftc`, `xcodebuild`, `xcrun`, and `plutil` are not installed on this host.

## Sensitive paths
none
