### PR TITLE
fix: refresh audit log files after delete failure

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -534,10 +534,11 @@ extension WorkspaceState {
             for file in auditLogFiles {
                 _ = try await client.deleteAuditLogFile(path: file.path)
             }
-            await loadAuditLogFiles()
         } catch {
             lastError = error.localizedDescription
         }
+
+        await loadAuditLogFiles()
     }
 
     func uploadAuditLogFiles() async {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7469,6 +7469,44 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func deleteAllAuditLogFilesRefreshesListAfterMidLoopFailure() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let firstFile = AuditLogFileFfi(
+            accountRef: account.label,
+            path: "/tmp/audit-1.jsonl",
+            fileName: "audit-1.jsonl",
+            sizeBytes: 123,
+            modifiedAtMs: nil
+        )
+        let secondFile = AuditLogFileFfi(
+            accountRef: account.label,
+            path: "/tmp/audit-2.jsonl",
+            fileName: "audit-2.jsonl",
+            sizeBytes: 456,
+            modifiedAtMs: nil
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.storedAuditLogFiles = [firstFile, secondFile]
+        runtime.auditLogDeleteFailurePaths = [secondFile.path]
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.auditLogFiles.map(\.path) == [firstFile.path, secondFile.path])
+
+        await state.deleteAllAuditLogFiles()
+
+        #expect(runtime.deletedAuditLogFilePaths == [firstFile.path])
+        #expect(state.auditLogFiles.map(\.path) == [secondFile.path])
+        #expect(state.lastError != nil)
+    }
+
+    @MainActor
     @Test func enablingLocalNotificationsRequestsPermissionAndUpdatesRuntime() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -8258,6 +8296,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     )
     var storedAuditLogSettings = AuditLogSettingsFfi(enabled: false, dataMode: .obfuscatedSensitiveData)
     var storedAuditLogFiles: [AuditLogFileFfi] = []
+    var auditLogDeleteFailurePaths: Set<String> = []
     var nextAuditLogTrackerUpdate = AuditLogTrackerUpdateResultFfi(
         enabled: true,
         uploaded: [],
@@ -8537,6 +8576,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func deleteAuditLogFile(path: String) async throws -> AuditLogDeleteResultFfi {
+        guard !auditLogDeleteFailurePaths.contains(path) else {
+            throw FakeMarmotRuntimeError.unused
+        }
         deletedAuditLogFilePaths.append(path)
         storedAuditLogFiles.removeAll { $0.path == path }
         return AuditLogDeleteResultFfi(stillRecording: storedAuditLogSettings.enabled)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7494,6 +7494,7 @@ struct whitenoise_macTests {
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.storedAuditLogFiles = [firstFile, secondFile]
         runtime.auditLogDeleteFailurePaths = [secondFile.path]
+        let expectedDeleteError = FakeMarmotRuntimeError.auditLogDeleteFailed.localizedDescription
         let state = WorkspaceState(clientFactory: { runtime })
 
         await state.bootstrap()
@@ -7503,7 +7504,7 @@ struct whitenoise_macTests {
 
         #expect(runtime.deletedAuditLogFilePaths == [firstFile.path])
         #expect(state.auditLogFiles.map(\.path) == [secondFile.path])
-        #expect(state.lastError != nil)
+        #expect(state.lastError == expectedDeleteError)
     }
 
     @MainActor
@@ -8577,7 +8578,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func deleteAuditLogFile(path: String) async throws -> AuditLogDeleteResultFfi {
         guard !auditLogDeleteFailurePaths.contains(path) else {
-            throw FakeMarmotRuntimeError.unused
+            throw FakeMarmotRuntimeError.auditLogDeleteFailed
         }
         deletedAuditLogFilePaths.append(path)
         storedAuditLogFiles.removeAll { $0.path == path }
@@ -9314,9 +9315,21 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 }
 
-private enum FakeMarmotRuntimeError: Error {
+private enum FakeMarmotRuntimeError: Error, LocalizedError {
     case missingCreatedAccount
+    case auditLogDeleteFailed
     case unused
+
+    var errorDescription: String? {
+        switch self {
+        case .missingCreatedAccount:
+            return "Missing created account."
+        case .auditLogDeleteFailed:
+            return "Audit log delete failed."
+        case .unused:
+            return "Unused fake runtime error."
+        }
+    }
 }
 
 private struct SentReply: Equatable {


### PR DESCRIPTION
## Summary
- refresh the audit log file list after `deleteAllAuditLogFiles()` finishes, even when a delete throws partway through
- add a regression test covering a mid-loop delete failure so already-deleted files disappear from state

## Test Plan
- `git diff --check`
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':!Vendored'` (no conflict markers)
- GitHub Actions: `PR Checks` passed
- GitHub Actions: `Static Analysis` passed
- Not run locally: `xcodebuild` / Swift tests unavailable on this Linux worker (`xcodebuild`, `xcrun`, and `swift` not installed)

Closes #214
