### PR TITLE
fix: bound markdown display recursion

### DIFF
--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -11,14 +11,26 @@ nonisolated struct MarkdownDisplayDocument {
     let blocks: [MarkdownDisplayBlockNode]
     let truncated: Bool
 
+    /// Block quotes, lists, and inline emphasis/link/image-alt all recurse over the
+    /// `MarkdownDocumentFfi` AST, which is derived from untrusted peer message content.
+    /// Bound the Swift-side recursion so attacker-chosen nesting cannot overflow the
+    /// stack. 32 matches the media JSON traversal guard in `Core/MarmotMapping.swift`.
+    /// Past the limit, the over-depth remainder collapses to empty safe display rather
+    /// than preserving nested structure.
+    fileprivate static let maxDepth = 32
+
     init(document: MarkdownDocumentFfi) {
-        self.blocks = Self.makeBlocks(from: document.blocks)
+        self.blocks = Self.makeBlocks(from: document.blocks, remainingDepth: Self.maxDepth)
         self.truncated = document.truncated
     }
 
-    fileprivate static func makeBlocks(from blocks: [MarkdownBlockFfi]) -> [MarkdownDisplayBlockNode] {
-        blocks.enumerated().map { index, block in
-            MarkdownDisplayBlockNode(id: index, block: MarkdownDisplayBlock(block))
+    fileprivate static func makeBlocks(
+        from blocks: [MarkdownBlockFfi],
+        remainingDepth: Int
+    ) -> [MarkdownDisplayBlockNode] {
+        guard remainingDepth > 0 else { return [] }
+        return blocks.enumerated().map { index, block in
+            MarkdownDisplayBlockNode(id: index, block: MarkdownDisplayBlock(block, remainingDepth: remainingDepth))
         }
     }
 }
@@ -38,25 +50,33 @@ nonisolated enum MarkdownDisplayBlock {
     case table(header: [MarkdownDisplayTableCell], rows: [MarkdownDisplayTableRow])
     case mathBlock(String)
 
-    init(_ block: MarkdownBlockFfi) {
+    init(_ block: MarkdownBlockFfi, remainingDepth: Int) {
         switch block {
         case .paragraph(let inlines):
-            self = .paragraph(MarkdownDisplayInlineBuilder.attributedString(from: inlines))
+            self = .paragraph(
+                MarkdownDisplayInlineBuilder.attributedString(from: inlines, remainingDepth: remainingDepth)
+            )
         case .heading(let level, let inlines):
-            self = .heading(level: level, text: MarkdownDisplayInlineBuilder.attributedString(from: inlines))
+            self = .heading(
+                level: level,
+                text: MarkdownDisplayInlineBuilder.attributedString(from: inlines, remainingDepth: remainingDepth)
+            )
         case .thematicBreak:
             self = .thematicBreak
         case .codeBlock(_, _, let content):
             self = .codeBlock(content)
         case .blockQuote(let blocks):
-            self = .blockQuote(MarkdownDisplayDocument.makeBlocks(from: blocks))
+            self = .blockQuote(MarkdownDisplayDocument.makeBlocks(from: blocks, remainingDepth: remainingDepth - 1))
         case .list(let kind, _, let items):
-            self = .list(items: Self.listItems(kind: kind, items: items))
+            self = .list(items: Self.listItems(kind: kind, items: items, remainingDepth: remainingDepth))
         case .table(_, let header, let rows):
             self = .table(
-                header: Self.tableCells(from: header),
+                header: Self.tableCells(from: header, remainingDepth: remainingDepth),
                 rows: rows.enumerated().map { rowIndex, row in
-                    MarkdownDisplayTableRow(id: rowIndex, cells: Self.tableCells(from: row))
+                    MarkdownDisplayTableRow(
+                        id: rowIndex,
+                        cells: Self.tableCells(from: row, remainingDepth: remainingDepth)
+                    )
                 }
             )
         case .mathBlock(let content):
@@ -68,13 +88,14 @@ nonisolated enum MarkdownDisplayBlock {
 
     private static func listItems(
         kind: MarkdownListKindFfi,
-        items: [MarkdownListItemFfi]
+        items: [MarkdownListItemFfi],
+        remainingDepth: Int
     ) -> [MarkdownDisplayListItem] {
         items.enumerated().map { index, item in
             MarkdownDisplayListItem(
                 id: index,
                 marker: listMarker(kind: kind, item: item, index: index),
-                blocks: MarkdownDisplayDocument.makeBlocks(from: item.blocks)
+                blocks: MarkdownDisplayDocument.makeBlocks(from: item.blocks, remainingDepth: remainingDepth - 1)
             )
         }
     }
@@ -97,11 +118,14 @@ nonisolated enum MarkdownDisplayBlock {
         }
     }
 
-    private static func tableCells(from cells: [MarkdownTableCellFfi]) -> [MarkdownDisplayTableCell] {
+    private static func tableCells(
+        from cells: [MarkdownTableCellFfi],
+        remainingDepth: Int
+    ) -> [MarkdownDisplayTableCell] {
         cells.enumerated().map { index, cell in
             MarkdownDisplayTableCell(
                 id: index,
-                text: MarkdownDisplayInlineBuilder.attributedString(from: cell.inlines)
+                text: MarkdownDisplayInlineBuilder.attributedString(from: cell.inlines, remainingDepth: remainingDepth)
             )
         }
     }
@@ -129,10 +153,11 @@ nonisolated struct MarkdownDisplayTableRow: Identifiable {
 }
 
 nonisolated enum MarkdownDisplayInlineBuilder {
-    static func attributedString(from inlines: [MarkdownInlineFfi]) -> AttributedString {
+    static func attributedString(from inlines: [MarkdownInlineFfi], remainingDepth: Int) -> AttributedString {
+        guard remainingDepth > 0 else { return AttributedString() }
         var result = AttributedString()
         for inline in inlines {
-            result.append(render(inline, intent: [], link: nil))
+            result.append(render(inline, intent: [], link: nil, remainingDepth: remainingDepth))
         }
         return result
     }
@@ -140,7 +165,8 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func render(
         _ inline: MarkdownInlineFfi,
         intent: InlinePresentationIntent,
-        link: URL?
+        link: URL?,
+        remainingDepth: Int
     ) -> AttributedString {
         switch inline {
         case .text(let content):
@@ -152,16 +178,26 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         case .code(let content):
             return styled(content, intent: intent.union(.code), link: link)
         case .emph(let children):
-            return concat(children, intent: intent.union(.emphasized), link: link)
+            return concat(children, intent: intent.union(.emphasized), link: link, remainingDepth: remainingDepth - 1)
         case .strong(let children):
-            return concat(children, intent: intent.union(.stronglyEmphasized), link: link)
+            return concat(
+                children,
+                intent: intent.union(.stronglyEmphasized),
+                link: link,
+                remainingDepth: remainingDepth - 1
+            )
         case .strikethrough(let children):
-            return concat(children, intent: intent.union(.strikethrough), link: link)
+            return concat(
+                children,
+                intent: intent.union(.strikethrough),
+                link: link,
+                remainingDepth: remainingDepth - 1
+            )
         case .link(let dest, _, let children):
-            return concat(children, intent: intent, link: URL(string: dest) ?? link)
+            return concat(children, intent: intent, link: URL(string: dest) ?? link, remainingDepth: remainingDepth - 1)
         case .image(_, let title, let alt):
             if !alt.isEmpty {
-                return concat(alt, intent: intent, link: link)
+                return concat(alt, intent: intent, link: link, remainingDepth: remainingDepth - 1)
             }
             return styled(title ?? "", intent: intent, link: link)
         case .autolink(let url, _):
@@ -178,11 +214,13 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func concat(
         _ inlines: [MarkdownInlineFfi],
         intent: InlinePresentationIntent,
-        link: URL?
+        link: URL?,
+        remainingDepth: Int
     ) -> AttributedString {
+        guard remainingDepth > 0 else { return AttributedString() }
         var result = AttributedString()
         for inline in inlines {
-            result.append(render(inline, intent: intent, link: link))
+            result.append(render(inline, intent: intent, link: link, remainingDepth: remainingDepth))
         }
         return result
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1371,6 +1371,81 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func deeplyNestedMarkdownBlocksCollapseInsteadOfRecursing() async throws {
+        // Regression for whitenoise-mac#231: contentTokens is parsed from untrusted peer
+        // content. A block quote nested far beyond the Swift-side depth bound must collapse
+        // the over-depth remainder to empty display rather than recursing the full attacker
+        // chain (which can overflow the stack).
+        let document = MarkdownDocumentFfi(
+            blocks: [nestedBlockQuote(depth: 256, leaf: .paragraph(inlines: [.text(content: "deep")]))],
+            truncated: false
+        )
+
+        let display = MarkdownDisplayDocument(document: document)
+
+        // The display tree stops nesting at the bound, so the deepest preserved quote holds
+        // no further blocks instead of the attacker's remaining 200+ levels.
+        let preservedDepth = blockQuoteNestingDepth(display.blocks)
+        #expect(preservedDepth <= 32)
+        #expect(preservedDepth >= 1)
+    }
+
+    @MainActor
+    @Test func deeplyNestedMarkdownInlinesCollapseInsteadOfRecursing() async throws {
+        // Inline emphasis/strong/strikethrough/link/image-alt recurse proportionally to
+        // attacker-chosen nesting. Past the bound the inline subtree must collapse to empty
+        // safe display rather than recursing the full chain.
+        let document = MarkdownDocumentFfi(
+            blocks: [.paragraph(inlines: [nestedStrong(depth: 256, leaf: .text(content: "deep"))])],
+            truncated: false
+        )
+
+        let display = MarkdownDisplayDocument(document: document)
+
+        guard case .paragraph(let text) = display.blocks.first?.block else {
+            Issue.record("expected a paragraph block")
+            return
+        }
+        // The leaf text sits below the bound, so it is dropped entirely rather than the
+        // renderer recursing through every wrapper to reach it.
+        #expect(String(text.characters).isEmpty)
+    }
+
+    @MainActor
+    @Test func boundedNestedMarkdownStillStylesAndLinks() async throws {
+        // Normal Markdown nesting (well within the bound) must keep its styles and links:
+        // the depth guard only collapses the over-depth remainder.
+        let document = MarkdownDocumentFfi(
+            blocks: [
+                nestedBlockQuote(
+                    depth: 3,
+                    leaf: .paragraph(inlines: [
+                        .strong(children: [
+                            .link(
+                                dest: "https://example.com",
+                                title: nil,
+                                children: [.text(content: "link text")]
+                            )
+                        ])
+                    ])
+                )
+            ],
+            truncated: false
+        )
+
+        let display = MarkdownDisplayDocument(document: document)
+
+        guard let paragraph = firstParagraph(in: display.blocks) else {
+            Issue.record("expected a nested paragraph block")
+            return
+        }
+        #expect(String(paragraph.characters) == "link text")
+        let run = paragraph.runs.first
+        #expect(run?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
+        #expect(run?.link == URL(string: "https://example.com"))
+    }
+
+    @MainActor
     @Test func transcriptRowStackLayoutPerformanceGuard() async throws {
         let messages = performanceMessageItems(count: 160)
         let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
@@ -11929,6 +12004,54 @@ private func dataContains(_ haystack: Data, _ needle: Data) -> Bool {
 
 private func emptyMarkdownDocument() -> MarkdownDocumentFfi {
     MarkdownDocumentFfi(blocks: [], truncated: false)
+}
+
+private func nestedBlockQuote(depth: Int, leaf: MarkdownBlockFfi) -> MarkdownBlockFfi {
+    var block = leaf
+    for _ in 0..<depth {
+        block = .blockQuote(blocks: [block])
+    }
+    return block
+}
+
+private func nestedStrong(depth: Int, leaf: MarkdownInlineFfi) -> MarkdownInlineFfi {
+    var inline = leaf
+    for _ in 0..<depth {
+        inline = .strong(children: [inline])
+    }
+    return inline
+}
+
+private func blockQuoteNestingDepth(_ blocks: [MarkdownDisplayBlockNode]) -> Int {
+    var depth = 0
+    var current = blocks
+    while case .blockQuote(let inner)? = current.first?.block {
+        depth += 1
+        current = inner
+    }
+    return depth
+}
+
+private func firstParagraph(in blocks: [MarkdownDisplayBlockNode]) -> AttributedString? {
+    for node in blocks {
+        switch node.block {
+        case .paragraph(let text):
+            return text
+        case .blockQuote(let inner):
+            if let found = firstParagraph(in: inner) {
+                return found
+            }
+        case .list(let items):
+            for item in items {
+                if let found = firstParagraph(in: item.blocks) {
+                    return found
+                }
+            }
+        default:
+            continue
+        }
+    }
+    return nil
 }
 
 private func restoreDefault(_ value: Any?, forKey key: String) {


### PR DESCRIPTION
Closes #231

## Summary
- Added a Swift-side Markdown display traversal depth bound (32 levels) for block quotes, lists, table inline cells, and inline emphasis/strong/strikethrough/link/image-alt children.
- Over-depth Markdown AST subtrees now collapse to empty safe display instead of preserving attacker-controlled nesting until the stack overflows.
- Added Swift Testing regression coverage for deeply nested block and inline Markdown plus normal bounded nested styling/link behavior.

## Verification
- `git diff --check` — passed.
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- $(git diff --name-only)` — no conflict markers.
- `python3` line-length probe over changed Swift files — no lines > 120 chars.
- `python3` brace-balance probe for `MarkdownDisplayModel.swift` — 39 `{` / 39 `}`.
- Remote CI on PR #233:
  - `Static Analysis` — passed.
  - `CodeRabbit` — passed / review completed.
  - `PR Checks` — failed in `Swift format lint` before build/test. The failure is pre-existing on `origin/master` (master run `28308192793` at `41367e30` fails with the same `UIFixtureWorkspace.swift`, `MarmotMapping.swift`, `AppLaunchConfiguration.swift`, `WorkspaceState.swift`, `MessageMediaDiskCache.swift`, and `whitenoise_macTests.swift` swift-format diagnostics). The new test lines are not reported by swift-format.
- Local macOS CI commands not runnable on this Linux host: `xcrun`, `swift`, `swift-format`, and `xcodebuild` are unavailable. `scripts/ci/macos-sanity-checks.sh` fails immediately because `xcodebuild` is missing.

## Sensitive paths
none

## Notes
The guard intentionally drops over-depth remainder content rather than recursively flattening it; this mirrors the existing media JSON guard's fail-closed behavior and only affects adversarially deep Markdown.

## CI caveat
This PR has had a red `PR Checks` run due to a master-side swift-format failure. Per Pip rules, it must not be auto-merged; the merge gate should require human handling after the master-side format break is resolved.
