### PR TITLE
Hardening: reject media cache stores during full wipe

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -214,8 +214,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     }
 
     func store(_ download: MessageMediaDownload, for key: MessageMediaDiskCacheKey) async {
-        await waitForActivePurge()
-        let startGeneration = currentGeneration()
+        guard let start = beginStore() else { return }
 
         let root: URL
         let symmetricKey: SymmetricKey
@@ -238,21 +237,22 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }.value
 
         guard let prepared else { return }
-        commitPreparedEntry(prepared, startGeneration: startGeneration)
+        commitPreparedEntry(prepared, startGeneration: start.generation)
     }
 
     func purgeAll(removeEncryptionKey: Bool = false) async {
         let root = try? directoryResolver()
+        let deleteKey = keyDeleter
         let task = beginPurge {
             if let root {
                 try? FileManager.default.removeItem(at: root)
             }
+            if removeEncryptionKey {
+                deleteKey()
+            }
         }
         await task.task.value
         finishPurge(task)
-        if removeEncryptionKey {
-            keyDeleter()
-        }
     }
 
     func purgeAccount(_ accountId: String) async {
@@ -301,6 +301,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return generation
+    }
+
+    private func beginStore() -> StoreHandle? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard purgeTask == nil else { return nil }
+        return StoreHandle(generation: generation)
     }
 
     private func beginPurge(_ work: @escaping @Sendable () -> Void) -> PurgeHandle {
@@ -360,6 +367,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private struct PreparedEntry {
         let stagingDirectory: URL
         let finalDirectory: URL
+    }
+
+    private struct StoreHandle {
+        let generation: Int
     }
 
     private struct PurgeHandle {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1042,6 +1042,52 @@ struct whitenoise_macTests {
         #expect(!fileManager.fileExists(atPath: root.path))
     }
 
+    @Test func messageMediaDiskCacheRejectsDirectStoreDuringFullWipe() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let keyProviderCalls = AtomicCounter()
+        let deleterEntered = DispatchSemaphore(value: 0)
+        let releaseDeleter = DispatchSemaphore(value: 0)
+        let cache = MessageMediaDiskCache(
+            directoryResolver: { root },
+            keyProvider: {
+                keyProviderCalls.increment()
+                return SymmetricKey(data: Data(repeating: 0x42, count: 32))
+            },
+            keyDeleter: {
+                deleterEntered.signal()
+                _ = releaseDeleter.wait(timeout: .now() + 5)
+            }
+        )
+        let plaintext = Data("store racing full wipe".utf8)
+        let reference = mediaDiskCacheReference(plaintext: plaintext)
+        let key = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: reference)
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "race.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(plaintext.count),
+            payloadId: "network-download"
+        )
+
+        let purge = Task {
+            await cache.purgeAll(removeEncryptionKey: true)
+        }
+        #expect(deleterEntered.wait(timeout: .now() + 2) == .success)
+
+        await cache.store(download, for: key)
+        #expect(keyProviderCalls.value == 0)
+        #expect(!fileManager.fileExists(atPath: root.path))
+
+        releaseDeleter.signal()
+        await purge.value
+        #expect(keyProviderCalls.value == 0)
+        #expect(!fileManager.fileExists(atPath: root.path))
+    }
+
     @MainActor
     @Test func chatSearchMatchesTitleSubtitleAndPreview() async throws {
         let chats = ChatItem.samples


### PR DESCRIPTION
## Summary
- reject direct `MessageMediaDiskCache.store(...)` calls that begin while a cache purge is active
- keep full-wipe key deletion inside the purge window so stores cannot recreate the cache root/key between root removal and key deletion
- add a focused regression test for a direct store racing `purgeAll(removeEncryptionKey: true)`

## Test Plan
- `git diff --check`
- `xcodebuild -version` (not available on this Linux host)
- `swift --version` (not available on this Linux host)

Closes #236


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/237">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->