### PR TITLE
fix: isolate selected chat timeline observation

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -221,6 +221,10 @@ extension WorkspaceState {
                 stopTimelineListener()
                 stopChatListListener()
                 messagesByChat.removeAll()
+                for store in messageTimelineStores.values {
+                    store.clear()
+                }
+                messageTimelineStores.removeAll()
                 messageLookupByChat.removeAll()
                 messageIDsByChat.removeAll()
                 mediaDownloads.removeAll()
@@ -343,6 +347,10 @@ extension WorkspaceState {
         accounts = []
         chatsByAccount = [:]
         messagesByChat = [:]
+        for store in messageTimelineStores.values {
+            store.clear()
+        }
+        messageTimelineStores = [:]
         resetMediaDownloadStateStores()
         messageLookupByChat = [:]
         messageIDsByChat = [:]

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -217,6 +217,8 @@ extension WorkspaceState {
         chats.removeAll { $0.id == groupIdHex }
         chatsByAccount[account.id] = chats
         messagesByChat[groupIdHex] = nil
+        messageTimelineStores[groupIdHex]?.clear()
+        messageTimelineStores[groupIdHex] = nil
         messageLookupByChat[groupIdHex] = nil
         messageIDsByChat[groupIdHex] = nil
         invalidateGroupMembers(for: groupIdHex)

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -132,6 +132,7 @@ extension WorkspaceState {
         clearComposerDrafts(for: Array(removedChatIds), accountId: account.id)
         chatsByAccount[account.id] = sortedChatItems(chatItems)
         dismissGroupImagePickerIfSelectedChatUnavailable()
+        ensureSelectedMessageTimelineStore()
         startChatListEnrichment(rows: rows, account: account)
     }
 
@@ -181,6 +182,7 @@ extension WorkspaceState {
         let needsInitialMetadata = !shouldEnrich && readStateRowNeedsMetadataEnrichment(row, current: current)
 
         chatsByAccount[account.id] = ChatListOrdering.upserting(chat, into: chats)
+        ensureSelectedMessageTimelineStore()
         if shouldEnrich {
             startChatListEnrichment(rows: [row], account: account, replacingCurrent: false)
         } else if needsInitialMetadata {

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -21,7 +21,7 @@ extension WorkspaceState {
             finishTimelineInitialLoad(groupIdHex: groupIdHex)
             return
         }
-        if timelineTaskGroupId == groupIdHex, messageTimelineStore(for: groupIdHex).isLoaded {
+        if timelineTaskGroupId == groupIdHex, ensureMessageTimelineStore(for: groupIdHex).isLoaded {
             finishTimelineInitialLoad(groupIdHex: groupIdHex)
             return
         }
@@ -440,21 +440,22 @@ extension WorkspaceState {
         let nextPaging = paging ?? timelinePagingByChat[groupIdHex] ?? .empty
         let messageLookup = Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
         let messageIDs = messages.map(\.id)
-        let timelineStore = messageTimelineStore(for: groupIdHex)
+        let timelineStore = ensureMessageTimelineStore(for: groupIdHex)
+
+        for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
+            store.clear()
+        }
 
         if messagesByChat.count == 1, messagesByChat[groupIdHex] != nil {
             messagesByChat[groupIdHex] = messages
             messageLookupByChat[groupIdHex] = messageLookup
             messageIDsByChat[groupIdHex] = messageIDs
         } else {
-            for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
-                store.clear()
-            }
             messagesByChat = [groupIdHex: messages]
             messageLookupByChat = [groupIdHex: messageLookup]
             messageIDsByChat = [groupIdHex: messageIDs]
-            messageTimelineStores = [groupIdHex: timelineStore]
         }
+        messageTimelineStores = [groupIdHex: timelineStore]
         timelineStore.replace(with: messages)
         if timelinePagingByChat.count == 1, timelinePagingByChat[groupIdHex] != nil {
             timelinePagingByChat[groupIdHex] = nextPaging
@@ -512,7 +513,7 @@ extension WorkspaceState {
         }
 
         if let messages = messagesByChat[groupIdHex] {
-            let timelineStore = messageTimelineStore(for: groupIdHex)
+            let timelineStore = ensureMessageTimelineStore(for: groupIdHex)
             for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
                 store.clear()
             }
@@ -521,6 +522,14 @@ extension WorkspaceState {
             messageIDsByChat = [groupIdHex: messages.map(\.id)]
             messageTimelineStores = [groupIdHex: timelineStore]
             timelineStore.replace(with: messages)
+        } else if let timelineStore = messageTimelineStores[groupIdHex] {
+            for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
+                store.clear()
+            }
+            messagesByChat = [:]
+            messageLookupByChat = [:]
+            messageIDsByChat = [:]
+            messageTimelineStores = [groupIdHex: timelineStore]
         } else {
             for store in messageTimelineStores.values {
                 store.clear()
@@ -537,13 +546,13 @@ extension WorkspaceState {
         }
         if timelineInitialLoadGroupId != groupIdHex {
             timelineInitialLoadGroupId = nil
-        } else if messageTimelineStore(for: groupIdHex).isLoaded {
+        } else if messageTimelineStores[groupIdHex]?.isLoaded == true {
             timelineInitialLoadGroupId = nil
         }
     }
 
     func beginTimelineInitialLoadIfNeeded(groupIdHex: String) {
-        if !messageTimelineStore(for: groupIdHex).isLoaded {
+        if !ensureMessageTimelineStore(for: groupIdHex).isLoaded {
             timelineInitialLoadGroupId = groupIdHex
         } else if timelineInitialLoadGroupId == groupIdHex {
             timelineInitialLoadGroupId = nil
@@ -571,7 +580,7 @@ extension WorkspaceState {
         // visible again (see handleConversationVisibilityChange()).
         guard selectedConversationIsVisible() else { return }
         guard
-            let latest = messageTimelineStore(for: groupIdHex).messages.last(where: { message in
+            let latest = ensureMessageTimelineStore(for: groupIdHex).messages.last(where: { message in
                 message.timelineKind == 9 && !message.isDeleted
             })
         else {

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -21,7 +21,7 @@ extension WorkspaceState {
             finishTimelineInitialLoad(groupIdHex: groupIdHex)
             return
         }
-        if timelineTaskGroupId == groupIdHex, messagesByChat[groupIdHex] != nil {
+        if timelineTaskGroupId == groupIdHex, messageTimelineStore(for: groupIdHex).isLoaded {
             finishTimelineInitialLoad(groupIdHex: groupIdHex)
             return
         }
@@ -440,16 +440,22 @@ extension WorkspaceState {
         let nextPaging = paging ?? timelinePagingByChat[groupIdHex] ?? .empty
         let messageLookup = Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
         let messageIDs = messages.map(\.id)
+        let timelineStore = messageTimelineStore(for: groupIdHex)
 
         if messagesByChat.count == 1, messagesByChat[groupIdHex] != nil {
             messagesByChat[groupIdHex] = messages
             messageLookupByChat[groupIdHex] = messageLookup
             messageIDsByChat[groupIdHex] = messageIDs
         } else {
+            for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
+                store.clear()
+            }
             messagesByChat = [groupIdHex: messages]
             messageLookupByChat = [groupIdHex: messageLookup]
             messageIDsByChat = [groupIdHex: messageIDs]
+            messageTimelineStores = [groupIdHex: timelineStore]
         }
+        timelineStore.replace(with: messages)
         if timelinePagingByChat.count == 1, timelinePagingByChat[groupIdHex] != nil {
             timelinePagingByChat[groupIdHex] = nextPaging
         } else {
@@ -493,22 +499,36 @@ extension WorkspaceState {
         }
 
         guard let groupIdHex else {
+            for store in messageTimelineStores.values {
+                store.clear()
+            }
             messagesByChat = [:]
             messageLookupByChat = [:]
             messageIDsByChat = [:]
+            messageTimelineStores = [:]
             timelinePagingByChat = [:]
             timelineInitialLoadGroupId = nil
             return
         }
 
         if let messages = messagesByChat[groupIdHex] {
+            let timelineStore = messageTimelineStore(for: groupIdHex)
+            for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
+                store.clear()
+            }
             messagesByChat = [groupIdHex: messages]
             messageLookupByChat = [groupIdHex: Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })]
             messageIDsByChat = [groupIdHex: messages.map(\.id)]
+            messageTimelineStores = [groupIdHex: timelineStore]
+            timelineStore.replace(with: messages)
         } else {
+            for store in messageTimelineStores.values {
+                store.clear()
+            }
             messagesByChat = [:]
             messageLookupByChat = [:]
             messageIDsByChat = [:]
+            messageTimelineStores = [:]
         }
         if let paging = timelinePagingByChat[groupIdHex] {
             timelinePagingByChat = [groupIdHex: paging]
@@ -517,13 +537,13 @@ extension WorkspaceState {
         }
         if timelineInitialLoadGroupId != groupIdHex {
             timelineInitialLoadGroupId = nil
-        } else if messagesByChat[groupIdHex] != nil {
+        } else if messageTimelineStore(for: groupIdHex).isLoaded {
             timelineInitialLoadGroupId = nil
         }
     }
 
     func beginTimelineInitialLoadIfNeeded(groupIdHex: String) {
-        if messagesByChat[groupIdHex] == nil {
+        if !messageTimelineStore(for: groupIdHex).isLoaded {
             timelineInitialLoadGroupId = groupIdHex
         } else if timelineInitialLoadGroupId == groupIdHex {
             timelineInitialLoadGroupId = nil
@@ -551,7 +571,7 @@ extension WorkspaceState {
         // visible again (see handleConversationVisibilityChange()).
         guard selectedConversationIsVisible() else { return }
         guard
-            let latest = (messagesByChat[groupIdHex] ?? []).last(where: { message in
+            let latest = messageTimelineStore(for: groupIdHex).messages.last(where: { message in
                 message.timelineKind == 9 && !message.isDeleted
             })
         else {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -176,6 +176,32 @@ final class MediaDownloadStateStore: ObservableObject {
 
 @MainActor
 @Observable
+final class MessageTimelineStore {
+    private(set) var messages: [MessageItem]
+    private(set) var messageIDs: [String]
+    private(set) var isLoaded: Bool
+
+    init(messages: [MessageItem]? = nil) {
+        self.messages = messages ?? []
+        self.messageIDs = messages?.map(\.id) ?? []
+        self.isLoaded = messages != nil
+    }
+
+    func replace(with messages: [MessageItem]) {
+        self.messages = messages
+        self.messageIDs = messages.map(\.id)
+        self.isLoaded = true
+    }
+
+    func clear() {
+        messages = []
+        messageIDs = []
+        isLoaded = false
+    }
+}
+
+@MainActor
+@Observable
 final class WorkspaceState {
     enum Phase: Equatable {
         case bootstrapping
@@ -204,7 +230,11 @@ final class WorkspaceState {
     var phase: Phase = .bootstrapping
     var accounts: [AccountItem]
     var chatsByAccount: [String: [ChatItem]]
-    var messagesByChat: [String: [MessageItem]]
+    /// Backing timeline cache for tests and non-UI lookups. Swift Observation tracks an
+    /// observed dictionary as one property, so UI reads must go through `messageTimelineStores`
+    /// to subscribe only to the selected chat's transcript (whitenoise-mac#176).
+    @ObservationIgnored var messagesByChat: [String: [MessageItem]]
+    @ObservationIgnored var messageTimelineStores: [String: MessageTimelineStore] = [:]
     @ObservationIgnored var mediaDownloads: [String: MediaDownloadStateStore] = [:]
     /// Error for the user-initiated action on the *current* screen. Rendered by form
     /// surfaces (login, settings, new-chat composer). Must never be written by
@@ -423,13 +453,13 @@ final class WorkspaceState {
     /// conversation is torn down.
     var activeTimelineSubscription: TimelineMessagesSubscription?
     var activeTimelineGroupId: String?
-    var messageLookupByChat: [String: [String: MessageItem]] = [:]
+    @ObservationIgnored var messageLookupByChat: [String: [String: MessageItem]] = [:]
     /// Cached per-chat message id arrays, materialized once per `messagesByChat`
     /// mutation and maintained in lockstep with it (alongside `messageLookupByChat`).
     /// SwiftUI re-evaluates `body` frequently; reading this cache avoids rebuilding a
     /// fresh `[String]` on every access. Invalidated/recomputed only when the
     /// underlying messages change.
-    var messageIDsByChat: [String: [String]] = [:]
+    @ObservationIgnored var messageIDsByChat: [String: [String]] = [:]
     var lastMarkedReadMarkers: [String: ReadMarker] = [:]
     var lastConfirmedReadMarkers: [String: ReadMarker] = [:]
     var deliveredNotificationKeys = Set<String>()
@@ -602,6 +632,7 @@ final class WorkspaceState {
         self.accounts = accounts
         self.chatsByAccount = chatsByAccount
         self.messagesByChat = messagesByChat
+        self.messageTimelineStores = messagesByChat.mapValues { MessageTimelineStore(messages: $0) }
         self.messageLookupByChat = messagesByChat.mapValues { messages in
             Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
         }
@@ -691,14 +722,23 @@ final class WorkspaceState {
         return newChatRecipient
     }
 
+    func messageTimelineStore(for groupIdHex: String) -> MessageTimelineStore {
+        if let store = messageTimelineStores[groupIdHex] {
+            return store
+        }
+        let store = MessageTimelineStore(messages: messagesByChat[groupIdHex])
+        messageTimelineStores[groupIdHex] = store
+        return store
+    }
+
     var selectedMessages: [MessageItem] {
         guard let selectedChat else { return [] }
-        return messagesByChat[selectedChat.id] ?? []
+        return messageTimelineStore(for: selectedChat.id).messages
     }
 
     var selectedMessageIDs: [String] {
         guard let selectedChat else { return [] }
-        return messageIDsByChat[selectedChat.id] ?? []
+        return messageTimelineStore(for: selectedChat.id).messageIDs
     }
 
     var selectedTimelinePaging: TimelinePagingState {
@@ -709,7 +749,7 @@ final class WorkspaceState {
     var selectedTimelineIsLoadingInitialPage: Bool {
         guard let selectedChat else { return false }
         return timelineInitialLoadGroupId == selectedChat.id
-            && messagesByChat[selectedChat.id] == nil
+            && !messageTimelineStore(for: selectedChat.id).isLoaded
     }
 
     func timelineMessage(groupIdHex: String, messageId: String) -> MessageItem? {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -181,10 +181,14 @@ final class MessageTimelineStore {
     private(set) var messageIDs: [String]
     private(set) var isLoaded: Bool
 
-    init(messages: [MessageItem]? = nil) {
-        self.messages = messages ?? []
-        self.messageIDs = messages?.map(\.id) ?? []
-        self.isLoaded = messages != nil
+    init(messages: [MessageItem] = [], isLoaded: Bool = false) {
+        self.messages = messages
+        self.messageIDs = messages.map(\.id)
+        self.isLoaded = isLoaded
+    }
+
+    static func loaded(with messages: [MessageItem]) -> MessageTimelineStore {
+        MessageTimelineStore(messages: messages, isLoaded: true)
     }
 
     func replace(with messages: [MessageItem]) {
@@ -248,7 +252,10 @@ final class WorkspaceState {
 
     var activeAccountId: String?
     var selection: WorkspaceSelection? {
-        didSet { dismissGroupImagePickerIfSelectedChatUnavailable() }
+        didSet {
+            dismissGroupImagePickerIfSelectedChatUnavailable()
+            ensureSelectedMessageTimelineStore()
+        }
     }
     var searchText = ""
     var isChatListVisible = true
@@ -454,11 +461,11 @@ final class WorkspaceState {
     var activeTimelineSubscription: TimelineMessagesSubscription?
     var activeTimelineGroupId: String?
     @ObservationIgnored var messageLookupByChat: [String: [String: MessageItem]] = [:]
-    /// Cached per-chat message id arrays, materialized once per `messagesByChat`
-    /// mutation and maintained in lockstep with it (alongside `messageLookupByChat`).
-    /// SwiftUI re-evaluates `body` frequently; reading this cache avoids rebuilding a
-    /// fresh `[String]` on every access. Invalidated/recomputed only when the
-    /// underlying messages change.
+    /// Cached per-chat message id arrays for tests and non-UI lookups, materialized once
+    /// per `messagesByChat` mutation and maintained in lockstep with it (alongside
+    /// `messageLookupByChat`). SwiftUI reads selected message ids through
+    /// `MessageTimelineStore` instead so the open conversation subscribes only to its
+    /// own transcript.
     @ObservationIgnored var messageIDsByChat: [String: [String]] = [:]
     var lastMarkedReadMarkers: [String: ReadMarker] = [:]
     var lastConfirmedReadMarkers: [String: ReadMarker] = [:]
@@ -632,7 +639,7 @@ final class WorkspaceState {
         self.accounts = accounts
         self.chatsByAccount = chatsByAccount
         self.messagesByChat = messagesByChat
-        self.messageTimelineStores = messagesByChat.mapValues { MessageTimelineStore(messages: $0) }
+        self.messageTimelineStores = messagesByChat.mapValues { MessageTimelineStore.loaded(with: $0) }
         self.messageLookupByChat = messagesByChat.mapValues { messages in
             Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
         }
@@ -668,6 +675,7 @@ final class WorkspaceState {
         self.localNotificationCenter.setResponseHandler { [weak self] userInfo in
             self?.handleNotificationResponse(userInfo)
         }
+        ensureSelectedMessageTimelineStore()
     }
 
     static func defaultConversationWindowVisibilityProvider() -> Bool {
@@ -722,23 +730,34 @@ final class WorkspaceState {
         return newChatRecipient
     }
 
-    func messageTimelineStore(for groupIdHex: String) -> MessageTimelineStore {
+    @discardableResult
+    func ensureMessageTimelineStore(for groupIdHex: String) -> MessageTimelineStore {
         if let store = messageTimelineStores[groupIdHex] {
             return store
         }
-        let store = MessageTimelineStore(messages: messagesByChat[groupIdHex])
+        let store: MessageTimelineStore
+        if let messages = messagesByChat[groupIdHex] {
+            store = MessageTimelineStore.loaded(with: messages)
+        } else {
+            store = MessageTimelineStore()
+        }
         messageTimelineStores[groupIdHex] = store
         return store
     }
 
+    func ensureSelectedMessageTimelineStore() {
+        guard let selectedChat else { return }
+        ensureMessageTimelineStore(for: selectedChat.id)
+    }
+
     var selectedMessages: [MessageItem] {
         guard let selectedChat else { return [] }
-        return messageTimelineStore(for: selectedChat.id).messages
+        return messageTimelineStores[selectedChat.id]?.messages ?? []
     }
 
     var selectedMessageIDs: [String] {
         guard let selectedChat else { return [] }
-        return messageTimelineStore(for: selectedChat.id).messageIDs
+        return messageTimelineStores[selectedChat.id]?.messageIDs ?? []
     }
 
     var selectedTimelinePaging: TimelinePagingState {
@@ -749,7 +768,7 @@ final class WorkspaceState {
     var selectedTimelineIsLoadingInitialPage: Bool {
         guard let selectedChat else { return false }
         return timelineInitialLoadGroupId == selectedChat.id
-            && !messageTimelineStore(for: selectedChat.id).isLoaded
+            && !(messageTimelineStores[selectedChat.id]?.isLoaded ?? false)
     }
 
     func timelineMessage(groupIdHex: String, messageId: String) -> MessageItem? {

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -264,7 +264,7 @@ private struct ConversationView: View {
     var body: some View {
         @Bindable var workspace = workspace
         let messages = workspace.selectedMessages
-        let messageIDs = messages.map(\.id)
+        let messageIDs = workspace.selectedMessageIDs
         let paging = workspace.selectedTimelinePaging
         let isLoadingInitialPage = workspace.selectedTimelineIsLoadingInitialPage
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1899,6 +1899,91 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func selectedMessagesObservationIgnoresUnselectedChatMutations() async throws {
+        // Regression for #176: observing the visible transcript must not subscribe the
+        // conversation view to the whole messagesByChat dictionary. A background-chat
+        // timeline delta should leave the selected transcript's observation token alone,
+        // while a selected-chat replacement must still invalidate it.
+        let account = AccountItem.samples[0]
+        let selectedChat = ChatItem.samples[0]
+        let backgroundChat = ChatItem.samples[1]
+        let selectedMessage = MessageItem(
+            id: "selected-1",
+            groupIdHex: selectedChat.id,
+            senderName: "Alice",
+            body: "Visible",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false
+        )
+        let backgroundMessage = MessageItem(
+            id: "background-1",
+            groupIdHex: backgroundChat.id,
+            senderName: "Bob",
+            body: "Background",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_001),
+            isOutgoing: false
+        )
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [selectedChat, backgroundChat]],
+            messagesByChat: [
+                selectedChat.id: [selectedMessage],
+                backgroundChat.id: [backgroundMessage],
+            ],
+            clientFactory: { FakeMarmotRuntime(accounts: []) }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(selectedChat.id)
+
+        #expect(state.selectedMessages.map(\.id) == ["selected-1"])
+
+        let backgroundInvalidated = ObservationInvalidationFlag()
+        withObservationTracking {
+            _ = state.selectedMessages.map(\.id)
+        } onChange: {
+            backgroundInvalidated.markInvalidated()
+        }
+
+        state.messagesByChat[backgroundChat.id] = [
+            MessageItem(
+                id: "background-2",
+                groupIdHex: backgroundChat.id,
+                senderName: "Bob",
+                body: "Background update",
+                sentAt: Date(timeIntervalSince1970: 1_700_000_002),
+                isOutgoing: false
+            )
+        ]
+
+        #expect(!backgroundInvalidated.value)
+        #expect(state.selectedMessages.map(\.id) == ["selected-1"])
+
+        let selectedInvalidated = ObservationInvalidationFlag()
+        withObservationTracking {
+            _ = state.selectedMessages.map(\.id)
+        } onChange: {
+            selectedInvalidated.markInvalidated()
+        }
+
+        state.replaceMessages(
+            [
+                MessageItem(
+                    id: "selected-2",
+                    groupIdHex: selectedChat.id,
+                    senderName: "Alice",
+                    body: "Visible update",
+                    sentAt: Date(timeIntervalSince1970: 1_700_000_003),
+                    isOutgoing: false
+                )
+            ],
+            groupIdHex: selectedChat.id
+        )
+
+        #expect(selectedInvalidated.value)
+        #expect(state.selectedMessages.map(\.id) == ["selected-2"])
+    }
+
+    @MainActor
     @Test func selectedMessageIDsCacheStaysInSyncAcrossTimelineMutations() async throws {
         // Regression for #44: selectedMessageIDs is served from a cache maintained in
         // lockstep with messagesByChat. Verify the cached ids always equal the live

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1944,18 +1944,22 @@ struct whitenoise_macTests {
             backgroundInvalidated.markInvalidated()
         }
 
-        state.messagesByChat[backgroundChat.id] = [
-            MessageItem(
-                id: "background-2",
-                groupIdHex: backgroundChat.id,
-                senderName: "Bob",
-                body: "Background update",
-                sentAt: Date(timeIntervalSince1970: 1_700_000_002),
-                isOutgoing: false
-            )
-        ]
+        let backgroundUpdatedMessage = MessageItem(
+            id: "background-2",
+            groupIdHex: backgroundChat.id,
+            senderName: "Bob",
+            body: "Background update",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_002),
+            isOutgoing: false
+        )
+        let backgroundTimelineStore = state.ensureMessageTimelineStore(for: backgroundChat.id)
+        state.messagesByChat[backgroundChat.id] = [backgroundUpdatedMessage]
+        state.messageLookupByChat[backgroundChat.id] = [backgroundUpdatedMessage.id: backgroundUpdatedMessage]
+        state.messageIDsByChat[backgroundChat.id] = [backgroundUpdatedMessage.id]
+        backgroundTimelineStore.replace(with: [backgroundUpdatedMessage])
 
         #expect(!backgroundInvalidated.value)
+        #expect(backgroundTimelineStore.messages.map(\.id) == ["background-2"])
         #expect(state.selectedMessages.map(\.id) == ["selected-1"])
 
         let selectedInvalidated = ObservationInvalidationFlag()
@@ -1985,9 +1989,9 @@ struct whitenoise_macTests {
 
     @MainActor
     @Test func selectedMessageIDsCacheStaysInSyncAcrossTimelineMutations() async throws {
-        // Regression for #44: selectedMessageIDs is served from a cache maintained in
-        // lockstep with messagesByChat. Verify the cached ids always equal the live
-        // message ids before and after the timeline window is replaced via a projection.
+        // Regression for #44: selectedMessageIDs is served from the selected timeline
+        // store's cached id array. Verify the cached ids always equal the live message ids
+        // before and after the timeline window is replaced via a projection.
         let account = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",


### PR DESCRIPTION
## Summary
- add a per-chat observable `MessageTimelineStore` so the open conversation observes only the selected chat's transcript
- keep the backing `messagesByChat` dictionary observation-ignored while maintaining lookup/id caches in lockstep
- use the cached selected message IDs in `ConversationView` instead of remapping the visible message array on every body pass
- add a regression test for background-chat message mutations not invalidating `selectedMessages`

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' HEAD -- . ':!Vendored'`
- attempted targeted unit test with `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' -only-testing:whitenoise-macTests/whitenoise_macTests/selectedMessagesObservationIgnoresUnselectedChatMutations CODE_SIGNING_ALLOWED=NO` (not run locally: `xcodebuild` is not installed on this Linux worker)

Closes #176


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/202">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->