### PR TITLE
fix: ensure local data wipe ignores relay cleanup failures

### DIFF
--- a/whitenoise-mac/Core/MarmotClient.swift
+++ b/whitenoise-mac/Core/MarmotClient.swift
@@ -212,13 +212,27 @@ nonisolated final class MarmotClient: MarmotRuntime, @unchecked Sendable {
     }
 
     func deleteAllLocalData() async throws {
-        let accounts = try marmot.listAccounts()
-        for account in accounts {
-            try await marmot.removeAccount(accountRef: account.label)
-        }
-        await marmot.shutdown()
+        try await Self.deleteAllLocalData(
+            listAccountRefs: { try marmot.listAccounts().map(\.label) },
+            removeAccount: { try await marmot.removeAccount(accountRef: $0) },
+            shutdown: { await marmot.shutdown() },
+            rootPath: rootPath
+        )
+    }
 
-        let fileManager = FileManager.default
+    static func deleteAllLocalData(
+        listAccountRefs: () throws -> [String],
+        removeAccount: (String) async throws -> Void,
+        shutdown: () async -> Void,
+        rootPath: String,
+        fileManager: FileManager = .default
+    ) async throws {
+        let accountRefs = (try? listAccountRefs()) ?? []
+        for accountRef in accountRefs {
+            try? await removeAccount(accountRef)
+        }
+        await shutdown()
+
         if fileManager.fileExists(atPath: rootPath) {
             try fileManager.removeItem(atPath: rootPath)
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -455,6 +455,65 @@ struct whitenoise_macTests {
         #expect(UserDefaults.standard.string(forKey: "whitenoise.mac.activeAccountId") == nil)
     }
 
+    @Test func deleteAllLocalDataWipesStorageWhenAccountCleanupFails() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-delete-all-data-\(UUID().uuidString)", isDirectory: true)
+        let secretFile = root.appendingPathComponent("private-identity.sqlite")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("private key material".utf8).write(to: secretFile)
+        defer { try? fileManager.removeItem(at: root) }
+
+        var removedRefs: [String] = []
+        var didShutdown = false
+
+        try await MarmotClient.deleteAllLocalData(
+            listAccountRefs: { ["Desktop Account", "Relay-Failing Account", "Backup Account"] },
+            removeAccount: { accountRef in
+                removedRefs.append(accountRef)
+                if accountRef == "Relay-Failing Account" {
+                    throw FakeMarmotRuntimeError.unused
+                }
+            },
+            shutdown: { didShutdown = true },
+            rootPath: root.path,
+            fileManager: fileManager
+        )
+
+        #expect(removedRefs == ["Desktop Account", "Relay-Failing Account", "Backup Account"])
+        #expect(didShutdown)
+        #expect(fileManager.fileExists(atPath: root.path))
+        #expect(!fileManager.fileExists(atPath: secretFile.path))
+        #expect(try fileManager.contentsOfDirectory(atPath: root.path).isEmpty)
+    }
+
+    @Test func deleteAllLocalDataWipesStorageWhenAccountListingFails() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-delete-all-data-\(UUID().uuidString)", isDirectory: true)
+        let secretFile = root.appendingPathComponent("mls-state.sqlite")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("mls group state".utf8).write(to: secretFile)
+        defer { try? fileManager.removeItem(at: root) }
+
+        var didAttemptRemove = false
+        var didShutdown = false
+
+        try await MarmotClient.deleteAllLocalData(
+            listAccountRefs: { throw FakeMarmotRuntimeError.unused },
+            removeAccount: { _ in didAttemptRemove = true },
+            shutdown: { didShutdown = true },
+            rootPath: root.path,
+            fileManager: fileManager
+        )
+
+        #expect(!didAttemptRemove)
+        #expect(didShutdown)
+        #expect(fileManager.fileExists(atPath: root.path))
+        #expect(!fileManager.fileExists(atPath: secretFile.path))
+        #expect(try fileManager.contentsOfDirectory(atPath: root.path).isEmpty)
+    }
+
     @MainActor
     @Test func bootstrappingStateDoesNotShowMessengerChrome() async throws {
         let state = WorkspaceState(clientFactory: {


### PR DESCRIPTION
## Summary
- Make per-account FFI removal best-effort during Delete All Local Data.
- Always shut down Marmot and remove/recreate the storage root even if account listing or relay cleanup fails.
- Add regression coverage for listAccounts/removeAccount failures still wiping on-disk private state.

## Test plan
- git diff --check
- git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' HEAD -- . ':!Vendored/MarmotKit/MarmotKit.xcframework'
- xcodebuild/xcrun unavailable on this Linux worker; GitHub macOS CI must run the Swift format, unit-test, build, and analysis gates.

Closes #174


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->