### PR TITLE
fix: omit hardware model from relay telemetry resource

### DIFF
--- a/whitenoise-mac/Core/TelemetryBuildConfig.swift
+++ b/whitenoise-mac/Core/TelemetryBuildConfig.swift
@@ -98,7 +98,7 @@ struct TelemetryBuildConfig: Equatable {
                 osVersion: osVersion,
                 // The audit-log source may still use the local model label, but the
                 // relay telemetry resource is exported to OTLP with a stable install
-                // id. Do not add hw.model to that correlation surface.
+                // id. Do not include hw.model in the OTLP-exported resource.
                 deviceModelIdentifier: nil
             )
         )

--- a/whitenoise-mac/Core/TelemetryBuildConfig.swift
+++ b/whitenoise-mac/Core/TelemetryBuildConfig.swift
@@ -96,7 +96,10 @@ struct TelemetryBuildConfig: Equatable {
                 tenant: Self.tenant,
                 osType: "darwin",
                 osVersion: osVersion,
-                deviceModelIdentifier: deviceModelIdentifier
+                // The audit-log source may still use the local model label, but the
+                // relay telemetry resource is exported to OTLP with a stable install
+                // id. Do not add hw.model to that correlation surface.
+                deviceModelIdentifier: nil
             )
         )
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6362,9 +6362,10 @@ struct whitenoise_macTests {
         #expect(telemetryResource?.tenant == "whitenoise-mac")
         #expect(telemetryResource?.osType == "darwin")
         #expect(telemetryResource?.osVersion == ProcessInfo.processInfo.operatingSystemVersionString)
-        #expect(telemetryResource?.deviceModelIdentifier == expectedDeviceModelIdentifier())
+        #expect(telemetryResource?.deviceModelIdentifier == nil)
         #expect(runtime.auditLogTrackerConfig?.authorizationBearerToken == "audit-token")
         #expect(runtime.auditLogTrackerConfig?.source.accountLabel == "Desktop Account")
+        #expect(runtime.auditLogTrackerConfig?.source.deviceLabel == expectedDeviceModelIdentifier())
 
         await state.setRelayTelemetryEnabled(false)
         await state.setAuditLoggingEnabled(true)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6274,7 +6274,7 @@ struct whitenoise_macTests {
         #expect(runtimeConfig.resource?.tenant == "whitenoise-mac")
         #expect(runtimeConfig.resource?.osType == "darwin")
         #expect(runtimeConfig.resource?.osVersion == "Version 26.0")
-        #expect(runtimeConfig.resource?.deviceModelIdentifier == "Mac15,3")
+        #expect(runtimeConfig.resource?.deviceModelIdentifier == nil)
 
         let auditConfig = config.auditTrackerConfig(accountLabel: "Desktop Account")
         #expect(auditConfig.authorizationBearerToken == "audit-token")


### PR DESCRIPTION
## Summary
- omit `hw.model` from the relay telemetry resource exported to OTLP
- keep the local device model available for the existing audit-log source path
- update telemetry config coverage to assert the relay resource does not carry the model identifier

## Test Plan
- [x] `git diff --check`
- [x] static search for relay telemetry `deviceModelIdentifier: nil`
- [ ] `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` (not run on vault: Linux host has no Xcode/xcodebuild)

Closes #186


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/190">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->