### PR TITLE
fix: downsample cached local message images

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -252,6 +252,21 @@ enum IPAddress {
     }
 }
 
+/// Pixel sizing helpers shared by downsampled image views and tests.
+enum DownsampledImageSizing {
+    static func requestedPixelSize(_ maxPixelSize: CGFloat) -> CGFloat {
+        max(1, ceil(maxPixelSize))
+    }
+
+    /// Buckets continuously-changing gallery sizes so drag-resizing a window does not create a
+    /// fresh decoded cache entry for every pixel delta. Rounds up to avoid under-resolving.
+    static func galleryPixelSize(for pointSize: CGSize, displayScale: CGFloat) -> CGFloat {
+        let rawPixels = max(pointSize.width, pointSize.height) * max(1, displayScale)
+        let bucketSize: CGFloat = 128
+        return max(bucketSize, ceil(rawPixels / bucketSize) * bucketSize)
+    }
+}
+
 /// Drop-in replacement for `AsyncImage` that loads a remote image once, downsamples it
 /// to the size it is actually displayed at (off the main thread), and caches the decoded
 /// result. Bare `AsyncImage` re-fetches and decodes the full-resolution image on the main
@@ -264,6 +279,7 @@ struct DownsampledAsyncImage<Content: View, Placeholder: View>: View {
     @ViewBuilder var placeholder: () -> Placeholder
 
     @State private var image: Image?
+    @State private var displayedURL: URL?
 
     var body: some View {
         ZStack {
@@ -273,17 +289,96 @@ struct DownsampledAsyncImage<Content: View, Placeholder: View>: View {
                 placeholder()
             }
         }
-        .task(id: TaskKey(url: url, size: maxPixelSize)) {
+        .task(id: taskKey) {
+            await loadImage(for: taskKey)
+        }
+    }
+
+    private var taskKey: TaskKey {
+        TaskKey(url: url, size: DownsampledImageSizing.requestedPixelSize(maxPixelSize))
+    }
+
+    @MainActor
+    private func loadImage(for taskKey: TaskKey) async {
+        guard let url = taskKey.url else {
+            displayedURL = nil
             image = nil
-            guard let url else { return }
-            if let loaded = await RemoteImageLoader.shared.image(for: url, maxPixelSize: maxPixelSize) {
-                image = Image(nsImage: loaded.nsImage)
-            }
+            return
+        }
+
+        if displayedURL != url {
+            image = nil
+        }
+
+        if let loaded = await RemoteImageLoader.shared.image(for: url, maxPixelSize: taskKey.size) {
+            guard !Task.isCancelled else { return }
+            displayedURL = url
+            image = Image(nsImage: loaded.nsImage)
+        } else if displayedURL != url {
+            guard !Task.isCancelled else { return }
+            image = nil
         }
     }
 
     private struct TaskKey: Equatable {
         let url: URL?
+        let size: CGFloat
+    }
+}
+
+/// Downsamples already-local image bytes off the main actor and reuses the shared decoded-image
+/// cache. This is for decrypted/local attachments where the bytes are already available; decoding
+/// with `NSImage(data:)` in a SwiftUI `body` would synchronously inflate the full-resolution bitmap
+/// every time Observation re-evaluates the view.
+struct DownsampledDataImage<Content: View, Placeholder: View>: View {
+    let data: Data
+    let cacheKey: String
+    let maxPixelSize: CGFloat
+    @ViewBuilder var content: (Image) -> Content
+    @ViewBuilder var placeholder: () -> Placeholder
+
+    @State private var image: Image?
+    @State private var displayedCacheKey: String?
+
+    var body: some View {
+        ZStack {
+            if let image {
+                content(image)
+            } else {
+                placeholder()
+            }
+        }
+        .task(id: taskKey) {
+            await loadImage(for: taskKey)
+        }
+    }
+
+    private var taskKey: TaskKey {
+        TaskKey(cacheKey: cacheKey, size: DownsampledImageSizing.requestedPixelSize(maxPixelSize))
+    }
+
+    @MainActor
+    private func loadImage(for taskKey: TaskKey) async {
+        if displayedCacheKey != taskKey.cacheKey {
+            image = nil
+        }
+
+        if let loaded = await RemoteImageLoader.shared.image(
+            for: data,
+            cacheKey: taskKey.cacheKey,
+            maxPixelSize: taskKey.size
+        ) {
+            guard !Task.isCancelled else { return }
+            displayedCacheKey = taskKey.cacheKey
+            image = Image(nsImage: loaded.nsImage)
+        } else if displayedCacheKey != taskKey.cacheKey {
+            guard !Task.isCancelled else { return }
+            image = nil
+        }
+    }
+
+    private struct TaskKey: Equatable {
+        let cacheKey: String
         let size: CGFloat
     }
 }
@@ -427,7 +522,36 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
 
         let task = inFlight.task(for: key) { [self] in
             Task { [self] in
-                await loadImage(for: url, cacheKey: key, maxPixelSize: maxPixelSize)
+                await loadRemoteImage(for: url, cacheKey: key, maxPixelSize: maxPixelSize)
+            }
+        }
+        let waiter = RemoteImageLoadWaiter { [inFlight] in
+            inFlight.releaseWaiter(for: key)
+        }
+
+        return await withTaskCancellationHandler {
+            let loaded = await task.value
+            waiter.release()
+            return Task.isCancelled ? nil : loaded
+        } onCancel: {
+            waiter.release()
+        }
+    }
+
+    /// Downsamples and caches local/decrypted image bytes.
+    ///
+    /// The cache key is part of the decoded-image identity and is checked before looking at
+    /// `data`, so callers must provide a stable key that uniquely identifies the bytes (for
+    /// example an immutable attachment id, or a content fingerprint when ids can be reused).
+    func image(for data: Data, cacheKey rawCacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
+        let key = Self.cacheKey(forLocalImageID: rawCacheKey, maxPixelSize: maxPixelSize)
+        if let cached = cache.object(forKey: key as NSString) {
+            return LoadedImage(nsImage: cached)
+        }
+
+        let task = inFlight.task(for: key) { [self] in
+            Task { [self] in
+                await loadLocalImage(data: data, cacheKey: key, maxPixelSize: maxPixelSize)
             }
         }
         let waiter = RemoteImageLoadWaiter { [inFlight] in
@@ -450,16 +574,20 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     #endif
 
     private static func cacheKey(for url: URL, maxPixelSize: CGFloat) -> String {
-        "\(url.absoluteString)|\(Int(maxPixelSize))"
+        "remote|\(url.absoluteString)|\(Int(maxPixelSize))"
     }
 
-    private func loadImage(for url: URL, cacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
-        let key = cacheKey as NSString
-        if let cached = cache.object(forKey: key) {
-            return LoadedImage(nsImage: cached)
-        }
+    private static func cacheKey(forLocalImageID cacheID: String, maxPixelSize: CGFloat) -> String {
+        "local|\(cacheID)|\(Int(maxPixelSize))"
+    }
 
+    private func loadRemoteImage(for url: URL, cacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
         guard let data = await Self.download(url, using: session) else { return nil }
+        return await loadLocalImage(data: data, cacheKey: cacheKey, maxPixelSize: maxPixelSize)
+    }
+
+    private func loadLocalImage(data: Data, cacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
+        let key = cacheKey as NSString
         let pixelSize = maxPixelSize
         let loaded = await Task.detached(priority: .utility) {
             Self.downsample(data: data, maxPixelSize: pixelSize).map(LoadedImage.init)

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2658,6 +2658,7 @@ private struct MessageVisualMediaGrid: View {
 
 private struct MessageVisualMediaTile: View {
     @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.displayScale) private var displayScale
     @ObservedObject var downloadState: MediaDownloadStateStore
     let message: MessageItem
     let attachment: MessageMediaAttachment
@@ -2702,14 +2703,18 @@ private struct MessageVisualMediaTile: View {
         case .loaded(let download):
             switch attachment.kind {
             case .image:
-                if let image = NSImage(data: download.data) {
-                    Image(nsImage: image)
+                DownsampledDataImage(
+                    data: download.data,
+                    cacheKey: attachment.id,
+                    maxPixelSize: sideLength * max(1, displayScale) * 2
+                ) { image in
+                    image
                         .resizable()
                         .scaledToFill()
                         .frame(width: sideLength, height: sideLength)
                         .clipped()
                         .accessibilityLabel(attachment.fileName)
-                } else {
+                } placeholder: {
                     placeholder(systemImage: "photo", isLoading: false)
                 }
             case .video:
@@ -2742,6 +2747,7 @@ private struct MessageVisualMediaTile: View {
 
 private struct MessageMediaAttachmentView: View {
     @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.displayScale) private var displayScale
     @ObservedObject var downloadState: MediaDownloadStateStore
     let message: MessageItem
     let attachment: MessageMediaAttachment
@@ -2781,15 +2787,19 @@ private struct MessageMediaAttachmentView: View {
     private func loadedContent(_ download: MessageMediaDownload) -> some View {
         switch attachment.kind {
         case .image:
-            if let image = NSImage(data: download.data) {
-                Image(nsImage: image)
+            DownsampledDataImage(
+                data: download.data,
+                cacheKey: attachment.id,
+                maxPixelSize: 260 * max(1, displayScale) * 2
+            ) { image in
+                image
                     .resizable()
                     .scaledToFill()
                     .frame(width: 260, height: 260)
                     .clipped()
                     .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                     .accessibilityLabel(attachment.fileName)
-            } else {
+            } placeholder: {
                 MessageAttachmentStatusRow(
                     systemImage: "photo",
                     title: download.fileName.nilIfBlank ?? attachment.fileName,
@@ -3366,16 +3376,38 @@ private struct MessageImageGalleryContent: View {
             }
             .foregroundStyle(.white)
         case .loaded(let download):
-            if let image = NSImage(data: download.data) {
-                Image(nsImage: image)
+            DownsampledMessageGalleryImage(download: download, attachment: attachment)
+        }
+    }
+}
+
+private struct DownsampledMessageGalleryImage: View {
+    @Environment(\.displayScale) private var displayScale
+    let download: MessageMediaDownload
+    let attachment: MessageMediaAttachment
+
+    var body: some View {
+        GeometryReader { proxy in
+            DownsampledDataImage(
+                data: download.data,
+                cacheKey: attachment.id,
+                maxPixelSize: DownsampledImageSizing.galleryPixelSize(
+                    for: proxy.size,
+                    displayScale: displayScale
+                )
+            ) { image in
+                image
                     .resizable()
                     .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .accessibilityLabel(attachment.fileName)
-            } else {
+            } placeholder: {
                 Text("Image unavailable")
                     .font(.callout.weight(.semibold))
                     .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+            .frame(width: proxy.size.width, height: proxy.size.height)
         }
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5482,6 +5482,69 @@ struct whitenoise_macTests {
         #expect(config.requestCachePolicy == .useProtocolCachePolicy)
     }
 
+    @Test func remoteImageLoaderDownsamplesAndCachesLocalAttachmentBytes() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let imageData = try Self.testPNGData(width: 400, height: 300)
+
+        let small = try #require(
+            await loader.image(for: imageData, cacheKey: "attachment-1", maxPixelSize: 64)
+        )
+        let smallSize = try #require(Self.pixelSize(of: small.nsImage))
+        #expect(max(smallSize.width, smallSize.height) <= 64)
+
+        let cached = try #require(
+            await loader.image(for: Data([0x00]), cacheKey: "attachment-1", maxPixelSize: 64)
+        )
+        #expect(cached.nsImage === small.nsImage)
+
+        let large = try #require(
+            await loader.image(for: imageData, cacheKey: "attachment-1", maxPixelSize: 128)
+        )
+        let largeSize = try #require(Self.pixelSize(of: large.nsImage))
+        #expect(max(largeSize.width, largeSize.height) <= 128)
+        #expect(max(largeSize.width, largeSize.height) > max(smallSize.width, smallSize.height))
+    }
+
+    @Test func downsampledImageSizingCeilsAndBucketsRequestedPixels() async throws {
+        #expect(DownsampledImageSizing.requestedPixelSize(0) == 1)
+        #expect(DownsampledImageSizing.requestedPixelSize(63.1) == 64)
+        #expect(
+            DownsampledImageSizing.galleryPixelSize(
+                for: CGSize(width: 100, height: 100),
+                displayScale: 2
+            ) == 256
+        )
+        #expect(
+            DownsampledImageSizing.galleryPixelSize(
+                for: CGSize(width: 321, height: 200),
+                displayScale: 2
+            ) == 768
+        )
+    }
+
+    @Test func remoteImageLoaderSeparatesRemoteAndLocalCacheNamespaces() async throws {
+        RemoteImageURLProtocolStub.reset(data: Self.singlePixelPNG, responseDelay: 0)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RemoteImageURLProtocolStub.self]
+        config.urlCache = nil
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://example.com/avatar.png"))
+        let localData = try Self.testPNGData(width: 64, height: 64)
+
+        let remote = try #require(await loader.image(for: url, maxPixelSize: 32))
+        let local = try #require(
+            await loader.image(for: localData, cacheKey: url.absoluteString, maxPixelSize: 32)
+        )
+        let localCached = try #require(
+            await loader.image(for: Data([0x00]), cacheKey: url.absoluteString, maxPixelSize: 32)
+        )
+
+        #expect(remote.nsImage !== local.nsImage)
+        #expect(localCached.nsImage === local.nsImage)
+        #expect(RemoteImageURLProtocolStub.requestCount() == 1)
+    }
+
     private static let singlePixelPNG = Data([
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
         0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
@@ -5493,6 +5556,13 @@ struct whitenoise_macTests {
         0x3D, 0x1D, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
         0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
     ])
+
+    private enum ImageFixtureError: Error {
+        case failedToCreateContext
+        case failedToCreateImage
+        case failedToCreateDestination
+        case failedToFinalize
+    }
 
     private static func jpegData(width: Int, height: Int) throws -> Data {
         let bytesPerPixel = 4
@@ -5526,6 +5596,53 @@ struct whitenoise_macTests {
         CGImageDestinationAddImage(destination, image, nil)
         #expect(CGImageDestinationFinalize(destination))
         return data as Data
+    }
+
+    private static func testPNGData(width: Int, height: Int) throws -> Data {
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0xFF, count: height * bytesPerRow)
+
+        return try pixels.withUnsafeMutableBytes { buffer in
+            guard
+                let context = CGContext(
+                    data: buffer.baseAddress,
+                    width: width,
+                    height: height,
+                    bitsPerComponent: 8,
+                    bytesPerRow: bytesPerRow,
+                    space: CGColorSpaceCreateDeviceRGB(),
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                )
+            else {
+                throw ImageFixtureError.failedToCreateContext
+            }
+            guard let image = context.makeImage() else {
+                throw ImageFixtureError.failedToCreateImage
+            }
+
+            let data = NSMutableData()
+            guard
+                let destination = CGImageDestinationCreateWithData(
+                    data,
+                    UTType.png.identifier as CFString,
+                    1,
+                    nil
+                )
+            else {
+                throw ImageFixtureError.failedToCreateDestination
+            }
+            CGImageDestinationAddImage(destination, image, nil)
+            guard CGImageDestinationFinalize(destination) else {
+                throw ImageFixtureError.failedToFinalize
+            }
+            return data as Data
+        }
+    }
+
+    private static func pixelSize(of image: NSImage) -> (width: Int, height: Int)? {
+        guard let representation = image.representations.first else { return nil }
+        return (representation.pixelsWide, representation.pixelsHigh)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- add a local-data image path that downscales decrypted attachment bytes off the main actor and reuses the shared decoded-image cache
- render message tiles, attachment rows, and gallery images through the cached downsampled path instead of `NSImage(data:)` in SwiftUI bodies
- address review follow-ups by keeping the current image during same-attachment resize loads, bucketing gallery target sizes, sizing fill thumbnails with extra display-scale headroom, and documenting the local cache-key contract
- add coverage for local attachment downsampling/cache reuse, sizing quantization/bucketing, and remote-vs-local cache namespace separation

## Test Plan
- `git diff --check origin/master...HEAD`
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' HEAD -- '*.swift'` reported no conflict markers
- GitHub Mac CI `PR Checks` passed on bfd367a59eb3144785e01ff7680bdd726d0328a2: https://github.com/marmot-protocol/whitenoise-mac/actions/runs/28129281031/job/83301107486
- GitHub Mac CI `Static Analysis` passed on bfd367a59eb3144785e01ff7680bdd726d0328a2: https://github.com/marmot-protocol/whitenoise-mac/actions/runs/28129281031/job/83301107611

Closes #132