### PR TITLE
fix: offload decrypted attachment file writes

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -3124,6 +3124,11 @@ private struct MessageVideoAttachmentPlayer: View {
     @State private var playbackURL: URL?
     @State private var isLoading = false
     @State private var didFail = false
+    @State private var playbackPreparationID: UUID?
+
+    private var isPreparingPlayback: Bool {
+        playbackPreparationID != nil
+    }
 
     var body: some View {
         ZStack {
@@ -3164,7 +3169,7 @@ private struct MessageVideoAttachmentPlayer: View {
             Task { await togglePlayback() }
         }
         .onDisappear {
-            teardown()
+            stopPlayback()
         }
         .accessibilityLabel("Video attachment")
     }
@@ -3180,9 +3185,26 @@ private struct MessageVideoAttachmentPlayer: View {
             return
         }
 
+        if isPreparingPlayback {
+            stopPlayback()
+            return
+        }
+
+        await startPlayback()
+    }
+
+    @MainActor
+    private func startPlayback() async {
+        let nextPreparationID = UUID()
+        playbackPreparationID = nextPreparationID
         isLoading = true
         didFail = false
-        defer { isLoading = false }
+        defer {
+            if playbackPreparationID == nextPreparationID {
+                playbackPreparationID = nil
+                isLoading = false
+            }
+        }
 
         let resolvedURL: URL?
         if let playbackURL {
@@ -3193,6 +3215,7 @@ private struct MessageVideoAttachmentPlayer: View {
                 download: download
             )
         }
+        guard playbackPreparationID == nextPreparationID else { return }
         guard let url = resolvedURL else {
             didFail = true
             return
@@ -3203,9 +3226,11 @@ private struct MessageVideoAttachmentPlayer: View {
         next.play()
     }
 
-    /// Releases the player and deletes the decrypted scratch file. Ordered so `AVPlayer`
-    /// no longer references the file before it is removed.
-    private func teardown() {
+    /// Cancels in-flight preparation, releases the player, and deletes the decrypted scratch
+    /// file. Ordered so `AVPlayer` no longer references the file before it is removed.
+    private func stopPlayback() {
+        playbackPreparationID = nil
+        isLoading = false
         player?.pause()
         player = nil
         if let url = playbackURL {

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -3125,6 +3125,7 @@ private struct MessageVideoAttachmentPlayer: View {
     @State private var isLoading = false
     @State private var didFail = false
     @State private var playbackPreparationID: UUID?
+    @State private var playbackTask: Task<Void, Never>?
 
     private var isPreparingPlayback: Bool {
         playbackPreparationID != nil
@@ -3166,9 +3167,18 @@ private struct MessageVideoAttachmentPlayer: View {
         .frame(width: sideLength, height: sideLength)
         .contentShape(Rectangle())
         .onTapGesture {
-            Task { await togglePlayback() }
+            if isPreparingPlayback {
+                playbackTask?.cancel()
+                playbackTask = nil
+                stopPlayback()
+            } else {
+                playbackTask?.cancel()
+                playbackTask = Task { await togglePlayback() }
+            }
         }
         .onDisappear {
+            playbackTask?.cancel()
+            playbackTask = nil
             stopPlayback()
         }
         .accessibilityLabel("Video attachment")
@@ -3176,6 +3186,8 @@ private struct MessageVideoAttachmentPlayer: View {
 
     @MainActor
     private func togglePlayback() async {
+        guard !Task.isCancelled else { return }
+
         if let player {
             if player.timeControlStatus == .playing {
                 player.pause()
@@ -3195,6 +3207,8 @@ private struct MessageVideoAttachmentPlayer: View {
 
     @MainActor
     private func startPlayback() async {
+        guard !Task.isCancelled else { return }
+
         let nextPreparationID = UUID()
         playbackPreparationID = nextPreparationID
         isLoading = true
@@ -3215,7 +3229,7 @@ private struct MessageVideoAttachmentPlayer: View {
                 download: download
             )
         }
-        guard playbackPreparationID == nextPreparationID else { return }
+        guard playbackPreparationID == nextPreparationID, !Task.isCancelled else { return }
         guard let url = resolvedURL else {
             didFail = true
             return

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2848,7 +2848,7 @@ private struct MessageDocumentAttachmentRow: View {
             detail: mediaDetail,
             isOutgoing: isOutgoing
         ) {
-            openAttachment()
+            Task { await openAttachment() }
         }
     }
 
@@ -2858,9 +2858,10 @@ private struct MessageDocumentAttachmentRow: View {
         return "\(type) - \(size)"
     }
 
-    private func openAttachment() {
+    @MainActor
+    private func openAttachment() async {
         guard
-            let url = MessageMediaPlaybackFileStore.fileURL(
+            let url = await MessageMediaPlaybackFileStore.fileURL(
                 attachment: attachment,
                 download: download
             )
@@ -3168,6 +3169,7 @@ private struct MessageVideoAttachmentPlayer: View {
         .accessibilityLabel("Video attachment")
     }
 
+    @MainActor
     private func togglePlayback() async {
         if let player {
             if player.timeControlStatus == .playing {
@@ -3182,13 +3184,16 @@ private struct MessageVideoAttachmentPlayer: View {
         didFail = false
         defer { isLoading = false }
 
-        guard
-            let url = playbackURL
-                ?? MessageMediaPlaybackFileStore.fileURL(
-                    attachment: attachment,
-                    download: download
-                )
-        else {
+        let resolvedURL: URL?
+        if let playbackURL {
+            resolvedURL = playbackURL
+        } else {
+            resolvedURL = await MessageMediaPlaybackFileStore.fileURL(
+                attachment: attachment,
+                download: download
+            )
+        }
+        guard let url = resolvedURL else {
             didFail = true
             return
         }
@@ -3214,22 +3219,30 @@ private enum MessageMediaPlaybackFileStore {
     /// Materializes decrypted attachment plaintext into the sandboxed playback scratch
     /// directory. Callers own the returned URL and must delete it via `remove(at:)` once
     /// the consuming action (open/playback) finishes.
-    static func fileURL(attachment: MessageMediaAttachment, download: MessageMediaDownload) -> URL? {
-        do {
-            let directory = try MediaPlaybackTempStore.directoryURL()
-            return try MediaPlaybackTempStore.materialize(
-                data: download.data,
-                id: attachment.id,
-                fileName: download.fileName.nilIfBlank ?? attachment.fileName,
-                fallbackExtension: OutgoingMediaAttachmentPolicy.fileExtension(
-                    for: download.mediaType.nilIfBlank ?? attachment.mediaType,
-                    fileName: download.fileName.nilIfBlank ?? attachment.fileName
-                ),
-                directory: directory
-            )
-        } catch {
-            return nil
-        }
+    @MainActor
+    static func fileURL(attachment: MessageMediaAttachment, download: MessageMediaDownload) async -> URL? {
+        let resolvedFileName = download.fileName.nilIfBlank ?? attachment.fileName
+        let resolvedMediaType = download.mediaType.nilIfBlank ?? attachment.mediaType
+        let attachmentID = attachment.id
+        let data = download.data
+
+        return await Task.detached(priority: .utility) {
+            do {
+                let directory = try MediaPlaybackTempStore.directoryURL()
+                return try MediaPlaybackTempStore.materialize(
+                    data: data,
+                    id: attachmentID,
+                    fileName: resolvedFileName,
+                    fallbackExtension: OutgoingMediaAttachmentPolicy.fileExtension(
+                        for: resolvedMediaType,
+                        fileName: resolvedFileName
+                    ),
+                    directory: directory
+                )
+            } catch {
+                return nil
+            }
+        }.value
     }
 
     static func remove(at url: URL) {


### PR DESCRIPTION
Closes #131

## Summary
- Offloads decrypted attachment temp-file creation/writes from the main actor into a detached utility task.
- Updates document open and video playback call sites to await the off-main file-store work before touching UI state, creating AVPlayer, or opening the file.
- Snapshots only Sendable values (`String`/`Data`) before the detached write so non-Sendable attachment/download model structs are not captured off-main.

## Verification
- `git diff --check` — pass.
- Static check — pass: document and video call sites both await `MessageMediaPlaybackFileStore.fileURL(...)`; file store uses `Task.detached(priority: .utility)`; detached closure captures only primitive/Data values; no edited lines exceed 120 chars.
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — not run locally; `xcrun`/`swift-format` are unavailable on this Linux host.
- `scripts/ci/macos-sanity-checks.sh` — not run locally; requires macOS/Xcode tools (`xcodebuild`, `plutil`, `PlistBuddy`) unavailable on this Linux host.
- `xcodebuild test/build/analyze ...` — not run locally; `xcodebuild` is unavailable on this Linux host.

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment opening and playback reliability for documents and videos.
  * Reduced failed or interrupted video playback when users switch actions quickly.
  * Added smoother loading behavior so attachments open and start more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->