### PR TITLE
fix: defer timeline sender member fallback

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -426,6 +426,14 @@ final class WorkspaceState {
     private var groupMemberDetailsLookups: [String: GroupMemberDetailsLookup] = [:]
     private var nextGroupMemberDetailsLookupToken: UInt64 = 0
 
+    #if DEBUG
+        /// Test-only instrumentation: the number of times `messageSenderProfiles` had to fetch the
+        /// group member list to build the sender-name fallback map. In the all-resolved steady
+        /// state this must stay flat across timeline windows (whitenoise-mac#171). Not read by
+        /// production code.
+        private(set) var timelineSenderMemberFallbackFetchCount = 0
+    #endif
+
     /// How long a *complete* peer-profile lookup is trusted before it is re-resolved
     /// from the Rust store. Incomplete lookups ignore the TTL and re-resolve every pass.
     private static let peerProfileCacheTTL: TimeInterval = 300
@@ -4200,24 +4208,6 @@ final class WorkspaceState {
         )
         guard !senderIds.isEmpty else { return [:] }
 
-        let nonLocalSenderIds = senderIds.filter { $0 != activeAccount.accountIdHex }
-        let groupMemberNames: [String: String]
-        if nonLocalSenderIds.isEmpty {
-            groupMemberNames = [:]
-        } else {
-            let members =
-                await cachedGroupMembers(
-                    groupIdHex: groupIdHex,
-                    account: activeAccount,
-                    client: client
-                ) ?? []
-            groupMemberNames = members.reduce(into: [String: String]()) { result, member in
-                if let displayName = firstNonBlank([member.displayName]) {
-                    result[member.memberIdHex] = displayName
-                }
-            }
-        }
-
         // Resolve any senders whose cached lookup is missing, incomplete, or stale in a
         // single off-main FFI batch, then cache the raw lookups (timestamped) so repeated
         // scroll-up pages skip Rust entirely. Incomplete lookups (relay not yet
@@ -4259,6 +4249,37 @@ final class WorkspaceState {
             if activeAccountId == activeAccount.id {
                 for (senderId, value) in resolved {
                     peerProfileFFICache[senderId] = CachedPeerProfile(resolved: value, resolvedAt: now)
+                }
+            }
+        }
+
+        // `groupMemberNames` is only ever read as a fallback for non-local senders whose
+        // resolved profile name is blank. In the common live-update steady state every sender
+        // already resolves from its cached profile display/name, so fetching the full member
+        // list and reducing it into a name map is wasted work on the timeline hot path. Only
+        // pay for the member fetch + dictionary when at least one sender actually needs the
+        // fallback after profile resolution (before the lower-priority directory name).
+        let sendersNeedingMemberFallback = senderIds.filter { senderId in
+            guard senderId != activeAccount.accountIdHex else { return false }
+            let resolved = peerProfileFFICache[senderId]?.resolved
+            return firstNonBlank([resolved?.profileDisplayName, resolved?.profileName]) == nil
+        }
+        let groupMemberNames: [String: String]
+        if sendersNeedingMemberFallback.isEmpty {
+            groupMemberNames = [:]
+        } else {
+            #if DEBUG
+                timelineSenderMemberFallbackFetchCount += 1
+            #endif
+            let members =
+                await cachedGroupMembers(
+                    groupIdHex: groupIdHex,
+                    account: activeAccount,
+                    client: client
+                ) ?? []
+            groupMemberNames = members.reduce(into: [String: String]()) { result, member in
+                if let displayName = firstNonBlank([member.displayName]) {
+                    result[member.memberIdHex] = displayName
                 }
             }
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3884,6 +3884,107 @@ struct whitenoise_macTests {
         #expect((runtime.groupDetailsCallCounts["group"] ?? 0) == groupDetailsCallsAfterBootstrap)
     }
 
+    @MainActor
+    @Test func timelineSenderProfilesSkipMemberFetchWhenSendersResolve() async throws {
+        // Regression for #171: when every non-local sender already resolves from its cached
+        // profile display/name, `messageSenderProfiles` must not fetch the group member list or
+        // build the member-name fallback map. The fallback is only ever consulted for senders
+        // with a blank resolved name, so in the all-resolved steady state the member fetch and
+        // dictionary allocation are wasted work on the timeline hot path.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        // Alice has a real profile, so the timeline resolves her name from the profile lookup and
+        // never needs the group-member-name fallback.
+        runtime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Cooper",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages(
+            (0..<150).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: 1_700_000_000 + UInt64(index)
+                )
+            },
+            groupIdHex: "group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        // Bootstrap auto-selects the only chat and applies its initial timeline window; the
+        // explicit pagination call below applies a second window. Both run through
+        // `messageSenderProfiles`, exercising the steady-state hot path.
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "group")
+        await state.loadOlderMessages(groupIdHex: "group")
+
+        let messages = state.messagesByChat["group"] ?? []
+        #expect(messages.first?.senderName == "Alice Cooper")
+        // The optimization: no member fetch for the sender-name fallback across any window,
+        // because every sender resolved from its profile. Before the #171 fix this would be >= 1.
+        #expect(state.timelineSenderMemberFallbackFetchCount == 0)
+    }
+
+    @MainActor
+    @Test func timelineSenderProfilesFallBackToMemberNameWhenProfileBlank() async throws {
+        // Companion to #171: behavior for blank profile names is preserved. When a non-local
+        // sender's resolved profile display/name is blank but the group exposes a member display
+        // name, the timeline must still fall back to the member name (ahead of the directory
+        // display name), which requires fetching the member list.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        // `groupDetailsFixture` exposes Alice with member display name "Alice".
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        // No profile/directory name for Alice, so the only usable name is the group member name.
+        runtime.accountIdsMissingProfiles.insert(aliceId)
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "alice-message",
+                    groupIdHex: "group",
+                    sender: aliceId,
+                    plaintext: "Member-name fallback still applies.",
+                    kind: 9,
+                    recordedAt: 1_700_000_000
+                )
+            ],
+            groupIdHex: "group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        // Bootstrap auto-selects the only chat and applies its initial timeline window.
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "group")
+
+        let messages = state.messagesByChat["group"] ?? []
+        #expect(messages.first?.senderName == "Alice")
+        // The blank-profile sender needs the fallback, so the member list is fetched at least once.
+        #expect(state.timelineSenderMemberFallbackFetchCount >= 1)
+    }
+
     // MARK: - ChatListRowEnrichmentTracker (issue #40 ownership invariants)
 
     @Test func enrichmentTrackerStaleTaskAfterReloadDoesNotDropNewerTask() {


### PR DESCRIPTION
Closes #171

## Summary
- Deferred the timeline sender member-name fallback map until after peer profile resolution.
- Only fetches/reduces group members when at least one non-local sender has blank profile display/name, preserving the existing member-name-before-directory fallback order.
- Added Debug-only test instrumentation plus regression coverage for the all-resolved hot path and the blank-profile member-name fallback path.

## Verification
- `git diff --check` — passed
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- ':!*.xcresult' ':!*.xcodeproj/project.pbxproj'` — no conflict markers
- `xcrun`, `swift-format`, `swiftlint`, `swift`, and `xcodebuild` are unavailable on this Linux host, so macOS CI checks/tests could not be run locally.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->