### PR TITLE
fix: track confirmed read markers for rollback (#166)

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -379,6 +379,7 @@ final class WorkspaceState {
     /// underlying messages change.
     private var messageIDsByChat: [String: [String]] = [:]
     private var lastMarkedReadMarkers: [String: ReadMarker] = [:]
+    private var lastConfirmedReadMarkers: [String: ReadMarker] = [:]
     private var deliveredNotificationKeys = Set<String>()
     private var deliveredNotificationKeyOrder: [String] = []
     private var newChatLookupGeneration = 0
@@ -2807,6 +2808,7 @@ final class WorkspaceState {
         timelinePagingByChat = [:]
         timelineInitialLoadGroupId = nil
         lastMarkedReadMarkers = [:]
+        lastConfirmedReadMarkers = [:]
         deliveredNotificationKeys = []
         deliveredNotificationKeyOrder = []
         UserDefaults.standard.removeObject(forKey: Self.activeAccountKey)
@@ -3430,6 +3432,7 @@ final class WorkspaceState {
             timelineInitialLoadGroupId = nil
         }
         lastMarkedReadMarkers[groupIdHex] = nil
+        lastConfirmedReadMarkers[groupIdHex] = nil
 
         guard case .chat(let selectedGroupId) = selection,
             selectedGroupId == groupIdHex
@@ -3777,28 +3780,36 @@ final class WorkspaceState {
             return
         }
         let marker = ReadMarker(sentAt: latest.sentAt, messageId: latest.id)
-        let previousMarker = lastMarkedReadMarkers[groupIdHex]
-        guard previousMarker != marker else { return }
-        guard previousMarker.map({ $0 < marker }) ?? true else { return }
+        let currentMarker = lastMarkedReadMarkers[groupIdHex]
+        guard currentMarker != marker else { return }
+        guard currentMarker.map({ $0 < marker }) ?? true else { return }
         lastMarkedReadMarkers[groupIdHex] = marker
 
         do {
             let accountRef = account.accountRef
             let messageId = latest.id
-            if let row = try await runOffMain({
+            let row = try await runOffMain({
                 try client.markTimelineMessageRead(
                     accountRef: accountRef,
                     groupIdHex: groupIdHex,
                     messageIdHex: messageId
                 )
-            }) {
+            })
+            let committedState = ReadMarker.afterSuccessfulCommit(
+                current: lastMarkedReadMarkers[groupIdHex],
+                confirmed: lastConfirmedReadMarkers[groupIdHex],
+                attempted: marker
+            )
+            lastMarkedReadMarkers[groupIdHex] = committedState.current
+            lastConfirmedReadMarkers[groupIdHex] = committedState.confirmed
+            if let row {
                 await applyChatRow(row, account: account)
             }
         } catch {
             lastMarkedReadMarkers[groupIdHex] = ReadMarker.afterFailedOptimisticAdvance(
                 current: lastMarkedReadMarkers[groupIdHex],
                 attempted: marker,
-                previous: previousMarker
+                confirmed: lastConfirmedReadMarkers[groupIdHex]
             )
             setBackgroundStatus(error.localizedDescription)
         }
@@ -4407,15 +4418,37 @@ struct ReadMarker: Equatable, Comparable {
 
     /// Returns the read marker to keep after a failed optimistic advance.
     ///
-    /// `previous` is the caller's snapshot from before it wrote `attempted`; it
-    /// is not proof of the last committed marker if another mark-read call
-    /// advanced this slot while the caller was suspended.
+    /// `confirmed` is the last marker known to have committed through FFI. A
+    /// caller's optimistic snapshot is not enough for rollback because another
+    /// overlapping call may have advanced the slot without committing.
     static func afterFailedOptimisticAdvance(
         current: ReadMarker?,
         attempted: ReadMarker,
-        previous: ReadMarker?
+        confirmed: ReadMarker?
     ) -> ReadMarker? {
-        current == attempted ? previous : current
+        current == attempted ? confirmed : current
+    }
+
+    /// Returns the marker slots to keep after FFI confirms `attempted`.
+    ///
+    /// If a newer optimistic marker is currently in flight, keep it as the read
+    /// gate while recording `attempted` as the latest confirmed value. If a
+    /// newer failed call already rolled the gate back, restore it to the marker
+    /// that just committed.
+    static func afterSuccessfulCommit(
+        current: ReadMarker?,
+        confirmed: ReadMarker?,
+        attempted: ReadMarker
+    ) -> (current: ReadMarker, confirmed: ReadMarker) {
+        (
+            current: latest(current, attempted),
+            confirmed: latest(confirmed, attempted)
+        )
+    }
+
+    private static func latest(_ marker: ReadMarker?, _ candidate: ReadMarker) -> ReadMarker {
+        guard let marker, marker > candidate else { return candidate }
+        return marker
     }
 }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -3795,6 +3795,7 @@ final class WorkspaceState {
                     messageIdHex: messageId
                 )
             })
+            guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
             let committedState = ReadMarker.afterSuccessfulCommit(
                 current: lastMarkedReadMarkers[groupIdHex],
                 confirmed: lastConfirmedReadMarkers[groupIdHex],
@@ -3806,6 +3807,7 @@ final class WorkspaceState {
                 await applyChatRow(row, account: account)
             }
         } catch {
+            guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
             lastMarkedReadMarkers[groupIdHex] = ReadMarker.afterFailedOptimisticAdvance(
                 current: lastMarkedReadMarkers[groupIdHex],
                 attempted: marker,
@@ -4434,7 +4436,8 @@ struct ReadMarker: Equatable, Comparable {
     /// If a newer optimistic marker is currently in flight, keep it as the read
     /// gate while recording `attempted` as the latest confirmed value. If a
     /// newer failed call already rolled the gate back, restore it to the marker
-    /// that just committed.
+    /// that just committed. The returned `current` value is written back to
+    /// `lastMarkedReadMarkers`; `confirmed` is written to `lastConfirmedReadMarkers`.
     static func afterSuccessfulCommit(
         current: ReadMarker?,
         confirmed: ReadMarker?,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1747,41 +1747,87 @@ struct whitenoise_macTests {
         #expect(state.selectedMessageIDs == ["m2", "stream"])
     }
 
-    @Test func failedReadMarkerRollbackPreservesConcurrentNewerAdvance() {
-        let previous = ReadMarker(
+    @Test func failedReadMarkerRollbackUsesLastConfirmedMarker() {
+        let committed = ReadMarker(
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
             messageId: "m0"
         )
-        let attempted = ReadMarker(
+        let firstAttempt = ReadMarker(
             sentAt: Date(timeIntervalSince1970: 1_700_000_010),
             messageId: "m1"
         )
-        let newer = ReadMarker(
+        let secondAttempt = ReadMarker(
             sentAt: Date(timeIntervalSince1970: 1_700_000_020),
             messageId: "m2"
         )
 
         #expect(
             ReadMarker.afterFailedOptimisticAdvance(
-                current: newer,
-                attempted: attempted,
-                previous: previous
-            ) == newer
+                current: secondAttempt,
+                attempted: firstAttempt,
+                confirmed: committed
+            ) == secondAttempt
         )
         #expect(
             ReadMarker.afterFailedOptimisticAdvance(
-                current: attempted,
-                attempted: attempted,
-                previous: previous
-            ) == previous
+                current: secondAttempt,
+                attempted: secondAttempt,
+                confirmed: committed
+            ) == committed
         )
         #expect(
             ReadMarker.afterFailedOptimisticAdvance(
                 current: nil,
-                attempted: attempted,
-                previous: previous
+                attempted: firstAttempt,
+                confirmed: committed
             ) == nil
         )
+        #expect(
+            ReadMarker.afterFailedOptimisticAdvance(
+                current: firstAttempt,
+                attempted: firstAttempt,
+                confirmed: nil
+            ) == nil
+        )
+    }
+
+    @Test func successfulReadMarkerCommitAdvancesConfirmedMarkerAndPreservesNewerOptimisticSlot() {
+        let committed = ReadMarker(
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            messageId: "m0"
+        )
+        let firstAttempt = ReadMarker(
+            sentAt: Date(timeIntervalSince1970: 1_700_000_010),
+            messageId: "m1"
+        )
+        let secondAttempt = ReadMarker(
+            sentAt: Date(timeIntervalSince1970: 1_700_000_020),
+            messageId: "m2"
+        )
+
+        let restoredAfterNewerFailure = ReadMarker.afterSuccessfulCommit(
+            current: committed,
+            confirmed: committed,
+            attempted: firstAttempt
+        )
+        #expect(restoredAfterNewerFailure.current == firstAttempt)
+        #expect(restoredAfterNewerFailure.confirmed == firstAttempt)
+
+        let newerStillInFlight = ReadMarker.afterSuccessfulCommit(
+            current: secondAttempt,
+            confirmed: committed,
+            attempted: firstAttempt
+        )
+        #expect(newerStillInFlight.current == secondAttempt)
+        #expect(newerStillInFlight.confirmed == firstAttempt)
+
+        let olderSuccessAfterNewerCommit = ReadMarker.afterSuccessfulCommit(
+            current: secondAttempt,
+            confirmed: secondAttempt,
+            attempted: firstAttempt
+        )
+        #expect(olderSuccessAfterNewerCommit.current == secondAttempt)
+        #expect(olderSuccessAfterNewerCommit.confirmed == secondAttempt)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- track confirmed read markers separately from optimistic in-flight read markers
- roll failed optimistic read-marker advances back only to the last FFI-confirmed marker
- keep the optimistic gate monotonic when older successes race with newer in-flight marks
- update read-marker regression coverage for overlapping failure/success ordering

## Test Plan
- `git diff --check`
- `scripts/ci/macos-sanity-checks.sh` (blocked locally: `xcodebuild: command not found` on the Linux fixer host)
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` (not run locally: `xcodebuild` is unavailable on the Linux fixer host)
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` (not run locally: `xcrun` is unavailable on the Linux fixer host)

Closes #166


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/168">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->