### PR TITLE
fix: avoid joined chat filter strings

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1581,9 +1581,9 @@ enum ChatFilter {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else { return chats }
         return chats.filter { chat in
-            [chat.title, chat.subtitle, chat.preview]
-                .joined(separator: " ")
-                .localizedCaseInsensitiveContains(needle)
+            chat.title.localizedCaseInsensitiveContains(needle)
+                || chat.subtitle.localizedCaseInsensitiveContains(needle)
+                || chat.preview.localizedCaseInsensitiveContains(needle)
         }
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -734,6 +734,11 @@ struct whitenoise_macTests {
         #expect(ChatFilter.filtered(chats, query: "relay").map(\.id) == ["chat-relays"])
         #expect(ChatFilter.filtered(chats, query: "desktop").map(\.id) == ["chat-design"])
         #expect(ChatFilter.filtered(chats, query: "direct").map(\.id) == ["chat-nvk"])
+
+        // A query is matched against each field independently and never across
+        // field boundaries, so "NVK Direct" does not match the chat whose title
+        // is "NVK" and subtitle is "Direct message".
+        #expect(ChatFilter.filtered(chats, query: "NVK Direct").isEmpty)
     }
 
     @MainActor


### PR DESCRIPTION
Closes #129

## Summary
- Replaced `ChatFilter.filtered`'s per-chat `[String]` + joined `String` allocation with direct short-circuiting field checks.
- Added a focused Swift Testing expectation documenting that search no longer matches across title/subtitle/preview field boundaries.

## Verification
Local Linux-host checks:
- `git diff --check` — passed.
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed.
- Static assertion: verified `ChatFilter` no longer contains `.joined(separator:)` or `[chat.title, chat.subtitle, chat.preview]`, and does contain direct title/subtitle/preview checks — passed.
- macOS-only local commands were not runnable here: `swift`, `swift-format`, `xcrun`, and `xcodebuild` are missing.

Remote GitHub checks:
- `Static Analysis` — passed.
- `Swift format lint` — passed in `PR Checks` before unit tests.
- `macOS project sanity checks` — passed in `PR Checks` before unit tests.
- `PR Checks / Unit tests` — failing in unrelated tests outside this diff. Latest master is also red for `whitenoise_macTests.incrementalChatRowUpdateEnrichesDirectChatTitle()` at `99316dc`; PR rerun failed the same test. Earlier PR run also timed out in `closingGroupDetailsInvalidatesInFlightLoad()`. Changed files are only `MessengerModels.swift` and `whitenoise_macTests.swift`'s chat-filter test block.

## Sensitive paths
none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat search so results match against the title, subtitle, and preview separately.
  * Prevented search terms from matching across combined text fields, making searches more precise.
* **Tests**
  * Added regression coverage to ensure mixed terms only match when they appear within the same field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->