### PR TITLE
refactor: deduplicate outgoing media temp URL setup

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -999,19 +999,18 @@ nonisolated private enum MediaVideoMetadata {
 
 nonisolated private enum TemporaryOutgoingMediaFile {
     static func withURL<T>(data: Data, fileExtension: String, _ work: (URL) -> T) -> T {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("WhiteNoiseMediaWork", isDirectory: true)
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let url =
-            directory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension(fileExtension)
-        try? data.write(to: url, options: [.atomic])
+        let url = makeTempURL(data: data, fileExtension: fileExtension)
         defer { try? FileManager.default.removeItem(at: url) }
         return work(url)
     }
 
     static func withURL<T>(data: Data, fileExtension: String, _ work: (URL) async -> T) async -> T {
+        let url = makeTempURL(data: data, fileExtension: fileExtension)
+        defer { try? FileManager.default.removeItem(at: url) }
+        return await work(url)
+    }
+
+    private static func makeTempURL(data: Data, fileExtension: String) -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("WhiteNoiseMediaWork", isDirectory: true)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -1020,8 +1019,7 @@ nonisolated private enum TemporaryOutgoingMediaFile {
             .appendingPathComponent(UUID().uuidString)
             .appendingPathExtension(fileExtension)
         try? data.write(to: url, options: [.atomic])
-        defer { try? FileManager.default.removeItem(at: url) }
-        return await work(url)
+        return url
     }
 }
 


### PR DESCRIPTION
Closes #187

## Summary
- Extracted `TemporaryOutgoingMediaFile.makeTempURL(data:fileExtension:)` so temp directory creation, UUID path construction, and atomic data write live in one helper.
- Kept the sync and async `withURL` overloads as thin wrappers that each retain their existing `defer` cleanup timing around the supplied work closure.
- Preserved the existing non-throwing behavior and best-effort write/cleanup semantics.

## Verification
- `git diff --check` — passed.
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .` — no conflict markers.
- Structural invariant check — passed: one temp directory literal, one atomic write, two `withURL` overloads, two cleanup `defer`s.
- macOS CI commands were not run locally: this Linux host does not have `xcrun`, `xcodebuild`, `swift-format`, `plutil`, or `/usr/libexec/PlistBuddy`.

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/195">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->