### PR TITLE
Simplicity & performance pass (audit) + two fixes

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -72,7 +72,7 @@ extension ChatItem {
 
         let presentation = MessageItem.presentation(for: preview.kind)
         let text = MessageItem.displayText(
-            kind: preview.kind,
+            presentation: presentation,
             plaintext: preview.plaintext,
             tags: [],
             deleted: preview.deleted,
@@ -104,19 +104,6 @@ extension ChatItem {
 }
 
 extension MessageItem {
-    init(record: TimelineMessageRecordFfi, activeAccountIdHex: String?) {
-        self.init(
-            record: record,
-            activeAccountIdHex: activeAccountIdHex,
-            senderProfiles: [:],
-            reactions: MessageReaction.summarize(record.reactions, activeAccountIdHex: activeAccountIdHex),
-            replyContext: MessageItem.replyContext(
-                for: record.replyPreview,
-                senderProfiles: [:]
-            )
-        )
-    }
-
     private init(
         record: TimelineMessageRecordFfi,
         activeAccountIdHex: String?,
@@ -135,7 +122,7 @@ extension MessageItem {
         let body =
             MessageItem.systemText(record.groupSystem)
             ?? MessageItem.displayText(
-                kind: record.kind,
+                presentation: presentation,
                 plaintext: record.plaintext,
                 tags: record.tags,
                 deleted: record.deleted,
@@ -271,7 +258,7 @@ extension MessageItem {
     }
 
     fileprivate static func displayText(
-        kind: UInt64,
+        presentation: MessagePresentation,
         plaintext: String,
         tags: [MessageTagFfi],
         deleted: Bool,
@@ -287,20 +274,11 @@ extension MessageItem {
         }
 
         let body = plaintext.trimmingCharacters(in: .whitespacesAndNewlines)
-        let messagePresentation = presentation(for: kind)
 
-        // Plain chat messages never consult the JSON payload, so skip decoding it for
-        // the common case (this runs for every message during mapping).
-        if case .chat = messagePresentation {
-            if !body.isEmpty {
-                return body
-            }
-            return hasMediaAttachments ? "" : L10n.string("Unsupported message")
-        }
-
-        let payload = TimelinePayload.decode(from: body)
-
-        switch messagePresentation {
+        // Only the agent / group-system rows consult the JSON payload, so each of those
+        // cases decodes it locally — the common chat path (and agent-stream-start) never
+        // pays for the decode. This runs for every message during mapping.
+        switch presentation {
         case .chat:
             if !body.isEmpty {
                 return body
@@ -312,12 +290,14 @@ extension MessageItem {
             }
             return L10n.string("Agent started a response")
         case .agentActivity:
+            let payload = TimelinePayload.decode(from: body)
             return firstNonBlank([
                 payload?.text,
                 payload?.status.map { "\(L10n.string("Agent activity")): \(humanized($0))" },
                 payload == nil ? body : nil,
             ]) ?? L10n.string("Agent activity")
         case .agentOperation:
+            let payload = TimelinePayload.decode(from: body)
             if let text = firstNonBlank([payload?.text, payload?.preview]) {
                 return text
             }
@@ -334,6 +314,7 @@ extension MessageItem {
             }
             return L10n.string("Agent operation")
         case .groupSystem:
+            let payload = TimelinePayload.decode(from: body)
             if let text = firstNonBlank([payload?.text]) {
                 return text
             }
@@ -358,7 +339,7 @@ extension MessageItem {
             messageIdHex: preview.messageIdHex
         )
         let body = displayText(
-            kind: preview.kind,
+            presentation: presentation(for: preview.kind),
             plaintext: preview.plaintext,
             tags: [],
             deleted: preview.deleted,

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -423,9 +423,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 using: symmetricKey,
                 authenticatedBy: payloadAAD(for: key.cacheID)
             )
-            guard UInt64(plaintext.count) == metadata.sizeBytes,
-                Self.hexSHA256(plaintext) == metadata.plaintextSha256
-            else {
+            // AES-GCM `open` above already authenticates the payload against its key
+            // and AAD, so a full SHA-256 re-hash of the plaintext on every read would
+            // be redundant tamper detection. Keep only the cheap length sanity check.
+            guard UInt64(plaintext.count) == metadata.sizeBytes else {
                 try? FileManager.default.removeItem(at: entryDirectory)
                 return nil
             }

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -543,33 +543,14 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         // to sanitize. This is the network chokepoint for all remote image loads.
         guard RemoteImageURLPolicy.isAllowed(url) else { return nil }
 
-        let key = Self.cacheKey(for: url, maxPixelSize: maxPixelSize)
-        if let cached = cachedImage(for: key) {
-            return LoadedImage(nsImage: cached)
-        }
-
-        let generation = currentCacheGeneration()
-        let taskKey = Self.inFlightKey(forCacheKey: key, generation: generation)
-        let task = inFlight.task(for: taskKey) { [self] in
-            Task { [self] in
-                await loadRemoteImage(
-                    for: url,
-                    cacheKey: key,
-                    maxPixelSize: maxPixelSize,
-                    cacheGeneration: generation
-                )
-            }
-        }
-        let waiter = RemoteImageLoadWaiter { [inFlight] in
-            inFlight.releaseWaiter(for: taskKey)
-        }
-
-        return await withTaskCancellationHandler {
-            let loaded = await task.value
-            waiter.release()
-            return Task.isCancelled ? nil : loaded
-        } onCancel: {
-            waiter.release()
+        return await coalescedLoad(cacheKey: Self.cacheKey(for: url, maxPixelSize: maxPixelSize)) {
+            [self] cacheKey, generation in
+            await loadRemoteImage(
+                for: url,
+                cacheKey: cacheKey,
+                maxPixelSize: maxPixelSize,
+                cacheGeneration: generation
+            )
         }
     }
 
@@ -579,33 +560,14 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     /// `data`, so callers must provide a stable key that uniquely identifies the bytes (for
     /// example an immutable attachment id, or a content fingerprint when ids can be reused).
     func image(for data: Data, cacheKey rawCacheKey: String, maxPixelSize: CGFloat) async -> LoadedImage? {
-        let key = Self.cacheKey(forLocalImageID: rawCacheKey, maxPixelSize: maxPixelSize)
-        if let cached = cachedImage(for: key) {
-            return LoadedImage(nsImage: cached)
-        }
-
-        let generation = currentCacheGeneration()
-        let taskKey = Self.inFlightKey(forCacheKey: key, generation: generation)
-        let task = inFlight.task(for: taskKey) { [self] in
-            Task { [self] in
-                await loadLocalImage(
-                    data: data,
-                    cacheKey: key,
-                    maxPixelSize: maxPixelSize,
-                    cacheGeneration: generation
-                )
-            }
-        }
-        let waiter = RemoteImageLoadWaiter { [inFlight] in
-            inFlight.releaseWaiter(for: taskKey)
-        }
-
-        return await withTaskCancellationHandler {
-            let loaded = await task.value
-            waiter.release()
-            return Task.isCancelled ? nil : loaded
-        } onCancel: {
-            waiter.release()
+        return await coalescedLoad(cacheKey: Self.cacheKey(forLocalImageID: rawCacheKey, maxPixelSize: maxPixelSize)) {
+            [self] cacheKey, generation in
+            await loadLocalImage(
+                data: data,
+                cacheKey: cacheKey,
+                maxPixelSize: maxPixelSize,
+                cacheGeneration: generation
+            )
         }
     }
 
@@ -613,7 +575,26 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     /// SwiftUI view values. The payload id is generated when the download completes, so a retry or
     /// replacement under the same attachment id cannot reuse a stale decoded image.
     func image(for payload: DownloadedMediaPayload, maxPixelSize: CGFloat) async -> LoadedImage? {
-        let key = Self.cacheKey(forLocalImageID: payload.id, maxPixelSize: maxPixelSize)
+        return await coalescedLoad(cacheKey: Self.cacheKey(forLocalImageID: payload.id, maxPixelSize: maxPixelSize)) {
+            [self] cacheKey, generation in
+            await loadLocalImage(
+                data: payload.data,
+                cacheKey: cacheKey,
+                maxPixelSize: maxPixelSize,
+                cacheGeneration: generation
+            )
+        }
+    }
+
+    /// Shared decode-coalescing front end for every `image(for:)` entry point: serve a cached
+    /// decode if present, otherwise join (or start) the single in-flight decode for `cacheKey`
+    /// and tear its waiter down on completion or cancellation. `load` performs the actual
+    /// decode for a cache miss, receiving the resolved cache key and the cache generation it
+    /// must still belong to.
+    private func coalescedLoad(
+        cacheKey key: String,
+        load: @escaping @Sendable (_ cacheKey: String, _ cacheGeneration: Int) async -> LoadedImage?
+    ) async -> LoadedImage? {
         if let cached = cachedImage(for: key) {
             return LoadedImage(nsImage: cached)
         }
@@ -622,12 +603,7 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         let taskKey = Self.inFlightKey(forCacheKey: key, generation: generation)
         let task = inFlight.task(for: taskKey) { [self] in
             Task { [self] in
-                await loadLocalImage(
-                    payload: payload,
-                    cacheKey: key,
-                    maxPixelSize: maxPixelSize,
-                    cacheGeneration: generation
-                )
+                await load(key, generation)
             }
         }
         let waiter = RemoteImageLoadWaiter { [inFlight] in
@@ -711,21 +687,6 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
             return nil
         }
         return loaded
-    }
-
-    private func loadLocalImage(
-        payload: DownloadedMediaPayload,
-        cacheKey: String,
-        maxPixelSize: CGFloat,
-        cacheGeneration generation: Int
-    ) async -> LoadedImage? {
-        let data = payload.data
-        return await loadLocalImage(
-            data: data,
-            cacheKey: cacheKey,
-            maxPixelSize: maxPixelSize,
-            cacheGeneration: generation
-        )
     }
 
     private func cachedImage(for key: String) -> NSImage? {

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -299,7 +299,7 @@ extension WorkspaceState {
         stopTimelineListener()
         cancelChatListReload()
         stopChatListListener()
-        messagesByChat.removeAll()
+        cachedMessageChatIds.removeAll()
         for store in messageTimelineStores.values {
             store.clear()
         }
@@ -487,7 +487,7 @@ extension WorkspaceState {
     func resetToNewInstallState(storageRootPath: String) {
         accounts = []
         resetChats()
-        messagesByChat = [:]
+        cachedMessageChatIds = []
         for store in messageTimelineStores.values {
             store.clear()
         }

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -286,7 +286,7 @@ extension WorkspaceState {
         guard activeAccountId == account.id else { return }
 
         let chats = removeChatFromList(chatId: groupIdHex, forAccountId: account.id)
-        messagesByChat[groupIdHex] = nil
+        cachedMessageChatIds.remove(groupIdHex)
         messageTimelineStores[groupIdHex]?.clear()
         messageTimelineStores[groupIdHex] = nil
         invalidateGroupMembers(for: groupIdHex)

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -589,8 +589,8 @@ extension WorkspaceState {
     ) {
         // The window is already ordered, deduped, and capped by the runtime subscription,
         // so render it as-is. The per-chat id/lookup caches live on the store
-        // (`MessageTimelineStore.replace` rebuilds them), so this only maintains the
-        // non-UI `messagesByChat` backing alongside it.
+        // (`MessageTimelineStore.replace` rebuilds them); we only mark this chat as the one
+        // cached window.
         let nextPaging = paging ?? timelinePagingByChat[groupIdHex] ?? .empty
         let timelineStore = ensureMessageTimelineStore(for: groupIdHex)
 
@@ -598,11 +598,7 @@ extension WorkspaceState {
             store.clear()
         }
 
-        if messagesByChat.count == 1, messagesByChat[groupIdHex] != nil {
-            messagesByChat[groupIdHex] = messages
-        } else {
-            messagesByChat = [groupIdHex: messages]
-        }
+        cachedMessageChatIds = [groupIdHex]
         messageTimelineStores = [groupIdHex: timelineStore]
         timelineStore.replace(with: messages)
         if timelinePagingByChat.count == 1, timelinePagingByChat[groupIdHex] != nil {
@@ -621,7 +617,7 @@ extension WorkspaceState {
         for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
             store.clear()
         }
-        messagesByChat = [groupIdHex: timelineStore.messages]
+        cachedMessageChatIds = [groupIdHex]
         messageTimelineStores = [groupIdHex: timelineStore]
         timelinePagingByChat = [groupIdHex: paging]
         finishTimelineInitialLoad(groupIdHex: groupIdHex)
@@ -665,33 +661,29 @@ extension WorkspaceState {
             for store in messageTimelineStores.values {
                 store.clear()
             }
-            messagesByChat = [:]
+            cachedMessageChatIds = []
             messageTimelineStores = [:]
             timelinePagingByChat = [:]
             timelineInitialLoadGroupId = nil
             return
         }
 
-        if let messages = messagesByChat[groupIdHex] {
-            let timelineStore = ensureMessageTimelineStore(for: groupIdHex)
+        // Keep only the surviving chat's store and drop the rest. Whether the survivor stays
+        // "cached" mirrors the old behaviour: it was cached iff its window had been recorded
+        // (now tracked by `cachedMessageChatIds`) rather than merely having an empty store.
+        let survivorWasCached = cachedMessageChatIds.contains(groupIdHex)
+        if let timelineStore = messageTimelineStores[groupIdHex] {
             for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
                 store.clear()
             }
-            messagesByChat = [groupIdHex: messages]
             messageTimelineStores = [groupIdHex: timelineStore]
-            timelineStore.replace(with: messages)
-        } else if let timelineStore = messageTimelineStores[groupIdHex] {
-            for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
-                store.clear()
-            }
-            messagesByChat = [:]
-            messageTimelineStores = [groupIdHex: timelineStore]
+            cachedMessageChatIds = survivorWasCached ? [groupIdHex] : []
         } else {
             for store in messageTimelineStores.values {
                 store.clear()
             }
-            messagesByChat = [:]
             messageTimelineStores = [:]
+            cachedMessageChatIds = []
         }
         if let paging = timelinePagingByChat[groupIdHex] {
             timelinePagingByChat = [groupIdHex: paging]

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1639,7 +1639,9 @@ struct OpenverseGroupImageSearchClient: GroupImageSearchClient, Sendable {
         var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)
         components?.queryItems = [
             URLQueryItem(name: "q", value: query),
-            URLQueryItem(name: "page_size", value: "24"),
+            // Openverse caps anonymous (unauthenticated) requests at page_size 20 and
+            // rejects anything larger with HTTP 401, so stay at the anonymous ceiling.
+            URLQueryItem(name: "page_size", value: "20"),
             URLQueryItem(name: "mature", value: "false"),
         ]
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -409,11 +409,28 @@ final class WorkspaceState {
     @ObservationIgnored var chatIndexByAccount: [String: [String: Int]] = [:]
     @ObservationIgnored var chatListGenerationByAccount: [String: Int] = [:]
     @ObservationIgnored var filteredChatsCache: FilteredChatsCache?
-    /// Backing timeline cache for tests and non-UI lookups. Swift Observation tracks an
-    /// observed dictionary as one property, so UI reads must go through `messageTimelineStores`
-    /// to subscribe only to the selected chat's transcript (whitenoise-mac#176).
-    @ObservationIgnored var messagesByChat: [String: [MessageItem]]
+    /// Ids of the chats whose transcript window is currently cached in `messageTimelineStores`.
+    /// The message arrays themselves live only on the stores; tracking membership in a small set
+    /// (rather than a parallel `[String: [MessageItem]]`) avoids copying the open conversation's
+    /// window on every timeline delta while preserving the cached/not-cached distinction the
+    /// prune and reseed paths rely on.
+    @ObservationIgnored var cachedMessageChatIds: Set<String> = []
     @ObservationIgnored var messageTimelineStores: [String: MessageTimelineStore] = [:]
+
+    /// Backing timeline snapshot for tests and non-UI lookups, derived from the per-chat stores.
+    /// Swift Observation tracks an observed dictionary as one property, so UI reads must still go
+    /// through `messageTimelineStores` to subscribe only to the selected chat's transcript
+    /// (whitenoise-mac#176); this derivation reads only `@ObservationIgnored` storage.
+    var messagesByChat: [String: [MessageItem]] {
+        var result: [String: [MessageItem]] = [:]
+        result.reserveCapacity(cachedMessageChatIds.count)
+        for id in cachedMessageChatIds {
+            if let store = messageTimelineStores[id] {
+                result[id] = store.messages
+            }
+        }
+        return result
+    }
     @ObservationIgnored var mediaDownloads: [String: MediaDownloadStateStore] = [:]
     @ObservationIgnored let mediaDiskCache: MessageMediaDiskCache
     @ObservationIgnored var mediaDiskStoreTasks: [String: MediaDiskStoreTask] = [:]
@@ -895,8 +912,8 @@ final class WorkspaceState {
     ) {
         self.accounts = accounts
         self.chatsByAccount = chatsByAccount
-        self.messagesByChat = messagesByChat
         self.messageTimelineStores = messagesByChat.mapValues { MessageTimelineStore.loaded(with: $0) }
+        self.cachedMessageChatIds = Set(messagesByChat.keys)
         self.localNotificationCenter = localNotificationCenter ?? MacLocalNotificationCenter()
         self.appActivityProvider = appActivityProvider
         self.conversationWindowVisibilityProvider = conversationWindowVisibilityProvider
@@ -1121,12 +1138,9 @@ final class WorkspaceState {
         if let store = messageTimelineStores[groupIdHex] {
             return store
         }
-        let store: MessageTimelineStore
-        if let messages = messagesByChat[groupIdHex] {
-            store = MessageTimelineStore.loaded(with: messages)
-        } else {
-            store = MessageTimelineStore()
-        }
+        // A chat is only ever cached while its store exists (`cachedMessageChatIds` is kept a
+        // subset of `messageTimelineStores`), so a missing store means there is nothing to seed.
+        let store = MessageTimelineStore()
         messageTimelineStores[groupIdHex] = store
         return store
     }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -189,8 +189,9 @@ nonisolated struct ChatListOrdering {
 }
 
 @MainActor
-final class MediaDownloadStateStore: ObservableObject {
-    @Published private(set) var state: MediaDownloadState = .idle
+@Observable
+final class MediaDownloadStateStore {
+    private(set) var state: MediaDownloadState = .idle
 
     var shouldStartAutomaticDownload: Bool {
         if case .idle = state {

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -392,7 +392,7 @@ struct MessageVisualMediaGrid: View {
 struct MessageVisualMediaTile: View {
     @Environment(WorkspaceState.self) private var workspace
     @Environment(\.displayScale) private var displayScale
-    @ObservedObject var downloadState: MediaDownloadStateStore
+    let downloadState: MediaDownloadStateStore
     let message: MessageItem
     let attachment: MessageMediaAttachment
     let isOutgoing: Bool
@@ -491,7 +491,7 @@ struct MessageVisualMediaTile: View {
 struct MessageMediaAttachmentView: View {
     @Environment(WorkspaceState.self) private var workspace
     @Environment(\.displayScale) private var displayScale
-    @ObservedObject var downloadState: MediaDownloadStateStore
+    let downloadState: MediaDownloadStateStore
     let message: MessageItem
     let attachment: MessageMediaAttachment
     let isOutgoing: Bool
@@ -1190,7 +1190,7 @@ struct MessageImageGalleryOverlay: View {
 
 struct MessageImageGalleryContent: View {
     @Environment(WorkspaceState.self) private var workspace
-    @ObservedObject var downloadState: MediaDownloadStateStore
+    let downloadState: MediaDownloadStateStore
     let message: MessageItem
     let attachment: MessageMediaAttachment
 

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -13,6 +13,14 @@ import AVKit
 import AppKit
 import SwiftUI
 
+/// Oversample factor applied to media thumbnails over their display-point size.
+/// Because tiles use `scaledToFill` (which crops to the center square), a source
+/// whose aspect ratio is `r:1` needs `r×` the display pixels on its shorter side
+/// to stay crisp. 1.5 keeps the common 4:3/3:2 photo ratios sharp while decoding
+/// ~44% fewer pixels than the previous 2× factor, which also lets ~2× more tiles
+/// fit in the cost-bounded decoded-image cache.
+private let mediaThumbnailOversample: CGFloat = 1.5
+
 struct ConversationMessageRow: View, Equatable {
     let message: MessageItem
     /// Whether this row is the currently text-selectable bubble (drives `.textSelection`).
@@ -441,7 +449,7 @@ struct MessageVisualMediaTile: View {
             case .image:
                 DownsampledDataImage(
                     payload: download.payload,
-                    maxPixelSize: sideLength * max(1, displayScale) * 2
+                    maxPixelSize: sideLength * max(1, displayScale) * mediaThumbnailOversample
                 ) { image in
                     image
                         .resizable()
@@ -535,7 +543,7 @@ struct MessageMediaAttachmentView: View {
         case .image:
             DownsampledDataImage(
                 payload: download.payload,
-                maxPixelSize: 260 * max(1, displayScale) * 2
+                maxPixelSize: 260 * max(1, displayScale) * mediaThumbnailOversample
             ) { image in
                 image
                     .resizable()

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -199,39 +199,45 @@ struct MessagesComposerFieldBackground: View {
     }
 }
 
-struct MessagesWindowBackground: View {
+/// The shared "liquid glass" recipe used by every chrome surface: a blurred
+/// material under a scheme-aware tint. Each surface wraps this with its own
+/// background-extension / safe-area composition (the order differs between the
+/// `Messages*` and `Glass*` families), so only the duplicated inner fill lives
+/// here.
+struct GlassFill: View {
     @Environment(\.colorScheme) private var colorScheme
+    var material: Material = .regularMaterial
+    var darkOpacity: Double
+    var lightOpacity: Double
+    var lightTint: NSColor = .windowBackgroundColor
 
     var body: some View {
         ZStack {
             Rectangle()
-                .fill(.regularMaterial)
-            Color(nsColor: colorScheme == .dark ? .black : .windowBackgroundColor)
-                .opacity(colorScheme == .dark ? 0.52 : 0.2)
+                .fill(material)
+            Color(nsColor: colorScheme == .dark ? .black : lightTint)
+                .opacity(colorScheme == .dark ? darkOpacity : lightOpacity)
         }
-        .nativeBackgroundExtensionEffect()
-        .ignoresSafeArea()
+    }
+}
+
+struct MessagesWindowBackground: View {
+    var body: some View {
+        GlassFill(darkOpacity: 0.52, lightOpacity: 0.2)
+            .nativeBackgroundExtensionEffect()
+            .ignoresSafeArea()
     }
 }
 
 struct MessagesTranscriptBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.regularMaterial)
-            Color(nsColor: colorScheme == .dark ? .black : .textBackgroundColor)
-                .opacity(colorScheme == .dark ? 0.72 : 0.52)
-        }
-        .nativeBackgroundExtensionEffect()
-        .ignoresSafeArea()
+        GlassFill(darkOpacity: 0.72, lightOpacity: 0.52, lightTint: .textBackgroundColor)
+            .nativeBackgroundExtensionEffect()
+            .ignoresSafeArea()
     }
 }
 
 struct MessagesSidebarBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     enum Level {
         case rail
         case drawer
@@ -240,57 +246,38 @@ struct MessagesSidebarBackground: View {
     let level: Level
 
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.regularMaterial)
-            Color(nsColor: colorScheme == .dark ? .black : .windowBackgroundColor)
-                .opacity(backgroundOpacity)
-        }
-        .nativeBackgroundExtensionEffect()
-        .ignoresSafeArea()
+        GlassFill(darkOpacity: darkOpacity, lightOpacity: lightOpacity)
+            .nativeBackgroundExtensionEffect()
+            .ignoresSafeArea()
     }
 
-    private var backgroundOpacity: Double {
-        if colorScheme == .dark {
-            switch level {
-            case .rail: 0.5
-            case .drawer: 0.44
-            }
-        } else {
-            switch level {
-            case .rail: 0.16
-            case .drawer: 0.1
-            }
+    private var darkOpacity: Double {
+        switch level {
+        case .rail: 0.5
+        case .drawer: 0.44
+        }
+    }
+
+    private var lightOpacity: Double {
+        switch level {
+        case .rail: 0.16
+        case .drawer: 0.1
         }
     }
 }
 
 struct MessagesHeaderBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-            Color(nsColor: colorScheme == .dark ? .black : .windowBackgroundColor)
-                .opacity(colorScheme == .dark ? 0.34 : 0.18)
-        }
-        .nativeBackgroundExtensionEffect()
-        .ignoresSafeArea()
+        GlassFill(material: .ultraThinMaterial, darkOpacity: 0.34, lightOpacity: 0.18)
+            .nativeBackgroundExtensionEffect()
+            .ignoresSafeArea()
     }
 }
 
 struct MessagesComposerBarBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-            Color(nsColor: colorScheme == .dark ? .black : .windowBackgroundColor)
-                .opacity(colorScheme == .dark ? 0.42 : 0.2)
-        }
-        .nativeBackgroundExtensionEffect()
+        GlassFill(material: .ultraThinMaterial, darkOpacity: 0.42, lightOpacity: 0.2)
+            .nativeBackgroundExtensionEffect()
     }
 }
 
@@ -319,71 +306,27 @@ struct GlassSeparator: View {
 }
 
 struct GlassPaneBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
     let opacity: Double
 
     var body: some View {
-        if #available(macOS 26.0, *) {
-            background
-                .backgroundExtensionEffect()
-        } else {
-            background
-        }
-    }
-
-    private var background: some View {
-        ZStack {
-            Rectangle()
-                .fill(.regularMaterial)
-            Color(nsColor: colorScheme == .dark ? .black : .windowBackgroundColor)
-                .opacity(colorScheme == .dark ? opacity * 0.42 : opacity * 0.32)
-        }
-        .ignoresSafeArea()
+        GlassFill(darkOpacity: opacity * 0.42, lightOpacity: opacity * 0.32)
+            .ignoresSafeArea()
+            .nativeBackgroundExtensionEffect()
     }
 }
 
 struct GlassToolbarBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
-        if #available(macOS 26.0, *) {
-            background
-                .backgroundExtensionEffect()
-        } else {
-            background
-        }
-    }
-
-    private var background: some View {
-        ZStack {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-            Color(nsColor: colorScheme == .dark ? .black : .windowBackgroundColor)
-                .opacity(colorScheme == .dark ? 0.24 : 0.34)
-        }
+        GlassFill(material: .ultraThinMaterial, darkOpacity: 0.24, lightOpacity: 0.34)
+            .nativeBackgroundExtensionEffect()
     }
 }
 
 struct LiquidGlassBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
-        if #available(macOS 26.0, *) {
-            background
-                .backgroundExtensionEffect()
-        } else {
-            background
-        }
-    }
-
-    private var background: some View {
-        ZStack {
-            Rectangle()
-                .fill(.regularMaterial)
-            Color(nsColor: colorScheme == .dark ? .black : .windowBackgroundColor)
-                .opacity(colorScheme == .dark ? 0.18 : 0.28)
-        }
-        .ignoresSafeArea()
+        GlassFill(darkOpacity: 0.18, lightOpacity: 0.28)
+            .ignoresSafeArea()
+            .nativeBackgroundExtensionEffect()
     }
 }
 

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -276,6 +276,7 @@ struct MessagesHeaderBackground: View {
                 .opacity(colorScheme == .dark ? 0.34 : 0.18)
         }
         .nativeBackgroundExtensionEffect()
+        .ignoresSafeArea()
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3175,7 +3175,7 @@ struct whitenoise_macTests {
             isOutgoing: false
         )
         let backgroundTimelineStore = state.ensureMessageTimelineStore(for: backgroundChat.id)
-        state.messagesByChat[backgroundChat.id] = [backgroundUpdatedMessage]
+        state.cachedMessageChatIds.insert(backgroundChat.id)
         backgroundTimelineStore.replace(with: [backgroundUpdatedMessage])
 
         #expect(!backgroundInvalidated.value)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2780,13 +2780,14 @@ struct whitenoise_macTests {
         }
 
         let firstStoreInvalidated = ObservationInvalidationFlag()
-        let firstStoreCancellable = firstStore.objectWillChange.sink { _ in
+        withObservationTracking {
+            _ = firstStore.state
+        } onChange: {
             firstStoreInvalidated.markInvalidated()
         }
 
         await state.loadMediaAttachment(secondAttachment, for: secondMessage)
 
-        withExtendedLifetime(firstStoreCancellable) {}
         #expect(!workspaceInvalidated.value)
         #expect(!firstStoreInvalidated.value)
         #expect(firstStore.state == .idle)


### PR DESCRIPTION
## Summary

A simplicity/performance pass over the app (from a full read-through audit), plus two small fixes that surfaced along the way. Each item is its own commit so the history bisects cleanly. Every commit builds clean, passes all 261 unit tests, and is `swift-format` lint clean.

### Fixes
- **Openverse image search 401** — Openverse now rejects unauthenticated requests with `page_size > 20` (HTTP 401), which broke every group-image search. Capped the request at the anonymous ceiling of 20.
- **Conversation header background** — `MessagesHeaderBackground` was the only glass surface missing `.ignoresSafeArea()`, so its background-extension effect rendered inconsistently against the sidebar. Brought it in line with the other chrome surfaces.

### Simplicity / performance
- **Media thumbnail decode cost** — tiles requested 2× their display size as the downsample target; since they render with `scaledToFill` (cropping to the centre square), the oversample only needs to cover the source aspect ratio. 1.5× keeps common 4:3/3:2 photos crisp while decoding ~44% fewer pixels, which also lets ~2× more tiles fit in the cost-bounded decoded-image cache. Also dropped a redundant read-path SHA-256 re-hash in the disk cache (AES-GCM `open` already authenticates the payload).
- **Dead message-mapping code** — deleted the unused `MessageItem.init(record:activeAccountIdHex:)`; `displayText` now takes the already-computed `MessagePresentation` instead of re-deriving it, collapses a duplicate/unreachable `.chat` branch, and decodes the JSON payload lazily only in the cases that use it.
- **Duplicated boilerplate** — the eight chrome-surface backgrounds collapsed into one parameterized `GlassFill` (each surface keeps its own safe-area/extension composition); `RemoteImageLoader`'s three identical `image(for:)` cache-check/coalescing/cancellation blocks collapsed into one `coalescedLoad` helper, removing a pass-through along the way.
- **`MediaDownloadStateStore` → Observation** — the last per-row state object still on Combine (`@Published`/`@ObservedObject`), recreated constantly while scrolling. Migrated to `@Observable`, dropping the per-tile subscription setup/teardown and matching the rest of the app's Observation model.
- **`messagesByChat` dedup** — this held a full parallel copy of every cached chat's message window alongside `MessageTimelineStore.messages`, and the timeline apply path copied the whole open-conversation array into it on every delta. Replaced it with a small `Set` of cached chat ids and derived `messagesByChat` from the stores, removing the per-delivery O(n) array copy while preserving the cached/not-cached distinction the prune and reseed paths rely on.

## Testing
- All 261 unit tests pass; `swift-format lint --strict` clean on every changed file.
- `UIPerformance` UI tests were **not** run — they require Accessibility/automation trust that command-line `xcodebuild` can't establish in this environment (the runner hangs before connecting). Worth running from Xcode (Product ▸ Test with the UIPerformance plan) on this branch vs `master` to confirm the scroll/render wins.

### Reviewer note on the `messagesByChat` change
This is the one item touching timeline state. The cached-id `Set` + computed `messagesByChat` reproduces the previous nil-vs-empty semantics exactly (verified against the existing `messagesByChat` snapshot/keys/nil assertions across the timeline, pagination, prune, and rename suites), but unit tests can't exercise every prune+reseed interleaving — worth a manual sanity check (scroll a long transcript, switch chats and back, send, remove a chat). It reverts cleanly on its own (`git revert b47ef91`) if anything looks off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message previews and reply snippets so they display the most relevant text more consistently.
  * Made media downloads and image loading more reliable, with better handling of cached content and fewer unnecessary reloads.
  * Fixed chat and account resets so conversation state clears more cleanly.
  * Updated timeline caching to reduce stale message data and improve switching between chats.

* **Style**
  * Refined glass-style backgrounds across the app for a more consistent look and feel.
  * Adjusted thumbnail rendering for sharper media previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->