### PR TITLE
fix: bound raw outgoing attachment reads

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -615,7 +615,7 @@ nonisolated enum OutgoingMediaDraftProcessor {
             if let fileSize = resourceValues.fileSize, fileSize > maxAttachmentBytes {
                 throw Failure.attachmentTooLarge(fileSize)
             }
-            let data = try Data(contentsOf: url)
+            let data = try readAttachmentData(from: url)
             return try await SendableAttachment(
                 attachment: preparedAttachmentValue(
                     from: data,
@@ -624,6 +624,16 @@ nonisolated enum OutgoingMediaDraftProcessor {
                 ))
         }.value
         return prepared.attachment
+    }
+
+    private static func readAttachmentData(from url: URL) throws -> Data {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        // Read at most one byte past the cap so URLs without fileSize cannot force
+        // unbounded buffering before the raw-size guard runs.
+        let data = try handle.read(upToCount: maxAttachmentBytes + 1) ?? Data()
+        try enforceRawAttachmentSize(data)
+        return data
     }
 
     static func preparedVoiceAttachment(from recording: VoiceRecordingResult) async throws -> PendingMediaAttachment {
@@ -655,6 +665,9 @@ nonisolated enum OutgoingMediaDraftProcessor {
         fileName: String?,
         typeIdentifier: String?
     ) async throws -> PendingMediaAttachment {
+        // Keep the raw-size invariant in the common funnel too, so no caller can
+        // branch into image decoding with unbounded data.
+        try enforceRawAttachmentSize(data)
         let kind = kind(for: typeIdentifier, fileName: fileName)
         if kind == .image {
             return try imageAttachment(from: data, fileName: fileName)
@@ -669,9 +682,6 @@ nonisolated enum OutgoingMediaDraftProcessor {
         else {
             throw Failure.unsupportedAttachment
         }
-        guard data.count <= maxAttachmentBytes else {
-            throw Failure.attachmentTooLarge(data.count)
-        }
         let videoDim = kind == .video ? await MediaVideoMetadata.dim(from: data, mediaType: mediaType) : nil
         return try genericAttachment(
             from: data,
@@ -680,6 +690,12 @@ nonisolated enum OutgoingMediaDraftProcessor {
             kind: kind,
             videoDim: videoDim
         )
+    }
+
+    private static func enforceRawAttachmentSize(_ data: Data) throws {
+        guard data.count <= maxAttachmentBytes else {
+            throw Failure.attachmentTooLarge(data.count)
+        }
     }
 
     private static func kind(for typeIdentifier: String?, fileName: String?) -> MessageMediaKind? {


### PR DESCRIPTION
Closes #169

## Summary
- Replaced the unbounded outgoing file read with a bounded FileHandle read that stops at `maxAttachmentBytes + 1`, so URLs with missing `fileSize` cannot force arbitrary buffering before validation.
- Added a shared raw-size guard and invoke it in the common attachment-value path before image/non-image branching, preventing images from reaching decode/re-encode without the same raw cap as other attachments.
- Removed the now-redundant non-image-only `data.count` guard.

## Verification
- `git diff --check` — passed.
- macOS CI commands were inspected in `.github/workflows/mac-ci.yml` but not run locally: this host is Linux and lacks `xcrun`, `xcodebuild`, and `swift`.

## Sensitive paths
None. This touches only outgoing attachment preparation in `whitenoise-mac/Models/MessengerModels.swift`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/189">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->