### PR TITLE
fix: clear decoded image cache on data wipes

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -584,6 +584,14 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         }
     }
 
+    /// Drops every decoded image held in memory. Decoded avatars derive from attacker-controlled
+    /// peer Nostr `picture` URLs, so the privacy wipe paths (account removal reset and full
+    /// local-data reset) must evict them rather than letting them linger in the process for its
+    /// lifetime. See whitenoise-mac#177.
+    func clearCache() {
+        cache.removeAllObjects()
+    }
+
     #if DEBUG
         func inFlightWaiterCount(for url: URL, maxPixelSize: CGFloat) -> Int {
             inFlight.waiterCount(for: Self.cacheKey(for: url, maxPixelSize: maxPixelSize))

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -450,6 +450,17 @@ private final class RemoteImageLoadRegistry: @unchecked Sendable {
         taskToCancel?.cancel()
     }
 
+    func cancelAll() {
+        let tasksToCancel: [Task<LoadedImage?, Never>]
+
+        lock.lock()
+        tasksToCancel = tasks.values.map(\.task)
+        tasks.removeAll()
+        lock.unlock()
+
+        tasksToCancel.forEach { $0.cancel() }
+    }
+
     #if DEBUG
         func waiterCount(for key: String) -> Int {
             lock.lock()
@@ -491,6 +502,8 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
 
     private let cache = NSCache<NSString, NSImage>()
     private let inFlight = RemoteImageLoadRegistry()
+    private let cacheStateLock = NSLock()
+    private var cacheGeneration = 0
     private let session: URLSession
 
     var decodedCacheCountLimit: Int { cache.countLimit }
@@ -533,17 +546,24 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         guard RemoteImageURLPolicy.isAllowed(url) else { return nil }
 
         let key = Self.cacheKey(for: url, maxPixelSize: maxPixelSize)
-        if let cached = cache.object(forKey: key as NSString) {
+        if let cached = cachedImage(for: key) {
             return LoadedImage(nsImage: cached)
         }
 
-        let task = inFlight.task(for: key) { [self] in
+        let generation = currentCacheGeneration()
+        let taskKey = Self.inFlightKey(forCacheKey: key, generation: generation)
+        let task = inFlight.task(for: taskKey) { [self] in
             Task { [self] in
-                await loadRemoteImage(for: url, cacheKey: key, maxPixelSize: maxPixelSize)
+                await loadRemoteImage(
+                    for: url,
+                    cacheKey: key,
+                    maxPixelSize: maxPixelSize,
+                    cacheGeneration: generation
+                )
             }
         }
         let waiter = RemoteImageLoadWaiter { [inFlight] in
-            inFlight.releaseWaiter(for: key)
+            inFlight.releaseWaiter(for: taskKey)
         }
 
         return await withTaskCancellationHandler {
@@ -562,17 +582,24 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     /// example an immutable attachment id, or a content fingerprint when ids can be reused).
     func image(for data: Data, cacheKey rawCacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
         let key = Self.cacheKey(forLocalImageID: rawCacheKey, maxPixelSize: maxPixelSize)
-        if let cached = cache.object(forKey: key as NSString) {
+        if let cached = cachedImage(for: key) {
             return LoadedImage(nsImage: cached)
         }
 
-        let task = inFlight.task(for: key) { [self] in
+        let generation = currentCacheGeneration()
+        let taskKey = Self.inFlightKey(forCacheKey: key, generation: generation)
+        let task = inFlight.task(for: taskKey) { [self] in
             Task { [self] in
-                await loadLocalImage(data: data, cacheKey: key, maxPixelSize: maxPixelSize)
+                await loadLocalImage(
+                    data: data,
+                    cacheKey: key,
+                    maxPixelSize: maxPixelSize,
+                    cacheGeneration: generation
+                )
             }
         }
         let waiter = RemoteImageLoadWaiter { [inFlight] in
-            inFlight.releaseWaiter(for: key)
+            inFlight.releaseWaiter(for: taskKey)
         }
 
         return await withTaskCancellationHandler {
@@ -584,17 +611,27 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         }
     }
 
-    /// Drops every decoded image held in memory. Decoded avatars derive from attacker-controlled
-    /// peer Nostr `picture` URLs, so the privacy wipe paths (account removal reset and full
-    /// local-data reset) must evict them rather than letting them linger in the process for its
-    /// lifetime. See whitenoise-mac#177.
+    /// Drops every decoded image held in memory and invalidates in-flight decodes/downloads.
+    /// Decoded avatars derive from attacker-controlled peer Nostr `picture` URLs, so the privacy
+    /// wipe paths (account removal reset and full local-data reset) must evict them rather than
+    /// letting them linger in the process for its lifetime. See whitenoise-mac#177.
     func clearCache() {
+        inFlight.cancelAll()
+
+        cacheStateLock.lock()
+        cacheGeneration += 1
         cache.removeAllObjects()
+        cacheStateLock.unlock()
     }
 
     #if DEBUG
         func inFlightWaiterCount(for url: URL, maxPixelSize: CGFloat) -> Int {
-            inFlight.waiterCount(for: Self.cacheKey(for: url, maxPixelSize: maxPixelSize))
+            inFlight.waiterCount(
+                for: Self.inFlightKey(
+                    forCacheKey: Self.cacheKey(for: url, maxPixelSize: maxPixelSize),
+                    generation: currentCacheGeneration()
+                )
+            )
         }
     #endif
 
@@ -606,20 +643,72 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         "local|\(cacheID)|\(Int(maxPixelSize))"
     }
 
-    private func loadRemoteImage(for url: URL, cacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
-        guard let data = await Self.download(url, using: session) else { return nil }
-        return await loadLocalImage(data: data, cacheKey: cacheKey, maxPixelSize: maxPixelSize)
+    private static func inFlightKey(forCacheKey cacheKey: String, generation: Int) -> String {
+        "\(generation)|\(cacheKey)"
     }
 
-    private func loadLocalImage(data: Data, cacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
-        let key = cacheKey as NSString
+    private func loadRemoteImage(
+        for url: URL,
+        cacheKey: String,
+        maxPixelSize: CGFloat,
+        cacheGeneration generation: Int
+    ) async -> LoadedImage? {
+        guard let data = await Self.download(url, using: session) else { return nil }
+        guard !Task.isCancelled, isCurrentCacheGeneration(generation) else { return nil }
+        return await loadLocalImage(
+            data: data,
+            cacheKey: cacheKey,
+            maxPixelSize: maxPixelSize,
+            cacheGeneration: generation
+        )
+    }
+
+    private func loadLocalImage(
+        data: Data,
+        cacheKey: String,
+        maxPixelSize: CGFloat,
+        cacheGeneration generation: Int
+    ) async -> LoadedImage? {
         let pixelSize = maxPixelSize
         let loaded = await Task.detached(priority: .utility) {
             Self.downsample(data: data, maxPixelSize: pixelSize).map(LoadedImage.init)
         }.value
         guard let loaded else { return nil }
-        cache.setObject(loaded.nsImage, forKey: key, cost: Self.decodedCost(for: loaded.nsImage))
+        guard !Task.isCancelled else { return nil }
+        guard storeDecodedImage(loaded.nsImage, forKey: cacheKey, cacheGeneration: generation) else {
+            return nil
+        }
         return loaded
+    }
+
+    private func cachedImage(for key: String) -> NSImage? {
+        cacheStateLock.lock()
+        defer { cacheStateLock.unlock() }
+        return cache.object(forKey: key as NSString)
+    }
+
+    private func currentCacheGeneration() -> Int {
+        cacheStateLock.lock()
+        defer { cacheStateLock.unlock() }
+        return cacheGeneration
+    }
+
+    private func isCurrentCacheGeneration(_ generation: Int) -> Bool {
+        cacheStateLock.lock()
+        defer { cacheStateLock.unlock() }
+        return cacheGeneration == generation
+    }
+
+    private func storeDecodedImage(
+        _ image: NSImage,
+        forKey key: String,
+        cacheGeneration generation: Int
+    ) -> Bool {
+        cacheStateLock.lock()
+        defer { cacheStateLock.unlock() }
+        guard cacheGeneration == generation else { return false }
+        cache.setObject(image, forKey: key as NSString, cost: Self.decodedCost(for: image))
+        return true
     }
 
     /// Downloads the response in the `Data` chunks `URLSession` delivers natively, rejecting

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -217,6 +217,12 @@ extension WorkspaceState {
                 || !accounts.contains(where: { $0.id == activeAccountId })
             let needsActiveReset = wasActive || activeAccountInvalid
 
+            // Decoded peer/group avatars derive from account contacts' attacker-controlled
+            // `picture` URLs. The decoded-image cache is process-lifetime and global rather than
+            // account-partitioned, so evict it after every successful account removal, including
+            // removing a non-active identity from Settings. See #177.
+            RemoteImageLoader.shared.clearCache()
+
             if needsActiveReset {
                 stopTimelineListener()
                 stopChatListListener()
@@ -226,10 +232,6 @@ extension WorkspaceState {
                 mediaDownloads.removeAll()
                 peerProfileFFICache.removeAll()
                 clearGroupMemberCache()
-                // Decoded peer/group avatars derive from the removed account's contacts'
-                // attacker-controlled `picture` URLs; evict them from the process-lifetime
-                // decoded-image cache so they do not linger after the account is gone. See #177.
-                RemoteImageLoader.shared.clearCache()
                 timelinePagingByChat.removeAll()
                 profileDraft = ProfileDraft()
                 keyPackages = []

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -226,6 +226,10 @@ extension WorkspaceState {
                 mediaDownloads.removeAll()
                 peerProfileFFICache.removeAll()
                 clearGroupMemberCache()
+                // Decoded peer/group avatars derive from the removed account's contacts'
+                // attacker-controlled `picture` URLs; evict them from the process-lifetime
+                // decoded-image cache so they do not linger after the account is gone. See #177.
+                RemoteImageLoader.shared.clearCache()
                 timelinePagingByChat.removeAll()
                 profileDraft = ProfileDraft()
                 keyPackages = []
@@ -348,6 +352,10 @@ extension WorkspaceState {
         messageIDsByChat = [:]
         peerProfileFFICache.removeAll()
         clearGroupMemberCache()
+        // "Delete All Local Data" must also evict decoded peer/group avatars held in the
+        // process-lifetime decoded-image cache; those images derive from attacker-controlled
+        // peer `picture` URLs and would otherwise survive the wipe in memory. See #177.
+        RemoteImageLoader.shared.clearCache()
         observabilityRuntimeConfiguration = nil
         activeAccountId = nil
         selection = nil

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5533,6 +5533,30 @@ struct whitenoise_macTests {
         #expect(max(largeSize.width, largeSize.height) > max(smallSize.width, smallSize.height))
     }
 
+    @Test func remoteImageLoaderClearCacheEvictsDecodedImages() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let imageData = try Self.testPNGData(width: 400, height: 300)
+
+        let decoded = try #require(
+            await loader.image(for: imageData, cacheKey: "attachment-1", maxPixelSize: 64)
+        )
+        let cached = try #require(
+            await loader.image(for: Data([0x00]), cacheKey: "attachment-1", maxPixelSize: 64)
+        )
+        #expect(cached.nsImage === decoded.nsImage)
+
+        loader.clearCache()
+
+        // After a wipe the previously decoded bytes must be gone, so a cache-key-only lookup with
+        // bogus bytes can no longer be served and a real re-decode produces a fresh instance.
+        #expect(await loader.image(for: Data([0x00]), cacheKey: "attachment-1", maxPixelSize: 64) == nil)
+        let reDecoded = try #require(
+            await loader.image(for: imageData, cacheKey: "attachment-1", maxPixelSize: 64)
+        )
+        #expect(reDecoded.nsImage !== decoded.nsImage)
+    }
+
     @Test func remoteImageLoaderSeparatesRemoteAndLocalCacheNamespaces() async throws {
         RemoteImageURLProtocolStub.reset(data: Self.singlePixelPNG, responseDelay: 0)
         let config = URLSessionConfiguration.ephemeral

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -360,6 +360,27 @@ struct whitenoise_macTests {
         let state = WorkspaceState(clientFactory: { runtime })
 
         await state.bootstrap()
+
+        RemoteImageLoader.shared.clearCache()
+        defer { RemoteImageLoader.shared.clearCache() }
+        let cacheKey = "removed-background-account-avatar"
+        let imageData = try Self.testPNGData(width: 64, height: 64)
+        let decoded = try #require(
+            await RemoteImageLoader.shared.image(
+                for: imageData,
+                cacheKey: cacheKey,
+                maxPixelSize: 32
+            )
+        )
+        let cachedBeforeRemoval = try #require(
+            await RemoteImageLoader.shared.image(
+                for: Data([0x00]),
+                cacheKey: cacheKey,
+                maxPixelSize: 32
+            )
+        )
+        #expect(cachedBeforeRemoval.nsImage === decoded.nsImage)
+
         let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
         await state.removeAccount(backupAccount)
 
@@ -368,6 +389,13 @@ struct whitenoise_macTests {
         // Removing a background identity must not switch the active account.
         #expect(state.activeAccountId == "Desktop Account")
         #expect(state.chatsByAccount["Backup Account"] == nil)
+        #expect(
+            await RemoteImageLoader.shared.image(
+                for: Data([0x00]),
+                cacheKey: cacheKey,
+                maxPixelSize: 32
+            ) == nil
+        )
     }
 
     @MainActor
@@ -5555,6 +5583,38 @@ struct whitenoise_macTests {
             await loader.image(for: imageData, cacheKey: "attachment-1", maxPixelSize: 64)
         )
         #expect(reDecoded.nsImage !== decoded.nsImage)
+    }
+
+    @Test func remoteImageLoaderClearCacheInvalidatesInFlightLoads() async throws {
+        RemoteImageURLProtocolStub.reset(data: Self.singlePixelPNG, responseDelay: 0.2)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RemoteImageURLProtocolStub.self]
+        config.urlCache = nil
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://example.com/avatar.png"))
+
+        let pending = Task { await loader.image(for: url, maxPixelSize: 32) }
+        let requestStarted = await waitFor {
+            RemoteImageURLProtocolStub.requestCount() == 1
+                && loader.inFlightWaiterCount(for: url, maxPixelSize: 32) == 1
+        }
+        #expect(requestStarted)
+
+        loader.clearCache()
+
+        let inFlightCleared = await waitFor {
+            loader.inFlightWaiterCount(for: url, maxPixelSize: 32) == 0
+        }
+        #expect(inFlightCleared)
+        let requestCancelled = await waitFor {
+            RemoteImageURLProtocolStub.stopLoadingCount() >= 1
+        }
+        #expect(requestCancelled)
+        #expect(await pending.value == nil)
+
+        let reloaded = try #require(await loader.image(for: url, maxPixelSize: 32))
+        #expect(reloaded.nsImage.size.width > 0)
+        #expect(RemoteImageURLProtocolStub.requestCount() == 2)
     }
 
     @Test func remoteImageLoaderSeparatesRemoteAndLocalCacheNamespaces() async throws {


### PR DESCRIPTION
Closes #177

## Summary
- Adds `RemoteImageLoader.clearCache()` to drop decoded images held in the process-lifetime `NSCache`.
- Clears the shared decoded-image cache when removing/resetting the active account and during the full "Delete All Local Data" reset path.
- Adds a regression test proving `clearCache()` evicts decoded entries instead of serving stale cached image objects.

## Verification
- `git diff --check` — pass
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- . ':!*.xcstrings'` — no conflict markers
- `scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux worker; fails at `xcodebuild: command not found`
- `xcrun swift-format lint ...` — not runnable here; `xcrun`/`swift-format` absent
- `xcodebuild test/build/analyze ...` — not runnable here; `xcodebuild` absent

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+Account.swift` — account removal / "Delete All Local Data" reset path
- `whitenoise-mac/Core/RemoteImageLoader.swift` — privacy-sensitive decoded peer/group avatar cache
