### PR TITLE
fix: keep remote image URL cache in memory

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -337,10 +337,13 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         URLSession(configuration: makeSessionConfiguration())
     }
 
+    // Internal so @testable configuration assertions can pin the privacy-sensitive defaults.
     static func makeSessionConfiguration() -> URLSessionConfiguration {
-        // Remote image URLs are attacker-controlled peer metadata. Keep URLSession's HTTP cache
-        // memory-only so fetched avatar URLs/bodies do not become persistent forensic artifacts
-        // in the app Caches directory, and let servers revalidate normally when avatars rotate.
+        // Remote image URLs are attacker-controlled peer metadata. Use an ephemeral session and
+        // an explicit diskCapacity: 0 URLCache as defense-in-depth so fetched avatar URLs/bodies
+        // do not become persistent forensic artifacts in the app Caches directory.
+        // .useProtocolCachePolicy lets servers revalidate when a download occurs; decoded NSCache
+        // entries may still serve same-session avatars until eviction.
         let config = URLSessionConfiguration.ephemeral
         config.urlCache = URLCache(
             memoryCapacity: 16 * 1024 * 1024,

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -334,13 +334,21 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     }
 
     private static func makeSession() -> URLSession {
-        let config = URLSessionConfiguration.default
+        URLSession(configuration: makeSessionConfiguration())
+    }
+
+    static func makeSessionConfiguration() -> URLSessionConfiguration {
+        // Remote image URLs are attacker-controlled peer metadata. Keep URLSession's HTTP cache
+        // memory-only so fetched avatar URLs/bodies do not become persistent forensic artifacts
+        // in the app Caches directory, and let servers revalidate normally when avatars rotate.
+        let config = URLSessionConfiguration.ephemeral
         config.urlCache = URLCache(
             memoryCapacity: 16 * 1024 * 1024,
-            diskCapacity: 256 * 1024 * 1024
+            diskCapacity: 0,
+            diskPath: nil
         )
-        config.requestCachePolicy = .returnCacheDataElseLoad
-        return URLSession(configuration: config)
+        config.requestCachePolicy = .useProtocolCachePolicy
+        return config
     }
 
     func image(for url: URL, maxPixelSize: CGFloat) async -> LoadedImage? {
@@ -402,8 +410,8 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         // A fresh per-download delegate keeps per-download collector state isolated (multiple
         // avatars can download concurrently). The delegate is attached to the *task*, not a new
         // session (see `CappedImageDownloadDelegate.download`), so every download runs on the
-        // shared `session` and reuses its connection pool + `URLCache` instead of paying a fresh
-        // DNS/TCP/TLS handshake and churning a throwaway `URLSession` per image.
+        // shared `session` and reuses its connection pool + in-memory `URLCache` instead of paying
+        // a fresh DNS/TCP/TLS handshake and churning a throwaway `URLSession` per image.
         let delegate = CappedImageDownloadDelegate(cap: cap)
         return await delegate.download(url, using: session)
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4730,10 +4730,12 @@ struct whitenoise_macTests {
         #expect(loader.decodedCacheTotalCostLimit > 0)
     }
 
-    @Test func remoteImageLoaderDefaultSessionUsesMemoryOnlyURLCache() async throws {
+    @Test func remoteImageLoaderDefaultSessionPinsMemoryOnlyURLCacheInvariant() async throws {
         let config = RemoteImageLoader.makeSessionConfiguration()
         let urlCache = try #require(config.urlCache)
 
+        // Foundation does not expose a stable cross-platform seam for asserting URLCache disk
+        // writes directly, so pin the privacy invariant that prevents them for the default loader.
         #expect(urlCache.memoryCapacity > 0)
         #expect(urlCache.diskCapacity == 0)
         #expect(config.requestCachePolicy == .useProtocolCachePolicy)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4730,6 +4730,15 @@ struct whitenoise_macTests {
         #expect(loader.decodedCacheTotalCostLimit > 0)
     }
 
+    @Test func remoteImageLoaderDefaultSessionUsesMemoryOnlyURLCache() async throws {
+        let config = RemoteImageLoader.makeSessionConfiguration()
+        let urlCache = try #require(config.urlCache)
+
+        #expect(urlCache.memoryCapacity > 0)
+        #expect(urlCache.diskCapacity == 0)
+        #expect(config.requestCachePolicy == .useProtocolCachePolicy)
+    }
+
     private static let singlePixelPNG = Data([
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
         0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,


### PR DESCRIPTION
## Summary

- Switch the default `RemoteImageLoader` session to an ephemeral configuration with a memory-only `URLCache` (`diskCapacity: 0`).
- Replace `.returnCacheDataElseLoad` with `.useProtocolCachePolicy` so rotated avatar responses can revalidate instead of being served indefinitely from cache.
- Add a regression test that asserts the default remote-image session config has no on-disk URL cache and uses protocol cache policy.

## Test plan

- [x] `git grep -n -E 'diskCapacity: 256|returnCacheDataElseLoad' -- whitenoise-mac whitenoise-macTests` → no matches
- [x] `git grep -n -E 'diskCapacity: 0|useProtocolCachePolicy|URLSessionConfiguration.ephemeral' -- whitenoise-mac/Core/RemoteImageLoader.swift whitenoise-macTests/whitenoise_macTests.swift`
- [ ] `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` (not run locally: Linux host lacks `xcrun`/Xcode)
- [ ] `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` (not run locally: Linux host lacks `xcodebuild`/Xcode)

Closes #136


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/158">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->