### PR TITLE
fix: coalesce overlapping chat reloads

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -81,6 +81,7 @@ extension WorkspaceState {
     ) {
         cancelVoiceRecording()
         stopTimelineListener()
+        cancelChatListReload()
         stopChatListListener()
         clearEnteredLoginIdentity()
         activeAccountId = account.id
@@ -232,6 +233,7 @@ extension WorkspaceState {
         do {
             if wasActive {
                 stopTimelineListener()
+                cancelChatListReload()
                 stopChatListListener()
             }
             try await client.removeAccount(accountRef: account.accountRef)
@@ -293,6 +295,7 @@ extension WorkspaceState {
     /// drafts, settings snapshots). Shared by account removal and sign-out.
     func resetActiveAccountUIState() {
         stopTimelineListener()
+        cancelChatListReload()
         stopChatListListener()
         messagesByChat.removeAll()
         for store in messageTimelineStores.values {
@@ -323,6 +326,7 @@ extension WorkspaceState {
         do {
             if wasActive {
                 stopTimelineListener()
+                cancelChatListReload()
                 stopChatListListener()
             }
             _ = try await client.signOut(accountRef: account.accountRef, deleteKeyPackages: true)
@@ -401,6 +405,7 @@ extension WorkspaceState {
 
         do {
             stopNotificationListener()
+            cancelChatListReload()
             stopChatListListener()
             stopTimelineListener()
 

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -16,7 +16,7 @@ import UserNotifications
 
 @MainActor
 extension WorkspaceState {
-    func reloadChats() async {
+    func reloadChats(forceFreshSnapshot: Bool = false) async {
         guard client != nil, let activeAccount else {
             cancelChatListReload()
             stopChatListListener()
@@ -26,16 +26,16 @@ extension WorkspaceState {
         let accountId = activeAccount.id
 
         // Coalesce concurrent reloads for the same account onto the same subscription/snapshot
-        // pass. Without this, independent Task call sites can duplicate FFI fan-out and have the
-        // second listener startup immediately cancel the first.
-        if let existing = reloadChatsTask, reloadChatsTaskAccountId == accountId {
+        // pass by default. Post-mutation callers can force a fresh pass so they never await a
+        // snapshot that was already in flight before the mutation completed.
+        if !forceFreshSnapshot, let existing = reloadChatsTask, reloadChatsTaskAccountId == accountId {
             await existing.value
             return
         }
 
-        // A reload for a different account supersedes the stale in-flight owner. The stale task may
-        // still resume after an FFI await, so generation checks in `performChatListReload` gate every
-        // state write and listener start.
+        // A reload for a different account, or a forced post-mutation reload for the same account,
+        // supersedes the stale in-flight owner. The stale task may still resume after an FFI await,
+        // so generation checks in `performChatListReload` gate every state write and listener start.
         reloadChatsTask?.cancel()
 
         reloadChatsGeneration &+= 1
@@ -71,27 +71,17 @@ extension WorkspaceState {
                 accountRef: activeAccount.accountRef,
                 includeArchived: false
             )
-            guard ownsChatListReload(generation: generation, accountId: accountId),
-                !Task.isCancelled
-            else { return }
+            guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
 
             let rows = try await runOffMain { subscription.snapshot() }
-            guard ownsChatListReload(generation: generation, accountId: accountId),
-                !Task.isCancelled
-            else { return }
+            guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
             await applyChatRows(rows, account: activeAccount)
-            guard ownsChatListReload(generation: generation, accountId: accountId),
-                !Task.isCancelled
-            else { return }
+            guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
             startChatListListener(account: activeAccount, subscription: subscription)
 
-            guard ownsChatListReload(generation: generation, accountId: accountId),
-                !Task.isCancelled
-            else { return }
+            guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
             await selectMostRecentChatIfNeeded()
-            guard ownsChatListReload(generation: generation, accountId: accountId),
-                !Task.isCancelled
-            else { return }
+            guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
             await refreshAccountUnreadSummary()
         } catch is CancellationError {
             return
@@ -103,6 +93,10 @@ extension WorkspaceState {
 
     func ownsChatListReload(generation: UInt64, accountId: String) -> Bool {
         reloadChatsGeneration == generation && activeAccountId == accountId
+    }
+
+    func canContinueChatListReload(generation: UInt64, accountId: String) -> Bool {
+        ownsChatListReload(generation: generation, accountId: accountId) && !Task.isCancelled
     }
 
     func cancelChatListReload() {

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -17,28 +17,100 @@ import UserNotifications
 @MainActor
 extension WorkspaceState {
     func reloadChats() async {
-        guard let client, let activeAccount else { return }
+        guard client != nil, let activeAccount else {
+            cancelChatListReload()
+            stopChatListListener()
+            return
+        }
+
+        let accountId = activeAccount.id
+
+        // Coalesce concurrent reloads for the same account onto the same subscription/snapshot
+        // pass. Without this, independent Task call sites can duplicate FFI fan-out and have the
+        // second listener startup immediately cancel the first.
+        if let existing = reloadChatsTask, reloadChatsTaskAccountId == accountId {
+            await existing.value
+            return
+        }
+
+        // A reload for a different account supersedes the stale in-flight owner. The stale task may
+        // still resume after an FFI await, so generation checks in `performChatListReload` gate every
+        // state write and listener start.
+        reloadChatsTask?.cancel()
+
+        reloadChatsGeneration &+= 1
+        let generation = reloadChatsGeneration
+        let task = Task<Void, Never> { [weak self] in
+            guard let self else { return }
+            await self.performChatListReload(accountId: accountId, generation: generation)
+        }
+        reloadChatsTask = task
+        reloadChatsTaskAccountId = accountId
+
+        await task.value
+
+        // Only clear ownership if no newer reload has since taken over this slot.
+        if reloadChatsTask == task {
+            reloadChatsTask = nil
+            reloadChatsTaskAccountId = nil
+        }
+    }
+
+    func performChatListReload(accountId: String, generation: UInt64) async {
+        guard let client, let activeAccount, activeAccount.id == accountId else { return }
         stopChatListListener()
         isRefreshing = true
-        defer { isRefreshing = false }
+        defer {
+            if ownsChatListReload(generation: generation, accountId: accountId) {
+                isRefreshing = false
+            }
+        }
 
         do {
             let subscription = try await client.subscribeChatList(
                 accountRef: activeAccount.accountRef,
                 includeArchived: false
             )
-            guard activeAccountId == activeAccount.id else { return }
+            guard ownsChatListReload(generation: generation, accountId: accountId),
+                !Task.isCancelled
+            else { return }
 
             let rows = try await runOffMain { subscription.snapshot() }
-            guard activeAccountId == activeAccount.id, !Task.isCancelled else { return }
+            guard ownsChatListReload(generation: generation, accountId: accountId),
+                !Task.isCancelled
+            else { return }
             await applyChatRows(rows, account: activeAccount)
+            guard ownsChatListReload(generation: generation, accountId: accountId),
+                !Task.isCancelled
+            else { return }
             startChatListListener(account: activeAccount, subscription: subscription)
 
+            guard ownsChatListReload(generation: generation, accountId: accountId),
+                !Task.isCancelled
+            else { return }
             await selectMostRecentChatIfNeeded()
+            guard ownsChatListReload(generation: generation, accountId: accountId),
+                !Task.isCancelled
+            else { return }
             await refreshAccountUnreadSummary()
+        } catch is CancellationError {
+            return
         } catch {
+            guard ownsChatListReload(generation: generation, accountId: accountId) else { return }
             lastError = error.localizedDescription
         }
+    }
+
+    func ownsChatListReload(generation: UInt64, accountId: String) -> Bool {
+        reloadChatsGeneration == generation && activeAccountId == accountId
+    }
+
+    func cancelChatListReload() {
+        reloadChatsTask?.cancel()
+        reloadChatsTask = nil
+        reloadChatsTaskAccountId = nil
+        reloadChatsGeneration &+= 1
+        isRefreshing = false
     }
 
     func startChatListListener(

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -112,7 +112,7 @@ extension WorkspaceState {
                 name: trimmedName,
                 description: trimmedDescription
             )
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
             await loadGroupDetails(groupIdHex: snapshot.groupIdHex)
         } catch {
             lastError = error.localizedDescription
@@ -142,7 +142,7 @@ extension WorkspaceState {
             )
             groupInviteMemberQuery = ""
             applyGroupMutationResult(result)
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
         } catch {
             lastError = error.localizedDescription
         }
@@ -196,7 +196,7 @@ extension WorkspaceState {
                 groupIdHex: snapshot.groupIdHex
             )
             applyGroupMutationResult(result)
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
         } catch {
             lastError = error.localizedDescription
         }
@@ -217,7 +217,7 @@ extension WorkspaceState {
             if archived {
                 closeGroupDetails()
             }
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
             if !archived {
                 await loadGroupDetails(groupIdHex: snapshot.groupIdHex)
             }
@@ -243,7 +243,7 @@ extension WorkspaceState {
                 groupIdHex: snapshot.groupIdHex
             )
             closeGroupDetails()
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
         } catch {
             lastError = error.localizedDescription
         }
@@ -333,7 +333,7 @@ extension WorkspaceState {
                 dim: dim,
                 thumbhash: nil
             )
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
             closeGroupImagePicker()
         } catch {
             lastError = error.localizedDescription
@@ -351,7 +351,7 @@ extension WorkspaceState {
                 accountRef: activeAccount.accountRef,
                 groupIdHex: groupIdHex
             )
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
             if isGroupDetailsPresented, groupDetailsSnapshot?.groupIdHex == groupIdHex {
                 await loadGroupDetails(groupIdHex: groupIdHex)
             }
@@ -379,7 +379,7 @@ extension WorkspaceState {
                 selection = nil
                 pruneMessageCache(keeping: nil)
             }
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
         } catch {
             lastError = error.localizedDescription
         }
@@ -442,7 +442,7 @@ extension WorkspaceState {
                 selection = nil
                 pruneMessageCache(keeping: nil)
             }
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
         } catch {
             lastError = error.localizedDescription
         }
@@ -519,7 +519,7 @@ extension WorkspaceState {
                 )
             }
             applyGroupMutationResult(result)
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
         } catch {
             lastError = error.localizedDescription
         }

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -128,7 +128,7 @@ extension WorkspaceState {
                 memberRefs: [recipient.memberRef],
                 description: trimmedDescription.isEmpty ? nil : trimmedDescription
             )
-            await reloadChats()
+            await reloadChats(forceFreshSnapshot: true)
             guard activeAccountId == accountId else { return }
             insertCreatedChatIfNeeded(
                 groupIdHex: groupIdHex,

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -609,10 +609,12 @@ final class WorkspaceState {
     var chatListTaskAccountId: String?
     /// Single-owner coalescing for full chat-list reloads (issue #210). `reloadChats()` is
     /// reachable from independently-spawned tasks (account switch, notification taps, group
-    /// mutations), so two same-account calls must share the in-flight subscription/snapshot work
-    /// instead of duplicating FFI fan-out and racing listener teardown. Requests for a different
-    /// account cancel the stale reload; the generation token prevents the stale task from applying
-    /// rows, starting a listener, or clearing the newer reload's spinner if it resumes later.
+    /// mutations), so two same-account calls should usually share the in-flight
+    /// subscription/snapshot work instead of duplicating FFI fan-out and racing listener teardown.
+    /// Post-mutation call sites can force a fresh snapshot to preserve immediate-refresh semantics.
+    /// Requests for a different account cancel the stale reload; the generation token prevents the
+    /// stale task from applying rows, starting a listener, or clearing the newer reload's spinner if
+    /// it resumes later.
     var reloadChatsTask: Task<Void, Never>?
     var reloadChatsTaskAccountId: String?
     var reloadChatsGeneration: UInt64 = 0

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -607,6 +607,15 @@ final class WorkspaceState {
     var notificationTask: Task<Void, Never>?
     var chatListTask: Task<Void, Never>?
     var chatListTaskAccountId: String?
+    /// Single-owner coalescing for full chat-list reloads (issue #210). `reloadChats()` is
+    /// reachable from independently-spawned tasks (account switch, notification taps, group
+    /// mutations), so two same-account calls must share the in-flight subscription/snapshot work
+    /// instead of duplicating FFI fan-out and racing listener teardown. Requests for a different
+    /// account cancel the stale reload; the generation token prevents the stale task from applying
+    /// rows, starting a listener, or clearing the newer reload's spinner if it resumes later.
+    var reloadChatsTask: Task<Void, Never>?
+    var reloadChatsTaskAccountId: String?
+    var reloadChatsGeneration: UInt64 = 0
     var chatListEnrichmentTask: Task<Void, Never>?
     /// Incremental, per-row chat-list enrichment task ownership (issue #40). Single-row updates
     /// (the chat-list subscription delta path) spawn one enrichment task per group; this tracker

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3093,6 +3093,8 @@ struct whitenoise_macTests {
         )
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
         let runtime = FakeMarmotRuntime(accounts: [account])
+        // Keep the live projection from racing ahead of the post-load cache assertion below.
+        runtime.timelineUpdateDelayNanoseconds = 100_000_000
         runtime.installDirectGroup(
             directGroup(),
             selfAccountIdHex: account.accountIdHex,
@@ -3622,6 +3624,88 @@ struct whitenoise_macTests {
         #expect(runtime.chatListSubscriptionCount == subscriptionBaseline + 1)
         #expect(state.isRefreshing == false)
         #expect(state.activeChats.count == 2)
+    }
+
+    @MainActor
+    @Test func forcedReloadChatsStartsFreshSnapshotInsteadOfCoalescing() async throws {
+        // Post-mutation reloads must not await a same-account reload whose snapshot may have been
+        // started before the mutation. They force a new generation while ordinary overlapping
+        // reloads still coalesce.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didHydrateChats = await waitFor {
+            state.activeChats.count == 2
+        }
+        #expect(didHydrateChats)
+
+        let subscriptionBaseline = runtime.chatListSubscriptionCount
+        runtime.chatListSubscriptionDelayNanoseconds = 100_000_000
+
+        async let firstReload: Void = state.reloadChats()
+        let didStartFirstReload = await waitFor {
+            runtime.chatListSubscriptionCount == subscriptionBaseline + 1
+        }
+        #expect(didStartFirstReload)
+
+        async let forcedReload: Void = state.reloadChats(forceFreshSnapshot: true)
+        let didStartForcedReload = await waitFor {
+            runtime.chatListSubscriptionCount == subscriptionBaseline + 2
+        }
+        #expect(didStartForcedReload)
+
+        _ = await (firstReload, forcedReload)
+
+        #expect(runtime.chatListSubscriptionCount == subscriptionBaseline + 2)
+        #expect(state.isRefreshing == false)
+        #expect(state.activeChats.count == 2)
+    }
+
+    @MainActor
+    @Test func cancellingSuspendedChatReloadClearsSpinnerOwnership() async throws {
+        // Teardown paths cancel reload ownership while the task may be suspended in FFI. The stale
+        // task must not re-own the spinner when it unwinds after cancellation.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didHydrateChats = await waitFor {
+            state.activeChats.count == 2
+        }
+        #expect(didHydrateChats)
+
+        let subscriptionBaseline = runtime.chatListSubscriptionCount
+        runtime.chatListSubscriptionDelayNanoseconds = 100_000_000
+
+        async let reload: Void = state.reloadChats()
+        let didSuspendReload = await waitFor {
+            state.isRefreshing && runtime.chatListSubscriptionCount == subscriptionBaseline + 1
+        }
+        #expect(didSuspendReload)
+
+        state.cancelChatListReload()
+        #expect(state.isRefreshing == false)
+        _ = await reload
+
+        #expect(runtime.chatListSubscriptionCount == subscriptionBaseline + 1)
+        #expect(state.isRefreshing == false)
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3586,6 +3586,45 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func concurrentReloadChatsForSameAccountCoalesces() async throws {
+        // Issue #210: reloadChats() is reachable from independently-spawned Tasks. Two overlapping
+        // same-account reloads must share one in-flight subscription/snapshot pass instead of
+        // duplicating FFI work and churn-cancelling the chat-list listener the first reload started.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didHydrateChats = await waitFor {
+            state.activeChats.count == 2
+        }
+        #expect(didHydrateChats)
+
+        let subscriptionBaseline = runtime.chatListSubscriptionCount
+        runtime.chatListSubscriptionDelayNanoseconds = 100_000_000
+
+        async let firstReload: Void = state.reloadChats()
+        let didStartFirstReload = await waitFor {
+            runtime.chatListSubscriptionCount == subscriptionBaseline + 1
+        }
+        #expect(didStartFirstReload)
+
+        async let secondReload: Void = state.reloadChats()
+        _ = await (firstReload, secondReload)
+
+        #expect(runtime.chatListSubscriptionCount == subscriptionBaseline + 1)
+        #expect(state.isRefreshing == false)
+        #expect(state.activeChats.count == 2)
+    }
+
+    @MainActor
     @Test func subscriptionSnapshotsRunOffMainThread() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -9607,6 +9646,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var timelineSubscriptionCount = 0
     private(set) var lastTimelineSubscription: FakeTimelineMessagesSubscription?
     var chatListStreamEndsAfterUpdates = false
+    /// Simulates async relay/runtime latency before a chat-list subscription is ready.
+    var chatListSubscriptionDelayNanoseconds: UInt64 = 0
     var notificationStreamEndsImmediately = false
     var timelineStreamEndsAfterUpdates = false
     private(set) var timelineMessageQueries: [TimelineMessageQueryFfi] = []
@@ -10439,6 +10480,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws -> ChatListSubscription {
         chatListSubscriptionCount += 1
+        if chatListSubscriptionDelayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: chatListSubscriptionDelayNanoseconds)
+        }
         return FakeChatListSubscription(
             rows: chatListRows(includeArchived: includeArchived),
             updates: chatListUpdates,


### PR DESCRIPTION
Closes #210

## Summary
- Add single-owner coalescing for `reloadChats()` keyed by active account id, so overlapping same-account requests await the in-flight subscription/snapshot work instead of duplicating it.
- Add a generation guard so superseded reloads cannot apply rows, start a stale listener, or clear the newer reload's refresh spinner after an await resumes.
- Cancel in-flight chat reload ownership during active-account teardown paths and add regression coverage for same-account reload coalescing.

## Verification
- `git diff --check origin/master...HEAD` — pass
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' HEAD -- . ':!Vendored'` — no conflict markers
- `bash -n scripts/ci/macos-sanity-checks.sh` — pass
- `scripts/ci/macos-sanity-checks.sh` — blocked locally: `xcodebuild: command not found`
- Swift/Xcode tests not run locally: `xcodebuild`, `xcrun`, `swift`, and `swift-format` are unavailable on this Linux worker.

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+Account.swift` — active-account switch/removal/signout/delete-all teardown now cancels any in-flight chat-list reload owner.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/224">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->