### PR TITLE
fix: precompute message bubble render content

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1079,6 +1079,7 @@ struct MessageItem: Identifiable, Hashable {
     let senderName: String
     let senderPictureURL: String?
     let body: String
+    let trimmedBody: String
     let sentAt: Date
     let timelineAt: UInt64
     let timelineKind: UInt64
@@ -1088,6 +1089,9 @@ struct MessageItem: Identifiable, Hashable {
     let reactions: [MessageReaction]
     let replyContext: MessageReplyContext?
     let mediaAttachments: [MessageMediaAttachment]
+    let visualMediaAttachments: [MessageMediaAttachment]
+    let nonvisualMediaAttachments: [MessageMediaAttachment]
+    let hasBubbleContent: Bool
     let presentation: MessagePresentation
     let timeLabel: String
     let statusLabel: String?
@@ -1111,12 +1115,16 @@ struct MessageItem: Identifiable, Hashable {
         mediaAttachments: [MessageMediaAttachment] = [],
         presentation: MessagePresentation = .chat
     ) {
+        let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        let partitionedAttachments = Self.partitionMediaAttachments(mediaAttachments)
+
         self.id = id
         self.groupIdHex = groupIdHex
         self.senderAccountIdHex = senderAccountIdHex ?? senderName
         self.senderName = senderName
         self.senderPictureURL = senderPictureURL
         self.body = body
+        self.trimmedBody = trimmedBody
         self.sentAt = sentAt
         self.timelineAt = timelineAt ?? UInt64(sentAt.timeIntervalSince1970)
         self.timelineKind = timelineKind
@@ -1126,6 +1134,9 @@ struct MessageItem: Identifiable, Hashable {
         self.reactions = reactions
         self.replyContext = replyContext
         self.mediaAttachments = mediaAttachments
+        self.visualMediaAttachments = partitionedAttachments.visual
+        self.nonvisualMediaAttachments = partitionedAttachments.nonvisual
+        self.hasBubbleContent = replyContext != nil || !trimmedBody.isEmpty
         self.presentation = presentation
         let timeLabel = DisplayText.messageTimestamp(for: sentAt)
         self.timeLabel = timeLabel
@@ -1143,6 +1154,24 @@ struct MessageItem: Identifiable, Hashable {
         self.metadataLabel = statusLabel.map { "\(timeLabel)  \($0)" } ?? timeLabel
     }
 
+    private static func partitionMediaAttachments(_ attachments: [MessageMediaAttachment]) -> (
+        visual: [MessageMediaAttachment], nonvisual: [MessageMediaAttachment]
+    ) {
+        var visual: [MessageMediaAttachment] = []
+        var nonvisual: [MessageMediaAttachment] = []
+
+        for attachment in attachments {
+            switch attachment.kind {
+            case .image, .video:
+                visual.append(attachment)
+            case .audio, .file:
+                nonvisual.append(attachment)
+            }
+        }
+
+        return (visual, nonvisual)
+    }
+
     var debugTitle: String {
         "kind \(timelineKind) - \(presentation.debugLabel)"
     }
@@ -1152,13 +1181,12 @@ struct MessageItem: Identifiable, Hashable {
     }
 
     private var hasCopyableBody: Bool {
-        !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !trimmedBody.isEmpty
     }
 
     var replyPreviewText: String {
-        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
-            return trimmed
+        if !trimmedBody.isEmpty {
+            return trimmedBody
         }
         return MessageMediaAttachment.previewText(for: mediaAttachments)
     }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -2403,16 +2403,16 @@ private struct MessageBubble: View {
                         .padding(.horizontal, 4)
                 }
 
-                if !visualMediaAttachments.isEmpty {
+                if !message.visualMediaAttachments.isEmpty {
                     MessageVisualMediaGrid(
                         message: message,
-                        attachments: visualMediaAttachments,
+                        attachments: message.visualMediaAttachments,
                         isOutgoing: message.isOutgoing,
                         onOpenImageGallery: onOpenImageGallery
                     )
                 }
 
-                ForEach(nonvisualMediaAttachments) { attachment in
+                ForEach(message.nonvisualMediaAttachments) { attachment in
                     MessageMediaAttachmentView(
                         downloadState: workspace.mediaDownloadStateStore(for: message, attachment: attachment),
                         message: message,
@@ -2421,7 +2421,7 @@ private struct MessageBubble: View {
                     )
                 }
 
-                if hasBubbleContent {
+                if workspace.streamingDebugEnabled || message.hasBubbleContent {
                     bubbleContent
                 }
 
@@ -2482,28 +2482,6 @@ private struct MessageBubble: View {
         message.supportsChatActions && (isHovering || isInlineActionPresentationActive)
     }
 
-    private var trimmedBody: String {
-        message.body.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var hasBubbleContent: Bool {
-        workspace.streamingDebugEnabled
-            || message.replyContext != nil
-            || !trimmedBody.isEmpty
-    }
-
-    private var visualMediaAttachments: [MessageMediaAttachment] {
-        message.mediaAttachments.filter { attachment in
-            attachment.kind == .image || attachment.kind == .video
-        }
-    }
-
-    private var nonvisualMediaAttachments: [MessageMediaAttachment] {
-        message.mediaAttachments.filter { attachment in
-            attachment.kind == .audio || attachment.kind == .file
-        }
-    }
-
     private var bubbleContent: some View {
         VStack(alignment: .leading, spacing: 8) {
             if workspace.streamingDebugEnabled {
@@ -2514,7 +2492,7 @@ private struct MessageBubble: View {
                 MessageReplyContextView(context: replyContext, isOutgoing: message.isOutgoing)
             }
 
-            if !trimmedBody.isEmpty {
+            if !message.trimmedBody.isEmpty {
                 Text(message.body)
                     .font(.system(size: 15.5))
                     .foregroundStyle(message.isOutgoing ? .white : .primary)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1164,6 +1164,59 @@ struct whitenoise_macTests {
         #expect(MessageMediaGridPresentation.gridHeight(totalCount: 4, maxWidth: 360, spacing: 3) == 360)
     }
 
+    @MainActor
+    @Test func messageItemPrecomputesBubbleRenderContent() async throws {
+        let image = MessageMediaAttachment(
+            id: "image",
+            reference: mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        )
+        let audio = MessageMediaAttachment(
+            id: "audio",
+            reference: mediaAttachmentReference(mediaType: "audio/mp4", fileName: "clip.m4a")
+        )
+        let video = MessageMediaAttachment(
+            id: "video",
+            reference: mediaAttachmentReference(mediaType: "video/mp4", fileName: "clip.mp4")
+        )
+        let file = MessageMediaAttachment(
+            id: "file",
+            reference: mediaAttachmentReference(mediaType: "application/pdf", fileName: "notes.pdf")
+        )
+        let replyContext = MessageReplyContext(
+            targetMessageId: "parent",
+            senderName: "Alice",
+            body: "Earlier note"
+        )
+
+        let message = MessageItem(
+            id: "mixed-media",
+            senderName: "Bob",
+            body: "  Render once  ",
+            sentAt: Date(timeIntervalSince1970: 1_800_000_000),
+            isOutgoing: false,
+            replyContext: replyContext,
+            mediaAttachments: [image, audio, video, file]
+        )
+
+        #expect(message.trimmedBody == "Render once")
+        #expect(message.hasBubbleContent)
+        #expect(message.visualMediaAttachments.map(\.id) == ["image", "video"])
+        #expect(message.nonvisualMediaAttachments.map(\.id) == ["audio", "file"])
+
+        let attachmentOnly = MessageItem(
+            id: "attachment-only",
+            senderName: "Bob",
+            body: "  \n  ",
+            sentAt: Date(timeIntervalSince1970: 1_800_000_001),
+            isOutgoing: false,
+            mediaAttachments: [image]
+        )
+        #expect(attachmentOnly.trimmedBody.isEmpty)
+        #expect(!attachmentOnly.hasBubbleContent)
+        #expect(attachmentOnly.replyPreviewText == "Photo")
+        #expect(!attachmentOnly.canCopyText)
+    }
+
     @Test func pendingMediaAttachmentDurationLabelFormatsSubhourHourBoundaryAndClampsNegative() {
         let longAttachment = PendingMediaAttachment(
             fileName: "long.m4a",


### PR DESCRIPTION
## Summary
- precomputes MessageItem trimmed body and media attachment partitions once during model construction
- switches MessageBubble to read the stored derived fields instead of filtering/trimming during SwiftUI body evaluation
- adds regression coverage for the derived bubble-render fields

## Test Plan
- `git diff --check`
- static render-path sweep: verified MessageBubble no longer contains the old computed filters/trimming
- macOS `xcodebuild test` not run locally: this worker is Linux and has no Xcode toolchain; GitHub Mac CI will run the PR checks

Closes #184


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/191">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->