### PR TITLE
fix: avoid duplicate avatar chrome

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1436,20 +1436,15 @@ private struct ProfileImageAvatarView: View {
                         .resizable()
                         .scaledToFill()
                 } placeholder: {
-                    AvatarView(seed: seed, initials: initials, size: size, isSelected: isSelected)
+                    AvatarView(seed: seed, initials: initials, size: size, isSelected: isSelected, drawsChrome: false)
                 }
             } else {
-                AvatarView(seed: seed, initials: initials, size: size, isSelected: isSelected)
+                AvatarView(seed: seed, initials: initials, size: size, isSelected: isSelected, drawsChrome: false)
             }
         }
         .frame(width: size, height: size)
         .clipShape(Circle())
-        .overlay {
-            Circle()
-                .strokeBorder(
-                    isSelected ? MessagesPalette.sentBubble : Color.white.opacity(0.2), lineWidth: isSelected ? 3 : 1)
-        }
-        .shadow(color: .black.opacity(0.12), radius: 2, y: 1)
+        .modifier(AvatarChromeModifier(isSelected: isSelected))
     }
 }
 
@@ -4940,6 +4935,9 @@ private struct AvatarView: View {
     let initials: String
     let size: CGFloat
     let isSelected: Bool
+    /// Whether this view draws its own ring + drop shadow. Set to `false` when a wrapper
+    /// (e.g. `ProfileImageAvatarView`) already owns the chrome, to avoid double-drawing it.
+    var drawsChrome = true
 
     var body: some View {
         Text(DisplayText.initials(for: initials, fallback: seed))
@@ -4950,13 +4948,30 @@ private struct AvatarView: View {
                 Circle()
                     .fill(AvatarPalette.gradient(for: seed))
             }
-            .overlay {
-                Circle()
-                    .strokeBorder(
-                        isSelected ? MessagesPalette.sentBubble : Color.white.opacity(0.2),
-                        lineWidth: isSelected ? 3 : 1)
-            }
-            .shadow(color: .black.opacity(0.12), radius: 2, y: 1)
+            .modifier(AvatarChromeModifier(isSelected: isSelected, isEnabled: drawsChrome))
+    }
+}
+
+/// Applies the shared avatar ring + drop shadow. Centralized so `AvatarView` and
+/// `ProfileImageAvatarView` stay visually identical and only one of them draws it.
+private struct AvatarChromeModifier: ViewModifier {
+    let isSelected: Bool
+    var isEnabled = true
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content
+                .overlay {
+                    Circle()
+                        .strokeBorder(
+                            isSelected ? MessagesPalette.sentBubble : Color.white.opacity(0.2),
+                            lineWidth: isSelected ? 3 : 1)
+                }
+                .shadow(color: .black.opacity(0.12), radius: 2, y: 1)
+        } else {
+            content
+        }
     }
 }
 


### PR DESCRIPTION
Closes #133

## Summary
- Added a shared `AvatarChromeModifier` for the avatar ring and drop shadow.
- Kept `AvatarView` chrome enabled by default for direct uses, but disabled it for generated fallbacks inside `ProfileImageAvatarView` where the wrapper already draws the chrome.
- This leaves remote images, placeholders, and generated avatars with exactly one ring/shadow layer.

## Verification
- `git diff --check` — pass
- `bash -n scripts/ci/macos-sanity-checks.sh` — pass
- `python3` sanity check over `MessengerShellView.swift` — pass; both `ProfileImageAvatarView` `AvatarView` fallbacks use `drawsChrome: false`, wrapper no longer has inline duplicate overlay/shadow, and direct `AvatarView` keeps the default chrome
- GitHub Mac CI / PR Checks — pass
- GitHub Mac CI / Static Analysis — pass
- Local `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — not runnable on this Linux host (`xcrun: command not found`)
- Local `scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host (`xcodebuild: command not found`)
- Local `xcodebuild` build/test/analyze CI steps — not runnable on this Linux host (`xcodebuild` missing)

## Review notes
- No inline PR review comments.
- CodeRabbit posted a rate-limit notice rather than an actionable review.

## Sensitive paths
none
