### PR TITLE
fix: avoid chat-list resort for row updates

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -503,6 +503,7 @@ final class WorkspaceState {
     /// that membership slice and invalidate it on membership-changing subscription events.
     private var groupMemberDetailsCache: [String: [GroupMemberDetailsFfi]] = [:]
     private var groupMemberDetailsLookups: [String: GroupMemberDetailsLookup] = [:]
+    private var readStateMetadataEnrichmentAttempts = Set<String>()
     private var nextGroupMemberDetailsLookupToken: UInt64 = 0
 
     /// How long a *complete* peer-profile lookup is trusted before it is re-resolved
@@ -3473,7 +3474,7 @@ final class WorkspaceState {
     ) async {
         guard activeAccountId == account.id else { return }
 
-        var chats = chatsByAccount[account.id] ?? []
+        let chats = chatsByAccount[account.id] ?? []
         if row.archived {
             removeChat(groupIdHex: row.groupIdHex, account: account)
             return
@@ -3494,7 +3495,7 @@ final class WorkspaceState {
             // direct chats to flicker back to their raw group-id fallback.
             chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: current)
         }
-        let needsInitialMetadata = readStateRowNeedsMetadataEnrichment(row, current: current)
+        let needsInitialMetadata = !shouldEnrich && readStateRowNeedsMetadataEnrichment(row, current: current)
 
         chatsByAccount[account.id] = ChatListOrdering.upserting(chat, into: chats)
         if shouldEnrich {
@@ -3502,9 +3503,9 @@ final class WorkspaceState {
         } else if needsInitialMetadata {
             // A read-state row normally does not need enrichment, but the first selected-chat
             // read-state row can arrive after reload wiring cancels the snapshot enrichment.
-            // Resolve that one missing membership cache synchronously so direct-chat metadata
-            // and timeline sender-name fallbacks are populated without leaving background work
-            // that can race later group-details tests or UI actions.
+            // Resolve at most one missing membership cache per invalidation; repeated failures
+            // must not put groupDetails/userProfile work back on every read-marker advance.
+            readStateMetadataEnrichmentAttempts.insert(row.groupIdHex)
             await enrichChatRows([row], account: account)
         }
     }
@@ -3514,11 +3515,15 @@ final class WorkspaceState {
     }
 
     private func readStateRowNeedsMetadataEnrichment(_ row: ChatListRowFfi, current: ChatItem?) -> Bool {
+        if readStateMetadataEnrichmentAttempts.contains(row.groupIdHex) { return false }
         if groupMemberDetailsCache[row.groupIdHex] == nil { return true }
         guard let current else { return true }
         guard !current.isDirect else { return false }
         let rawTitle = row.title.trimmingCharacters(in: .whitespacesAndNewlines)
         let groupNameIsBlank = row.groupName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        // Blank-name group rows use the raw row title until one enrichment pass can confirm
+        // whether this is a direct chat. Retry once after invalidation, then leave later
+        // read-state-only rows on the hot path without another synchronous metadata lookup.
         return groupNameIsBlank && current.title == rawTitle
     }
 
@@ -4148,24 +4153,21 @@ final class WorkspaceState {
 
     private func insertCreatedChatIfNeeded(groupIdHex: String, title: String, avatarSeed: String, pictureURL: String?) {
         guard let activeAccountId else { return }
-        var chats = chatsByAccount[activeAccountId] ?? []
+        let chats = chatsByAccount[activeAccountId] ?? []
         guard !chats.contains(where: { $0.id == groupIdHex }) else { return }
 
-        chats.insert(
-            ChatItem(
-                id: groupIdHex,
-                title: title,
-                subtitle: L10n.string("Direct message"),
-                preview: L10n.string("No messages yet"),
-                updatedAt: nil,
-                avatarSeed: avatarSeed,
-                pictureURL: pictureURL,
-                unreadCount: 0,
-                isDirect: true
-            ),
-            at: 0
+        let chat = ChatItem(
+            id: groupIdHex,
+            title: title,
+            subtitle: L10n.string("Direct message"),
+            preview: L10n.string("No messages yet"),
+            updatedAt: nil,
+            avatarSeed: avatarSeed,
+            pictureURL: pictureURL,
+            unreadCount: 0,
+            isDirect: true
         )
-        chatsByAccount[activeAccountId] = chats
+        chatsByAccount[activeAccountId] = ChatListOrdering.upserting(chat, into: chats)
     }
 
     private func storeGroupMembers(_ members: [GroupMemberDetailsFfi], for groupIdHex: String) {
@@ -4178,6 +4180,7 @@ final class WorkspaceState {
         groupMemberDetailsCache[groupIdHex] = nil
         groupMemberDetailsLookups[groupIdHex]?.task.cancel()
         groupMemberDetailsLookups[groupIdHex] = nil
+        readStateMetadataEnrichmentAttempts.remove(groupIdHex)
     }
 
     private func clearGroupMemberCache() {
@@ -4186,6 +4189,7 @@ final class WorkspaceState {
             lookup.task.cancel()
         }
         groupMemberDetailsLookups.removeAll()
+        readStateMetadataEnrichmentAttempts.removeAll()
     }
 
     private func cachedGroupMembers(

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -85,6 +85,85 @@ struct ChatListRowEnrichmentTracker {
     }
 }
 
+struct ChatListOrdering {
+    static func sorted(_ chatItems: [ChatItem]) -> [ChatItem] {
+        chatItems.sorted(by: areInDisplayOrder)
+    }
+
+    static func upserting(_ chat: ChatItem, into chats: [ChatItem]) -> [ChatItem] {
+        var result = chats
+        if let index = result.firstIndex(where: { $0.id == chat.id }) {
+            if canReplaceInPlace(chat, at: index, in: result) {
+                result[index] = chat
+                return result
+            }
+            result.remove(at: index)
+        }
+
+        result.insert(chat, at: insertionIndex(for: chat, in: result))
+        return result
+    }
+
+    static func preservingResolvedMetadata(in chat: ChatItem, from current: ChatItem) -> ChatItem {
+        ChatItem(
+            id: chat.id,
+            title: current.title,
+            subtitle: current.subtitle,
+            preview: chat.preview,
+            updatedAt: chat.updatedAt,
+            avatarSeed: current.avatarSeed,
+            pictureURL: current.pictureURL,
+            unreadCount: chat.unreadCount,
+            isDirect: current.isDirect,
+            pendingConfirmation: chat.pendingConfirmation
+        )
+    }
+
+    static func isOlder(_ candidate: ChatItem, than current: ChatItem) -> Bool {
+        guard let currentUpdatedAt = current.updatedAt else { return false }
+        guard let candidateUpdatedAt = candidate.updatedAt else { return true }
+        return candidateUpdatedAt < currentUpdatedAt
+    }
+
+    private static func canReplaceInPlace(_ chat: ChatItem, at index: Int, in chats: [ChatItem]) -> Bool {
+        let previousStillBefore = index == chats.startIndex || !areInDisplayOrder(chat, chats[index - 1])
+        let nextStillAfter: Bool
+        if index == chats.index(before: chats.endIndex) {
+            nextStillAfter = true
+        } else {
+            nextStillAfter = !areInDisplayOrder(chats[index + 1], chat)
+        }
+        return previousStillBefore && nextStillAfter
+    }
+
+    private static func insertionIndex(for chat: ChatItem, in chats: [ChatItem]) -> Int {
+        var lowerBound = chats.startIndex
+        var upperBound = chats.endIndex
+        while lowerBound < upperBound {
+            let middle = lowerBound + (upperBound - lowerBound) / 2
+            if areInDisplayOrder(chats[middle], chat) {
+                lowerBound = middle + 1
+            } else {
+                upperBound = middle
+            }
+        }
+        return lowerBound
+    }
+
+    private static func areInDisplayOrder(_ lhs: ChatItem, _ rhs: ChatItem) -> Bool {
+        switch (lhs.updatedAt, rhs.updatedAt) {
+        case (let left?, let right?) where left != right:
+            return left > right
+        case (_?, nil):
+            return true
+        case (nil, _?):
+            return false
+        default:
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        }
+    }
+}
+
 @MainActor
 final class MediaDownloadStateStore: ObservableObject {
     @Published private(set) var state: MediaDownloadState = .idle
@@ -1554,7 +1633,12 @@ final class WorkspaceState {
                 // `initializeChatReadState` may race a live chat-list delta. Do not let an
                 // older read-state row roll back a newer preview/timestamp already applied
                 // by the subscription listener while the FFI call was in flight.
-                await applyChatRow(row, account: activeAccount, skippingStaleRow: true)
+                await applyChatRow(
+                    row,
+                    account: activeAccount,
+                    skippingStaleRow: true,
+                    shouldEnrich: false
+                )
             }
 
             let subscription = try await client.subscribeTimelineMessages(
@@ -3384,7 +3468,8 @@ final class WorkspaceState {
     private func applyChatRow(
         _ row: ChatListRowFfi,
         account: AccountItem,
-        skippingStaleRow: Bool = false
+        skippingStaleRow: Bool = false,
+        shouldEnrich: Bool = true
     ) async {
         guard activeAccountId == account.id else { return }
 
@@ -3394,26 +3479,47 @@ final class WorkspaceState {
             return
         }
 
-        let chat = baseChatItem(from: row, account: account)
+        var chat = baseChatItem(from: row, account: account)
+        let current = chats.first(where: { $0.id == chat.id })
         if skippingStaleRow,
-            let current = chats.first(where: { $0.id == chat.id }),
+            let current,
             isOlderChatRow(chat, than: current)
         {
             return
         }
-        if let index = chats.firstIndex(where: { $0.id == chat.id }) {
-            chats[index] = chat
-        } else {
-            chats.append(chat)
+        if !shouldEnrich, let current {
+            // Read-state-only rows do not change the metadata resolved by enrichment
+            // (direct-chat title/avatar/isDirect). Preserve it while applying the row's
+            // unread/preview/timestamp fields, otherwise skipping enrichment would cause
+            // direct chats to flicker back to their raw group-id fallback.
+            chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: current)
         }
-        chatsByAccount[account.id] = sortedChatItems(chats)
-        startChatListEnrichment(rows: [row], account: account, replacingCurrent: false)
+        let needsInitialMetadata = readStateRowNeedsMetadataEnrichment(row, current: current)
+
+        chatsByAccount[account.id] = ChatListOrdering.upserting(chat, into: chats)
+        if shouldEnrich {
+            startChatListEnrichment(rows: [row], account: account, replacingCurrent: false)
+        } else if needsInitialMetadata {
+            // A read-state row normally does not need enrichment, but the first selected-chat
+            // read-state row can arrive after reload wiring cancels the snapshot enrichment.
+            // Resolve that one missing membership cache synchronously so direct-chat metadata
+            // and timeline sender-name fallbacks are populated without leaving background work
+            // that can race later group-details tests or UI actions.
+            await enrichChatRows([row], account: account)
+        }
     }
 
     private func isOlderChatRow(_ candidate: ChatItem, than current: ChatItem) -> Bool {
-        guard let currentUpdatedAt = current.updatedAt else { return false }
-        guard let candidateUpdatedAt = candidate.updatedAt else { return true }
-        return candidateUpdatedAt < currentUpdatedAt
+        ChatListOrdering.isOlder(candidate, than: current)
+    }
+
+    private func readStateRowNeedsMetadataEnrichment(_ row: ChatListRowFfi, current: ChatItem?) -> Bool {
+        if groupMemberDetailsCache[row.groupIdHex] == nil { return true }
+        guard let current else { return true }
+        guard !current.isDirect else { return false }
+        let rawTitle = row.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let groupNameIsBlank = row.groupName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return groupNameIsBlank && current.title == rawTitle
     }
 
     private func removeChat(groupIdHex: String, account: AccountItem) {
@@ -3667,6 +3773,7 @@ final class WorkspaceState {
         guard activeAccountId == account.id, !enrichedItems.isEmpty else { return }
 
         var chats = chatsByAccount[account.id] ?? []
+        let incremental = enrichedItems.count == 1
         var didUpdate = false
         for enrichedItem in enrichedItems {
             guard let index = chats.firstIndex(where: { $0.id == enrichedItem.id }) else { continue }
@@ -3684,12 +3791,16 @@ final class WorkspaceState {
                 pendingConfirmation: current.pendingConfirmation
             )
             guard next != current else { continue }
-            chats[index] = next
+            if incremental {
+                chats = ChatListOrdering.upserting(next, into: chats)
+            } else {
+                chats[index] = next
+            }
             didUpdate = true
         }
 
         if didUpdate {
-            chatsByAccount[account.id] = sortedChatItems(chats)
+            chatsByAccount[account.id] = incremental ? chats : sortedChatItems(chats)
         }
     }
 
@@ -3744,18 +3855,7 @@ final class WorkspaceState {
     }
 
     private func sortedChatItems(_ chatItems: [ChatItem]) -> [ChatItem] {
-        chatItems.sorted { lhs, rhs in
-            switch (lhs.updatedAt, rhs.updatedAt) {
-            case (let left?, let right?) where left != right:
-                return left > right
-            case (_?, nil):
-                return true
-            case (nil, _?):
-                return false
-            default:
-                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
-            }
-        }
+        ChatListOrdering.sorted(chatItems)
     }
 
     private func markLatestVisibleMessageRead(
@@ -3804,7 +3904,7 @@ final class WorkspaceState {
             lastMarkedReadMarkers[groupIdHex] = committedState.current
             lastConfirmedReadMarkers[groupIdHex] = committedState.confirmed
             if let row {
-                await applyChatRow(row, account: account)
+                await applyChatRow(row, account: account, shouldEnrich: false)
             }
         } catch {
             guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3832,6 +3832,91 @@ struct whitenoise_macTests {
         #expect((runtime.groupDetailsCallCounts["direct-group"] ?? 0) == 1)
     }
 
+    @Test func chatListOrderingUpdatesSingleRowWithoutResortingWholeList() {
+        let newest = chatListOrderingTestItem(id: "newest", title: "Newest", updatedAt: 300)
+        let middle = chatListOrderingTestItem(id: "middle", title: "Middle", preview: "old", updatedAt: 200)
+        let oldest = chatListOrderingTestItem(id: "oldest", title: "Oldest", updatedAt: 100)
+
+        let updatedMiddle = chatListOrderingTestItem(
+            id: "middle",
+            title: "Middle",
+            preview: "new read-state preview",
+            updatedAt: 200,
+            unreadCount: 0
+        )
+        let updated = ChatListOrdering.upserting(updatedMiddle, into: [newest, middle, oldest])
+
+        #expect(updated.map(\.id) == ["newest", "middle", "oldest"])
+        #expect(updated[1].preview == "new read-state preview")
+        #expect(updated[1].unreadCount == 0)
+    }
+
+    @Test func chatListOrderingMovesSingleRowWithBinaryInsertionWhenSortKeyChanges() {
+        let newest = chatListOrderingTestItem(id: "newest", title: "Newest", updatedAt: 300)
+        let middle = chatListOrderingTestItem(id: "middle", title: "Middle", updatedAt: 200)
+        let oldest = chatListOrderingTestItem(id: "oldest", title: "Oldest", updatedAt: 100)
+
+        let promotedOldest = chatListOrderingTestItem(id: "oldest", title: "Oldest", updatedAt: 400)
+        let promoted = ChatListOrdering.upserting(promotedOldest, into: [newest, middle, oldest])
+        #expect(promoted.map(\.id) == ["oldest", "newest", "middle"])
+
+        let inserted = chatListOrderingTestItem(id: "inserted", title: "Inserted", updatedAt: 250)
+        let withInserted = ChatListOrdering.upserting(inserted, into: [newest, middle, oldest])
+        #expect(withInserted.map(\.id) == ["newest", "inserted", "middle", "oldest"])
+    }
+
+    @Test func chatListOrderingMovesSingleRowWhenTitleTieBreakerChanges() {
+        let timestamp = Date(timeIntervalSince1970: 100)
+        let alpha = chatListOrderingTestItem(id: "alpha", title: "Alpha", date: timestamp)
+        let bravo = chatListOrderingTestItem(id: "bravo", title: "Bravo", date: timestamp)
+        let zulu = chatListOrderingTestItem(id: "zulu", title: "Zulu", date: timestamp)
+
+        let renamedZulu = chatListOrderingTestItem(id: "zulu", title: "Beta", date: timestamp)
+        let renamed = ChatListOrdering.upserting(renamedZulu, into: [alpha, bravo, zulu])
+
+        #expect(renamed.map(\.id) == ["alpha", "zulu", "bravo"])
+        #expect(renamed.map(\.title) == ["Alpha", "Beta", "Bravo"])
+    }
+
+    @Test func readStateChatRowsPreserveResolvedMetadataWhenSkippingEnrichment() {
+        let current = ChatItem(
+            id: "direct-group",
+            title: "Alice Actual",
+            subtitle: "Direct message",
+            preview: "old preview",
+            updatedAt: Date(timeIntervalSince1970: 100),
+            avatarSeed: "alice-id",
+            pictureURL: "https://example.com/alice.png",
+            unreadCount: 4,
+            isDirect: true,
+            pendingConfirmation: false
+        )
+        let readState = ChatItem(
+            id: "direct-group",
+            title: "direct-group",
+            subtitle: "Group message",
+            preview: "new read marker preview",
+            updatedAt: Date(timeIntervalSince1970: 200),
+            avatarSeed: "direct-group",
+            pictureURL: nil,
+            unreadCount: 0,
+            isDirect: false,
+            pendingConfirmation: true
+        )
+
+        let merged = ChatListOrdering.preservingResolvedMetadata(in: readState, from: current)
+
+        #expect(merged.title == "Alice Actual")
+        #expect(merged.subtitle == "Direct message")
+        #expect(merged.avatarSeed == "alice-id")
+        #expect(merged.pictureURL == "https://example.com/alice.png")
+        #expect(merged.isDirect)
+        #expect(merged.preview == "new read marker preview")
+        #expect(merged.updatedAt == Date(timeIntervalSince1970: 200))
+        #expect(merged.unreadCount == 0)
+        #expect(merged.pendingConfirmation)
+    }
+
     @MainActor
     @Test func timelineSenderProfilesReusePrimedGroupMemberDetails() async throws {
         // Regression for #9: loading/reprojecting a timeline should not hit `groupDetails`
@@ -8504,6 +8589,43 @@ private func chatListRow(
         lastReadMessageIdHex: nil,
         lastReadTimelineAt: nil,
         updatedAt: timelineAt
+    )
+}
+
+private func chatListOrderingTestItem(
+    id: String,
+    title: String,
+    preview: String = "preview",
+    updatedAt: UInt64,
+    unreadCount: Int = 1
+) -> ChatItem {
+    chatListOrderingTestItem(
+        id: id,
+        title: title,
+        preview: preview,
+        date: Date(timeIntervalSince1970: TimeInterval(updatedAt)),
+        unreadCount: unreadCount
+    )
+}
+
+private func chatListOrderingTestItem(
+    id: String,
+    title: String,
+    preview: String = "preview",
+    date: Date?,
+    unreadCount: Int = 1
+) -> ChatItem {
+    ChatItem(
+        id: id,
+        title: title,
+        subtitle: "Group message",
+        preview: preview,
+        updatedAt: date,
+        avatarSeed: id,
+        pictureURL: nil,
+        unreadCount: unreadCount,
+        isDirect: false,
+        pendingConfirmation: false
     )
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3865,6 +3865,16 @@ struct whitenoise_macTests {
         #expect(withInserted.map(\.id) == ["newest", "inserted", "middle", "oldest"])
     }
 
+    @Test func chatListOrderingInsertsNilUpdatedAtRowsAfterDatedChats() {
+        let newest = chatListOrderingTestItem(id: "newest", title: "Newest", updatedAt: 300)
+        let oldest = chatListOrderingTestItem(id: "oldest", title: "Oldest", updatedAt: 100)
+        let optimistic = chatListOrderingTestItem(id: "optimistic", title: "Alice", date: nil)
+
+        let withOptimistic = ChatListOrdering.upserting(optimistic, into: [newest, oldest])
+
+        #expect(withOptimistic.map(\.id) == ["newest", "oldest", "optimistic"])
+    }
+
     @Test func chatListOrderingMovesSingleRowWhenTitleTieBreakerChanges() {
         let timestamp = Date(timeIntervalSince1970: 100)
         let alpha = chatListOrderingTestItem(id: "alpha", title: "Alpha", date: timestamp)
@@ -3915,6 +3925,168 @@ struct whitenoise_macTests {
         #expect(merged.updatedAt == Date(timeIntervalSince1970: 200))
         #expect(merged.unreadCount == 0)
         #expect(merged.pendingConfirmation)
+    }
+
+    @MainActor
+    @Test func readMarkerChatRowPreservesResolvedDirectMetadataWhenSkippingEnrichment() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: "https://example.com/alice.png",
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "latest",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Latest message",
+                    kind: 9,
+                    recordedAt: 1_700_000_010
+                )
+            ], groupIdHex: "direct-group")
+        var isActive = false
+        let state = WorkspaceState(
+            appActivityProvider: { isActive },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        let didResolveDirectMetadata = await waitFor(attempts: 300) {
+            state.activeChats.first?.title == "Alice Actual"
+                && state.activeChats.first?.pictureURL == "https://example.com/alice.png"
+                && state.activeChats.first?.isDirect == true
+        }
+        #expect(didResolveDirectMetadata)
+        #expect(runtime.markedReadMessageIds.isEmpty)
+
+        isActive = true
+        await state.handleConversationVisibilityChange()
+
+        #expect(runtime.markedReadMessageIds == ["latest"])
+        #expect(state.activeChats.first?.title == "Alice Actual")
+        #expect(state.activeChats.first?.subtitle == "Direct message")
+        #expect(state.activeChats.first?.avatarSeed == aliceId)
+        #expect(state.activeChats.first?.pictureURL == "https://example.com/alice.png")
+        #expect(state.activeChats.first?.isDirect == true)
+        #expect(state.activeChats.first?.preview == "Alice Actual: Latest message")
+    }
+
+    @MainActor
+    @Test func repeatedReadMarkerRowsWithMissingMetadataDoNotRepeatGroupDetailsLookups() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: "https://example.com/alice.png",
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.groupDetailsFailureGroupIds.insert("direct-group")
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "m1",
+                    groupIdHex: "direct-group",
+                    sender: account.accountIdHex,
+                    plaintext: "first",
+                    kind: 9,
+                    recordedAt: 1_700_000_010
+                )
+            ], groupIdHex: "direct-group")
+        runtime.installTimelineUpdates(
+            [
+                .projection(
+                    update: RuntimeProjectionUpdateFfi(
+                        accountIdHex: account.accountIdHex,
+                        accountLabel: account.label,
+                        update: TimelineProjectionUpdateFfi(
+                            groupIdHex: "direct-group",
+                            messages: [],
+                            changes: [
+                                .upsert(
+                                    trigger: .newMessage,
+                                    message: timelineMessage(
+                                        id: "m2",
+                                        groupIdHex: "direct-group",
+                                        sender: account.accountIdHex,
+                                        plaintext: "second",
+                                        recordedAt: 1_700_000_020
+                                    ))
+                            ],
+                            chatListRow: nil,
+                            chatListTrigger: .newLastMessage
+                        )
+                    )),
+                .projection(
+                    update: RuntimeProjectionUpdateFfi(
+                        accountIdHex: account.accountIdHex,
+                        accountLabel: account.label,
+                        update: TimelineProjectionUpdateFfi(
+                            groupIdHex: "direct-group",
+                            messages: [],
+                            changes: [
+                                .upsert(
+                                    trigger: .newMessage,
+                                    message: timelineMessage(
+                                        id: "m3",
+                                        groupIdHex: "direct-group",
+                                        sender: account.accountIdHex,
+                                        plaintext: "third",
+                                        recordedAt: 1_700_000_030
+                                    ))
+                            ],
+                            chatListRow: nil,
+                            chatListTrigger: .newLastMessage
+                        )
+                    )),
+            ], groupIdHex: "direct-group")
+        runtime.timelineStreamEndsAfterUpdates = true
+        let state = WorkspaceState(
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        let didMarkAllVisibleMessages = await waitFor(attempts: 300) {
+            runtime.markedReadMessageIds == ["m1", "m2", "m3"]
+        }
+
+        #expect(didMarkAllVisibleMessages)
+        #expect((runtime.groupDetailsCallCounts["direct-group"] ?? 0) <= 2)
     }
 
     @MainActor
@@ -7051,6 +7223,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// Per-group call count for `groupDetails`, used to assert chat-list enrichment runs
     /// through the incremental per-row path (issue #40 regression).
     private(set) var groupDetailsCallCounts: [String: Int] = [:]
+    var groupDetailsFailureGroupIds = Set<String>()
     private(set) var chatListSubscriptionCount = 0
     private(set) var notificationSubscriptionCount = 0
     private(set) var timelineSubscriptionCount = 0
@@ -7539,6 +7712,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func groupDetails(accountRef: String, groupIdHex: String) async throws -> GroupDetailsFfi {
         groupDetailsCallCounts[groupIdHex, default: 0] += 1
+        if groupDetailsFailureGroupIds.contains(groupIdHex) {
+            throw FakeMarmotRuntimeError.unused
+        }
         // Snapshot the value *before* the gate so a held older load captures the older details and a
         // later mutation cannot retroactively change what it returns (issue #135 last-request-wins).
         let result: GroupDetailsFfi


### PR DESCRIPTION
## Summary
- Replace per-row full chat-list sorting with a single-row upsert that updates in place when ordering is unchanged and uses binary insertion when `updatedAt`/title ordering changes.
- Suppress chat-list enrichment for read-state-only rows returned by `initializeChatReadState` and `markTimelineMessageRead`.
- Preserve already-resolved direct-chat metadata when applying read-state-only rows so skipping enrichment does not regress titles/avatars.
- Add regression coverage for single-row ordering updates, binary insertion, tie-breaker moves, and metadata preservation.

## Verification
- `git diff --check`
- `bash -n scripts/ci/macos-sanity-checks.sh`
- changed Swift line-length scan (<=120 chars)
- conflict-marker scan

Not run locally: `xcrun swift-format`, `xcodebuild test`, `xcodebuild build`, and `xcodebuild analyze` are unavailable on this Linux worker. GitHub macOS CI should run the repo's PR checks.

Closes #170


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/172">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->