### PR TITLE
fix: cache public identity QR image

### DIFF
--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -445,15 +445,28 @@ struct PublicIdentityQRCodeSheet: View {
 struct QRCodeImageView: View {
     let payload: String
 
+    @State private var renderedPayload: String?
+    @State private var renderedImage: NSImage?
+
     var body: some View {
-        if let image = Self.image(for: payload) {
-            Image(nsImage: image)
-                .interpolation(.none)
-                .resizable()
-                .scaledToFit()
-        } else {
-            ContentUnavailableView("QR code unavailable", systemImage: "qrcode")
-                .foregroundStyle(.black)
+        Group {
+            if renderedPayload == payload, let renderedImage {
+                Image(nsImage: renderedImage)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+            } else if renderedPayload == payload {
+                ContentUnavailableView("QR code unavailable", systemImage: "qrcode")
+                    .foregroundStyle(.black)
+            } else {
+                ProgressView()
+                    .controlSize(.small)
+                    .foregroundStyle(.black)
+            }
+        }
+        .task(id: payload) {
+            renderedImage = Self.image(for: payload)
+            renderedPayload = payload
         }
     }
 


### PR DESCRIPTION
## Summary
- Cache the generated public-identity QR image in `QRCodeImageView` state.
- Move QR synthesis/rasterization behind `.task(id: payload)` so ordinary body re-evaluations reuse the cached `NSImage`.
- Preserve the existing unavailable fallback for empty or failed QR payloads.

## Verification
- `git diff --check`
- Python source check: verified `QRCodeImageView` has `@State` cache fields, `.task(id: payload)`, and no synchronous generator call during the pre-task render path.
- `xcrun swift-format lint ...` not run: `xcrun` is missing on this Linux worker.
- `scripts/ci/macos-sanity-checks.sh` not run: `xcodebuild` is missing on this Linux worker.

Closes #180


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/193">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->