### PR TITLE
Multi-recipient new chat, slide-in chat info, and AGPL-3.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ the Marmot/MLS core in `MarmotKit` rather than in app code.
 
 ## License
 
-No license file is currently present in this repository. Until one is added,
-all rights are reserved by the project authors.
+This project is licensed under the GNU Affero General Public License v3.0
+(AGPL-3.0). See [LICENSE](LICENSE) for the full text.

--- a/whitenoise-mac.xcodeproj/project.pbxproj
+++ b/whitenoise-mac.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 				EXTRACT_APP_INTENTS_METADATA = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Config/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "White Noise";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -506,6 +507,7 @@
 				EXTRACT_APP_INTENTS_METADATA = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Config/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "White Noise";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -17,7 +17,6 @@ import UserNotifications
 @MainActor
 extension WorkspaceState {
     func showGroupDetails(for chat: ChatItem) async {
-        guard !chat.isDirect else { return }
         lastError = nil
         groupDetailsSnapshot = nil
         groupInviteMemberQuery = ""

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -109,17 +109,23 @@ extension WorkspaceState {
         }
         guard let recipient else { return false }
 
-        appendNewChatRecipient(recipient)
+        let didAppend = appendNewChatRecipient(recipient)
         invalidateNewChatLookup()
         newChatQuery = ""
         newChatRecipient = nil
         lastError = nil
-        return true
+        // `false` when the pubkey was already in the list (deduped), so callers
+        // can tell "nothing new added" from a genuine failure to resolve.
+        return didAppend
     }
 
-    func appendNewChatRecipient(_ recipient: NewChatRecipient) {
-        guard !newChatRecipients.contains(where: { $0.accountIdHex == recipient.accountIdHex }) else { return }
+    @discardableResult
+    func appendNewChatRecipient(_ recipient: NewChatRecipient) -> Bool {
+        guard !newChatRecipients.contains(where: { $0.accountIdHex == recipient.accountIdHex }) else {
+            return false
+        }
         newChatRecipients.append(recipient)
+        return true
     }
 
     func removeNewChatRecipient(_ recipient: NewChatRecipient) {
@@ -128,6 +134,13 @@ extension WorkspaceState {
 
     func createNewChat() async {
         guard let client, let activeAccount, !isCreatingChat else { return }
+
+        // Claim the in-flight flag before the first await (the pending-query
+        // resolve below). Otherwise two rapid submits both pass the `!isCreatingChat`
+        // guard while suspended and each reach `createGroup`, creating duplicate chats.
+        lastError = nil
+        isCreatingChat = true
+        defer { isCreatingChat = false }
 
         // Capture the creating account on entry so a mid-await A→B account switch (e.g. via
         // a notification tap while `createGroup`/`reloadChats` are suspended) cannot graft
@@ -156,10 +169,6 @@ extension WorkspaceState {
         }
         guard let primary = recipients.first else { return }
         let isDirect = recipients.count == 1
-
-        lastError = nil
-        isCreatingChat = true
-        defer { isCreatingChat = false }
 
         do {
             let trimmedName = newChatName.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -97,6 +97,35 @@ extension WorkspaceState {
         await resolveNewChatQuery()
     }
 
+    /// Resolve the current query (if needed) and move that recipient into the
+    /// confirmed members list, clearing the input so the next pubkey can be added.
+    @discardableResult
+    func addCurrentNewChatRecipient() async -> Bool {
+        let recipient: NewChatRecipient?
+        if let resolvedNewChatRecipient {
+            recipient = resolvedNewChatRecipient
+        } else {
+            recipient = await resolveNewChatQuery()
+        }
+        guard let recipient else { return false }
+
+        appendNewChatRecipient(recipient)
+        invalidateNewChatLookup()
+        newChatQuery = ""
+        newChatRecipient = nil
+        lastError = nil
+        return true
+    }
+
+    func appendNewChatRecipient(_ recipient: NewChatRecipient) {
+        guard !newChatRecipients.contains(where: { $0.accountIdHex == recipient.accountIdHex }) else { return }
+        newChatRecipients.append(recipient)
+    }
+
+    func removeNewChatRecipient(_ recipient: NewChatRecipient) {
+        newChatRecipients.removeAll { $0.accountIdHex == recipient.accountIdHex }
+    }
+
     func createNewChat() async {
         guard let client, let activeAccount, !isCreatingChat else { return }
 
@@ -107,13 +136,19 @@ extension WorkspaceState {
         // only guards the workspace UI state. See whitenoise-mac#229.
         let accountId = activeAccount.id
 
-        let recipient: NewChatRecipient?
-        if let resolvedNewChatRecipient {
-            recipient = resolvedNewChatRecipient
-        } else {
-            recipient = await resolveNewChatQuery()
+        // Gather every member: the confirmed list plus any pubkey still sitting
+        // resolved-but-unadded in the input, falling back to resolving the raw
+        // query when nothing has been added yet. Dedup by account so the same
+        // person can't be invited twice.
+        var recipients = newChatRecipients
+        if let resolvedNewChatRecipient,
+            !recipients.contains(where: { $0.accountIdHex == resolvedNewChatRecipient.accountIdHex }) {
+            recipients.append(resolvedNewChatRecipient)
+        } else if recipients.isEmpty, let resolved = await resolveNewChatQuery() {
+            recipients.append(resolved)
         }
-        guard let recipient else { return }
+        guard let primary = recipients.first else { return }
+        let isDirect = recipients.count == 1
 
         lastError = nil
         isCreatingChat = true
@@ -122,19 +157,24 @@ extension WorkspaceState {
         do {
             let trimmedName = newChatName.trimmingCharacters(in: .whitespacesAndNewlines)
             let trimmedDescription = newChatDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+            let fallbackTitle = isDirect
+                ? primary.title
+                : recipients.map(\.title).joined(separator: ", ")
+            let groupName = trimmedName.isEmpty ? fallbackTitle : trimmedName
             let groupIdHex = try await client.createGroup(
                 accountRef: activeAccount.accountRef,
-                name: trimmedName.isEmpty ? recipient.title : trimmedName,
-                memberRefs: [recipient.memberRef],
+                name: groupName,
+                memberRefs: recipients.map(\.memberRef),
                 description: trimmedDescription.isEmpty ? nil : trimmedDescription
             )
             await reloadChats(forceFreshSnapshot: true)
             guard activeAccountId == accountId else { return }
             insertCreatedChatIfNeeded(
                 groupIdHex: groupIdHex,
-                title: trimmedName.isEmpty ? recipient.title : trimmedName,
-                avatarSeed: recipient.accountIdHex,
-                pictureURL: recipient.pictureURL
+                title: groupName,
+                avatarSeed: primary.accountIdHex,
+                pictureURL: isDirect ? primary.pictureURL : nil,
+                isDirect: isDirect
             )
             selection = .chat(groupIdHex)
             closeNewChatComposer()
@@ -151,6 +191,7 @@ extension WorkspaceState {
         newChatName = ""
         newChatDescription = ""
         newChatRecipient = nil
+        newChatRecipients = []
     }
 
     func beginNewChatLookup() -> UInt64 {
@@ -168,20 +209,26 @@ extension WorkspaceState {
             && newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
     }
 
-    func insertCreatedChatIfNeeded(groupIdHex: String, title: String, avatarSeed: String, pictureURL: String?) {
+    func insertCreatedChatIfNeeded(
+        groupIdHex: String,
+        title: String,
+        avatarSeed: String,
+        pictureURL: String?,
+        isDirect: Bool = true
+    ) {
         guard let activeAccountId else { return }
         guard chatItem(accountId: activeAccountId, chatId: groupIdHex) == nil else { return }
 
         let chat = ChatItem(
             id: groupIdHex,
             title: title,
-            subtitle: L10n.string("Direct message"),
+            subtitle: isDirect ? L10n.string("Direct message") : L10n.string("Group chat"),
             preview: L10n.string("No messages yet"),
             updatedAt: nil,
             avatarSeed: avatarSeed,
             pictureURL: pictureURL,
             unreadCount: 0,
-            isDirect: true
+            isDirect: isDirect
         )
         upsertChat(chat, forAccountId: activeAccountId)
     }

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -136,17 +136,23 @@ extension WorkspaceState {
         // only guards the workspace UI state. See whitenoise-mac#229.
         let accountId = activeAccount.id
 
-        // Gather every member: the confirmed list plus any pubkey still sitting
-        // resolved-but-unadded in the input, falling back to resolving the raw
-        // query when nothing has been added yet. Dedup by account so the same
+        // Gather every member: the confirmed list plus whatever is still sitting
+        // in the input, so a pubkey typed but not yet added via return/+ is never
+        // silently dropped. If the pending query already resolved, fold it in; if
+        // there is non-empty text that has not resolved yet (e.g. the debounce
+        // hadn't fired), resolve it now and *block* creation when it can't, rather
+        // than quietly leaving that recipient out. Dedup by account so the same
         // person can't be invited twice.
         var recipients = newChatRecipients
-        if let resolvedNewChatRecipient,
-            !recipients.contains(where: { $0.accountIdHex == resolvedNewChatRecipient.accountIdHex })
-        {
-            recipients.append(resolvedNewChatRecipient)
-        } else if recipients.isEmpty, let resolved = await resolveNewChatQuery() {
-            recipients.append(resolved)
+        if let resolvedNewChatRecipient {
+            if !recipients.contains(where: { $0.accountIdHex == resolvedNewChatRecipient.accountIdHex }) {
+                recipients.append(resolvedNewChatRecipient)
+            }
+        } else if !newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            guard let resolved = await resolveNewChatQuery() else { return }
+            if !recipients.contains(where: { $0.accountIdHex == resolved.accountIdHex }) {
+                recipients.append(resolved)
+            }
         }
         guard let primary = recipients.first else { return }
         let isDirect = recipients.count == 1

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -142,7 +142,8 @@ extension WorkspaceState {
         // person can't be invited twice.
         var recipients = newChatRecipients
         if let resolvedNewChatRecipient,
-            !recipients.contains(where: { $0.accountIdHex == resolvedNewChatRecipient.accountIdHex }) {
+            !recipients.contains(where: { $0.accountIdHex == resolvedNewChatRecipient.accountIdHex })
+        {
             recipients.append(resolvedNewChatRecipient)
         } else if recipients.isEmpty, let resolved = await resolveNewChatQuery() {
             recipients.append(resolved)
@@ -157,7 +158,8 @@ extension WorkspaceState {
         do {
             let trimmedName = newChatName.trimmingCharacters(in: .whitespacesAndNewlines)
             let trimmedDescription = newChatDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-            let fallbackTitle = isDirect
+            let fallbackTitle =
+                isDirect
                 ? primary.title
                 : recipients.map(\.title).joined(separator: ", ")
             let groupName = trimmedName.isEmpty ? fallbackTitle : trimmedName

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -566,6 +566,7 @@ final class WorkspaceState {
     var newChatName = ""
     var newChatDescription = ""
     var newChatRecipient: NewChatRecipient?
+    var newChatRecipients: [NewChatRecipient] = []
     var replyDraftContext: MessageReplyContext? {
         get {
             guard let selectedComposerDraftKey else { return nil }

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -480,7 +480,7 @@ struct NewChatColumnView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
                     VStack(alignment: .leading, spacing: 6) {
-                        Text("Public key")
+                        Text("Members")
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(.secondary)
 
@@ -488,7 +488,7 @@ struct NewChatColumnView: View {
                             .textFieldStyle(.plain)
                             .focused($isSearchFocused)
                             .onSubmit {
-                                Task { await workspace.resolveNewChatQuery() }
+                                Task { await workspace.addCurrentNewChatRecipient() }
                             }
                             .task(id: workspace.newChatQuery) {
                                 // Debounce keystrokes and let `.task(id:)` cancel the
@@ -506,6 +506,10 @@ struct NewChatColumnView: View {
                                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                                     .stroke(isSearchFocused ? MessagesPalette.sentBubble : Color.clear, lineWidth: 1)
                             }
+
+                        Text("Add one or more people by npub or hex public key. Press return or tap + to add each one.")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
                     }
 
                     if workspace.isResolvingNewChat {
@@ -514,8 +518,25 @@ struct NewChatColumnView: View {
                             .foregroundStyle(.secondary)
                     }
 
-                    if let recipient = workspace.resolvedNewChatRecipient {
-                        NewChatRecipientCard(recipient: recipient)
+                    if let recipient = workspace.resolvedNewChatRecipient,
+                        !workspace.newChatRecipients.contains(where: { $0.accountIdHex == recipient.accountIdHex }) {
+                        NewChatRecipientCard(recipient: recipient, role: .pending)
+                    }
+
+                    if !workspace.newChatRecipients.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(
+                                workspace.newChatRecipients.count == 1
+                                    ? L10n.string("1 member added")
+                                    : "\(workspace.newChatRecipients.count) \(L10n.string("members added"))"
+                            )
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+
+                            ForEach(workspace.newChatRecipients, id: \.accountIdHex) { recipient in
+                                NewChatRecipientCard(recipient: recipient, role: .added)
+                            }
+                        }
                     }
 
                     NewChatDetailsForm()
@@ -582,14 +603,25 @@ struct NewChatDetailsForm: View {
             }
             .controlSize(.large)
             .nativeGlassProminentButtonStyle()
-            .disabled(workspace.resolvedNewChatRecipient == nil || workspace.isCreatingChat)
+            .disabled(
+                (workspace.newChatRecipients.isEmpty && workspace.resolvedNewChatRecipient == nil)
+                    || workspace.isCreatingChat
+            )
         }
     }
 }
 
 struct NewChatRecipientCard: View {
+    enum Role {
+        /// Freshly resolved from the input, not yet added to the members list.
+        case pending
+        /// Already in the confirmed members list.
+        case added
+    }
+
     @Environment(WorkspaceState.self) private var workspace
     let recipient: NewChatRecipient
+    var role: Role = .pending
 
     var body: some View {
         let publicKey = recipient.npub.isEmpty ? recipient.accountIdHex : recipient.npub
@@ -628,6 +660,29 @@ struct NewChatRecipientCard: View {
             }
 
             Spacer()
+
+            switch role {
+            case .pending:
+                Button {
+                    Task { await workspace.addCurrentNewChatRecipient() }
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 13, weight: .semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .nativeGlassCircleButtonStyle()
+                .help(L10n.string("Add member"))
+            case .added:
+                Button {
+                    workspace.removeNewChatRecipient(recipient)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .nativeGlassCircleButtonStyle()
+                .help(L10n.string("Remove member"))
+            }
         }
         .padding(12)
         .glassCard()
@@ -677,85 +732,76 @@ struct ConversationHeader: View {
     var body: some View {
         @Bindable var workspace = workspace
 
-        ZStack {
-            VStack(spacing: 4) {
-                ProfileImageAvatarView(
-                    seed: chat.avatarSeed,
-                    initials: chat.title,
-                    pictureURL: chat.pictureURL,
-                    size: 38,
-                    isSelected: false
-                )
+        HStack(spacing: 10) {
+            // Tapping the avatar or title opens the chat info / settings panel,
+            // which slides in over the transcript (see ConversationView).
+            Button {
+                Task { await workspace.showGroupDetails(for: chat) }
+            } label: {
+                HStack(spacing: 10) {
+                    ProfileImageAvatarView(
+                        seed: chat.avatarSeed,
+                        initials: chat.title,
+                        pictureURL: chat.pictureURL,
+                        size: 38,
+                        isSelected: false
+                    )
 
-                Text(chat.title)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background(.thinMaterial, in: Capsule())
+                    Text(chat.title)
+                        .font(.system(size: 15, weight: .semibold))
+                        .lineLimit(1)
+                        .foregroundStyle(.primary)
+                }
+                .contentShape(Rectangle())
             }
-            .frame(maxWidth: 220)
+            .buttonStyle(.plain)
+            .help("Chat info")
 
-            HStack {
-                Spacer()
+            Spacer()
 
-                if chat.pendingConfirmation {
-                    Button {
-                        Task { await workspace.acceptGroupInvite(for: chat) }
-                    } label: {
-                        Image(systemName: "checkmark")
-                            .font(.system(size: 14, weight: .semibold))
-                            .frame(width: 34, height: 34)
-                            .background {
-                                MessagesCircleControlBackground()
-                            }
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
-                    .help("Accept invite")
-
-                    Button(role: .destructive) {
-                        Task { await workspace.declineGroupInvite(for: chat) }
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 14, weight: .semibold))
-                            .frame(width: 34, height: 34)
-                            .background {
-                                MessagesCircleControlBackground()
-                            }
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
-                    .help("Decline invite")
+            if chat.pendingConfirmation {
+                Button {
+                    Task { await workspace.acceptGroupInvite(for: chat) }
+                } label: {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(width: 34, height: 34)
+                        .background {
+                            MessagesCircleControlBackground()
+                        }
                 }
+                .buttonStyle(.plain)
+                .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
+                .help("Accept invite")
 
-                if !chat.isDirect {
-                    Button {
-                        Task { await workspace.showGroupDetails(for: chat) }
-                    } label: {
-                        Image(systemName: "info.circle")
-                            .font(.system(size: 15, weight: .semibold))
-                            .frame(width: 34, height: 34)
-                            .background {
-                                MessagesCircleControlBackground()
-                            }
-                    }
-                    .buttonStyle(.plain)
-                    .help("Group details")
-
-                    Button {
-                        workspace.showGroupImagePicker(for: chat)
-                    } label: {
-                        Image(systemName: "photo.badge.plus")
-                            .font(.system(size: 15, weight: .semibold))
-                            .frame(width: 34, height: 34)
-                            .background {
-                                MessagesCircleControlBackground()
-                            }
-                    }
-                    .buttonStyle(.plain)
-                    .help("Set group image")
+                Button(role: .destructive) {
+                    Task { await workspace.declineGroupInvite(for: chat) }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(width: 34, height: 34)
+                        .background {
+                            MessagesCircleControlBackground()
+                        }
                 }
+                .buttonStyle(.plain)
+                .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
+                .help("Decline invite")
+            }
+
+            if !chat.isDirect {
+                Button {
+                    workspace.showGroupImagePicker(for: chat)
+                } label: {
+                    Image(systemName: "photo.badge.plus")
+                        .font(.system(size: 15, weight: .semibold))
+                        .frame(width: 34, height: 34)
+                        .background {
+                            MessagesCircleControlBackground()
+                        }
+                }
+                .buttonStyle(.plain)
+                .help("Set group image")
             }
         }
         .padding(.horizontal, 14)
@@ -764,9 +810,6 @@ struct ConversationHeader: View {
         .frame(height: 76)
         .background {
             MessagesHeaderBackground()
-        }
-        .sheet(isPresented: $workspace.isGroupDetailsPresented) {
-            GroupDetailsSheet(chat: chat)
         }
         .sheet(isPresented: $workspace.isGroupImagePickerPresented) {
             GroupImagePickerSheet()

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -519,7 +519,8 @@ struct NewChatColumnView: View {
                     }
 
                     if let recipient = workspace.resolvedNewChatRecipient,
-                        !workspace.newChatRecipients.contains(where: { $0.accountIdHex == recipient.accountIdHex }) {
+                        !workspace.newChatRecipients.contains(where: { $0.accountIdHex == recipient.accountIdHex })
+                    {
                         NewChatRecipientCard(recipient: recipient, role: .pending)
                     }
 

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -118,13 +118,18 @@ struct GroupDetailsSheet: View {
                             .lineLimit(2...4)
 
                         HStack(spacing: 10) {
-                            Button {
-                                workspace.closeGroupDetails()
-                                workspace.showGroupImagePicker(for: chat)
-                            } label: {
-                                Label("Search Web Image", systemImage: "photo.badge.plus")
+                            // Group image is a group-only affordance;
+                            // `showGroupImagePicker` no-ops for direct chats, so
+                            // don't surface a dead button when a DM opens details.
+                            if !chat.isDirect {
+                                Button {
+                                    workspace.closeGroupDetails()
+                                    workspace.showGroupImagePicker(for: chat)
+                                } label: {
+                                    Label("Search Web Image", systemImage: "photo.badge.plus")
+                                }
+                                .disabled(workspace.isSavingGroupImage)
                             }
-                            .disabled(workspace.isSavingGroupImage)
 
                             Spacer()
 

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -57,12 +57,12 @@ struct GroupDetailsSheet: View {
                 Button {
                     workspace.closeGroupDetails()
                 } label: {
-                    Image(systemName: "xmark")
+                    Image(systemName: "chevron.backward")
                         .font(.system(size: 13, weight: .semibold))
                         .frame(width: 28, height: 28)
                 }
                 .nativeGlassCircleButtonStyle()
-                .help("Close")
+                .help("Back to chat")
             }
             .padding(20)
 
@@ -331,7 +331,7 @@ struct GroupDetailsSheet: View {
                     }
             }
         }
-        .frame(width: 620, height: 720)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background {
             LiquidGlassBackground()
         }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -571,6 +571,30 @@ private struct ConversationView: View {
                     .allowsHitTesting(false)
             }
         }
+        // Chat info / settings slides in from the right and replaces the
+        // transcript instead of presenting as a modal sheet, giving the
+        // settings page the full conversation width. An opaque base behind the
+        // glass keeps the transcript from bleeding through while it stays
+        // mounted underneath (preserving scroll position on the way back).
+        .overlay {
+            if workspace.isGroupDetailsPresented {
+                GroupDetailsSheet(chat: chat)
+                    .background {
+                        Rectangle().fill(.background)
+                        MessagesTranscriptBackground()
+                    }
+                    .transition(.move(edge: .trailing))
+                    .zIndex(3)
+            }
+        }
+        .animation(.smooth(duration: 0.24), value: workspace.isGroupDetailsPresented)
+        // Switching conversations must not leave the previous chat's info panel
+        // open over a different transcript.
+        .onChange(of: chat.id) { _, _ in
+            if workspace.isGroupDetailsPresented {
+                workspace.closeGroupDetails()
+            }
+        }
     }
 
     private var bottomAnchorId: String {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7788,6 +7788,36 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func createNewChatIncludesPendingQueryAlongsideAddedMembers() async throws {
+        // Regression: a pubkey typed into the input but not yet committed via
+        // return/+ must not be silently dropped when confirmed members already
+        // exist — createNewChat resolves the pending query and folds it in.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installNormalizedMemberRef(query: "npub1alice", accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: "npub1bob", accountIdHex: bobId, npub: "npub1bob")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+
+        // Commit the first member the normal way (this clears the input).
+        state.newChatQuery = "npub1alice"
+        _ = await state.addCurrentNewChatRecipient()
+        #expect(state.newChatRecipients.map(\.accountIdHex) == [aliceId])
+        #expect(state.newChatQuery.isEmpty)
+
+        // Leave the second pubkey pending in the input, then create directly.
+        state.newChatQuery = "npub1bob"
+        await state.createNewChat()
+
+        #expect(runtime.createdGroupMemberRefs == ["npub1alice", "npub1bob"])
+        #expect(state.selection == .chat("created-group"))
+    }
+
+    @MainActor
     @Test func createNewChatDoesNotGraftGroupOntoAccountSwitchedToMidCreate() async throws {
         // Issue #229: `createNewChat()` suspends across `createGroup`/`reloadChats`. If the active
         // account changes (e.g. a notification tap) while suspended, the group created under

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6600,10 +6600,12 @@ struct whitenoise_macTests {
         #expect(!state.isGroupImagePickerPresented)
     }
 
-    @Test func conversationHeaderChatInfoButtonOpensGroupDetailsSheet() throws {
-        // The header is a private SwiftUI view, so this source-shape regression
-        // guards the user-facing toolbar affordance directly: the info button
-        // must remain wired to the group details sheet instead of an empty action.
+    @Test func conversationHeaderChatInfoOpensSlideInGroupDetails() throws {
+        // These are private SwiftUI views, so this source-shape regression guards
+        // the user-facing wiring directly. The chat-info affordance is now the
+        // header's avatar/title button (works for direct chats too), and the
+        // details screen slides in over the transcript from ConversationView
+        // rather than presenting as a header sheet.
         let viewsDirURL =
             URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -6633,13 +6635,18 @@ struct whitenoise_macTests {
         }
         let headerSource = try #require(extractedHeader)
 
+        // Tapping the header avatar/title opens the chat info screen.
         #expect(headerSource.contains("Task { await workspace.showGroupDetails(for: chat) }"))
-        #expect(headerSource.contains("Image(systemName: \"info.circle\")"))
-        #expect(headerSource.contains(".sheet(isPresented: $workspace.isGroupDetailsPresented)"))
-        #expect(headerSource.contains("GroupDetailsSheet(chat: chat)"))
-        #expect(!headerSource.contains("Button {} label: {\n                        Image(systemName: \"info.circle"))
-        #expect(
-            !headerSource.contains("Button {} label: {\n                        Image(systemName: \"info.circle.fill"))
+        // The details screen is no longer a modal sheet hung off the header.
+        #expect(!headerSource.contains(".sheet(isPresented: $workspace.isGroupDetailsPresented)"))
+
+        // ConversationView presents the details panel inline as a slide-in,
+        // gated on the same flag, so it replaces the transcript in place.
+        let shellURL = viewsDirURL.appendingPathComponent("MessengerShellView.swift")
+        let shellSource = try String(contentsOf: shellURL, encoding: .utf8)
+        #expect(shellSource.contains("if workspace.isGroupDetailsPresented"))
+        #expect(shellSource.contains("GroupDetailsSheet(chat: chat)"))
+        #expect(shellSource.contains(".move(edge: .trailing)"))
     }
 
     @MainActor


### PR DESCRIPTION
## What & why

Three related pieces of work from this session.

### 1. Multi-recipient new chat (group creation)
The "Create New Chat" composer previously accepted a **single** recipient. It now lets you build a group from **multiple** public keys.

- Added `newChatRecipients: [NewChatRecipient]` to `WorkspaceState`.
- Type/paste an npub or hex key → it resolves → **return** or the **+** button adds it to a members list and clears the input for the next one. Each added member has an **✕** to remove; duplicates are deduped by account.
- The field is relabeled **Members** with a hint line.
- `createNewChat()` now gathers the full members list (plus any still-resolved-but-unadded input), passes all `memberRefs`, and creates a **group vs. direct** chat accordingly. Group name defaults to the joined member titles when left blank.
- `createGroup` already accepted `[String]` member refs, so this is purely the UI/state layer.

### 2. Left-aligned, tappable chat header + slide-in info panel
- The conversation header avatar and title are now **left-aligned** (was centered avatar-over-title), and tapping **either** opens the chat info screen — now enabled for **direct chats** too, not just groups.
- The group-details screen no longer presents as a **modal sheet**. It **slides in from the right over the transcript** with a `.move(edge: .trailing)` transition, giving the settings page the full conversation width. It fills its container, sits on an opaque base so the transcript doesn't bleed through, and closes back with a **back-chevron**. Switching conversations dismisses it.

### 3. Licensing
- Added the full **GNU AGPL-3.0** `LICENSE` (verbatim from gnu.org) and updated the README's License section to point at it.

## Reviewer notes
- The slide-in panel reuses `GroupDetailsSheet`, which was built for group context. For direct chats it shows whatever `loadGroupDetails` returns for the underlying MLS group — a leaner "contact info" layout for 1:1s could be a follow-up.
- Also flips `CFBundleDisplayName` to "White Noise" in `project.pbxproj` — this was a pre-existing working-tree change, unrelated to the above, included so the tree is clean.
- Builds green: `xcodebuild -scheme whitenoise-mac -configuration Debug` → **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the new chat composer to support adding multiple recipients before creating a chat, with clearer member/pending recipient cards and improved “Create Chat” availability.
  * Group details now open as an inline, trailing-edge slide-in panel from the conversation view, with updated header access and member card presentation.

* **Bug Fixes**
  * Group details no longer persist or display incorrectly when switching between chats; improved panel layering to prevent transcript bleed.
  * Group image search is now hidden for direct messages.

* **Documentation**
  * Updated licensing text in both the README and the project license.

* **Chores**
  * Set the desktop app display name to “White Noise.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->