### PR TITLE
fix: cancel unused coalesced remote image loads

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -291,23 +291,71 @@ struct DownsampledAsyncImage<Content: View, Placeholder: View>: View {
 /// Shared image cache + downsampling pipeline. `NSCache` is thread-safe, so this needs no
 /// actor for decoded-image storage; in-flight work is coordinated by `RemoteImageLoadRegistry`
 /// so concurrent views that need the same URL/size await one download and decode.
-private actor RemoteImageLoadRegistry {
-    private var tasks: [String: Task<LoadedImage?, Never>] = [:]
+private final class RemoteImageLoadRegistry: @unchecked Sendable {
+    private struct Entry {
+        let task: Task<LoadedImage?, Never>
+        var waiters: Int
+    }
+
+    private let lock = NSLock()
+    private var tasks: [String: Entry] = [:]
 
     func task(
         for key: String,
         create: @Sendable () -> Task<LoadedImage?, Never>
-    ) -> (task: Task<LoadedImage?, Never>, owner: Bool) {
-        if let task = tasks[key] {
-            return (task, false)
+    ) -> Task<LoadedImage?, Never> {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if var entry = tasks[key] {
+            entry.waiters += 1
+            tasks[key] = entry
+            return entry.task
         }
+
         let task = create()
-        tasks[key] = task
-        return (task, true)
+        tasks[key] = Entry(task: task, waiters: 1)
+        return task
     }
 
-    func removeTask(for key: String) {
-        tasks[key] = nil
+    func releaseWaiter(for key: String) {
+        var taskToCancel: Task<LoadedImage?, Never>?
+
+        lock.lock()
+        if var entry = tasks[key] {
+            entry.waiters -= 1
+            if entry.waiters <= 0 {
+                tasks[key] = nil
+                taskToCancel = entry.task
+            } else {
+                tasks[key] = entry
+            }
+        }
+        lock.unlock()
+
+        taskToCancel?.cancel()
+    }
+}
+
+private final class RemoteImageLoadWaiter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var released = false
+    private let onRelease: @Sendable () -> Void
+
+    init(onRelease: @escaping @Sendable () -> Void) {
+        self.onRelease = onRelease
+    }
+
+    func release() {
+        lock.lock()
+        guard !released else {
+            lock.unlock()
+            return
+        }
+        released = true
+        lock.unlock()
+
+        onRelease()
     }
 }
 
@@ -364,16 +412,22 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
             return LoadedImage(nsImage: cached)
         }
 
-        let (task, owner) = await inFlight.task(for: key) { [self] in
+        let task = inFlight.task(for: key) { [self] in
             Task { [self] in
                 await loadImage(for: url, cacheKey: key, maxPixelSize: maxPixelSize)
             }
         }
-        let loaded = await task.value
-        if owner {
-            await inFlight.removeTask(for: key)
+        let waiter = RemoteImageLoadWaiter { [inFlight] in
+            inFlight.releaseWaiter(for: key)
         }
-        return loaded
+
+        return await withTaskCancellationHandler {
+            let loaded = await task.value
+            waiter.release()
+            return Task.isCancelled ? nil : loaded
+        } onCancel: {
+            waiter.release()
+        }
     }
 
     private static func cacheKey(for url: URL, maxPixelSize: CGFloat) -> String {

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -288,9 +288,9 @@ struct DownsampledAsyncImage<Content: View, Placeholder: View>: View {
     }
 }
 
-/// Shared image cache + downsampling pipeline. `NSCache` is thread-safe, so this needs no
-/// actor for decoded-image storage; in-flight work is coordinated by `RemoteImageLoadRegistry`
-/// so concurrent views that need the same URL/size await one download and decode.
+/// Shared decoded-image cache + downsampling pipeline. `NSCache` owns the decoded-image
+/// storage; in-flight work is coordinated by `RemoteImageLoadRegistry` so concurrent views
+/// that need the same URL/size await one download and decode.
 private final class RemoteImageLoadRegistry: @unchecked Sendable {
     private struct Entry {
         let task: Task<LoadedImage?, Never>
@@ -313,6 +313,8 @@ private final class RemoteImageLoadRegistry: @unchecked Sendable {
             return entry.task
         }
 
+        // Keep this under the lock so a missing key creates exactly one shared task. Callers
+        // must keep `create` cheap and non-reentrant; it should only allocate the download task.
         let task = create()
         tasks[key] = Entry(task: task, waiters: 1)
         return task
@@ -335,8 +337,19 @@ private final class RemoteImageLoadRegistry: @unchecked Sendable {
 
         taskToCancel?.cancel()
     }
+
+    #if DEBUG
+        func waiterCount(for key: String) -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return tasks[key]?.waiters ?? 0
+        }
+    #endif
 }
 
+/// One-shot release latch for a coalesced waiter. Both the cancellation handler and the
+/// successful await path may try to release the same waiter; only the first release should
+/// decrement the registry count and potentially cancel the shared download.
 private final class RemoteImageLoadWaiter: @unchecked Sendable {
     private let lock = NSLock()
     private var released = false
@@ -429,6 +442,12 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
             waiter.release()
         }
     }
+
+    #if DEBUG
+        func inFlightWaiterCount(for url: URL, maxPixelSize: CGFloat) -> Int {
+            inFlight.waiterCount(for: Self.cacheKey(for: url, maxPixelSize: maxPixelSize))
+        }
+    #endif
 
     private static func cacheKey(for url: URL, maxPixelSize: CGFloat) -> String {
         "\(url.absoluteString)|\(Int(maxPixelSize))"

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4759,18 +4759,31 @@ struct whitenoise_macTests {
         let url = try #require(URL(string: "https://example.com/avatar.png"))
 
         let first = Task { await loader.image(for: url, maxPixelSize: 32) }
-        let second = Task { await loader.image(for: url, maxPixelSize: 32) }
 
         let requestStarted = await waitFor { RemoteImageURLProtocolStub.requestCount() == 1 }
         #expect(requestStarted)
 
+        let second = Task { await loader.image(for: url, maxPixelSize: 32) }
+
+        let secondJoined = await waitFor {
+            loader.inFlightWaiterCount(for: url, maxPixelSize: 32) == 2
+                && RemoteImageURLProtocolStub.requestCount() == 1
+        }
+        #expect(secondJoined)
+
         first.cancel()
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        let firstReleased = await waitFor {
+            loader.inFlightWaiterCount(for: url, maxPixelSize: 32) == 1
+        }
+        #expect(firstReleased)
         #expect(RemoteImageURLProtocolStub.stopLoadingCount() == 0)
 
         second.cancel()
 
-        let requestCancelled = await waitFor { RemoteImageURLProtocolStub.stopLoadingCount() == 1 }
+        let requestCancelled = await waitFor {
+            RemoteImageURLProtocolStub.stopLoadingCount() == 1
+                && loader.inFlightWaiterCount(for: url, maxPixelSize: 32) == 0
+        }
         #expect(requestCancelled)
 
         let results = await [first.value, second.value]
@@ -8564,8 +8577,8 @@ private final class RemoteImageURLProtocolStub: URLProtocol {
     }
 
     override func stopLoading() {
-        Self.recordStop()
         Self.lock.lock()
+        Self.stops += 1
         stopped = true
         Self.lock.unlock()
     }
@@ -8575,12 +8588,6 @@ private final class RemoteImageURLProtocolStub: URLProtocol {
         defer { lock.unlock() }
         requests += 1
         return (responseData, delay)
-    }
-
-    private static func recordStop() {
-        lock.lock()
-        stops += 1
-        lock.unlock()
     }
 
     private var isStopped: Bool {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4750,6 +4750,34 @@ struct whitenoise_macTests {
         #expect(RemoteImageURLProtocolStub.requestCount() == 1)
     }
 
+    @Test func remoteImageLoaderCancelsCoalescedDownloadAfterLastWaiterCancels() async throws {
+        RemoteImageURLProtocolStub.reset(data: Self.singlePixelPNG, responseDelay: 2)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RemoteImageURLProtocolStub.self]
+        config.urlCache = nil
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://example.com/avatar.png"))
+
+        let first = Task { await loader.image(for: url, maxPixelSize: 32) }
+        let second = Task { await loader.image(for: url, maxPixelSize: 32) }
+
+        let requestStarted = await waitFor { RemoteImageURLProtocolStub.requestCount() == 1 }
+        #expect(requestStarted)
+
+        first.cancel()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(RemoteImageURLProtocolStub.stopLoadingCount() == 0)
+
+        second.cancel()
+
+        let requestCancelled = await waitFor { RemoteImageURLProtocolStub.stopLoadingCount() == 1 }
+        #expect(requestCancelled)
+
+        let results = await [first.value, second.value]
+        #expect(results.allSatisfy { $0 == nil })
+        #expect(RemoteImageURLProtocolStub.requestCount() == 1)
+    }
+
     @Test func remoteImageLoaderUsesBoundedDecodedCache() async throws {
         let config = URLSessionConfiguration.ephemeral
         let loader = RemoteImageLoader(session: URLSession(configuration: config))
@@ -8479,12 +8507,15 @@ private final class RemoteImageURLProtocolStub: URLProtocol {
     private static var responseData = Data()
     private static var delay: TimeInterval = 0
     private static var requests = 0
+    private static var stops = 0
+    private var stopped = false
 
     static func reset(data: Data, responseDelay: TimeInterval) {
         lock.lock()
         responseData = data
         delay = responseDelay
         requests = 0
+        stops = 0
         lock.unlock()
     }
 
@@ -8492,6 +8523,12 @@ private final class RemoteImageURLProtocolStub: URLProtocol {
         lock.lock()
         defer { lock.unlock() }
         return requests
+    }
+
+    static func stopLoadingCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return stops
     }
 
     override class func canInit(with request: URLRequest) -> Bool {
@@ -8505,7 +8542,7 @@ private final class RemoteImageURLProtocolStub: URLProtocol {
     override func startLoading() {
         let (data, responseDelay) = Self.recordRequest()
         let complete = { [weak self] in
-            guard let self, let url = self.request.url else { return }
+            guard let self, let url = self.request.url, !self.isStopped else { return }
             let response = HTTPURLResponse(
                 url: url,
                 statusCode: 200,
@@ -8526,13 +8563,30 @@ private final class RemoteImageURLProtocolStub: URLProtocol {
         }
     }
 
-    override func stopLoading() {}
+    override func stopLoading() {
+        Self.recordStop()
+        Self.lock.lock()
+        stopped = true
+        Self.lock.unlock()
+    }
 
     private static func recordRequest() -> (Data, TimeInterval) {
         lock.lock()
         defer { lock.unlock() }
         requests += 1
         return (responseData, delay)
+    }
+
+    private static func recordStop() {
+        lock.lock()
+        stops += 1
+        lock.unlock()
+    }
+
+    private var isStopped: Bool {
+        Self.lock.lock()
+        defer { Self.lock.unlock() }
+        return stopped
     }
 }
 


### PR DESCRIPTION
## Summary
- track waiters for coalesced remote image loads
- cancel the shared download task when the last waiter is cancelled or completes
- keep cancelled waiters from applying a coalesced image result after cancellation
- add a regression test covering last-waiter cancellation while preserving coalescing

## Test Plan
- `git diff --check`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -destination 'platform=macOS' -only-testing:whitenoise-macTests/whitenoise_macTests/remoteImageLoaderCancelsCoalescedDownloadAfterLastWaiterCancels` (not run locally: `xcodebuild` is not installed on this Linux worker)

Closes #126


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/167">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->