### PR TITLE
fix: preserve newer read marker on mark-read failure (#128)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -4405,6 +4405,11 @@ struct ReadMarker: Equatable, Comparable {
         return lhs.messageId < rhs.messageId
     }
 
+    /// Returns the read marker to keep after a failed optimistic advance.
+    ///
+    /// `previous` is the caller's snapshot from before it wrote `attempted`; it
+    /// is not proof of the last committed marker if another mark-read call
+    /// advanced this slot while the caller was suspended.
     static func afterFailedOptimisticAdvance(
         current: ReadMarker?,
         attempted: ReadMarker,

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -3795,7 +3795,11 @@ final class WorkspaceState {
                 await applyChatRow(row, account: account)
             }
         } catch {
-            lastMarkedReadMarkers[groupIdHex] = previousMarker
+            lastMarkedReadMarkers[groupIdHex] = ReadMarker.afterFailedOptimisticAdvance(
+                current: lastMarkedReadMarkers[groupIdHex],
+                attempted: marker,
+                previous: previousMarker
+            )
             setBackgroundStatus(error.localizedDescription)
         }
     }
@@ -4392,13 +4396,21 @@ private enum GroupMemberMutationAction {
     case remove
 }
 
-private struct ReadMarker: Equatable, Comparable {
+struct ReadMarker: Equatable, Comparable {
     let sentAt: Date
     let messageId: String
 
     static func < (lhs: ReadMarker, rhs: ReadMarker) -> Bool {
         if lhs.sentAt != rhs.sentAt { return lhs.sentAt < rhs.sentAt }
         return lhs.messageId < rhs.messageId
+    }
+
+    static func afterFailedOptimisticAdvance(
+        current: ReadMarker?,
+        attempted: ReadMarker,
+        previous: ReadMarker?
+    ) -> ReadMarker? {
+        current == attempted ? previous : current
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1717,6 +1717,43 @@ struct whitenoise_macTests {
         #expect(state.selectedMessageIDs == ["m2", "stream"])
     }
 
+    @Test func failedReadMarkerRollbackPreservesConcurrentNewerAdvance() {
+        let previous = ReadMarker(
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            messageId: "m0"
+        )
+        let attempted = ReadMarker(
+            sentAt: Date(timeIntervalSince1970: 1_700_000_010),
+            messageId: "m1"
+        )
+        let newer = ReadMarker(
+            sentAt: Date(timeIntervalSince1970: 1_700_000_020),
+            messageId: "m2"
+        )
+
+        #expect(
+            ReadMarker.afterFailedOptimisticAdvance(
+                current: newer,
+                attempted: attempted,
+                previous: previous
+            ) == newer
+        )
+        #expect(
+            ReadMarker.afterFailedOptimisticAdvance(
+                current: attempted,
+                attempted: attempted,
+                previous: previous
+            ) == previous
+        )
+        #expect(
+            ReadMarker.afterFailedOptimisticAdvance(
+                current: nil,
+                attempted: attempted,
+                previous: previous
+            ) == nil
+        )
+    }
+
     @MainActor
     @Test func olderTimelineProjectionDeltaDoesNotMoveReadMarkerBackward() async throws {
         let account = AccountSummaryFfi(


### PR DESCRIPTION
## Summary
- preserve the newest in-memory read marker when an older optimistic `markTimelineMessageRead` call fails after a concurrent newer advance
- centralize the failed-mark rollback as compare-and-set semantics on `ReadMarker`
- add a regression test for the failed rollback helper preserving newer/nil slots while rolling back only the marker it installed

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` (not run locally: `xcodebuild` is unavailable on the Linux fixer host)
- `scripts/ci/macos-sanity-checks.sh` (blocked locally at `xcodebuild: command not found` on the Linux fixer host)
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` (not run locally: `xcrun` is unavailable on the Linux fixer host)

Closes #128


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->