### PR TITLE
fix: gate markdown link schemes

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -17,6 +17,12 @@ struct ContentView: View {
             .frame(minWidth: 940, minHeight: 620)
             .preferredColorScheme(effectiveColorScheme)
             .environment(\.locale, workspace.preferredLocale)
+            .environment(
+                \.openURL,
+                OpenURLAction { url in
+                    workspace.handleMessageLinkOpen(url)
+                }
+            )
             .tint(Color(nsColor: .systemBlue))
             .nativeWindowGlassBackground()
             .onAppear {

--- a/whitenoise-mac/Core/MarkdownLinkPolicy.swift
+++ b/whitenoise-mac/Core/MarkdownLinkPolicy.swift
@@ -11,6 +11,10 @@ import Foundation
 /// LaunchServices. `http`/`https` links may be handed to the system browser after the app-side
 /// `OpenURLAction` gate runs; `nostr:` links are handled internally by `WorkspaceState`.
 nonisolated enum MarkdownLinkPolicy {
+    private static let resolvableProfilePrefixes = ["npub1", "nprofile1"]
+    private static let recognizedNostrReferencePrefixes =
+        resolvableProfilePrefixes + ["note1", "nevent1", "naddr1", "nrelay1"]
+
     static func sanitizedURL(from raw: String) -> URL? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
@@ -53,13 +57,27 @@ nonisolated enum MarkdownLinkPolicy {
     }
 
     static func isResolvableProfileReference(_ reference: String) -> Bool {
-        reference.lowercased().hasPrefix("npub1")
+        hasNostrPrefix(in: reference, prefixes: resolvableProfilePrefixes)
+    }
+
+    static func isProfileReferenceInput(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = trimmed.lowercased()
+        let reference: String
+        if normalized.hasPrefix("nostr:") {
+            reference = String(normalized.dropFirst("nostr:".count))
+        } else {
+            reference = normalized
+        }
+        return hasNostrPrefix(in: reference, prefixes: resolvableProfilePrefixes)
     }
 
     private static func isRecognizedNostrReference(_ reference: String) -> Bool {
+        hasNostrPrefix(in: reference, prefixes: recognizedNostrReferencePrefixes)
+    }
+
+    private static func hasNostrPrefix(in reference: String, prefixes: [String]) -> Bool {
         let normalized = reference.lowercased()
-        return ["npub1", "note1", "nevent1", "nprofile1", "naddr1", "nrelay1"].contains { prefix in
-            normalized.hasPrefix(prefix)
-        }
+        return prefixes.contains { normalized.hasPrefix($0) }
     }
 }

--- a/whitenoise-mac/Core/MarkdownLinkPolicy.swift
+++ b/whitenoise-mac/Core/MarkdownLinkPolicy.swift
@@ -1,0 +1,65 @@
+//
+//  MarkdownLinkPolicy.swift
+//  whitenoise-mac
+//
+//  Safety policy for links rendered from untrusted peer Markdown.
+//
+
+import Foundation
+
+/// Peer-controlled message text must never be allowed to hand arbitrary URL schemes to
+/// LaunchServices. `http`/`https` links may be handed to the system browser after the app-side
+/// `OpenURLAction` gate runs; `nostr:` links are handled internally by `WorkspaceState`.
+nonisolated enum MarkdownLinkPolicy {
+    static func sanitizedURL(from raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+            let url = URL(string: trimmed),
+            isAllowed(url)
+        else { return nil }
+        return url
+    }
+
+    static func nostrURL(for bech32: String) -> URL? {
+        sanitizedURL(from: "nostr:\(bech32)")
+    }
+
+    static func isAllowed(_ url: URL) -> Bool {
+        isAllowedExternalURL(url) || isInternalNostrURL(url)
+    }
+
+    static func isAllowedExternalURL(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+            return false
+        }
+        guard let host = url.host, !host.isEmpty else { return false }
+        return true
+    }
+
+    static func isInternalNostrURL(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "nostr",
+            let reference = nostrReference(from: url)
+        else { return false }
+        return isRecognizedNostrReference(reference)
+    }
+
+    static func nostrReference(from url: URL) -> String? {
+        guard url.scheme?.lowercased() == "nostr" else { return nil }
+        let absolute = url.absoluteString
+        guard let separator = absolute.firstIndex(of: ":") else { return nil }
+        let reference = String(absolute[absolute.index(after: separator)...])
+        guard !reference.isEmpty else { return nil }
+        return reference
+    }
+
+    static func isResolvableProfileReference(_ reference: String) -> Bool {
+        reference.lowercased().hasPrefix("npub1")
+    }
+
+    private static func isRecognizedNostrReference(_ reference: String) -> Bool {
+        let normalized = reference.lowercased()
+        return ["npub1", "note1", "nevent1", "nprofile1", "naddr1", "nrelay1"].contains { prefix in
+            normalized.hasPrefix(prefix)
+        }
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Links.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Links.swift
@@ -1,0 +1,39 @@
+//
+//  WorkspaceState+Links.swift
+//  whitenoise-mac
+//
+//  Link-opening policy for untrusted message Markdown.
+//
+
+import Foundation
+import SwiftUI
+
+@MainActor
+extension WorkspaceState {
+    /// Gate every tappable link rendered from peer-controlled Markdown before SwiftUI can fall
+    /// through to LaunchServices. Only browser-safe web links may use the system action; Nostr
+    /// links are consumed in-app, and every other scheme is dropped.
+    func handleMessageLinkOpen(_ url: URL) -> OpenURLAction.Result {
+        guard MarkdownLinkPolicy.isAllowed(url) else { return .discarded }
+
+        if MarkdownLinkPolicy.isInternalNostrURL(url) {
+            Task { await handleNostrMessageLink(url) }
+            return .handled
+        }
+
+        guard MarkdownLinkPolicy.isAllowedExternalURL(url) else { return .discarded }
+        return .systemAction
+    }
+
+    private func handleNostrMessageLink(_ url: URL) async {
+        guard let reference = MarkdownLinkPolicy.nostrReference(from: url) else { return }
+
+        if MarkdownLinkPolicy.isResolvableProfileReference(reference) {
+            showNewChat()
+            newChatQuery = "nostr:\(reference)"
+            _ = await resolveNewChatQuery()
+        } else {
+            backgroundStatus = L10n.string("This Nostr link type is not supported yet.")
+        }
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -189,7 +189,7 @@ extension WorkspaceState {
     func looksLikeMemberRef(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         let lowercased = trimmed.lowercased()
-        if lowercased.hasPrefix("npub") || lowercased.hasPrefix("nostr:npub") {
+        if MarkdownLinkPolicy.isProfileReferenceInput(trimmed) {
             return true
         }
         if lowercased.hasPrefix("darkmatter://profile/") {

--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -194,14 +194,16 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 remainingDepth: remainingDepth - 1
             )
         case .link(let dest, _, let children):
-            return concat(children, intent: intent, link: URL(string: dest) ?? link, remainingDepth: remainingDepth - 1)
+            return concat(
+                children, intent: intent, link: MarkdownLinkPolicy.sanitizedURL(from: dest),
+                remainingDepth: remainingDepth - 1)
         case .image(_, let title, let alt):
             if !alt.isEmpty {
                 return concat(alt, intent: intent, link: link, remainingDepth: remainingDepth - 1)
             }
             return styled(title ?? "", intent: intent, link: link)
         case .autolink(let url, _):
-            return styled(url, intent: intent, link: URL(string: url) ?? link)
+            return styled(url, intent: intent, link: MarkdownLinkPolicy.sanitizedURL(from: url))
         case .math(let content):
             return styled(content, intent: intent.union(.code), link: link)
         case .nostrMention(let entity), .nostrUri(let entity):
@@ -257,7 +259,9 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         if !intent.isEmpty {
             attributed.inlinePresentationIntent = intent
         }
-        attributed.link = URL(string: "nostr:\(entity.bech32)")
+        if let link = MarkdownLinkPolicy.nostrURL(for: entity.bech32) {
+            attributed.link = link
+        }
         return attributed
     }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -238,4 +238,84 @@ struct PureValueTests {
         #expect(RelayURLValidator.classify("ws://notlocalhost") == .insecureRejected)
         #expect(RelayURLValidator.classify("ws://127.0.0.256") == .insecureRejected)
     }
+
+    @Test func markdownLinkPolicyAllowsOnlyWebAndNostrSchemes() async throws {
+        let httpsURL = MarkdownLinkPolicy.sanitizedURL(from: "https://example.com/path")
+        #expect(httpsURL?.absoluteString == "https://example.com/path")
+
+        let httpURL = MarkdownLinkPolicy.sanitizedURL(from: " HTTP://example.com/path ")
+        #expect(httpURL?.scheme?.lowercased() == "http")
+
+        let nostrURL = MarkdownLinkPolicy.sanitizedURL(
+            from: "nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+        )
+        #expect(nostrURL?.scheme == "nostr")
+
+        for raw in [
+            "",
+            "   ",
+            "https:example.com",
+            "file:///Applications/Calculator.app",
+            "smb://attacker/share",
+            "mailto:peer@example.com",
+            "javascript:alert(1)",
+            "x-whatever://payload",
+            "nostr:unknown1payload",
+        ] {
+            #expect(
+                MarkdownLinkPolicy.sanitizedURL(from: raw) == nil,
+                "expected rejection for \(String(reflecting: raw))"
+            )
+        }
+    }
+
+    @Test func markdownInlineBuilderDropsUnsafeMarkdownLinks() async throws {
+        let safe = MarkdownDisplayInlineBuilder.attributedString(
+            from: [
+                .link(
+                    dest: "https://example.com/profile",
+                    title: nil,
+                    children: [.text(content: "safe")]
+                )
+            ], remainingDepth: 32)
+        #expect(String(safe.characters) == "safe")
+        #expect(links(in: safe).map(\.absoluteString) == ["https://example.com/profile"])
+
+        let unsafe = MarkdownDisplayInlineBuilder.attributedString(
+            from: [
+                .link(
+                    dest: "file:///Applications/Calculator.app",
+                    title: nil,
+                    children: [.text(content: "unsafe")]
+                )
+            ], remainingDepth: 32)
+        #expect(String(unsafe.characters) == "unsafe")
+        #expect(links(in: unsafe).isEmpty)
+
+        let unsafeAutolink = MarkdownDisplayInlineBuilder.attributedString(
+            from: [
+                .autolink(url: "smb://attacker/share", kind: .uri)
+            ], remainingDepth: 32)
+        #expect(String(unsafeAutolink.characters) == "smb://attacker/share")
+        #expect(links(in: unsafeAutolink).isEmpty)
+    }
+
+    @Test func markdownInlineBuilderKeepsNostrEntitiesInternal() async throws {
+        let bech32 = "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+        let attributed = MarkdownDisplayInlineBuilder.attributedString(
+            from: [
+                .nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: bech32))
+            ], remainingDepth: 32)
+        #expect(links(in: attributed).map(\.absoluteString) == ["nostr:\(bech32)"])
+    }
+
+    private func links(in attributed: AttributedString) -> [URL] {
+        var result: [URL] = []
+        for run in attributed.runs {
+            if let link = run.link {
+                result.append(link)
+            }
+        }
+        return result
+    }
 }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -251,6 +251,13 @@ struct PureValueTests {
         )
         #expect(nostrURL?.scheme == "nostr")
 
+        let nprofileURL = MarkdownLinkPolicy.sanitizedURL(from: "nostr:nprofile1alice")
+        #expect(nprofileURL?.absoluteString == "nostr:nprofile1alice")
+        #expect(MarkdownLinkPolicy.isResolvableProfileReference("npub1alice"))
+        #expect(MarkdownLinkPolicy.isResolvableProfileReference("nprofile1alice"))
+        #expect(MarkdownLinkPolicy.isProfileReferenceInput("nostr:nprofile1alice"))
+        #expect(!MarkdownLinkPolicy.isResolvableProfileReference("note1alice"))
+
         for raw in [
             "",
             "   ",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7857,6 +7857,43 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func openingNostrProfileLinkShowsNewChatComposerAndResolvesRecipient() async throws {
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let nprofile = "nprofile1alice"
+        let query = "nostr:\(nprofile)"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installNormalizedMemberRef(query: query, accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Link",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.newChatQuery = "stale draft"
+        state.newChatName = "Stale room"
+        _ = state.handleMessageLinkOpen(URL(string: query)!)
+        let resolved = await waitFor {
+            state.resolvedNewChatRecipient?.sourceQuery == query
+        }
+
+        #expect(resolved)
+        #expect(state.isNewChatComposerVisible)
+        #expect(state.newChatQuery == query)
+        #expect(state.newChatName.isEmpty)
+        #expect(state.resolvedNewChatRecipient?.npub == "npub1alice")
+        #expect(state.resolvedNewChatRecipient?.title == "Alice Link")
+    }
+
+    @MainActor
     @Test func staleNewChatRecipientLookupDoesNotReplaceCurrentResult() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
## Summary
- Add a shared Markdown link policy that only allows http/https external links and recognized nostr: references.
- Install an app-level OpenURLAction gate so unsafe schemes are discarded before LaunchServices can open them.
- Route nostr: profile links into the in-app new-chat resolver and keep unsupported nostr entity types in-app instead of handing them to macOS.
- Add regression coverage for unsafe Markdown links/autolinks and nostr entity links.

## Verification
- Local: git diff --check origin/master..HEAD
- Local: git grep conflict-marker sweep on HEAD
- Local: git grep confirmed the old unsafe Markdown URL assignment patterns are absent
- Local xcodebuild/Swift tests not run: this Linux worker does not have xcodebuild or swift installed
- GitHub CI: PR Checks passed; Static Analysis passed

Closes #206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown links and Nostr mentions now open more predictably, with safer handling for supported link types.
  * Opening a Nostr profile link can now start a new chat and fill in the recipient automatically.

* **Bug Fixes**
  * Unsafe or unsupported links are now ignored instead of opening unexpected destinations.
  * Link rendering no longer falls back to a previous URL when a markdown link is invalid.

* **Tests**
  * Added coverage for safe link filtering, Nostr link rendering, and profile-link chat handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->