### PR TITLE
fix: clean up canceled video playback scratch file

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -900,7 +900,15 @@ struct MessageVideoAttachmentPlayer: View {
                 download: download
             )
         }
-        guard playbackPreparationID == nextPreparationID, !Task.isCancelled else { return }
+        guard playbackPreparationID == nextPreparationID, !Task.isCancelled else {
+            // Preparation was superseded or cancelled after `fileURL` materialized a fresh
+            // decrypted scratch file. `playbackURL` is still unset on this path, so the
+            // teardown paths can't reclaim it — delete it here to avoid leaking plaintext.
+            if let resolvedURL, resolvedURL != playbackURL {
+                MessageMediaPlaybackFileStore.remove(at: resolvedURL)
+            }
+            return
+        }
         guard let url = resolvedURL else {
             didFail = true
             return


### PR DESCRIPTION
Closes #209

## Summary
- Cleans up a freshly materialized decrypted video playback scratch file when playback preparation is superseded or cancelled before `playbackURL` takes ownership.
- Preserves the existing reuse path by only removing a resolved URL that is not already the active `playbackURL`.
- Keeps teardown behavior unchanged for the normal playback path.

## Verification
- `git diff --check` — pass
- `command -v xcodebuild && xcodebuild -version` — xcodebuild unavailable on this Linux host
- `command -v swift && swift --version` — Swift toolchain unavailable on this Linux host
- Static inspection of `MessageVideoAttachmentPlayer.startPlayback()`, `MessageMediaPlaybackFileStore.remove(at:)`, and `MediaPlaybackTempStore.remove(at:)`

## Sensitive paths
- `whitenoise-mac/Views/MessageMediaViews.swift` — decrypted media plaintext scratch-file cleanup


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/223">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->