### PR TITLE
fix: guard secure delete expired reentry

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -406,7 +406,11 @@ extension WorkspaceState {
     }
 
     func secureDeleteExpiredMessages(groupIdHex: String) async {
-        guard let client, let activeAccount else { return }
+        guard let client, let activeAccount, !isSecureDeletingExpired else { return }
+        lastError = nil
+        isSecureDeletingExpired = true
+        defer { isSecureDeletingExpired = false }
+
         do {
             _ = try await client.secureDeleteExpired(
                 accountRef: activeAccount.accountRef,

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -398,6 +398,7 @@ final class WorkspaceState {
     var isArchivingGroup = false
     var isLeavingGroup = false
     var isUpdatingDisappearingMessages = false
+    var isSecureDeletingExpired = false
     var isDeletingGroupLocally = false
     var isExportingGroupTranscript = false
     var groupTranscriptExportStatus: String?

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -180,6 +180,7 @@ struct GroupDetailsSheet: View {
                             } label: {
                                 Label("Delete expired now", systemImage: "trash")
                             }
+                            .disabled(workspace.isSecureDeletingExpired)
                             .help(L10n.string("Securely prune already-expired messages on this device"))
                         }
                     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5726,6 +5726,32 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func secureDeleteExpiredMessagesDropsOverlappingDuplicateInvocation() async throws {
+        // Issue #216: secure-delete is destructive, so overlapping invocations must be dropped
+        // before they issue duplicate FFI calls.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+
+        runtime.secureDeleteExpiredGateEnabled = true
+        async let firstDelete: Void = state.secureDeleteExpiredMessages(groupIdHex: "group")
+        while !(state.isSecureDeletingExpired && runtime.didReachSecureDeleteExpiredGate) {
+            await Task.yield()
+        }
+
+        await state.secureDeleteExpiredMessages(groupIdHex: "group")
+        #expect(runtime.secureDeleteExpiredCallCount == 1)
+
+        runtime.releaseSecureDeleteExpiredGate()
+        await firstDelete
+
+        #expect(runtime.secureDeleteExpiredCallCount == 1)
+        #expect(!state.isSecureDeletingExpired)
+    }
+
+    @MainActor
     @Test func groupDetailsSelfDemoteUsesDetailedMutation() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
@@ -9177,6 +9203,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var updateMessageRetentionCallCount = 0
     var lastRetentionSecs: UInt64?
     var secureDeleteExpiredCallCount = 0
+    var secureDeleteExpiredGateEnabled = false
+    private(set) var didReachSecureDeleteExpiredGate = false
+    private var secureDeleteExpiredGateContinuation: CheckedContinuation<Void, Never>?
     var accountUnreadSummaryRows: [AccountUnreadFfi] = []
 
     func parseMarkdown(text: String) -> MarkdownDocumentFfi {
@@ -9235,7 +9264,23 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func secureDeleteExpired(accountRef: String, groupIdHex: String) async throws -> SecureDeleteExpiredResultFfi {
         secureDeleteExpiredCallCount += 1
+        await passSecureDeleteExpiredGateIfArmed()
         return SecureDeleteExpiredResultFfi(prunedMessages: 0, mediaCiphertextSha256: [])
+    }
+
+    private func passSecureDeleteExpiredGateIfArmed() async {
+        guard secureDeleteExpiredGateEnabled, secureDeleteExpiredGateContinuation == nil,
+            !didReachSecureDeleteExpiredGate
+        else { return }
+        didReachSecureDeleteExpiredGate = true
+        await withCheckedContinuation { continuation in
+            secureDeleteExpiredGateContinuation = continuation
+        }
+    }
+
+    func releaseSecureDeleteExpiredGate() {
+        secureDeleteExpiredGateContinuation?.resume()
+        secureDeleteExpiredGateContinuation = nil
     }
 
     private func chatListRow(for group: AppGroupRecordFfi) -> ChatListRowFfi {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5741,6 +5741,8 @@ struct whitenoise_macTests {
             await Task.yield()
         }
 
+        // The overlapping call should return at the WorkspaceState guard before suspending
+        // in the fake FFI gate, so the runtime invocation count must stay unchanged.
         await state.secureDeleteExpiredMessages(groupIdHex: "group")
         #expect(runtime.secureDeleteExpiredCallCount == 1)
 


### PR DESCRIPTION
## Summary
- add an `isSecureDeletingExpired` busy flag around secure-delete of expired messages
- disable the “Delete expired now” action while a secure-delete is in flight
- add a regression test proving overlapping calls issue only one FFI request

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- .`
- attempted `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` (not available on this Linux host: `xcrun: command not found`)
- attempted `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` (not available on this Linux host: `xcodebuild: command not found`)

Closes #216


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/218">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->