### PR TITLE
fix: guard new chat creation across account switches

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -99,6 +99,14 @@ extension WorkspaceState {
 
     func createNewChat() async {
         guard let client, let activeAccount, !isCreatingChat else { return }
+
+        // Capture the creating account on entry so a mid-await A→B account switch (e.g. via
+        // a notification tap while `createGroup`/`reloadChats` are suspended) cannot graft
+        // account A's freshly created group onto account B's chat list or select/load it
+        // under B's context. The group's FFI data stays partitioned by account ref; this
+        // only guards the workspace UI state. See whitenoise-mac#229.
+        let accountId = activeAccount.id
+
         let recipient: NewChatRecipient?
         if let resolvedNewChatRecipient {
             recipient = resolvedNewChatRecipient
@@ -121,6 +129,7 @@ extension WorkspaceState {
                 description: trimmedDescription.isEmpty ? nil : trimmedDescription
             )
             await reloadChats()
+            guard activeAccountId == accountId else { return }
             insertCreatedChatIfNeeded(
                 groupIdHex: groupIdHex,
                 title: trimmedName.isEmpty ? recipient.title : trimmedName,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7219,6 +7219,62 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func createNewChatDoesNotGraftGroupOntoAccountSwitchedToMidCreate() async throws {
+        // Issue #229: `createNewChat()` suspends across `createGroup`/`reloadChats`. If the active
+        // account changes (e.g. a notification tap) while suspended, the group created under
+        // account A must not be inserted into / selected / loaded under account B's context. The
+        // post-await `activeAccountId == accountId` guard drops the stale UI mutations.
+        let accountA = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == "Desktop Account")
+
+        state.showNewChat()
+        state.newChatQuery = "npub1alice"
+        state.newChatName = "Project Room"
+
+        // Arm the gate so the create suspends in-flight inside `createGroup`.
+        runtime.createGroupGateEnabled = true
+        async let pendingCreate: Void = state.createNewChat()
+        while !runtime.didReachCreateGroupGate {
+            await Task.yield()
+        }
+
+        // Switch to account B while the create is suspended. Drop the runtime's shared group
+        // fixture so B's own `reloadChats()` does not legitimately surface the created group —
+        // isolating the assertion to the cross-account contamination path under test.
+        runtime.installGroups([])
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.selectAccountFromSettings(backupAccount)
+        #expect(state.activeAccountId == "Backup Account")
+
+        // Release the stale create. Its post-await mutations must be dropped under B's context.
+        runtime.releaseCreateGroupGate()
+        _ = await pendingCreate
+
+        #expect(state.activeAccountId == "Backup Account")
+        #expect(state.selection != .chat("created-group"))
+        #expect(!state.activeChats.contains { $0.id == "created-group" })
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
     @Test func resolvingNewChatRecipientUsesProfilePicture() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -9016,6 +9072,13 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var accountKeyPackagesGateEnabled = false
     private(set) var didReachAccountKeyPackagesGate = false
     private var accountKeyPackagesGateContinuation: CheckedContinuation<Void, Never>?
+    /// Issue #229 stale-account-test support: when armed, the first `createGroup` FFI call suspends
+    /// until `releaseCreateGroupGate()` is invoked, holding `createNewChat()` in-flight so a test can
+    /// switch the active account before the create resolves and assert the freshly created group is
+    /// not grafted onto / selected under the switched-to account.
+    var createGroupGateEnabled = false
+    private(set) var didReachCreateGroupGate = false
+    private var createGroupGateContinuation: CheckedContinuation<Void, Never>?
     /// Per-account key packages keyed by `accountRef`. Falls back to the default `keyPackages`
     /// fixture when an account has no explicit install, so existing single-account tests are
     /// unaffected.
@@ -9476,7 +9539,21 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
             groupDetailsById[group.groupIdHex] = details
             groupManagementStateById[group.groupIdHex] = defaultGroupManagementState(for: details)
         }
+        await passCreateGroupGateIfArmed()
         return "created-group"
+    }
+
+    private func passCreateGroupGateIfArmed() async {
+        guard createGroupGateEnabled, createGroupGateContinuation == nil, !didReachCreateGroupGate else { return }
+        didReachCreateGroupGate = true
+        await withCheckedContinuation { continuation in
+            createGroupGateContinuation = continuation
+        }
+    }
+
+    func releaseCreateGroupGate() {
+        createGroupGateContinuation?.resume()
+        createGroupGateContinuation = nil
     }
 
     func acceptGroupInvite(accountRef: String, groupIdHex: String) async throws -> AppGroupRecordFfi {


### PR DESCRIPTION
Closes #229

## Summary
- Captures the account that started `createNewChat()` and re-checks it after `createGroup` + `reloadChats()` complete.
- Drops stale post-await UI mutations when the active account changed, preventing the newly-created group from being inserted, selected, or loaded under the switched-to account.
- Adds a regression test that gates the fake `createGroup` call, switches accounts while the create is suspended, and verifies the stale group is not grafted into the active account state.

## Verification
- `git diff --check` — pass
- `bash -n scripts/ci/macos-sanity-checks.sh` — pass
- `command -v xcodebuild xcrun swift swift-format` — all missing on this Linux host, so macOS-only Xcode/Swift checks were not run locally

Pending on macOS CI:
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests`
- `scripts/ci/macos-sanity-checks.sh`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' -resultBundlePath TestResults.xcresult -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO`
- Release build smoke
- Static analysis

## Sensitive paths
none — UI/workspace-state and test harness only.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/234">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented new chats from being attached to the wrong workspace if the active account changes during creation.
  * New chats now stop early when the account switches mid-process, avoiding incorrect selection and loading.

* **Tests**
  * Added regression coverage for the mid-creation account-switch scenario.
  * Improved test support to reliably pause and resume chat creation during the scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->