### PR TITLE
fix: guard media cache stores during account purges

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -246,7 +246,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
         guard let prepared else { return }
         guard !Task.isCancelled else {
-            try? FileManager.default.removeItem(at: prepared.stagingDirectory)
+            Self.discardPreparedEntry(prepared)
             return
         }
         commitPreparedEntry(prepared, startGeneration: start.generation)
@@ -349,7 +349,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         defer { lock.unlock() }
 
         guard generation == startGeneration else {
-            try? FileManager.default.removeItem(at: prepared.stagingDirectory)
+            Self.discardPreparedEntry(prepared)
             return
         }
 
@@ -377,6 +377,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     }
 
     private struct PreparedEntry {
+        let root: URL
         let stagingDirectory: URL
         let finalDirectory: URL
     }
@@ -492,10 +493,34 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 to: stagingDirectory.appendingPathComponent(payloadFileName),
                 options: [.atomic, .completeFileProtection]
             )
-            return PreparedEntry(stagingDirectory: stagingDirectory, finalDirectory: finalDirectory)
+            return PreparedEntry(root: root, stagingDirectory: stagingDirectory, finalDirectory: finalDirectory)
         } catch {
-            try? FileManager.default.removeItem(at: stagingDirectory)
+            discardStagingDirectory(stagingDirectory, root: root)
             return nil
+        }
+    }
+
+    private static func discardPreparedEntry(_ prepared: PreparedEntry) {
+        discardStagingDirectory(prepared.stagingDirectory, root: prepared.root)
+    }
+
+    private static func discardStagingDirectory(_ stagingDirectory: URL, root: URL) {
+        try? FileManager.default.removeItem(at: stagingDirectory)
+        removeEmptyDirectory(stagingDirectory.deletingLastPathComponent())
+        removeEmptyDirectory(root)
+    }
+
+    private static func removeEmptyDirectory(_ directory: URL) {
+        do {
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+            guard contents.isEmpty else { return }
+            try FileManager.default.removeItem(at: directory)
+        } catch {
+            return
         }
     }
 

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -214,7 +214,14 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     }
 
     func store(_ download: MessageMediaDownload, for key: MessageMediaDiskCacheKey) async {
+        // #236: atomically reject the store if a wipe/purge is in flight — `beginStore()`
+        // returns nil under an active purge, so we never resurrect the cache root after the
+        // key has been (or is about to be) deleted. #230: also honor cooperative cancellation
+        // so a store whose owning WorkspaceState task is cancelled mid-flight (account purge)
+        // bails and cleans up its staging rather than committing late. `start.generation` is
+        // the snapshot taken under the lock by `beginStore()`.
         guard let start = beginStore() else { return }
+        guard !Task.isCancelled else { return }
 
         let root: URL
         let symmetricKey: SymmetricKey
@@ -224,6 +231,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         } catch {
             return
         }
+        guard !Task.isCancelled, currentGeneration() == start.generation else { return }
 
         let plaintext = download.payload.data
         let prepared = await Task.detached(priority: .utility) {
@@ -237,6 +245,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }.value
 
         guard let prepared else { return }
