### PR TITLE
fix: precompute chat timestamp labels

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -57,6 +57,9 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     let unreadMentionCount: Int
     let isDirect: Bool
     let pendingConfirmation: Bool
+    /// Precomputed once from `updatedAt` (which is immutable for a given value) to
+    /// avoid re-formatting the date on every chat-row render.
+    let timestampLabel: String
 
     /// Whether this chat has at least one unread @-mention of the active account.
     var hasMention: Bool { unreadMentionCount > 0 }
@@ -85,11 +88,11 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         self.unreadMentionCount = unreadMentionCount
         self.isDirect = isDirect
         self.pendingConfirmation = pendingConfirmation
-    }
-
-    var timestampLabel: String {
-        guard let updatedAt else { return "" }
-        return DisplayText.relativeTimestamp(for: updatedAt)
+        if let updatedAt {
+            self.timestampLabel = DisplayText.relativeTimestamp(for: updatedAt)
+        } else {
+            self.timestampLabel = ""
+        }
     }
 }
 


### PR DESCRIPTION
Closes #215

## Summary
- Precomputes `ChatItem.timestampLabel` once in `ChatItem.init` instead of formatting `updatedAt` every time the property is read during chat-row rendering.
- Keeps the existing `ChatRowContent` call site unchanged; the stored label follows the same precompute pattern already used by `MessageItem.timeLabel`.

## Verification
- `git diff --check` — passed locally.
- Conflict-marker sweep for changed Swift file — passed locally.
- `which xcodebuild xcrun swift-format swift` — all not found on this Linux worker, so local Xcode/Swift checks were unavailable.
- GitHub Mac CI: `PR Checks` — passed.
- GitHub Mac CI: `Static Analysis` — passed.
- CodeRabbit — passed; no actionable comments.

## Sensitive paths
none
