### PR TITLE
fix: show attachment label for media-only previews

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -77,7 +77,12 @@ extension ChatItem {
             invalidationStatus: nil,
             hasMediaAttachments: false
         )
-        guard !text.isEmpty else {
+        // `ChatListMessagePreviewFfi` carries no media payload, so a media-only chat
+        // message arrives with empty `plaintext` and `displayText` reports it as
+        // "Unsupported message". Treat that as the media-only sentinel for chat bubbles
+        // so the preview shows the "Attachment" fallback instead.
+        let isMediaOnlyChat = presentation.isChatBubble && text == L10n.string("Unsupported message")
+        guard !text.isEmpty, !isMediaOnlyChat else {
             return presentation.isChatBubble ? L10n.string("Attachment") : L10n.string("Unsupported message")
         }
         guard presentation.isChatBubble,

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -79,9 +79,13 @@ extension ChatItem {
         )
         // `ChatListMessagePreviewFfi` carries no media payload, so a media-only chat
         // message arrives with empty `plaintext` and `displayText` reports it as
-        // "Unsupported message". Treat that as the media-only sentinel for chat bubbles
-        // so the preview shows the "Attachment" fallback instead.
-        let isMediaOnlyChat = presentation.isChatBubble && text == L10n.string("Unsupported message")
+        // "Unsupported message". Only treat that sentinel as media-only when the
+        // source preview text is empty; a user can send that literal text.
+        let sourceTextIsEmpty = preview.plaintext.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let isMediaOnlyChat =
+            presentation.isChatBubble
+            && sourceTextIsEmpty
+            && text == L10n.string("Unsupported message")
         guard !text.isEmpty, !isMediaOnlyChat else {
             return presentation.isChatBubble ? L10n.string("Attachment") : L10n.string("Unsupported message")
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1204,6 +1204,70 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func mediaOnlyChatPreviewShowsAttachmentLabelInsteadOfUnsupported() async throws {
+        // Regression for whitenoise-mac#175: `ChatListMessagePreviewFfi` carries no media
+        // payload, so a media-only chat message arrives with empty plaintext. The chat-list
+        // preview must fall back to "Attachment" rather than "Unsupported message".
+        let directRow = ChatListRowFfi(
+            groupIdHex: "direct-group",
+            archived: false,
+            pendingConfirmation: false,
+            title: "Alice",
+            groupName: "",
+            avatarUrl: nil,
+            avatar: nil,
+            lastMessage: ChatListMessagePreviewFfi(
+                messageIdHex: "media-preview",
+                sender: "alice1234567890alice1234567890alice1234567890alice1234567890",
+                senderDisplayName: "Alice",
+                plaintext: "",
+                contentTokens: emptyMarkdownDocument(),
+                kind: 9,
+                timelineAt: 1_700_000_000,
+                deleted: false
+            ),
+            unreadCount: 0,
+            hasUnread: false,
+            firstUnreadMessageIdHex: nil,
+            lastReadMessageIdHex: nil,
+            lastReadTimelineAt: nil,
+            updatedAt: 1_700_000_000
+        )
+
+        let directChat = ChatItem(row: directRow, activeAccountIdHex: "self")
+        #expect(directChat.preview == "Attachment")
+
+        let groupRow = ChatListRowFfi(
+            groupIdHex: "group",
+            archived: false,
+            pendingConfirmation: false,
+            title: "Planning",
+            groupName: "Planning",
+            avatarUrl: nil,
+            avatar: nil,
+            lastMessage: ChatListMessagePreviewFfi(
+                messageIdHex: "media-preview",
+                sender: "alice1234567890alice1234567890alice1234567890alice1234567890",
+                senderDisplayName: "Alice",
+                plaintext: "",
+                contentTokens: emptyMarkdownDocument(),
+                kind: 9,
+                timelineAt: 1_700_000_000,
+                deleted: false
+            ),
+            unreadCount: 0,
+            hasUnread: false,
+            firstUnreadMessageIdHex: nil,
+            lastReadMessageIdHex: nil,
+            lastReadTimelineAt: nil,
+            updatedAt: 1_700_000_000
+        )
+
+        let groupChat = ChatItem(row: groupRow, activeAccountIdHex: "self")
+        #expect(groupChat.preview == "Attachment")
+    }
+
+    @MainActor
     @Test func imetaInsideJSONReadsSourceEpochInBothSpellings() async throws {
         // Regression for whitenoise-mac#137: the imeta-within-object branch must
         // accept both snake_case `source_epoch` and camelCase `sourceEpoch` so a

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1268,6 +1268,23 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func literalUnsupportedChatPreviewPreservesMessageText() async throws {
+        // A valid chat body can equal the localized unsupported-message label. That
+        // literal text must not be mistaken for the empty media-only preview sentinel.
+        let literalText = L10n.string("Unsupported message")
+        let row = chatListRow(
+            groupIdHex: "group",
+            title: "Planning",
+            preview: literalText,
+            sender: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            timelineAt: 1_700_000_001
+        )
+
+        let chat = ChatItem(row: row, activeAccountIdHex: "self")
+        #expect(chat.preview == literalText)
+    }
+
+    @MainActor
     @Test func imetaInsideJSONReadsSourceEpochInBothSpellings() async throws {
         // Regression for whitenoise-mac#137: the imeta-within-object branch must
         // accept both snake_case `source_epoch` and camelCase `sourceEpoch` so a


### PR DESCRIPTION
Closes #175

## Summary
- Treat empty chat-list preview sentinels as media-only attachments so image/voice/file messages show `Attachment` instead of `Unsupported message`.
- Gate that workaround on `preview.plaintext` being empty so a real chat message whose text equals the localized `Unsupported message` label is preserved.
- Add regression coverage for direct/group empty media previews and for the literal unsupported-message text case.

## Verification
- `git diff --check origin/master...HEAD` — passed.
- `git diff --check` — passed.
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed.
- `scripts/ci/macos-sanity-checks.sh` — expected local failure on Linux: `xcodebuild: command not found`.
- GitHub PR Checks — passed for head `205fc473512b14993187accf7ab20ecbf07366c9`.
- GitHub Static Analysis — passed for head `205fc473512b14993187accf7ab20ecbf07366c9`.
- CodeRabbit status — passed.
- CI-exact macOS checks from `.github/workflows/mac-ci.yml` could not be run locally because this host lacks `xcrun`, `xcodebuild`, `swift`, and `swift-format`.

## Review follow-up
- Addressed the adversarial review blocker from https://github.com/marmot-protocol/whitenoise-mac/pull/204#issuecomment-4811979517 in commit `205fc47`.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/204">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat preview text handling so media-only messages now show a clearer attachment label instead of an unsupported-message placeholder.
  * Preserved the unsupported-message text when it appears as a real message, avoiding incorrect replacement in chat previews.
  * Added regression coverage for both preview behaviors to help prevent future display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->