### PR TITLE
fix: ignore unsupported imeta blurhash field

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -570,7 +570,7 @@ private nonisolated enum MessageMediaParser {
 
         for field in tag.dropFirst() {
             if field.hasPrefix("blurhash ") {
-                return nil
+                continue
             }
             if let locator = field.dropPrefix("locator "),
                 let split = locator.firstIndex(of: " ")

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -570,6 +570,7 @@ private nonisolated enum MessageMediaParser {
 
         for field in tag.dropFirst() {
             if field.hasPrefix("blurhash ") {
+                // Recognized NIP-92 placeholder; unsupported locally, but keep the attachment.
                 continue
             }
             if let locator = field.dropPrefix("locator "),

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1362,6 +1362,38 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func imetaBlurhashFieldDoesNotDropAttachment() async throws {
+        // Regression for whitenoise-mac#208: `blurhash` is a standard optional NIP-92
+        // imeta field. The macOS client does not consume it, but its presence must not
+        // make the local-parse fallback discard the whole media attachment.
+        let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "blurhash-imeta",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJson(
+                        for: reference,
+                        appendingIMetaField: "blurhash LEHV6nWB2yk8pyo0adR*.7kCMdnj"
+                    )
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+
+        #expect(message.mediaAttachments.count == 1)
+        #expect(message.mediaAttachments.first?.reference.fileName == reference.fileName)
+        #expect(message.mediaAttachments.first?.reference.thumbhash == nil)
+    }
+
+    @MainActor
     @Test func invalidNumericSourceEpochFallsBackToZeroInsteadOfWrapping() async throws {
         // Regression for whitenoise-mac#179: a peer-controlled `source_epoch` is the MLS
         // decryption epoch, so a negative (`-1` would wrap to `UInt64.max`), fractional
@@ -10400,6 +10432,12 @@ private func mediaAttachmentReference(
 
 private func mediaJson(for reference: MediaAttachmentReferenceFfi) -> String {
     let tag = mediaIMetaTag(for: reference).values
+    return mediaJSONString(fromJSONObject: ["imeta": [tag]])
+}
+
+private func mediaJson(for reference: MediaAttachmentReferenceFfi, appendingIMetaField field: String) -> String {
+    var tag = mediaIMetaTag(for: reference).values
+    tag.append(field)
     return mediaJSONString(fromJSONObject: ["imeta": [tag]])
 }
 


### PR DESCRIPTION
## Summary
- Treat NIP-92 `blurhash` imeta fields as unsupported optional metadata instead of dropping the whole attachment.
- Add a regression test covering local media JSON parsing with a blurhash field.

## Verification
- `git diff --check`
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':!*.xcstrings'` (no matches)
- `bash -n scripts/ci/macos-sanity-checks.sh`
- Added-line length check against 120-char Swift format limit
- `xcodebuild`, `xcrun`, `swift`, and `swift-format` are not installed on this Linux worker, so macOS build/test/format checks need GitHub CI/macOS.

## Sensitive paths
None by repo policy. This changes local NIP-92 media metadata parsing only; it does not touch auth, key handling, crypto/MLS/CGKA, trust anchors, group-state core, entitlements, or app secrets.

Closes #208


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/226">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->