### PR TITLE
fix: reject invalid numeric media source epochs

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -588,7 +588,15 @@ private nonisolated enum MessageMediaParser {
 
     private static func unsignedInteger(_ value: Any?) -> UInt64? {
         if let number = value as? NSNumber {
-            return number.uint64Value
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return nil
+            }
+            // `uint64Value` silently wraps negatives (`-1` -> `UInt64.max`) and truncates
+            // fractions (`3.9` -> `3`). A peer-controlled `source_epoch` feeds MLS epoch
+            // selection, so reject anything that is not an exact, in-range unsigned integer
+            // rather than letting garbage flow into the crypto layer. Round-tripping through
+            // the string value keeps this path semantically aligned with the `String` branch.
+            return UInt64(number.stringValue)
         }
         if let string = value as? String {
             return UInt64(string.trimmingCharacters(in: .whitespacesAndNewlines))

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1211,6 +1211,46 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func invalidNumericSourceEpochFallsBackToZeroInsteadOfWrapping() async throws {
+        // Regression for whitenoise-mac#179: a peer-controlled `source_epoch` is the MLS
+        // decryption epoch, so a negative (`-1` would wrap to `UInt64.max`), fractional
+        // (`3.9` would truncate to `3`), out-of-range (`1e30` would saturate), or boolean
+        // (`true` would parse as `1`) JSON value must be rejected by `unsignedInteger(_:)`
+        // instead of flowing through as a garbage epoch. Rejected values default the parsed
+        // attachment epoch to 0, matching `nil` from `unsignedInteger`.
+        let reference = mediaAttachmentReference(sourceEpoch: 0, mediaType: "image/png", fileName: "photo.png")
+        let invalidEpochs: [NSNumber] = [
+            NSNumber(value: -1),
+            NSNumber(value: 3.9),
+            NSNumber(value: 1e30),
+            NSNumber(value: true),
+            NSNumber(value: false),
+        ]
+        let page = TimelinePageFfi(
+            messages: invalidEpochs.enumerated().flatMap { index, rawEpoch in
+                ["source_epoch", "sourceEpoch"].enumerated().map { keyIndex, key in
+                    timelineMessage(
+                        id: "invalid-epoch-\(index)-\(keyIndex)",
+                        groupIdHex: "group",
+                        sender: "alice",
+                        plaintext: "",
+                        recordedAt: 1_700_000_000 + UInt64(index * 2 + keyIndex),
+                        mediaJson: mediaJson(for: reference, sourceEpochKey: key, rawSourceEpoch: rawEpoch)
+                    )
+                }
+            },
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+
+        #expect(messages.count == invalidEpochs.count * 2)
+        #expect(messages.allSatisfy { $0.mediaAttachments.count == 1 })
+        #expect(messages.allSatisfy { $0.mediaAttachments.first?.reference.sourceEpoch == 0 })
+    }
+
+    @MainActor
     @Test func mediaJSONObjectWithIMetaAndFlatKeysMapsSingleAttachment() async throws {
         // Regression for whitenoise-mac#185: a single peer-controlled object carrying
         // both an `imeta` array and the flat direct-reference keys must not emit both the
@@ -9954,6 +9994,15 @@ private func mediaJson(for reference: MediaAttachmentReferenceFfi) -> String {
 private func mediaJson(for reference: MediaAttachmentReferenceFfi, sourceEpochKey key: String) -> String {
     let tag = mediaIMetaTag(for: reference).values
     return mediaJSONString(fromJSONObject: ["imeta": [tag], key: NSNumber(value: reference.sourceEpoch)])
+}
+
+private func mediaJson(
+    for reference: MediaAttachmentReferenceFfi,
+    sourceEpochKey key: String,
+    rawSourceEpoch: NSNumber
+) -> String {
+    let tag = mediaIMetaTag(for: reference).values
+    return mediaJSONString(fromJSONObject: ["imeta": [tag], key: rawSourceEpoch])
 }
 
 private func mediaJson(for reference: MediaAttachmentReferenceFfi, mediaObjectDepth depth: Int) -> String {


### PR DESCRIPTION
Closes #179

## Summary
- Hardened `MarmotMapping.unsignedInteger(_:)` so peer-controlled `source_epoch` values must parse as exact in-range `UInt64` strings instead of using `NSNumber.uint64Value`.
- Invalid negative, fractional, out-of-range, or boolean epochs now return `nil` and fall back to the existing epoch `0` behavior instead of wrapping/truncating/coercing into garbage MLS epochs.
- Added a regression test covering invalid numeric and boolean `source_epoch` / `sourceEpoch` values from media JSON.

## Verification
- `git diff --check origin/master...HEAD` — passed.
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' HEAD -- .` — clean.
- `command -v swift xcodebuild xcrun` — all missing on this Linux worker, so macOS CI commands could not be run locally.
- GitHub Mac CI on PR #199 after final rebase — passed: `PR Checks`, `Static Analysis`, `CodeRabbit`.
- CodeRabbit was retriggered after the initial rate-limit notice; one Major finding about JSON booleans was addressed and CodeRabbit confirmed it was handled.
- Not run locally: `xcrun swift-format lint`, `xcodebuild test`, `xcodebuild build`, `xcodebuild analyze`, `scripts/ci/macos-sanity-checks.sh` (macOS/Xcode required).

## Sensitive paths
- `whitenoise-mac/Core/MarmotMapping.swift` — untrusted media JSON mapping path that feeds MLS media attachment epoch selection.