+        guard !Task.isCancelled else {
+            try? FileManager.default.removeItem(at: prepared.stagingDirectory)
+            return
+        }
         commitPreparedEntry(prepared, startGeneration: start.generation)
     }
 

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -515,7 +515,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             let contents = try FileManager.default.contentsOfDirectory(
                 at: directory,
                 includingPropertiesForKeys: nil,
-                options: [.skipsHiddenFiles]
+                options: []
             )
             guard contents.isEmpty else { return }
             try FileManager.default.removeItem(at: directory)

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -229,6 +229,8 @@ extension WorkspaceState {
         let removedAccountId = account.id
         let removedAccountIdHex = account.accountIdHex
         let wasActive = activeAccountId == removedAccountId
+        suppressMediaDiskStores(forAccountId: removedAccountId)
+        defer { resumeMediaDiskStores(forAccountId: removedAccountId) }
         do {
             if wasActive {
                 stopTimelineListener()
@@ -397,6 +399,8 @@ extension WorkspaceState {
 
         isDeletingAllData = true
         lastError = nil
+        suppressAllMediaDiskStores()
+        defer { resumeAllMediaDiskStores() }
         defer { isDeletingAllData = false }
 
         do {

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -56,6 +56,7 @@ extension WorkspaceState {
     ) -> Bool {
         storeGuard.globalGeneration == mediaDiskStoreGlobalGeneration
             && storeGuard.accountGeneration == mediaDiskStoreAccountGenerations[accountId, default: 0]
+            && !isMediaDiskStoreGloballySuppressed
             && !mediaDiskStoreSuppressedAccountIds.contains(accountId)
             && activeAccountId == accountId
             && accounts.contains(where: { $0.id == accountId })
@@ -74,12 +75,12 @@ extension WorkspaceState {
 
     func suppressAllMediaDiskStores() {
         mediaDiskStoreGlobalGeneration &+= 1
-        mediaDiskStoreSuppressedAccountIds.formUnion(accounts.map(\.id))
+        isMediaDiskStoreGloballySuppressed = true
         cancelAllMediaDiskStoreTasks()
     }
 
     func resumeAllMediaDiskStores() {
-        mediaDiskStoreSuppressedAccountIds.removeAll()
+        isMediaDiskStoreGloballySuppressed = false
         mediaDiskStoreGlobalGeneration &+= 1
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -43,6 +43,99 @@ extension WorkspaceState {
         }
     }
 
+    func mediaDiskStoreGuard(forAccountId accountId: String) -> MediaDiskStoreGuard {
+        MediaDiskStoreGuard(
+            globalGeneration: mediaDiskStoreGlobalGeneration,
+            accountGeneration: mediaDiskStoreAccountGenerations[accountId, default: 0]
+        )
+    }
+
+    func isMediaDiskStoreAllowed(
+        forAccountId accountId: String,
+        storeGuard: MediaDiskStoreGuard
+    ) -> Bool {
+        storeGuard.globalGeneration == mediaDiskStoreGlobalGeneration
+            && storeGuard.accountGeneration == mediaDiskStoreAccountGenerations[accountId, default: 0]
+            && !mediaDiskStoreSuppressedAccountIds.contains(accountId)
+            && activeAccountId == accountId
+            && accounts.contains(where: { $0.id == accountId })
+    }
+
+    func suppressMediaDiskStores(forAccountId accountId: String) {
+        mediaDiskStoreAccountGenerations[accountId, default: 0] &+= 1
+        mediaDiskStoreSuppressedAccountIds.insert(accountId)
+        cancelMediaDiskStoreTasks(forAccountId: accountId)
+    }
+
+    func resumeMediaDiskStores(forAccountId accountId: String) {
+        mediaDiskStoreSuppressedAccountIds.remove(accountId)
+        mediaDiskStoreAccountGenerations[accountId, default: 0] &+= 1
+    }
+
+    func suppressAllMediaDiskStores() {
+        mediaDiskStoreGlobalGeneration &+= 1
+        mediaDiskStoreSuppressedAccountIds.formUnion(accounts.map(\.id))
+        cancelAllMediaDiskStoreTasks()
+    }
+
+    func resumeAllMediaDiskStores() {
+        mediaDiskStoreSuppressedAccountIds.removeAll()
+        mediaDiskStoreGlobalGeneration &+= 1
+    }
+
+    func cancelMediaDiskStoreTasks(forAccountId accountId: String) {
+        let cacheIDs = mediaDiskStoreTasks.compactMap { cacheID, tracked in
+            tracked.accountId == accountId ? cacheID : nil
+        }
+        for cacheID in cacheIDs {
+            mediaDiskStoreTasks[cacheID]?.task.cancel()
+            mediaDiskStoreTasks[cacheID] = nil
+        }
+    }
+
+    func cancelAllMediaDiskStoreTasks() {
+        for tracked in mediaDiskStoreTasks.values {
+            tracked.task.cancel()
+        }
+        mediaDiskStoreTasks.removeAll()
+    }
+
+    func scheduleMediaDiskCacheStore(
+        _ download: MessageMediaDownload,
+        for cacheKey: MessageMediaDiskCacheKey,
+        accountId: String,
+        storeGuard: MediaDiskStoreGuard
+    ) {
+        guard isMediaDiskStoreAllowed(forAccountId: accountId, storeGuard: storeGuard) else { return }
+
+        let cacheID = cacheKey.cacheID
+        mediaDiskStoreTasks[cacheID]?.task.cancel()
+        nextMediaDiskStoreTaskToken &+= 1
+        let token = nextMediaDiskStoreTaskToken
+        let mediaDiskCache = mediaDiskCache
+        let task = Task { [weak self, mediaDiskCache, download, cacheKey, accountId, storeGuard, cacheID, token] in
+            guard !Task.isCancelled,
+                await self?.isMediaDiskStoreAllowed(forAccountId: accountId, storeGuard: storeGuard) == true
+            else {
+                await self?.finishMediaDiskCacheStore(cacheID: cacheID, token: token)
+                return
+            }
+
+            await mediaDiskCache.store(download, for: cacheKey)
+            await self?.finishMediaDiskCacheStore(cacheID: cacheID, token: token)
+        }
+        mediaDiskStoreTasks[cacheID] = MediaDiskStoreTask(
+            accountId: accountId,
+            token: token,
+            task: task
+        )
+    }
+
+    func finishMediaDiskCacheStore(cacheID: String, token: UInt64) {
+        guard mediaDiskStoreTasks[cacheID]?.token == token else { return }
+        mediaDiskStoreTasks[cacheID] = nil
+    }
+
     func mediaDownloadState(for message: MessageItem, attachment: MessageMediaAttachment) -> MediaDownloadState {
         mediaDownloadStateStore(for: message, attachment: attachment).state
     }
@@ -72,6 +165,7 @@ extension WorkspaceState {
         let accountId = activeAccount.id
         let accountRef = activeAccount.accountRef
         let groupIdHex = message.groupIdHex
+        let storeGuard = mediaDiskStoreGuard(forAccountId: accountId)
         stateStore.update(.loading)
         let cacheKey = MessageMediaDiskCacheKey(
             accountId: accountId,
@@ -80,7 +174,7 @@ extension WorkspaceState {
         )
 
         if let cachedDownload = await mediaDiskCache.cachedDownload(for: cacheKey) {
-            guard activeAccountId == accountId else { return }
+            guard isMediaDiskStoreAllowed(forAccountId: accountId, storeGuard: storeGuard) else { return }
             stateStore.update(.loaded(cachedDownload))
             return
         }
@@ -97,7 +191,7 @@ extension WorkspaceState {
                 groupIdHex: groupIdHex,
                 reference: reference
             )
-            guard activeAccountId == accountId else { return }
+            guard isMediaDiskStoreAllowed(forAccountId: accountId, storeGuard: storeGuard) else { return }
             let mediaDownload = MessageMediaDownload(
                 payload: DownloadedMediaPayload(
                     id: "\(key)|\(UUID().uuidString)",
@@ -108,9 +202,12 @@ extension WorkspaceState {
                 sizeBytes: download.sizeBytes
             )
             stateStore.update(.loaded(mediaDownload))
-            Task {
-                await mediaDiskCache.store(mediaDownload, for: cacheKey)
-            }
+            scheduleMediaDiskCacheStore(
+                mediaDownload,
+                for: cacheKey,
+                accountId: accountId,
+                storeGuard: storeGuard
+            )
         } catch {
             guard activeAccountId == accountId else { return }
             stateStore.update(.failed(error.localizedDescription))

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -415,6 +415,11 @@ final class WorkspaceState {
     @ObservationIgnored var messageTimelineStores: [String: MessageTimelineStore] = [:]
     @ObservationIgnored var mediaDownloads: [String: MediaDownloadStateStore] = [:]
     @ObservationIgnored let mediaDiskCache: MessageMediaDiskCache
+    @ObservationIgnored var mediaDiskStoreTasks: [String: MediaDiskStoreTask] = [:]
+    @ObservationIgnored var mediaDiskStoreSuppressedAccountIds = Set<String>()
+    @ObservationIgnored var mediaDiskStoreAccountGenerations: [String: UInt64] = [:]
+    @ObservationIgnored var mediaDiskStoreGlobalGeneration: UInt64 = 0
+    @ObservationIgnored var nextMediaDiskStoreTaskToken: UInt64 = 0
     /// Error for the user-initiated action on the *current* screen. Rendered by form
     /// surfaces (login, settings, new-chat composer). Must never be written by
     /// background tasks — see `backgroundStatus`.
@@ -822,6 +827,17 @@ final class WorkspaceState {
     struct GroupMemberDetailsLookup {
         var token: UInt64
         var task: Task<[GroupMemberDetailsFfi]?, Never>
+    }
+
+    struct MediaDiskStoreGuard: Equatable {
+        var globalGeneration: UInt64
+        var accountGeneration: UInt64
+    }
+
+    struct MediaDiskStoreTask {
+        var accountId: String
+        var token: UInt64
+        var task: Task<Void, Never>
     }
 
     /// Raw output of the per-account bootstrap/settings FFI lookups.

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -416,6 +416,7 @@ final class WorkspaceState {
     @ObservationIgnored var mediaDownloads: [String: MediaDownloadStateStore] = [:]
     @ObservationIgnored let mediaDiskCache: MessageMediaDiskCache
     @ObservationIgnored var mediaDiskStoreTasks: [String: MediaDiskStoreTask] = [:]
+    @ObservationIgnored var isMediaDiskStoreGloballySuppressed = false
     @ObservationIgnored var mediaDiskStoreSuppressedAccountIds = Set<String>()
     @ObservationIgnored var mediaDiskStoreAccountGenerations: [String: UInt64] = [:]
     @ObservationIgnored var mediaDiskStoreGlobalGeneration: UInt64 = 0

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2472,6 +2472,7 @@ struct whitenoise_macTests {
             ]
         )
         let attachment = try #require(message.mediaAttachments.first)
+        let stateStore = state.mediaDownloadStateStore(for: message, attachment: attachment)
         let cacheKey = MessageMediaDiskCacheKey(
             accountId: AccountItem(summary: account).id,
             groupIdHex: "group",
@@ -2494,6 +2495,9 @@ struct whitenoise_macTests {
         }
 
         #expect(state.mediaDiskStoreTasks.isEmpty)
+        if case .loaded = stateStore.state {
+            Issue.record("Late download should not update loaded state after deleteAllData()")
+        }
         #expect(await mediaDiskCache.cachedDownload(for: cacheKey) == nil)
         #expect(!fileManager.fileExists(atPath: root.path))
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -73,6 +73,39 @@ private final class BlockingFfiGate: @unchecked Sendable {
     }
 }
 
+private final class OneShotKeyProviderGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private let reached = DispatchSemaphore(value: 0)
+    private let release = DispatchSemaphore(value: 0)
+    private let keyData: Data
+    private var shouldBlock = true
+
+    init(keyData: Data = Data(repeating: 0x42, count: 32)) {
+        self.keyData = keyData
+    }
+
+    func symmetricKey() throws -> SymmetricKey {
+        let shouldWait = lock.withLock {
+            let value = shouldBlock
+            shouldBlock = false
+            return value
+        }
+        if shouldWait {
+            reached.signal()
+            release.wait()
+        }
+        return SymmetricKey(data: keyData)
+    }
+
+    func waitUntilReached() {
+        reached.wait()
+    }
+
+    func releaseGate() {
+        release.signal()
+    }
+}
+
 private final class ObservationInvalidationFlag: @unchecked Sendable {
     private let lock = NSLock()
     private var invalidated = false
@@ -2370,6 +2403,135 @@ struct whitenoise_macTests {
         #expect(loaded.payload.id == cacheKey.payloadID)
         #expect(runtime.listMediaCallCount == 0)
         #expect(runtime.downloadMediaCallCount == 0)
+    }
+
+    @MainActor
+    @Test func mediaDownloadFinishingAfterDeleteAllDataDoesNotRecreateDiskCache() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: false
+        )
+        let plaintext = Data([0xde, 0xad, 0xbe, 0xef])
+        let reference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "image/png",
+            fileName: "late.png",
+            plaintextSha256: hexSHA256(plaintext)
+        )
+        let download = MediaDownloadResultFfi(
+            plaintext: plaintext,
+            fileName: "late.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(plaintext.count)
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "late-media-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: reference,
+                caption: nil,
+                recordedAt: 1_700_000_000,
+                receivedAt: 1_700_000_000
+            ),
+            download: download
+        )
+        let mediaDiskCache = messageMediaDiskCache(root: root)
+        let state = WorkspaceState(
+            mediaDiskCache: mediaDiskCache,
+            clientFactory: { runtime }
+        )
+        await state.bootstrap()
+        let message = MessageItem(
+            id: "late-media-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "late-media-message#0#\(reference.plaintextSha256)",
+                    reference: reference
+                )
+            ]
+        )
+        let attachment = try #require(message.mediaAttachments.first)
+        let cacheKey = MessageMediaDiskCacheKey(
+            accountId: AccountItem(summary: account).id,
+            groupIdHex: "group",
+            reference: reference
+        )
+
+        runtime.mediaDownloadGateEnabled = true
+        async let load: Void = state.loadMediaAttachment(attachment, for: message)
+        while !runtime.didReachMediaDownloadGate {
+            await Task.yield()
+        }
+
+        await state.deleteAllData()
+        #expect(!fileManager.fileExists(atPath: root.path))
+
+        runtime.releaseMediaDownloadGate()
+        await load
+        for _ in 0..<20 where !state.mediaDiskStoreTasks.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(state.mediaDiskStoreTasks.isEmpty)
+        #expect(await mediaDiskCache.cachedDownload(for: cacheKey) == nil)
+        #expect(!fileManager.fileExists(atPath: root.path))
+    }
+
+    @Test func messageMediaDiskCacheCancelledStoreDoesNotCommitAfterKeyProviderReturns() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let keyProviderGate = OneShotKeyProviderGate()
+        let cache = MessageMediaDiskCache(
+            directoryResolver: { root },
+            keyProvider: keyProviderGate.symmetricKey,
+            keyDeleter: {}
+        )
+        let plaintext = Data("late store should not commit".utf8)
+        let reference = mediaDiskCacheReference(plaintext: plaintext)
+        let key = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: reference)
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "late.bin",
+            mediaType: "application/octet-stream",
+            sizeBytes: UInt64(plaintext.count),
+            payloadId: "late-store"
+        )
+
+        let storeTask = Task {
+            await cache.store(download, for: key)
+        }
+        await Task.detached {
+            keyProviderGate.waitUntilReached()
+        }.value
+        storeTask.cancel()
+        keyProviderGate.releaseGate()
+        await storeTask.value
+
+        #expect(await cache.cachedDownload(for: key) == nil)
     }
 
     @Test func messageAudioMetadataCacheCoalescesAndCachesPayloadAnalysis() async throws {
@@ -9628,6 +9790,11 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var messageActionGateEnabled = false
     private(set) var didReachMessageActionGate = false
     private var messageActionGateContinuation: CheckedContinuation<Void, Never>?
+    /// Issue #230 media-cache teardown-test support: when armed, the first `downloadMedia`
+    /// call suspends after capturing the download bytes so a purge can complete before it returns.
+    var mediaDownloadGateEnabled = false
+    private(set) var didReachMediaDownloadGate = false
+    private var mediaDownloadGateContinuation: CheckedContinuation<Void, Never>?
     /// Issue #134 reentrancy-test support: when armed, the first group-avatar update FFI call
     /// suspends until `releaseGroupAvatarUpdateGate()` is invoked, holding the first invocation
     /// in-flight so a test can issue an overlapping clear/set action and assert the guard dropped it.
@@ -10590,6 +10757,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         guard let download = mediaDownloadsByPlaintextSha256[reference.plaintextSha256] else {
             throw FakeMarmotRuntimeError.unused
         }
+        await passMediaDownloadGateIfArmed()
         return download
     }
 
@@ -10667,6 +10835,22 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func releaseMessageActionGate() {
         messageActionGateContinuation?.resume()
         messageActionGateContinuation = nil
+    }
+
+    /// Suspends the first media download FFI call when the gate is armed, after the fake runtime
+    /// has captured the bytes it will return. This models a network download completing after a
+    /// user-initiated purge has already removed the account/cache.
+    private func passMediaDownloadGateIfArmed() async {
+        guard mediaDownloadGateEnabled, mediaDownloadGateContinuation == nil, !didReachMediaDownloadGate else { return }
+        didReachMediaDownloadGate = true
+        await withCheckedContinuation { continuation in
+            mediaDownloadGateContinuation = continuation
+        }
+    }
+
+    func releaseMediaDownloadGate() {
+        mediaDownloadGateContinuation?.resume()
+        mediaDownloadGateContinuation = nil
     }
 
     // MARK: - darkmatter 745959e FFI additions

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2532,6 +2532,7 @@ struct whitenoise_macTests {
         await storeTask.value
 
         #expect(await cache.cachedDownload(for: key) == nil)
+        #expect(!fileManager.fileExists(atPath: root.path))
     }
 
     @Test func messageAudioMetadataCacheCoalescesAndCachesPayloadAnalysis() async throws {
@@ -9792,9 +9793,14 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private var messageActionGateContinuation: CheckedContinuation<Void, Never>?
     /// Issue #230 media-cache teardown-test support: when armed, the first `downloadMedia`
     /// call suspends after capturing the download bytes so a purge can complete before it returns.
+    private let mediaDownloadGateLock = NSLock()
     var mediaDownloadGateEnabled = false
-    private(set) var didReachMediaDownloadGate = false
+    private var mediaDownloadGateReached = false
+    var didReachMediaDownloadGate: Bool {
+        mediaDownloadGateLock.withLock { mediaDownloadGateReached }
+    }
     private var mediaDownloadGateContinuation: CheckedContinuation<Void, Never>?
+    private var mediaDownloadGateReleased = false
     /// Issue #134 reentrancy-test support: when armed, the first group-avatar update FFI call
     /// suspends until `releaseGroupAvatarUpdateGate()` is invoked, holding the first invocation
     /// in-flight so a test can issue an overlapping clear/set action and assert the guard dropped it.
@@ -10841,16 +10847,34 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// has captured the bytes it will return. This models a network download completing after a
     /// user-initiated purge has already removed the account/cache.
     private func passMediaDownloadGateIfArmed() async {
-        guard mediaDownloadGateEnabled, mediaDownloadGateContinuation == nil, !didReachMediaDownloadGate else { return }
-        didReachMediaDownloadGate = true
+        let shouldSuspend = mediaDownloadGateLock.withLock {
+            mediaDownloadGateEnabled && mediaDownloadGateContinuation == nil && !mediaDownloadGateReached
+        }
+        guard shouldSuspend else { return }
         await withCheckedContinuation { continuation in
-            mediaDownloadGateContinuation = continuation
+            let resumeImmediately = mediaDownloadGateLock.withLock {
+                mediaDownloadGateContinuation = continuation
+                mediaDownloadGateReached = true
+                if mediaDownloadGateReleased {
+                    mediaDownloadGateContinuation = nil
+                    return true
+                }
+                return false
+            }
+            if resumeImmediately {
+                continuation.resume()
+            }
         }
     }
 
     func releaseMediaDownloadGate() {
-        mediaDownloadGateContinuation?.resume()
-        mediaDownloadGateContinuation = nil
+        let continuation = mediaDownloadGateLock.withLock {
+            mediaDownloadGateReleased = true
+            let continuation = mediaDownloadGateContinuation
+            mediaDownloadGateContinuation = nil
+            return continuation
+        }
+        continuation?.resume()
     }
 
     // MARK: - darkmatter 745959e FFI additions


### PR DESCRIPTION
## Summary
- track media disk-cache store tasks and cancel/suppress them during account removal and Delete All Local Data
- gate late media download completions on account membership plus per-account/global store generations before updating loaded state or scheduling disk writes
- make `MessageMediaDiskCache.store` cancellation-aware and reject stores whose generation predates a purge
- add regression coverage for a download finishing after `deleteAllData()` and for a canceled store reaching key creation

## Test Plan
- `git diff --check`
- `git diff --check HEAD^ HEAD`
- GitHub `Static Analysis`: pass
- GitHub `PR Checks`: fail in `xcrun swift-format lint` with pre-existing repository-wide formatting failures; `origin/master` head `41367e3` is already red in Mac CI run 28308192793 before this branch
- `xcodebuild` not run locally: unavailable on this Linux worker

Closes #230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media cache handling so interrupted or cancelled saves no longer leave partial data behind.
  * Prevented stale media cache writes from completing after data cleanup or account removal.
  * Reduced the chance of media cache entries reappearing after a full data wipe.
  * Added regression coverage for cancelled saves and cleanup during in-flight media downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->