### PR TITLE
fix: guard notification settings writes after account switch

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -84,6 +84,7 @@ extension WorkspaceState {
         stopChatListListener()
         clearEnteredLoginIdentity()
         activeAccountId = account.id
+        invalidateNotificationSettingsOperations()
         UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
         searchText = ""
         closeNewChatComposer()
@@ -261,6 +262,7 @@ extension WorkspaceState {
 
             if accounts.isEmpty {
                 activeAccountId = nil
+                invalidateNotificationSettingsOperations()
                 UserDefaults.standard.removeObject(forKey: Self.activeAccountKey)
                 selection = nil
                 phase = .onboarding
@@ -335,6 +337,7 @@ extension WorkspaceState {
                 await loadSettingsData()
             } else {
                 activeAccountId = nil
+                invalidateNotificationSettingsOperations()
                 UserDefaults.standard.removeObject(forKey: Self.activeAccountKey)
                 selection = nil
                 phase = .onboarding
@@ -431,6 +434,7 @@ extension WorkspaceState {
             return
         }
         activeAccountId = accounts.first?.id
+        invalidateNotificationSettingsOperations()
         if let activeAccountId {
             UserDefaults.standard.set(activeAccountId, forKey: Self.activeAccountKey)
         }
@@ -447,6 +451,7 @@ extension WorkspaceState {
 
         accounts = refreshed
         activeAccountId = preferredAccount.id
+        invalidateNotificationSettingsOperations()
         UserDefaults.standard.set(preferredAccount.id, forKey: Self.activeAccountKey)
         searchText = ""
         clearAllComposerDrafts()
@@ -484,6 +489,7 @@ extension WorkspaceState {
         RemoteImageLoader.shared.clearCache()
         observabilityRuntimeConfiguration = nil
         activeAccountId = nil
+        invalidateNotificationSettingsOperations()
         selection = nil
         searchText = ""
         isChatListVisible = true

--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -148,9 +148,15 @@ extension WorkspaceState {
         })
     }
 
-    func handleNotificationPermissionError(_ error: Error) async {
+    func handleNotificationPermissionError(
+        _ error: Error,
+        shouldApply: @MainActor () -> Bool = { true }
+    ) async {
+        let status = await localNotificationCenter.authorizationStatus()
+        guard shouldApply() else { return }
+
+        notificationAuthorizationStatus = status
         if isNotificationsNotAllowedError(error) {
-            await refreshNotificationAuthorizationStatus()
             if !notificationAuthorizationStatus.canPostNotifications {
                 notificationAuthorizationStatus = .denied
             }
@@ -159,7 +165,6 @@ extension WorkspaceState {
         }
 
         lastError = error.localizedDescription
-        await refreshNotificationAuthorizationStatus()
     }
 
     func isNotificationsNotAllowedError(_ error: Error) -> Bool {

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -178,6 +178,21 @@ extension WorkspaceState {
         notificationAuthorizationStatus = await localNotificationCenter.authorizationStatus()
     }
 
+    func beginNotificationSettingsOperation() -> UInt64 {
+        notificationSettingsGeneration &+= 1
+        return notificationSettingsGeneration
+    }
+
+    func invalidateNotificationSettingsOperations() {
+        notificationSettingsGeneration &+= 1
+    }
+
+    func ownsNotificationSettingsOperation(accountId: String, generation: UInt64) -> Bool {
+        !Task.isCancelled
+            && activeAccountId == accountId
+            && notificationSettingsGeneration == generation
+    }
+
     func requestLocalNotificationPermission() async {
         lastError = nil
         do {
@@ -195,6 +210,7 @@ extension WorkspaceState {
 
         let accountId = activeAccount.id
         let accountRef = activeAccount.accountRef
+        let generation = beginNotificationSettingsOperation()
 
         lastError = nil
         isSavingNotifications = true
@@ -205,15 +221,20 @@ extension WorkspaceState {
             if !status.canPostNotifications {
                 do {
                     status = try await localNotificationCenter.requestAuthorization()
+                    let isCurrent = ownsNotificationSettingsOperation(accountId: accountId, generation: generation)
+                    guard isCurrent else { return }
                     notificationAuthorizationStatus = status
                 } catch {
-                    guard !Task.isCancelled, activeAccountId == accountId else { return }
-                    await handleNotificationPermissionError(error)
+                    let isCurrent = ownsNotificationSettingsOperation(accountId: accountId, generation: generation)
+                    guard isCurrent else { return }
+                    await handleNotificationPermissionError(error) { [accountId, generation] in
+                        self.ownsNotificationSettingsOperation(accountId: accountId, generation: generation)
+                    }
                     return
                 }
             }
 
-            guard !Task.isCancelled, activeAccountId == accountId else { return }
+            guard ownsNotificationSettingsOperation(accountId: accountId, generation: generation) else { return }
             guard status.canPostNotifications else {
                 lastError = Self.notificationPermissionGuidance
                 return
@@ -227,10 +248,10 @@ extension WorkspaceState {
                     enabled: enabled
                 )
             }
-            guard !Task.isCancelled, activeAccountId == accountId else { return }
+            guard ownsNotificationSettingsOperation(accountId: accountId, generation: generation) else { return }
             notificationSettings = NotificationSettingsSnapshot(settings: settings)
         } catch {
-            guard !Task.isCancelled, activeAccountId == accountId else { return }
+            guard ownsNotificationSettingsOperation(accountId: accountId, generation: generation) else { return }
             lastError = error.localizedDescription
         }
     }
@@ -394,15 +415,16 @@ extension WorkspaceState {
 
         let accountId = activeAccount.id
         let accountRef = activeAccount.accountRef
+        let generation = beginNotificationSettingsOperation()
 
         do {
             let settings = try await runOffMain {
                 try client.notificationSettings(accountRef: accountRef)
             }
-            guard !Task.isCancelled, activeAccountId == accountId else { return }
+            guard ownsNotificationSettingsOperation(accountId: accountId, generation: generation) else { return }
             notificationSettings = NotificationSettingsSnapshot(settings: settings)
         } catch {
-            guard !Task.isCancelled, activeAccountId == accountId else { return }
+            guard ownsNotificationSettingsOperation(accountId: accountId, generation: generation) else { return }
             notificationSettings = .defaults
             lastError = error.localizedDescription
         }

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -193,6 +193,9 @@ extension WorkspaceState {
     func setLocalNotificationsEnabled(_ enabled: Bool) async {
         guard let client, let activeAccount, !isSavingNotifications else { return }
 
+        let accountId = activeAccount.id
+        let accountRef = activeAccount.accountRef
+
         lastError = nil
         isSavingNotifications = true
         defer { isSavingNotifications = false }
@@ -204,18 +207,18 @@ extension WorkspaceState {
                     status = try await localNotificationCenter.requestAuthorization()
                     notificationAuthorizationStatus = status
                 } catch {
+                    guard !Task.isCancelled, activeAccountId == accountId else { return }
                     await handleNotificationPermissionError(error)
                     return
                 }
             }
 
+            guard !Task.isCancelled, activeAccountId == accountId else { return }
             guard status.canPostNotifications else {
                 lastError = Self.notificationPermissionGuidance
                 return
             }
         }
-
-        let accountRef = activeAccount.accountRef
 
         do {
             let settings = try await runOffMain {
@@ -224,8 +227,10 @@ extension WorkspaceState {
                     enabled: enabled
                 )
             }
+            guard !Task.isCancelled, activeAccountId == accountId else { return }
             notificationSettings = NotificationSettingsSnapshot(settings: settings)
         } catch {
+            guard !Task.isCancelled, activeAccountId == accountId else { return }
             lastError = error.localizedDescription
         }
     }
@@ -387,13 +392,17 @@ extension WorkspaceState {
             return
         }
 
+        let accountId = activeAccount.id
+        let accountRef = activeAccount.accountRef
+
         do {
-            let accountRef = activeAccount.accountRef
             let settings = try await runOffMain {
                 try client.notificationSettings(accountRef: accountRef)
             }
+            guard !Task.isCancelled, activeAccountId == accountId else { return }
             notificationSettings = NotificationSettingsSnapshot(settings: settings)
         } catch {
+            guard !Task.isCancelled, activeAccountId == accountId else { return }
             notificationSettings = .defaults
             lastError = error.localizedDescription
         }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -633,6 +633,10 @@ final class WorkspaceState {
     /// wraparound, and wrapping avoids overflow traps (issue #182). See `loadSettingsData` /
     /// issue #4.
     var settingsLoadGeneration: UInt64 = 0
+    /// Monotonic token for notification-settings reads/writes. Unlike `activeAccountId`, this
+    /// bumps on every active-account transition, so an older A request cannot commit after a rapid
+    /// A→B→A re-entry or after a newer notification load/toggle for the same account.
+    var notificationSettingsGeneration: UInt64 = 0
     var timelineTask: Task<Void, Never>?
     var timelineTaskGroupId: String?
     /// The live timeline subscription for the open conversation. It owns the

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -37,6 +37,42 @@ private final class MutableFlag: @unchecked Sendable {
     }
 }
 
+private final class BlockingFfiGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var enabled = false
+    private var semaphore: DispatchSemaphore?
+    private var reached = false
+
+    var isEnabled: Bool {
+        get { lock.withLock { enabled } }
+        set { lock.withLock { enabled = newValue } }
+    }
+
+    var didReach: Bool {
+        lock.withLock { reached }
+    }
+
+    func passIfArmed() {
+        let semaphore = lock.withLock { () -> DispatchSemaphore? in
+            guard enabled, self.semaphore == nil, !reached else { return nil }
+            reached = true
+            let semaphore = DispatchSemaphore(value: 0)
+            self.semaphore = semaphore
+            return semaphore
+        }
+        semaphore?.wait()
+    }
+
+    func release() {
+        let semaphore = lock.withLock { () -> DispatchSemaphore? in
+            let semaphore = self.semaphore
+            self.semaphore = nil
+            return semaphore
+        }
+        semaphore?.signal()
+    }
+}
+
 private final class ObservationInvalidationFlag: @unchecked Sendable {
     private let lock = NSLock()
     private var invalidated = false
@@ -7733,6 +7769,70 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func staleNotificationSettingsLoadDoesNotClobberReenteredAccountSettings() async throws {
+        // A monotonic notification-settings generation closes the A→B→A hole that an id-only stale
+        // guard leaves open: the older A read must not overwrite a newer A snapshot after re-entry.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+        let accountA = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.installNotificationSettings(
+            accountRef: "Desktop Account",
+            settings: notificationSettings(for: accountA, localEnabled: true)
+        )
+        runtime.installNotificationSettings(
+            accountRef: "Backup Account",
+            settings: notificationSettings(for: accountB, localEnabled: false)
+        )
+        UserDefaults.standard.set("Desktop Account", forKey: WorkspaceState.activeAccountKey)
+        let state = WorkspaceState(
+            localNotificationCenter: FakeLocalNotificationCenter(status: .authorized),
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.notificationSettings.localNotificationsEnabled)
+
+        runtime.notificationSettingsGateEnabled = true
+        async let staleLoad: Void = state.loadNotificationSettings()
+        while !runtime.didReachNotificationSettingsGate {
+            await Task.yield()
+        }
+
+        runtime.installNotificationSettings(
+            accountRef: "Desktop Account",
+            settings: notificationSettings(for: accountA, localEnabled: false)
+        )
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.selectAccountFromSettings(backupAccount)
+        let desktopAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+        state.selectAccountFromSettings(desktopAccount)
+        await state.loadNotificationSettings()
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+
+        runtime.releaseNotificationSettingsGate()
+        _ = await staleLoad
+
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
     @Test func staleLocalNotificationToggleDoesNotClobberSwitchedAccountSettings() async throws {
         // Issue #228: `setLocalNotificationsEnabled(_:)` also awaits an FFI write before publishing
         // the returned snapshot. A stale account A toggle must not overwrite account B's snapshot.
@@ -7786,6 +7886,134 @@ struct whitenoise_macTests {
 
         #expect(runtime.localNotificationsEnabledSet == true)
         #expect(state.notificationSettings.localNotificationsEnabled == false)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
+    @Test func staleLocalNotificationToggleDoesNotClobberReenteredAccountSettings() async throws {
+        // The stale toggle returns an older A snapshot after the user has switched A→B→A and loaded
+        // a newer A snapshot. The generation guard must keep the newer A value.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+        let accountA = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.installNotificationSettings(
+            accountRef: "Desktop Account",
+            settings: notificationSettings(for: accountA, localEnabled: false)
+        )
+        runtime.installNotificationSettings(
+            accountRef: "Backup Account",
+            settings: notificationSettings(for: accountB, localEnabled: false)
+        )
+        UserDefaults.standard.set("Desktop Account", forKey: WorkspaceState.activeAccountKey)
+        let state = WorkspaceState(
+            localNotificationCenter: FakeLocalNotificationCenter(status: .authorized),
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+
+        runtime.setLocalNotificationsGateEnabled = true
+        async let staleToggle: Void = state.setLocalNotificationsEnabled(true)
+        while !runtime.didReachSetLocalNotificationsGate {
+            await Task.yield()
+        }
+
+        runtime.installNotificationSettings(
+            accountRef: "Desktop Account",
+            settings: notificationSettings(for: accountA, localEnabled: false)
+        )
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.selectAccountFromSettings(backupAccount)
+        let desktopAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+        state.selectAccountFromSettings(desktopAccount)
+        await state.loadNotificationSettings()
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+
+        runtime.releaseSetLocalNotificationsGate()
+        _ = await staleToggle
+
+        #expect(runtime.localNotificationsEnabledSet == true)
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
+    @Test func staleLocalNotificationPermissionRequestDoesNotPublishAuthorizationAfterSwitch() async throws {
+        // If account A is waiting on the macOS permission sheet and the user switches accounts, the
+        // eventual permission result must not update the now-current account's UI snapshot.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+        let accountA = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.installNotificationSettings(
+            accountRef: "Desktop Account",
+            settings: notificationSettings(for: accountA, localEnabled: false)
+        )
+        runtime.installNotificationSettings(
+            accountRef: "Backup Account",
+            settings: notificationSettings(for: accountB, localEnabled: false)
+        )
+        UserDefaults.standard.set("Desktop Account", forKey: WorkspaceState.activeAccountKey)
+        let notificationCenter = FakeLocalNotificationCenter(
+            status: .notDetermined,
+            requestedStatus: .authorized
+        )
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.notificationAuthorizationStatus == .notDetermined)
+
+        notificationCenter.requestAuthorizationGateEnabled = true
+        async let staleToggle: Void = state.setLocalNotificationsEnabled(true)
+        while !notificationCenter.didReachRequestAuthorizationGate {
+            await Task.yield()
+        }
+
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.selectAccountFromSettings(backupAccount)
+        #expect(state.activeAccountId == "Backup Account")
+
+        notificationCenter.releaseRequestAuthorizationGate()
+        _ = await staleToggle
+
+        #expect(notificationCenter.didRequestAuthorization)
+        #expect(runtime.localNotificationsEnabledSet == nil)
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+        #expect(state.notificationAuthorizationStatus == .notDetermined)
         #expect(state.lastError == nil)
     }
 
@@ -9201,20 +9429,22 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// Issue #228 last-request-wins support for synchronous notification FFI reads: when armed,
     /// the first `notificationSettings` call blocks on the FFI queue until released, holding an
     /// older account's result while the test switches accounts and loads the newer snapshot.
-    var notificationSettingsGateEnabled = false
-    private let notificationSettingsGateLock = NSLock()
-    private var notificationSettingsGateSemaphore: DispatchSemaphore?
-    private var _didReachNotificationSettingsGate = false
+    private let notificationSettingsGate = BlockingFfiGate()
+    var notificationSettingsGateEnabled: Bool {
+        get { notificationSettingsGate.isEnabled }
+        set { notificationSettingsGate.isEnabled = newValue }
+    }
     var didReachNotificationSettingsGate: Bool {
-        notificationSettingsGateLock.withLock { _didReachNotificationSettingsGate }
+        notificationSettingsGate.didReach
     }
     /// Issue #228 equivalent gate for the synchronous `setLocalNotificationsEnabled` FFI write.
-    var setLocalNotificationsGateEnabled = false
-    private let setLocalNotificationsGateLock = NSLock()
-    private var setLocalNotificationsGateSemaphore: DispatchSemaphore?
-    private var _didReachSetLocalNotificationsGate = false
+    private let setLocalNotificationsGate = BlockingFfiGate()
+    var setLocalNotificationsGateEnabled: Bool {
+        get { setLocalNotificationsGate.isEnabled }
+        set { setLocalNotificationsGate.isEnabled = newValue }
+    }
     var didReachSetLocalNotificationsGate: Bool {
-        setLocalNotificationsGateLock.withLock { _didReachSetLocalNotificationsGate }
+        setLocalNotificationsGate.didReach
     }
     /// Per-account key packages keyed by `accountRef`. Falls back to the default `keyPackages`
     /// fixture when an account has no explicit install, so existing single-account tests are
@@ -9556,25 +9786,11 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     private func passNotificationSettingsGateIfArmed() {
-        let semaphore = notificationSettingsGateLock.withLock { () -> DispatchSemaphore? in
-            guard notificationSettingsGateEnabled, notificationSettingsGateSemaphore == nil,
-                !_didReachNotificationSettingsGate
-            else { return nil }
-            _didReachNotificationSettingsGate = true
-            let semaphore = DispatchSemaphore(value: 0)
-            notificationSettingsGateSemaphore = semaphore
-            return semaphore
-        }
-        semaphore?.wait()
+        notificationSettingsGate.passIfArmed()
     }
 
     func releaseNotificationSettingsGate() {
-        let semaphore = notificationSettingsGateLock.withLock { () -> DispatchSemaphore? in
-            let semaphore = notificationSettingsGateSemaphore
-            notificationSettingsGateSemaphore = nil
-            return semaphore
-        }
-        semaphore?.signal()
+        notificationSettingsGate.release()
     }
 
     func postAuditLogTrackerUpdate() async throws -> AuditLogTrackerUpdateResultFfi {
@@ -9614,25 +9830,11 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     private func passSetLocalNotificationsGateIfArmed() {
-        let semaphore = setLocalNotificationsGateLock.withLock { () -> DispatchSemaphore? in
-            guard setLocalNotificationsGateEnabled, setLocalNotificationsGateSemaphore == nil,
-                !_didReachSetLocalNotificationsGate
-            else { return nil }
-            _didReachSetLocalNotificationsGate = true
-            let semaphore = DispatchSemaphore(value: 0)
-            setLocalNotificationsGateSemaphore = semaphore
-            return semaphore
-        }
-        semaphore?.wait()
+        setLocalNotificationsGate.passIfArmed()
     }
 
     func releaseSetLocalNotificationsGate() {
-        let semaphore = setLocalNotificationsGateLock.withLock { () -> DispatchSemaphore? in
-            let semaphore = setLocalNotificationsGateSemaphore
-            setLocalNotificationsGateSemaphore = nil
-            return semaphore
-        }
-        semaphore?.signal()
+        setLocalNotificationsGate.release()
     }
 
     func setRelayTelemetryRuntimeConfig(config: RelayTelemetryRuntimeConfigFfi) async throws {
@@ -10680,6 +10882,9 @@ private final class FakeLocalNotificationCenter: LocalNotificationCenter {
     private let requestError: Error?
     private let postError: Error?
     private(set) var didRequestAuthorization = false
+    var requestAuthorizationGateEnabled = false
+    private(set) var didReachRequestAuthorizationGate = false
+    private var requestAuthorizationGateContinuation: CheckedContinuation<Void, Never>?
     private(set) var postedRequests: [LocalNotificationRequest] = []
     private var responseHandler: (@MainActor ([String: String]) -> Void)?
 
@@ -10701,11 +10906,22 @@ private final class FakeLocalNotificationCenter: LocalNotificationCenter {
 
     func requestAuthorization() async throws -> LocalNotificationAuthorizationStatus {
         didRequestAuthorization = true
+        if requestAuthorizationGateEnabled {
+            didReachRequestAuthorizationGate = true
+            await withCheckedContinuation { continuation in
+                requestAuthorizationGateContinuation = continuation
+            }
+        }
         if let requestError {
             throw requestError
         }
         status = requestedStatus
         return status
+    }
+
+    func releaseRequestAuthorizationGate() {
+        requestAuthorizationGateContinuation?.resume()
+        requestAuthorizationGateContinuation = nil
     }
 
     func post(_ notification: LocalNotificationRequest) async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7676,6 +7676,120 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func staleNotificationSettingsLoadDoesNotClobberSwitchedAccountSettings() async throws {
+        // Issue #228: `loadNotificationSettings()` reads over the non-cancellation-aware FFI
+        // boundary. If account A's read completes after switching to account B, its result must not
+        // overwrite B's published notification preference.
+        let accountA = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.installNotificationSettings(
+            accountRef: "Desktop Account",
+            settings: notificationSettings(for: accountA, localEnabled: true)
+        )
+        runtime.installNotificationSettings(
+            accountRef: "Backup Account",
+            settings: notificationSettings(for: accountB, localEnabled: false)
+        )
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(
+            localNotificationCenter: FakeLocalNotificationCenter(status: .authorized),
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.notificationSettings.localNotificationsEnabled)
+
+        runtime.notificationSettingsGateEnabled = true
+        async let staleLoad: Void = state.loadNotificationSettings()
+        while !runtime.didReachNotificationSettingsGate {
+            await Task.yield()
+        }
+
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.selectAccountFromSettings(backupAccount)
+        #expect(state.activeAccountId == "Backup Account")
+        await state.loadNotificationSettings()
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+
+        runtime.releaseNotificationSettingsGate()
+        _ = await staleLoad
+
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
+    @Test func staleLocalNotificationToggleDoesNotClobberSwitchedAccountSettings() async throws {
+        // Issue #228: `setLocalNotificationsEnabled(_:)` also awaits an FFI write before publishing
+        // the returned snapshot. A stale account A toggle must not overwrite account B's snapshot.
+        let accountA = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.installNotificationSettings(
+            accountRef: "Desktop Account",
+            settings: notificationSettings(for: accountA, localEnabled: false)
+        )
+        runtime.installNotificationSettings(
+            accountRef: "Backup Account",
+            settings: notificationSettings(for: accountB, localEnabled: false)
+        )
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(
+            localNotificationCenter: FakeLocalNotificationCenter(status: .authorized),
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+
+        runtime.setLocalNotificationsGateEnabled = true
+        async let staleToggle: Void = state.setLocalNotificationsEnabled(true)
+        while !runtime.didReachSetLocalNotificationsGate {
+            await Task.yield()
+        }
+
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.selectAccountFromSettings(backupAccount)
+        #expect(state.activeAccountId == "Backup Account")
+        await state.loadNotificationSettings()
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+
+        runtime.releaseSetLocalNotificationsGate()
+        _ = await staleToggle
+
+        #expect(runtime.localNotificationsEnabledSet == true)
+        #expect(state.notificationSettings.localNotificationsEnabled == false)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
     @Test func telemetryBuildConfigUsesSeparateMacBuildSettings() async throws {
         let config = TelemetryBuildConfig.current(
             infoDictionary: [
@@ -9084,6 +9198,24 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var createGroupGateEnabled = false
     private(set) var didReachCreateGroupGate = false
     private var createGroupGateContinuation: CheckedContinuation<Void, Never>?
+    /// Issue #228 last-request-wins support for synchronous notification FFI reads: when armed,
+    /// the first `notificationSettings` call blocks on the FFI queue until released, holding an
+    /// older account's result while the test switches accounts and loads the newer snapshot.
+    var notificationSettingsGateEnabled = false
+    private let notificationSettingsGateLock = NSLock()
+    private var notificationSettingsGateSemaphore: DispatchSemaphore?
+    private var _didReachNotificationSettingsGate = false
+    var didReachNotificationSettingsGate: Bool {
+        notificationSettingsGateLock.withLock { _didReachNotificationSettingsGate }
+    }
+    /// Issue #228 equivalent gate for the synchronous `setLocalNotificationsEnabled` FFI write.
+    var setLocalNotificationsGateEnabled = false
+    private let setLocalNotificationsGateLock = NSLock()
+    private var setLocalNotificationsGateSemaphore: DispatchSemaphore?
+    private var _didReachSetLocalNotificationsGate = false
+    var didReachSetLocalNotificationsGate: Bool {
+        setLocalNotificationsGateLock.withLock { _didReachSetLocalNotificationsGate }
+    }
     /// Per-account key packages keyed by `accountRef`. Falls back to the default `keyPackages`
     /// fixture when an account has no explicit install, so existing single-account tests are
     /// unaffected.
@@ -9098,6 +9230,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         localNotificationsEnabled: false,
         nativePushEnabled: false
     )
+    private var notificationSettingsByAccountRef: [String: NotificationSettingsFfi] = [:]
     var storedAuditLogSettings = AuditLogSettingsFfi(enabled: false, dataMode: .obfuscatedSensitiveData)
     var storedAuditLogFiles: [AuditLogFileFfi] = []
     var auditLogDeleteFailurePaths: Set<String> = []
@@ -9413,7 +9546,35 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func notificationSettings(accountRef: String) throws -> NotificationSettingsFfi {
         recordSyncCall("notificationSettings")
-        return notificationSettings
+        let result = notificationSettingsByAccountRef[accountRef] ?? notificationSettings
+        passNotificationSettingsGateIfArmed()
+        return result
+    }
+
+    func installNotificationSettings(accountRef: String, settings: NotificationSettingsFfi) {
+        notificationSettingsByAccountRef[accountRef] = settings
+    }
+
+    private func passNotificationSettingsGateIfArmed() {
+        let semaphore = notificationSettingsGateLock.withLock { () -> DispatchSemaphore? in
+            guard notificationSettingsGateEnabled, notificationSettingsGateSemaphore == nil,
+                !_didReachNotificationSettingsGate
+            else { return nil }
+            _didReachNotificationSettingsGate = true
+            let semaphore = DispatchSemaphore(value: 0)
+            notificationSettingsGateSemaphore = semaphore
+            return semaphore
+        }
+        semaphore?.wait()
+    }
+
+    func releaseNotificationSettingsGate() {
+        let semaphore = notificationSettingsGateLock.withLock { () -> DispatchSemaphore? in
+            let semaphore = notificationSettingsGateSemaphore
+            notificationSettingsGateSemaphore = nil
+            return semaphore
+        }
+        semaphore?.signal()
     }
 
     func postAuditLogTrackerUpdate() async throws -> AuditLogTrackerUpdateResultFfi {
@@ -9441,8 +9602,37 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func setLocalNotificationsEnabled(accountRef: String, enabled: Bool) throws -> NotificationSettingsFfi {
         recordSyncCall("setLocalNotificationsEnabled")
         localNotificationsEnabledSet = enabled
-        notificationSettings.localNotificationsEnabled = enabled
-        return notificationSettings
+        var updated = notificationSettingsByAccountRef[accountRef] ?? notificationSettings
+        updated.localNotificationsEnabled = enabled
+        if notificationSettingsByAccountRef[accountRef] != nil {
+            notificationSettingsByAccountRef[accountRef] = updated
+        } else {
+            notificationSettings = updated
+        }
+        passSetLocalNotificationsGateIfArmed()
+        return updated
+    }
+
+    private func passSetLocalNotificationsGateIfArmed() {
+        let semaphore = setLocalNotificationsGateLock.withLock { () -> DispatchSemaphore? in
+            guard setLocalNotificationsGateEnabled, setLocalNotificationsGateSemaphore == nil,
+                !_didReachSetLocalNotificationsGate
+            else { return nil }
+            _didReachSetLocalNotificationsGate = true
+            let semaphore = DispatchSemaphore(value: 0)
+            setLocalNotificationsGateSemaphore = semaphore
+            return semaphore
+        }
+        semaphore?.wait()
+    }
+
+    func releaseSetLocalNotificationsGate() {
+        let semaphore = setLocalNotificationsGateLock.withLock { () -> DispatchSemaphore? in
+            let semaphore = setLocalNotificationsGateSemaphore
+            setLocalNotificationsGateSemaphore = nil
+            return semaphore
+        }
+        semaphore?.signal()
     }
 
     func setRelayTelemetryRuntimeConfig(config: RelayTelemetryRuntimeConfigFfi) async throws {


### PR DESCRIPTION
## Summary
- capture the active account id before notification settings FFI calls
- drop stale `loadNotificationSettings()` success/error writes after an account switch
- drop stale `setLocalNotificationsEnabled(_:)` success/error writes after an account switch
- add regression coverage for stale notification settings loads and toggles

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' -- . || true`
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` (not run: `xcodebuild` is not installed on this Linux worker)
- `scripts/ci/macos-sanity-checks.sh` (not run: `xcodebuild` is not installed on this Linux worker)
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` (not run: `xcrun` is not installed on this Linux worker)

Closes #228


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification settings and permission updates so they no longer overwrite the current account’s preferences after switching accounts or restoring a previous account.
  * Improved reliability of notification changes during account sign-in, sign-out, refresh, and app reset flows.
  * Reduced cases where outdated notification permission results could briefly show incorrect settings or error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->