### PR TITLE
fix: enforce max 5 redirect hops in CappedImageDownloadDelegate

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -498,6 +498,7 @@ private final class CappedImageDownloadDelegate: NSObject, URLSessionDataDelegat
     private var task: URLSessionDataTask?
     private var cancelled = false
     private var finished = false
+    private var redirectHopCount = 0
 
     init(cap: Int64) {
         self.cap = cap
@@ -570,6 +571,13 @@ private final class CappedImageDownloadDelegate: NSObject, URLSessionDataDelegat
         newRequest request: URLRequest,
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
+        redirectHopCount += 1
+        if redirectHopCount > 5 {
+            completionHandler(nil)
+            task.cancel()
+            finish(with: nil)
+            return
+        }
         guard let url = request.url, RemoteImageURLPolicy.isAllowed(url) else {
             completionHandler(nil)
             task.cancel()


### PR DESCRIPTION
Closes #183

Adds a `redirectHopCount` counter to `CappedImageDownloadDelegate`.
Each redirect increments the counter; once >5 hops are exceeded,
the redirect is rejected via `completionHandler(nil)` +
`task.cancel()` + `finish(with: nil)`.

**What changed**
- Added `private var redirectHopCount = 0` property
- In `urlSession(_:task:willPerformHTTPRedirection:...)`: increment
  hop count on every redirect, reject when >5 before the SSRF check

**Why**
The per-redirect SSRF re-check bounds host/scheme but not chain
length. A policy-passing public host could issue an unbounded
redirect chain. The incremental byte cap doesn't constrain
zero-body redirect responses, and URLSession's soft internal
limit is undocumented. This adds an explicit small bound (5 hops).

**Verification**
- macOS CI (`.github/workflows/mac-ci.yml`) runs format lint,
  build, and test suite on PR. Windows platform prevented local
  `xcodebuild` execution.
- Manual logic trace confirmed: first 5 redirects allowed,
  6th+ are rejected.

Fix is defense-in-depth — LOW severity as noted in the issue.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/188">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading reliability by stopping downloads that get stuck in repeated redirects.
  * Added a limit to redirect attempts and safely cancel requests when the limit is exceeded.
  * Continued to validate each redirect target before allowing the download to proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->