### PR TITLE
fix: avoid duplicate mixed media JSON attachments

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -390,26 +390,31 @@ private nonisolated enum MessageMediaParser {
         guard remainingDepth >= 0 else { return [] }
 
         if let dictionary = value as? [String: Any] {
-            var output: [MediaAttachmentReferenceFfi] = []
-
+            // Branches are mutually exclusive in precedence order so a single object
+            // carrying multiple shapes (e.g. both `imeta` and the flat direct-reference
+            // keys) cannot emit duplicate references for the same logical attachment.
             if let imeta = dictionary["imeta"] {
                 // Safe without its own depth counter because the raw JSON pre-scan rejects
                 // any object graph deeper than maxMediaJSONTraversalDepth before parsing.
-                output.append(
-                    contentsOf: references(
-                        fromIMetaValue: imeta,
-                        sourceEpoch: unsignedInteger(dictionary["source_epoch"] ?? dictionary["sourceEpoch"])
-                    )
+                let imetaReferences = references(
+                    fromIMetaValue: imeta,
+                    sourceEpoch: unsignedInteger(dictionary["source_epoch"] ?? dictionary["sourceEpoch"])
                 )
+                if !imetaReferences.isEmpty {
+                    return imetaReferences
+                }
             }
             if let media = dictionary["media"] {
-                output.append(contentsOf: references(fromJSONObject: media, remainingDepth: remainingDepth - 1))
+                let mediaReferences = references(fromJSONObject: media, remainingDepth: remainingDepth - 1)
+                if !mediaReferences.isEmpty {
+                    return mediaReferences
+                }
             }
             if let direct = reference(fromJSONObject: dictionary) {
-                output.append(direct)
+                return [direct]
             }
 
-            return output
+            return []
         }
 
         if let array = value as? [Any] {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1151,6 +1151,37 @@ struct whitenoise_macTests {
         #expect(messages.allSatisfy { $0.mediaAttachments.first?.reference.sourceEpoch == 7 })
     }
 
+    @MainActor
+    @Test func mediaJSONObjectWithIMetaAndFlatKeysMapsSingleAttachment() async throws {
+        // Regression for whitenoise-mac#185: a single peer-controlled object carrying
+        // both an `imeta` array and the flat direct-reference keys must not emit both the
+        // imeta-derived reference and a separate direct reference for the same logical
+        // attachment. Object branches are mutually exclusive (`imeta`, else `media`, else
+        // flat), so the object maps to exactly one attachment instead of rendering twice.
+        let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "imeta-and-flat",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJsonWithIMetaAndFlatKeys(for: reference)
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+
+        #expect(message.mediaAttachments.count == 1)
+        #expect(message.mediaAttachments.first?.reference.plaintextSha256 == reference.plaintextSha256)
+        #expect(message.mediaAttachments.first?.reference.fileName == reference.fileName)
+    }
+
     @Test func mediaGridPresentationUsesSquareFourTileLayout() {
         #expect(MessageMediaGridPresentation.visibleCount(totalCount: 6) == 4)
         #expect(MessageMediaGridPresentation.hiddenCount(totalCount: 6) == 2)
@@ -9754,6 +9785,19 @@ private func mediaJson(for reference: MediaAttachmentReferenceFfi, arrayDepth de
     for _ in 0..<depth {
         object = [object]
     }
+    return mediaJSONString(fromJSONObject: object)
+}
+
+private func mediaJsonWithIMetaAndFlatKeys(for reference: MediaAttachmentReferenceFfi) -> String {
+    let object: [String: Any] = [
+        "imeta": [mediaIMetaTag(for: reference).values],
+        "ciphertext_sha256": reference.ciphertextSha256,
+        "plaintext_sha256": reference.plaintextSha256,
+        "nonce": reference.nonceHex,
+        "file_name": reference.fileName,
+        "media_type": reference.mediaType,
+        "version": reference.version,
+    ]
     return mediaJSONString(fromJSONObject: object)
 }
 


### PR DESCRIPTION
Closes #185

## Summary
- Make media JSON object parsing choose the first successful reference shape in precedence order (`imeta`, then nested `media`, then flat direct-reference keys) instead of appending all shapes from one object.
- Add a regression test for a mixed-shape peer JSON object carrying both `imeta` and equivalent flat keys, asserting it maps to one attachment.

## Verification
- `git diff --check` — passed.
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':!Vendored'` — no conflict markers.
- `awk 'length($0) > 120 { ... }' whitenoise-mac/Core/MarmotMapping.swift whitenoise-macTests/whitenoise_macTests.swift` — no over-120 lines.
- CI-exact macOS commands not runnable on this Linux host: `xcrun`, `xcodebuild`, `swift`, and `swift-format` are missing. GitHub macOS CI is authoritative for compile/test/format.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/196">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->