### PR TITLE
fix: hash media playback temp-file keys

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import AVKit
 import AppKit
 import CoreImage
+import CryptoKit
 import MarmotKit
 import SwiftUI
 import UniformTypeIdentifiers
@@ -3094,12 +3095,8 @@ private enum MessageMediaPlaybackFileStore {
     }
 
     private static func stableStem(for id: String) -> String {
-        id.unicodeScalars.map { scalar in
-            CharacterSet.alphanumerics.contains(scalar) ? String(scalar) : "-"
-        }
-        .joined()
-        .prefix(48)
-        .description
+        let digest = SHA256.hash(data: Data(id.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 
     private static func sanitizedFileName(_ fileName: String, fallbackExtension: String) -> String {


### PR DESCRIPTION
Closes #127

## Summary
- Replace the lossy 48-character playback temp-file stem with a full SHA-256 hex digest of `attachment.id`.
- Keeps the existing sanitized display filename suffix, but keys reuse on the full attachment reference so same-message attachments with the same filename no longer collide.

## Verification
- `git diff --check HEAD^` — pass
- `git diff --check` — pass before commit
- Static collision proof with two attachment ids sharing the same 64-character message id and differing by index/hash — old stem collides, new SHA-256 digests differ
- `search_files` for `stableStem(`/`SHA256.hash` — single caller, helper output is a filesystem-safe hex path component
- Xcode/macOS-only CI commands unavailable on this Linux host: `xcrun swift-format`, `scripts/ci/macos-sanity-checks.sh`, `xcodebuild test`, `xcodebuild build`, `xcodebuild analyze`

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/161">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->