### PR TITLE
fix: resolve localization caches outside locks

### DIFF
--- a/whitenoise-mac/Core/AppLanguage.swift
+++ b/whitenoise-mac/Core/AppLanguage.swift
@@ -41,7 +41,15 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     // cache the resolved locale in memory and only recompute it when the stored
     // language preference or effective system locale changes. The unfair lock
     // keeps the cache safe if `currentLocale` is ever touched off the main thread.
-    private static let cachedLocale = OSAllocatedUnfairLock<Locale?>(initialState: nil)
+    // The generation token prevents a cache-miss resolver from publishing a stale
+    // `UserDefaults` read if `refreshCachedLocale()` updates the preference while
+    // resolution happens outside the lock.
+    private struct LocaleCache {
+        var locale: Locale?
+        var generation: UInt64 = 0
+    }
+
+    private static let cachedLocale = OSAllocatedUnfairLock<LocaleCache>(initialState: LocaleCache())
 
     #if DEBUG
         private static let systemLocaleOverride = OSAllocatedUnfairLock<Locale?>(initialState: nil)
@@ -52,13 +60,27 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     #endif
 
     static var currentLocale: Locale {
-        cachedLocale.withLock { cache in
-            if let cache {
-                return cache
+        while true {
+            let snapshot = cachedLocale.withLock { cache in
+                (locale: cache.locale, generation: cache.generation)
             }
-            let locale = resolvedLocaleFromDefaults()
-            cache = locale
-            return locale
+            if let locale = snapshot.locale {
+                return locale
+            }
+
+            let resolvedLocale = resolvedLocaleFromDefaults()
+            if let locale = cachedLocale.withLock({ cache -> Locale? in
+                if let locale = cache.locale {
+                    return locale
+                }
+                guard cache.generation == snapshot.generation else {
+                    return nil
+                }
+                cache.locale = resolvedLocale
+                return resolvedLocale
+            }) {
+                return locale
+            }
         }
     }
 
@@ -68,7 +90,10 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     /// `L10n`'s cached `.lproj` bundle, which is keyed on the same preference.
     static func refreshCachedLocale() {
         let locale = resolvedLocaleFromDefaults()
-        cachedLocale.withLock { $0 = locale }
+        cachedLocale.withLock { cache in
+            cache.generation &+= 1
+            cache.locale = locale
+        }
         // The localized `.lproj` bundle is cached against this same preference,
         // so invalidate it here too (the single shared invalidation point).
         L10n.refreshCachedLocalizedBundle()

--- a/whitenoise-mac/Core/L10n.swift
+++ b/whitenoise-mac/Core/L10n.swift
@@ -14,12 +14,15 @@ enum L10n {
     // with the cached locale), so it stays correct while the common-case read is
     // an allocation-free in-memory lookup.
     //
-    // The outer optional distinguishes "not yet resolved" (`nil`) from "resolved,
-    // no matching `.lproj` bundle" (`.some(nil)`), so a genuine miss (e.g. the
-    // base/development language, which has no separate `.lproj`) is cached too
-    // and not re-statted on every call. The unfair lock keeps the cache safe if
-    // `string(_:)` is ever touched off the main thread.
-    private static let cachedLocalizedBundle = OSAllocatedUnfairLock<Bundle??>(initialState: nil)
+    // The cache key records the locale used for the lookup so a concurrent
+    // preference refresh that lands while the bundle is being resolved cannot
+    // make a later call reuse a stale `.lproj` bundle.
+    private struct LocalizedBundleCache {
+        let localeIdentifier: String
+        let bundle: Bundle?
+    }
+
+    private static let cachedLocalizedBundle = OSAllocatedUnfairLock<LocalizedBundleCache?>(initialState: nil)
 
     static func string(_ key: String) -> String {
         if let localizedBundle = currentLocalizedBundle() {
@@ -41,12 +44,19 @@ enum L10n {
     }
 
     private static func currentLocalizedBundle() -> Bundle? {
-        cachedLocalizedBundle.withLock { cache in
-            if let cache {
-                return cache
+        let locale = AppLanguage.currentLocale
+        let localeIdentifier = locale.identifier
+
+        if let cache = cachedLocalizedBundle.withLock({ $0 }), cache.localeIdentifier == localeIdentifier {
+            return cache.bundle
+        }
+
+        let bundle = localizedBundle(for: locale)
+        return cachedLocalizedBundle.withLock { cache in
+            if let cache, cache.localeIdentifier == localeIdentifier {
+                return cache.bundle
             }
-            let bundle = localizedBundle(for: AppLanguage.currentLocale)
-            cache = .some(bundle)
+            cache = LocalizedBundleCache(localeIdentifier: localeIdentifier, bundle: bundle)
             return bundle
         }
     }


### PR DESCRIPTION
## Summary
- Resolve `AppLanguage.currentLocale` outside the unfair-lock critical section on cache miss.
- Resolve the localized `.lproj` bundle outside the L10n cache lock.
- Store the L10n bundle with a locale identifier so concurrent preference refreshes cannot make later calls reuse a stale bundle.

## Test Plan
- `git diff --check`
- Not run: `xcodebuild`/Swift tests are unavailable on this Linux worker (`xcodebuild: not installed`, `swift: not installed`).

Closes #138

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/155">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app language handling so the selected language is resolved more efficiently and with less locking overhead.
  * Made localized text loading more reliable by ensuring cached language resources are reused only when they match the current language, reducing the chance of stale translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->