### PR TITLE
fix: roll media duration labels over hours

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -279,6 +279,20 @@ nonisolated enum MessageMediaGridPresentation {
     }
 }
 
+nonisolated enum MediaDurationLabel {
+    static func string(for durationSeconds: Double) -> String {
+        let total = max(0, Int(durationSeconds.rounded(.down)))
+        let hours = total / 3_600
+        let minutes = (total % 3_600) / 60
+        let seconds = total % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
 enum MediaDownloadState: Equatable {
     case idle
     case loading
@@ -336,8 +350,7 @@ nonisolated struct PendingMediaAttachment: Identifiable, Hashable, Sendable {
 
     var durationLabel: String? {
         guard let durationSeconds else { return nil }
-        let total = max(0, Int(durationSeconds.rounded(.down)))
-        return "\(total / 60):\(String(format: "%02d", total % 60))"
+        return MediaDurationLabel.string(for: durationSeconds)
     }
 }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1184,8 +1184,7 @@ private struct VoiceRecordingComposerView: View {
     }
 
     private static func durationLabel(_ duration: Double) -> String {
-        let total = max(0, Int(duration.rounded(.down)))
-        return "\(total / 60):\(String(format: "%02d", total % 60))"
+        MediaDurationLabel.string(for: duration)
     }
 }
 
@@ -3014,8 +3013,7 @@ private struct MessageAudioAttachmentPlayer: View {
 
     private var durationLabel: String {
         if let durationSeconds = metadata?.durationSeconds {
-            let total = max(0, Int(durationSeconds.rounded(.down)))
-            return "\(total / 60):\(String(format: "%02d", total % 60))"
+            return MediaDurationLabel.string(for: durationSeconds)
         }
         return ByteCountFormatter.string(fromByteCount: Int64(clamping: download.sizeBytes), countStyle: .file)
     }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1162,7 +1162,7 @@ private struct VoiceRecordingComposerView: View {
             Text(Self.durationLabel(durationSeconds))
                 .font(.caption.monospacedDigit().weight(.semibold))
                 .foregroundStyle(.secondary)
-                .frame(width: 44, alignment: .trailing)
+                .frame(minWidth: 44, alignment: .trailing)
 
             Button(action: onStop) {
                 Image(systemName: "stop.fill")

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -996,7 +996,7 @@ struct whitenoise_macTests {
         #expect(MessageMediaGridPresentation.gridHeight(totalCount: 4, maxWidth: 360, spacing: 3) == 360)
     }
 
-    @Test func pendingMediaAttachmentDurationLabelRollsHoursOver() {
+    @Test func pendingMediaAttachmentDurationLabelFormatsSubhourHourBoundaryAndClampsNegative() {
         let longAttachment = PendingMediaAttachment(
             fileName: "long.m4a",
             mediaType: "audio/mp4",
@@ -1022,6 +1022,8 @@ struct whitenoise_macTests {
         #expect(longAttachment.durationLabel == "1:15:00")
         #expect(shortAttachment.durationLabel == "1:05")
         #expect(negativeAttachment.durationLabel == "0:00")
+        #expect(MediaDurationLabel.string(for: 3_599) == "59:59")
+        #expect(MediaDurationLabel.string(for: 3_600) == "1:00:00")
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -996,6 +996,34 @@ struct whitenoise_macTests {
         #expect(MessageMediaGridPresentation.gridHeight(totalCount: 4, maxWidth: 360, spacing: 3) == 360)
     }
 
+    @Test func pendingMediaAttachmentDurationLabelRollsHoursOver() {
+        let longAttachment = PendingMediaAttachment(
+            fileName: "long.m4a",
+            mediaType: "audio/mp4",
+            data: Data(),
+            dim: nil,
+            durationSeconds: 4_500.9
+        )
+        let shortAttachment = PendingMediaAttachment(
+            fileName: "short.m4a",
+            mediaType: "audio/mp4",
+            data: Data(),
+            dim: nil,
+            durationSeconds: 65.9
+        )
+        let negativeAttachment = PendingMediaAttachment(
+            fileName: "negative.m4a",
+            mediaType: "audio/mp4",
+            data: Data(),
+            dim: nil,
+            durationSeconds: -2
+        )
+
+        #expect(longAttachment.durationLabel == "1:15:00")
+        #expect(shortAttachment.durationLabel == "1:05")
+        #expect(negativeAttachment.durationLabel == "0:00")
+    }
+
     @MainActor
     @Test func deeplyNestedMediaJSONDoesNotProduceAttachments() async throws {
         // Regression for whitenoise-mac#120: mediaJson is decrypted peer content.


### PR DESCRIPTION
## Summary
- Add a shared media duration formatter that rolls durations >= 1 hour into `H:MM:SS`
- Use it for pending media attachments, voice recording composer labels, and received audio attachment labels
- Add a regression test for pending attachment labels covering hour rollover, sub-hour formatting, and negative clamping

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS' -only-testing:whitenoise-macTests/whitenoise_macTests/pendingMediaAttachmentDurationLabelRollsHoursOver` (not run locally: `xcodebuild` is not installed on this Linux host)

Closes #130