### PR TITLE
fix: harden workspace generation counters

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -494,8 +494,8 @@ extension WorkspaceState {
         }
     }
 
-    func beginGroupDetailsLoad() -> Int {
-        groupDetailsLoadGeneration += 1
+    func beginGroupDetailsLoad() -> UInt64 {
+        groupDetailsLoadGeneration &+= 1
         return groupDetailsLoadGeneration
     }
 
@@ -503,23 +503,23 @@ extension WorkspaceState {
     /// clear the spinner, or report an error against closed/superseded UI state. Also clears the
     /// (now-orphaned) spinner: the in-flight load, once superseded, declines to touch it.
     func invalidateGroupDetailsLoad() {
-        groupDetailsLoadGeneration += 1
+        groupDetailsLoadGeneration &+= 1
         isLoadingGroupDetails = false
     }
 
     /// True while `generation` still owns the group-details load — i.e. no newer `loadGroupDetails`
     /// or `invalidateGroupDetailsLoad` (via `closeGroupDetails`) has bumped the generation.
-    func ownsGroupDetailsLoad(generation: Int) -> Bool {
+    func ownsGroupDetailsLoad(generation: UInt64) -> Bool {
         groupDetailsLoadGeneration == generation
     }
 
-    func beginGroupImageSearch() -> Int {
-        groupImageSearchGeneration += 1
+    func beginGroupImageSearch() -> UInt64 {
+        groupImageSearchGeneration &+= 1
         return groupImageSearchGeneration
     }
 
     func invalidateGroupImageSearch() {
-        groupImageSearchGeneration += 1
+        groupImageSearchGeneration &+= 1
         isSearchingGroupImages = false
     }
 
@@ -529,7 +529,7 @@ extension WorkspaceState {
     /// presented or the live query to match, because spinner ownership must transfer cleanly even
     /// when the user edits the query mid-flight without resubmitting (otherwise the spinner would
     /// stay stuck `true` and disable the Search button — issue #110 review).
-    func ownsGroupImageSearch(generation: Int) -> Bool {
+    func ownsGroupImageSearch(generation: UInt64) -> Bool {
         groupImageSearchGeneration == generation
     }
 
@@ -537,7 +537,7 @@ extension WorkspaceState {
     /// presented, and the live (trimmed) query still equals the one this search was issued for.
     /// Any of: a newer search, a dismissed/reopened picker, or an edited query invalidates the
     /// in-flight result so it cannot overwrite current UI state.
-    func isCurrentGroupImageSearch(generation: Int, query: String) -> Bool {
+    func isCurrentGroupImageSearch(generation: UInt64, query: String) -> Bool {
         ownsGroupImageSearch(generation: generation)
             && isGroupImagePickerPresented
             && groupImageSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -144,17 +144,17 @@ extension WorkspaceState {
         newChatRecipient = nil
     }
 
-    func beginNewChatLookup() -> Int {
-        newChatLookupGeneration += 1
+    func beginNewChatLookup() -> UInt64 {
+        newChatLookupGeneration &+= 1
         return newChatLookupGeneration
     }
 
     func invalidateNewChatLookup() {
-        newChatLookupGeneration += 1
+        newChatLookupGeneration &+= 1
         isResolvingNewChat = false
     }
 
-    func isCurrentNewChatLookup(generation: Int, query: String) -> Bool {
+    func isCurrentNewChatLookup(generation: UInt64, query: String) -> Bool {
         newChatLookupGeneration == generation
             && newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
     }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -411,7 +411,9 @@ final class WorkspaceState {
     /// still the current generation — i.e. no newer load has superseded it. This distinguishes
     /// "superseded by a newer load" (must NOT dismiss the spinner the newer load owns) from
     /// "cancelled with no replacement" (the active account was cleared, so the spinner MUST be
-    /// dismissed instead of left stuck). See `loadSettingsData` / issue #4.
+    /// dismissed instead of left stuck). The token wraps with `&+=`: equality ownership tolerates
+    /// wraparound, and wrapping avoids overflow traps (issue #182). See `loadSettingsData` /
+    /// issue #4.
     var settingsLoadGeneration: UInt64 = 0
     var timelineTask: Task<Void, Never>?
     var timelineTaskGroupId: String?
@@ -434,7 +436,9 @@ final class WorkspaceState {
     var lastConfirmedReadMarkers: [String: ReadMarker] = [:]
     var deliveredNotificationKeys = Set<String>()
     var deliveredNotificationKeyOrder: [String] = []
-    var newChatLookupGeneration = 0
+    /// Wrapping owner token for new-chat lookup. Stale-result guards only compare equality, so
+    /// wraparound preserves ownership semantics while avoiding overflow traps (issues #2, #182).
+    var newChatLookupGeneration: UInt64 = 0
     /// Monotonic token identifying the most recently started group-image (Openverse) search.
     /// `searchGroupImages` captures the value before its `await` and only commits results /
     /// clears `isSearchingGroupImages` while it is still current — i.e. no newer search has
@@ -442,8 +446,9 @@ final class WorkspaceState {
     /// search last-request-wins (a slow earlier search cannot overwrite a newer one) and
     /// prevents a search resolving after the picker is dismissed/reopened from repopulating
     /// `groupImageResults`. Mirrors the new-chat lookup / settings-load generation guards
-    /// (issues #2, #4). See `searchGroupImages` / issue #110.
-    var groupImageSearchGeneration = 0
+    /// (issues #2, #4) and uses the same wrapping-token overflow hardening (issue #182).
+    /// See `searchGroupImages` / issue #110.
+    var groupImageSearchGeneration: UInt64 = 0
     /// Monotonic token identifying the most recently started group-details load. `loadGroupDetails`
     /// captures the value on entry and only applies the fetched snapshot, clears
     /// `isLoadingGroupDetails`, or reports errors while it is still current — i.e. no newer load or
@@ -453,9 +458,10 @@ final class WorkspaceState {
     /// `loadGroupDetails` is reachable concurrently for the same group from `showGroupDetails`,
     /// `reloadSelectedGroupDetails`, `saveGroupProfile`, member-mutation paths, and
     /// `acceptGroupInvite`, and `applyGroupDetails` is completion-ordered, not request-ordered.
-    /// Mirrors the settings-load / group-image-search generation guards (issues #2, #4, #110).
+    /// Mirrors the settings-load / group-image-search generation guards (issues #2, #4, #110)
+    /// and uses the same wrapping-token overflow hardening (issue #182).
     /// See `loadGroupDetails` / issue #135.
-    var groupDetailsLoadGeneration = 0
+    var groupDetailsLoadGeneration: UInt64 = 0
     /// Raw per-sender FFI lookups (userProfile + directory displayName), cached so that
     /// scrolling back through history does not re-resolve the same senders from Rust on
     /// every page. Keyed by sender accountIdHex.
@@ -485,6 +491,43 @@ final class WorkspaceState {
         /// state this must stay flat across timeline windows (whitenoise-mac#171). Not read by
         /// production code.
         var timelineSenderMemberFallbackFetchCount = 0
+
+        /// Test hook for stale-result generation counter overflow hardening (issue #182).
+        /// Production code only compares owner tokens for equality, so wraparound is valid.
+        func seedStaleResultGenerationsForTesting(_ generation: UInt64) {
+            newChatLookupGeneration = generation
+            groupImageSearchGeneration = generation
+            groupDetailsLoadGeneration = generation
+        }
+
+        /// Bumps the same counters through their production `begin*` paths so tests exercise `&+=`.
+        func bumpStaleResultGenerationsForTesting() -> (
+            newChatLookup: UInt64,
+            groupImageSearch: UInt64,
+            groupDetailsLoad: UInt64
+        ) {
+            return (
+                beginNewChatLookup(),
+                beginGroupImageSearch(),
+                beginGroupDetailsLoad()
+            )
+        }
+
+        /// Evaluates the production equality guards for a captured generation token.
+        func ownsStaleResultGenerationsForTesting(
+            generation: UInt64,
+            newChatQuery query: String
+        ) -> (
+            newChatLookup: Bool,
+            groupImageSearch: Bool,
+            groupDetailsLoad: Bool
+        ) {
+            return (
+                isCurrentNewChatLookup(generation: generation, query: query),
+                ownsGroupImageSearch(generation: generation),
+                ownsGroupDetailsLoad(generation: generation)
+            )
+        }
     #endif
 
     /// How long a *complete* peer-profile lookup is trusted before it is re-resolved

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4494,6 +4494,43 @@ struct whitenoise_macTests {
         #expect(state.timelineSenderMemberFallbackFetchCount >= 1)
     }
 
+    // MARK: - Workspace generation counters (issue #182)
+
+    @MainActor
+    @Test func workspaceStaleResultGenerationCountersWrapAndRetainOwnership() {
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+        state.newChatQuery = "alice@example.com"
+
+        state.seedStaleResultGenerationsForTesting(UInt64.max)
+        let wrappedGenerations = state.bumpStaleResultGenerationsForTesting()
+
+        #expect(wrappedGenerations.newChatLookup == 0)
+        #expect(wrappedGenerations.groupImageSearch == 0)
+        #expect(wrappedGenerations.groupDetailsLoad == 0)
+
+        let currentOwnership = state.ownsStaleResultGenerationsForTesting(
+            generation: 0,
+            newChatQuery: "alice@example.com"
+        )
+        #expect(currentOwnership.newChatLookup)
+        #expect(currentOwnership.groupImageSearch)
+        #expect(currentOwnership.groupDetailsLoad)
+
+        let staleOwnership = state.ownsStaleResultGenerationsForTesting(
+            generation: UInt64.max,
+            newChatQuery: "alice@example.com"
+        )
+        #expect(!staleOwnership.newChatLookup)
+        #expect(!staleOwnership.groupImageSearch)
+        #expect(!staleOwnership.groupDetailsLoad)
+
+        let wrongQueryOwnership = state.ownsStaleResultGenerationsForTesting(
+            generation: 0,
+            newChatQuery: "bob@example.com"
+        )
+        #expect(!wrongQueryOwnership.newChatLookup)
+    }
+
     // MARK: - ChatListRowEnrichmentTracker (issue #40 ownership invariants)
 
     @Test func enrichmentTrackerStaleTaskAfterReloadDoesNotDropNewerTask() {


### PR DESCRIPTION
## Summary
- Convert the new-chat lookup, group-image search, and group-details load generation counters to `UInt64`.
- Use wrapping `&+= 1` increments for those counters, matching the hardened settings-load guard.
- Add a regression test that asserts the stale-result generation counters stay on wrapping `UInt64` tokens.

## Test Plan
- `git diff --check`
- Python source assertions for the three generation counters
- GitHub Mac CI on commit `4a683f3`: PR Checks passed, Static Analysis passed, CodeRabbit status passed
- Swift/Xcode checks not run locally: this Linux host has no `xcrun`, `xcodebuild`, `swift-format`, or `swift`.

Closes #182
