### PR TITLE
fix: clear unread badge cache on account teardown

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -227,6 +227,7 @@ extension WorkspaceState {
         defer { isRemovingAccount = false }
 
         let removedAccountId = account.id
+        let removedAccountIdHex = account.accountIdHex
         let wasActive = activeAccountId == removedAccountId
         do {
             if wasActive {
@@ -238,6 +239,7 @@ extension WorkspaceState {
             await mediaDiskCache.purgeAccount(removedAccountId)
             accounts = try await accountItemsFromRuntime(client: client)
             removeChats(forAccountId: removedAccountId)
+            accountUnreadByIdHex[removedAccountIdHex] = nil
 
             // `activeAccountId` may have changed during the await above — e.g. the user
             // selected an account from settings while this removal was in flight. Decide
@@ -301,6 +303,7 @@ extension WorkspaceState {
         peerProfileFFICache.removeAll()
         clearGroupMemberCache()
         timelinePagingByChat.removeAll()
+        accountUnreadByIdHex.removeAll()
         profileDraft = ProfileDraft()
         keyPackages = []
         auditLogFiles = []
@@ -483,6 +486,7 @@ extension WorkspaceState {
         resetMediaDownloadStateStores()
         peerProfileFFICache.removeAll()
         clearGroupMemberCache()
+        accountUnreadByIdHex.removeAll()
         // "Delete All Local Data" must also evict decoded peer/group avatars held in the
         // process-lifetime decoded-image cache; those images derive from attacker-controlled
         // peer `picture` URLs and would otherwise survive the wipe in memory. See #177.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -595,6 +595,115 @@ struct whitenoise_macTests {
         #expect(UserDefaults.standard.string(forKey: "whitenoise.mac.activeAccountId") == nil)
     }
 
+    @MainActor
+    @Test func deleteAllDataClearsAccountUnreadBadges() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary])
+        runtime.accountUnreadSummaryRows = [
+            AccountUnreadFfi(
+                accountIdHex: primary.accountIdHex,
+                unreadCount: 7,
+                unreadConversations: 1,
+                hasUnread: true
+            )
+        ]
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: primary.accountIdHex) == 7)
+
+        await state.deleteAllData()
+
+        // The per-account unread cache must not survive a full local-data wipe. See #213.
+        #expect(state.unreadCount(forAccountIdHex: primary.accountIdHex) == 0)
+    }
+
+    @MainActor
+    @Test func resetActiveAccountUIStateClearsAccountUnreadBadges() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary])
+        runtime.accountUnreadSummaryRows = [
+            AccountUnreadFfi(
+                accountIdHex: primary.accountIdHex,
+                unreadCount: 4,
+                unreadConversations: 1,
+                hasUnread: true
+            )
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: primary.accountIdHex) == 4)
+
+        state.resetActiveAccountUIState()
+
+        // Sign-out and active-account removal share this reset path. See #213.
+        #expect(state.unreadCount(forAccountIdHex: primary.accountIdHex) == 0)
+    }
+
+    @MainActor
+    @Test func removeNonActiveAccountClearsItsUnreadBadge() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        runtime.accountUnreadSummaryRows = [
+            AccountUnreadFfi(
+                accountIdHex: primary.accountIdHex,
+                unreadCount: 3,
+                unreadConversations: 1,
+                hasUnread: true
+            ),
+            AccountUnreadFfi(
+                accountIdHex: secondary.accountIdHex,
+                unreadCount: 5,
+                unreadConversations: 1,
+                hasUnread: true
+            ),
+        ]
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: secondary.accountIdHex) == 5)
+
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        await state.removeAccount(backupAccount)
+
+        // Removing a background identity must drop its unread badge without
+        // disturbing the surviving active account's count. See #213.
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.unreadCount(forAccountIdHex: secondary.accountIdHex) == 0)
+        #expect(state.unreadCount(forAccountIdHex: primary.accountIdHex) == 3)
+    }
+
     @Test func deleteAllLocalDataWipesStorageWhenAccountCleanupFails() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
Closes #213

## Summary
- Clear `accountUnreadByIdHex` when removing an account, when resetting active-account UI state, and when resetting to a fresh install after Delete All Local Data.
- Use `account.accountIdHex` for per-account unread cache eviction during removal; `AccountItem.id` can be the account label, while `accountUnreadByIdHex` is keyed by pubkey hex.
- Add regression coverage for Delete All Local Data, the shared sign-out/active-removal reset path, and non-active account removal preserving surviving account unread counts.

## Verification
- `git diff --check` — pass
- `bash -n scripts/ci/macos-sanity-checks.sh` — pass
- GitHub `Static Analysis` — pass
- GitHub `PR Checks` — pass after fixing the first-run regression-test expectation to use `accountIdHex` for eviction
- CodeRabbit — no actionable review; bot posted a rate-limit notice, inline review comments count is 0

## Sensitive paths
None.
