### PR TITLE
fix: clean up decrypted playback attachments

### DIFF
--- a/whitenoise-mac/Core/MediaPlaybackTempStore.swift
+++ b/whitenoise-mac/Core/MediaPlaybackTempStore.swift
@@ -1,0 +1,163 @@
+import CryptoKit
+import Foundation
+
+/// Manages on-disk scratch files used to hand decrypted attachment plaintext to
+/// macOS playback/open APIs (`AVPlayer`, `NSWorkspace.open`) that require a file URL.
+///
+/// For an E2EE messenger, decrypted media must not linger on disk after it has been
+/// viewed. The previous implementation wrote plaintext into the shared OS temp
+/// directory (`FileManager.temporaryDirectory/WhiteNoiseMediaPlayback`) and never
+/// removed it, leaving decrypted media in a predictable, world-adjacent path
+/// indefinitely. This store fixes that by:
+///
+/// - Keeping scratch files inside the app's Application Support container (the same
+///   durable, sandbox-friendly location as Marmot storage) rather than the shared
+///   temp dir, and excluding that scratch directory from backups.
+/// - Applying `.completeFileProtection` so the bytes stay encrypted at rest when the
+///   platform supports it.
+/// - Giving each consumer its own scratch file so one cleanup timer/teardown cannot
+///   delete a file still in use by a later open/playback of the same attachment.
+/// - Exposing explicit `remove(at:)` and `purge()` entry points so callers can delete
+///   a file as soon as the consuming action finishes and so launch/"Delete All Local
+///   Data" can wipe the whole directory.
+///
+/// All file-system inputs are injectable to keep the logic unit-testable without a real
+/// `AVPlayer`/`NSWorkspace`.
+enum MediaPlaybackTempStore {
+    private static let directoryName = "WhiteNoiseMediaPlayback"
+
+    /// Resolves the playback scratch directory inside the app container.
+    ///
+    /// Mirrors `MarmotStorageRoot`'s Application Support location but lives in a
+    /// sibling playback scratch directory so purges never touch Marmot storage.
+    static func directoryURL(
+        fileManager: FileManager = .default,
+        applicationSupportDirectory: (FileManager) throws -> URL = { fileManager in
+            try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        }
+    ) throws -> URL {
+        let base = try applicationSupportDirectory(fileManager)
+        return directoryURL(baseURL: base)
+    }
+
+    static func directoryURL(baseURL: URL) -> URL {
+        baseURL
+            .appendingPathComponent("White Noise", isDirectory: true)
+            .appendingPathComponent(directoryName, isDirectory: true)
+    }
+
+    /// The legacy pre-fix location that used the shared OS temp directory. Purges keep
+    /// deleting it so already-leaked plaintext from older app versions does not survive
+    /// a launch or "Delete All Local Data".
+    static func legacySharedTemporaryDirectory(fileManager: FileManager = .default) -> URL {
+        fileManager.temporaryDirectory.appendingPathComponent(directoryName, isDirectory: true)
+    }
+
+    /// Writes `data` to a per-consumer scratch file for `id`/`fileName` and returns its URL.
+    ///
+    /// The attachment id contributes a deterministic, collision-resistant stem while
+    /// `uniqueID` makes each handoff/playback own an independent file. That prevents a
+    /// delayed cleanup from an earlier open from deleting the file a later consumer is
+    /// still reading.
+    static func materialize(
+        data: Data,
+        id: String,
+        fileName: String,
+        fallbackExtension: String,
+        directory: URL,
+        uniqueID: UUID = UUID(),
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try prepareDirectory(directory, fileManager: fileManager)
+        let sanitized = sanitizedFileName(fileName, fallbackExtension: fallbackExtension)
+        let url = directory.appendingPathComponent("\(stableStem(for: id))-\(uniqueID.uuidString)-\(sanitized)")
+        try data.write(to: url, options: [.atomic, .completeFileProtection])
+        return url
+    }
+
+    /// Removes a single scratch file. Missing files are treated as success.
+    static func remove(at url: URL, fileManager: FileManager = .default) {
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        try? fileManager.removeItem(at: url)
+    }
+
+    /// Removes the entire playback scratch directory. Used on launch and when the user
+    /// deletes all local data. Missing directories are treated as success.
+    static func purge(
+        fileManager: FileManager = .default,
+        applicationSupportDirectory: (FileManager) throws -> URL = { fileManager in
+            try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        }
+    ) {
+        guard
+            let directory = try? directoryURL(
+                fileManager: fileManager,
+                applicationSupportDirectory: applicationSupportDirectory
+            )
+        else {
+            purge(directory: legacySharedTemporaryDirectory(fileManager: fileManager), fileManager: fileManager)
+            return
+        }
+        purge(
+            directory: directory,
+            legacyDirectory: legacySharedTemporaryDirectory(fileManager: fileManager),
+            fileManager: fileManager
+        )
+    }
+
+    static func purge(directory: URL, legacyDirectory: URL? = nil, fileManager: FileManager = .default) {
+        purgeSingleDirectory(directory, fileManager: fileManager)
+        if let legacyDirectory {
+            purgeSingleDirectory(legacyDirectory, fileManager: fileManager)
+        }
+    }
+
+    private static func prepareDirectory(_ directory: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        var directoryURL = directory
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try directoryURL.setResourceValues(values)
+    }
+
+    private static func purgeSingleDirectory(_ directory: URL, fileManager: FileManager) {
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        try? fileManager.removeItem(at: directory)
+    }
+
+    static func stableStem(for id: String) -> String {
+        let sanitizedPrefix = id.unicodeScalars.map { scalar in
+            CharacterSet.alphanumerics.contains(scalar) ? String(scalar) : "-"
+        }
+        .joined()
+        .prefix(32)
+
+        let digest = SHA256.hash(data: Data(id.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+            .prefix(16)
+
+        let prefix = sanitizedPrefix.isEmpty ? "attachment" : String(sanitizedPrefix)
+        return "\(prefix)-\(digest)"
+    }
+
+    static func sanitizedFileName(_ fileName: String, fallbackExtension: String) -> String {
+        let trimmed = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallback = "attachment.\(fallbackExtension)"
+        let rawName = trimmed.isEmpty ? fallback : trimmed
+        let illegal = CharacterSet(charactersIn: "/:\\")
+        let components = rawName.components(separatedBy: illegal).filter { !$0.isEmpty }
+        let sanitized = components.joined(separator: "-").trimmingCharacters(in: .whitespacesAndNewlines)
+        return sanitized.isEmpty ? fallback : sanitized
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -727,6 +727,9 @@ final class WorkspaceState {
     func bootstrap() async {
         guard client == nil, case .bootstrapping = phase else { return }
         lastError = nil
+        // Wipe any decrypted attachment plaintext left in the playback scratch directory by
+        // a prior session before the UI can surface new media.
+        try? await runOffMain { MediaPlaybackTempStore.purge() }
         do {
             let runtime = try clientFactory()
             client = runtime
@@ -1010,6 +1013,10 @@ final class WorkspaceState {
             stopChatListListener()
             stopTimelineListener()
 
+            // Marmot only owns its storage root; the decrypted-attachment playback scratch
+            // directory lives outside it, so purge it before the potentially throwing
+            // Marmot deletion call when wiping local data.
+            try? await runOffMain { MediaPlaybackTempStore.purge() }
             try await client.deleteAllLocalData()
             self.client = nil
             observabilityRuntimeConfiguration = nil

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2,7 +2,6 @@ import AVFoundation
 import AVKit
 import AppKit
 import CoreImage
-import CryptoKit
 import ImageIO
 import MarmotKit
 import SwiftUI
@@ -2856,8 +2855,17 @@ private struct MessageDocumentAttachmentRow: View {
                 download: download
             )
         else { return }
-        NSWorkspace.shared.open(url)
+        // `open` returns once LaunchServices accepts the handoff; the receiving app may
+        // still be reading the file. Delete shortly after so we don't leave decrypted
+        // plaintext on disk, while giving the app a brief window to read the bytes.
+        let didOpen = NSWorkspace.shared.open(url)
+        let cleanupDelay: TimeInterval = didOpen ? cleanupDelaySeconds : 0
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + cleanupDelay) {
+            MediaPlaybackTempStore.remove(at: url)
+        }
     }
+
+    private var cleanupDelaySeconds: TimeInterval { 30 }
 }
 
 private struct MessageAttachmentStatusRow: View {
@@ -3145,7 +3153,7 @@ private struct MessageVideoAttachmentPlayer: View {
             Task { await togglePlayback() }
         }
         .onDisappear {
-            player?.pause()
+            teardown()
         }
         .accessibilityLabel("Video attachment")
     }
@@ -3179,44 +3187,43 @@ private struct MessageVideoAttachmentPlayer: View {
         player = next
         next.play()
     }
+
+    /// Releases the player and deletes the decrypted scratch file. Ordered so `AVPlayer`
+    /// no longer references the file before it is removed.
+    private func teardown() {
+        player?.pause()
+        player = nil
+        if let url = playbackURL {
+            MessageMediaPlaybackFileStore.remove(at: url)
+            playbackURL = nil
+        }
+    }
 }
 
 private enum MessageMediaPlaybackFileStore {
+    /// Materializes decrypted attachment plaintext into the sandboxed playback scratch
+    /// directory. Callers own the returned URL and must delete it via `remove(at:)` once
+    /// the consuming action (open/playback) finishes.
     static func fileURL(attachment: MessageMediaAttachment, download: MessageMediaDownload) -> URL? {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("WhiteNoiseMediaPlayback", isDirectory: true)
         do {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-            let fileName = sanitizedFileName(
-                download.fileName.nilIfBlank ?? attachment.fileName,
+            let directory = try MediaPlaybackTempStore.directoryURL()
+            return try MediaPlaybackTempStore.materialize(
+                data: download.data,
+                id: attachment.id,
+                fileName: download.fileName.nilIfBlank ?? attachment.fileName,
                 fallbackExtension: OutgoingMediaAttachmentPolicy.fileExtension(
                     for: download.mediaType.nilIfBlank ?? attachment.mediaType,
                     fileName: download.fileName.nilIfBlank ?? attachment.fileName
-                )
+                ),
+                directory: directory
             )
-            let url = directory.appendingPathComponent("\(stableStem(for: attachment.id))-\(fileName)")
-            if !FileManager.default.fileExists(atPath: url.path) {
-                try download.data.write(to: url, options: [.atomic])
-            }
-            return url
         } catch {
             return nil
         }
     }
 
-    private static func stableStem(for id: String) -> String {
-        let digest = SHA256.hash(data: Data(id.utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
-    }
-
-    private static func sanitizedFileName(_ fileName: String, fallbackExtension: String) -> String {
-        let trimmed = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let fallback = "attachment.\(fallbackExtension)"
-        let rawName = trimmed.isEmpty ? fallback : trimmed
-        let illegal = CharacterSet(charactersIn: "/:\\")
-        let components = rawName.components(separatedBy: illegal).filter { !$0.isEmpty }
-        let sanitized = components.joined(separator: "-").trimmingCharacters(in: .whitespacesAndNewlines)
-        return sanitized.isEmpty ? fallback : sanitized
+    static func remove(at url: URL) {
+        MediaPlaybackTempStore.remove(at: url)
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -564,6 +564,169 @@ struct whitenoise_macTests {
         }
     }
 
+    @Test func mediaPlaybackTempStoreLivesInsideAppContainerNotSharedTemp() {
+        let base = URL(fileURLWithPath: "/Container", isDirectory: true)
+        let directory = MediaPlaybackTempStore.directoryURL(baseURL: base)
+
+        #expect(
+            directory.path == "/Container/White Noise/WhiteNoiseMediaPlayback"
+        )
+        #expect(!directory.path.contains(FileManager.default.temporaryDirectory.path))
+    }
+
+    @Test func mediaPlaybackTempStoreMaterializesIndependentConsumerFiles() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let firstConsumer = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let secondConsumer = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        let url = try MediaPlaybackTempStore.materialize(
+            data: Data("secret".utf8),
+            id: "attachment-id/with:illegal",
+            fileName: "report.pdf",
+            fallbackExtension: "bin",
+            directory: directory,
+            uniqueID: firstConsumer
+        )
+
+        #expect(fileManager.fileExists(atPath: url.path))
+        #expect(url.lastPathComponent.hasSuffix("-report.pdf"))
+        #expect(url.lastPathComponent.contains(firstConsumer.uuidString))
+        #expect(url.deletingLastPathComponent().path == directory.path)
+
+        // Re-materializing the same attachment for a later consumer must not reuse the
+        // previous URL; an older cleanup timer could otherwise delete the later handoff.
+        let again = try MediaPlaybackTempStore.materialize(
+            data: Data("different".utf8),
+            id: "attachment-id/with:illegal",
+            fileName: "report.pdf",
+            fallbackExtension: "bin",
+            directory: directory,
+            uniqueID: secondConsumer
+        )
+        #expect(again != url)
+        #expect(again.lastPathComponent.contains(secondConsumer.uuidString))
+        #expect(try Data(contentsOf: url) == Data("secret".utf8))
+        #expect(try Data(contentsOf: again) == Data("different".utf8))
+    }
+
+    @Test func mediaPlaybackTempStoreUsesFullIdHashInStem() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let sharedPrefix = String(repeating: "a", count: 64)
+        let firstID = "\(sharedPrefix)-one"
+        let secondID = "\(sharedPrefix)-two"
+        let firstStem = MediaPlaybackTempStore.stableStem(for: firstID)
+        let secondStem = MediaPlaybackTempStore.stableStem(for: secondID)
+        let first = try MediaPlaybackTempStore.materialize(
+            data: Data("first".utf8),
+            id: firstID,
+            fileName: "report.pdf",
+            fallbackExtension: "bin",
+            directory: directory,
+            uniqueID: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+        )
+        let second = try MediaPlaybackTempStore.materialize(
+            data: Data("second".utf8),
+            id: secondID,
+            fileName: "report.pdf",
+            fallbackExtension: "bin",
+            directory: directory,
+            uniqueID: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!
+        )
+
+        #expect(firstStem.prefix(32) == secondStem.prefix(32))
+        #expect(firstStem != secondStem)
+        #expect(first.lastPathComponent.hasPrefix("\(firstStem)-"))
+        #expect(second.lastPathComponent.hasPrefix("\(secondStem)-"))
+        #expect(try Data(contentsOf: first) == Data("first".utf8))
+        #expect(try Data(contentsOf: second) == Data("second".utf8))
+    }
+
+    @Test func mediaPlaybackTempStoreExcludesScratchDirectoryFromBackups() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        _ = try MediaPlaybackTempStore.materialize(
+            data: Data("secret".utf8),
+            id: "attachment",
+            fileName: "report.pdf",
+            fallbackExtension: "bin",
+            directory: directory
+        )
+
+        let values = try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        #expect(values.isExcludedFromBackup == true)
+    }
+
+    @Test func mediaPlaybackTempStoreRemovesSingleFile() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let url = try MediaPlaybackTempStore.materialize(
+            data: Data("bytes".utf8),
+            id: "video",
+            fileName: "clip.mp4",
+            fallbackExtension: "mp4",
+            directory: directory
+        )
+        #expect(fileManager.fileExists(atPath: url.path))
+
+        MediaPlaybackTempStore.remove(at: url)
+        #expect(!fileManager.fileExists(atPath: url.path))
+
+        // Removing a missing file is a no-op.
+        MediaPlaybackTempStore.remove(at: url)
+        #expect(!fileManager.fileExists(atPath: url.path))
+    }
+
+    @Test func mediaPlaybackTempStorePurgesDirectory() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        _ = try MediaPlaybackTempStore.materialize(
+            data: Data("a".utf8),
+            id: "one",
+            fileName: "a.txt",
+            fallbackExtension: "txt",
+            directory: directory
+        )
+        _ = try MediaPlaybackTempStore.materialize(
+            data: Data("b".utf8),
+            id: "two",
+            fileName: "b.txt",
+            fallbackExtension: "txt",
+            directory: directory
+        )
+        #expect(fileManager.fileExists(atPath: directory.path))
+
+        let legacyDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-legacy-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+        try Data("legacy".utf8).write(to: legacyDirectory.appendingPathComponent("old-video.mp4"))
+        defer { try? fileManager.removeItem(at: legacyDirectory) }
+
+        MediaPlaybackTempStore.purge(directory: directory, legacyDirectory: legacyDirectory)
+        #expect(!fileManager.fileExists(atPath: directory.path))
+        #expect(!fileManager.fileExists(atPath: legacyDirectory.path))
+
+        // Purging a missing directory is a no-op.
+        MediaPlaybackTempStore.purge(directory: directory, legacyDirectory: legacyDirectory)
+        #expect(!fileManager.fileExists(atPath: directory.path))
+        #expect(!fileManager.fileExists(atPath: legacyDirectory.path))
+    }
+
     @MainActor
     @Test func chatSearchMatchesTitleSubtitleAndPreview() async throws {
         let chats = ChatItem.samples


### PR DESCRIPTION
Closes #125

## Summary
- Add `MediaPlaybackTempStore` for decrypted attachment playback scratch files under the app's Application Support container instead of the shared OS temp directory, with `.completeFileProtection` on writes.
- Delete document scratch files after the LaunchServices handoff, delete video scratch files on player teardown / `onDisappear`, and purge both the new container directory and legacy `/tmp/WhiteNoiseMediaPlayback` directory on bootstrap and Delete All Local Data.
- Add focused tests for path placement, materialization/reuse, single-file removal, and current+legacy directory purge behavior.

## Verification
- `git diff --cached --check` before commit: passed.
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':!*.xcstrings'`: no conflict markers.
- Added-line length check against 120-char Swift format limit: passed.
- `bash -n scripts/ci/macos-sanity-checks.sh`: passed.
- `xcrun`, `xcodebuild`, `swift`, and `swift-format` are not installed on this Linux worker, so I could not run the macOS CI commands locally. The draft PR needs the macos-26 CI run for `swift-format`, `xcodebuild test/build/analyze`, and project sanity checks.

## Sensitive paths
None by repo policy. This does not touch `MarmotClient.swift`, `MarmotKit`, entitlements, app secrets, crypto/MLS/key/trust-anchor/auth/group-state code.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of media playback by storing decrypted attachment plaintext in the app’s own Application Support area (excluded from backups) instead of the shared OS temp area.
  * Playback scratch files now use per-consumer unique filenames to keep decrypted media isolated.

* **Bug Fixes**
  * More reliable cleanup: deferred deletion now depends on whether the attachment handoff was accepted.
  * Playback teardown and local data wipe now also purge decrypted media leftovers, reducing stale plaintext exposure on startup.

* **Tests**
  * Added unit tests covering storage location, filename behavior, backups exclusion, removal, and purge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->