### PR TITLE
fix: clear new-chat lookup spinner on edited query

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -31,7 +31,14 @@ extension WorkspaceState {
         let lookupGeneration = beginNewChatLookup()
         isResolvingNewChat = true
         defer {
-            if isCurrentNewChatLookup(generation: lookupGeneration, query: query) {
+            // Spinner ownership is keyed on the generation ALONE, independent of the stricter
+            // generation+query guard used for committing results. Only a newer lookup or an
+            // `invalidateNewChatLookup` (both bump the generation, and each sets the spinner
+            // state itself) supersedes this one's ownership of `isResolvingNewChat`. Editing the
+            // query mid-flight without resubmitting must NOT strand the spinner at `true`, so it
+            // is deliberately not part of this check — see issue #255 (mirrors the #110 fix for
+            // group-image search).
+            if ownsNewChatLookup(generation: lookupGeneration) {
                 isResolvingNewChat = false
             }
         }
@@ -221,8 +228,20 @@ extension WorkspaceState {
         isResolvingNewChat = false
     }
 
-    func isCurrentNewChatLookup(generation: UInt64, query: String) -> Bool {
+    /// True while `generation` still owns the new-chat lookup spinner — i.e. no newer
+    /// `beginNewChatLookup` or `invalidateNewChatLookup` has bumped the generation. This is
+    /// intentionally looser than `isCurrentNewChatLookup`: it does NOT require the live query to
+    /// match, because spinner ownership must transfer cleanly even when the user edits the query
+    /// mid-flight without resubmitting (otherwise the spinner would stay stuck `true` — issue #255).
+    func ownsNewChatLookup(generation: UInt64) -> Bool {
         newChatLookupGeneration == generation
+    }
+
+    /// True only if `generation` is still the latest new-chat lookup and the live (trimmed) query
+    /// still equals the one this lookup was issued for. Either a newer lookup or an edited query
+    /// invalidates the in-flight result so it cannot overwrite `newChatRecipient` / `lastError`.
+    func isCurrentNewChatLookup(generation: UInt64, query: String) -> Bool {
+        ownsNewChatLookup(generation: generation)
             && newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -764,17 +764,14 @@ final class WorkspaceState {
             )
         }
 
-        /// Evaluates the production equality guards for a captured generation token.
-        func ownsStaleResultGenerationsForTesting(
-            generation: UInt64,
-            newChatQuery query: String
-        ) -> (
+        /// Evaluates the production generation-ownership guards for a captured token.
+        func ownsStaleResultGenerationsForTesting(generation: UInt64) -> (
             newChatLookup: Bool,
             groupImageSearch: Bool,
             groupDetailsLoad: Bool
         ) {
             return (
-                isCurrentNewChatLookup(generation: generation, query: query),
+                ownsNewChatLookup(generation: generation),
                 ownsGroupImageSearch(generation: generation),
                 ownsGroupDetailsLoad(generation: generation)
             )

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6241,26 +6241,24 @@ struct whitenoise_macTests {
         #expect(wrappedGenerations.groupDetailsLoad == 0)
 
         let currentOwnership = state.ownsStaleResultGenerationsForTesting(
-            generation: 0,
-            newChatQuery: "alice@example.com"
+            generation: 0
         )
         #expect(currentOwnership.newChatLookup)
         #expect(currentOwnership.groupImageSearch)
         #expect(currentOwnership.groupDetailsLoad)
 
         let staleOwnership = state.ownsStaleResultGenerationsForTesting(
-            generation: UInt64.max,
-            newChatQuery: "alice@example.com"
+            generation: UInt64.max
         )
         #expect(!staleOwnership.newChatLookup)
         #expect(!staleOwnership.groupImageSearch)
         #expect(!staleOwnership.groupDetailsLoad)
 
-        let wrongQueryOwnership = state.ownsStaleResultGenerationsForTesting(
-            generation: 0,
-            newChatQuery: "bob@example.com"
+        state.newChatQuery = "bob@example.com"
+        let editedQueryOwnership = state.ownsStaleResultGenerationsForTesting(
+            generation: 0
         )
-        #expect(!wrongQueryOwnership.newChatLookup)
+        #expect(editedQueryOwnership.newChatLookup)
     }
 
     // MARK: - ChatListRowEnrichmentTracker (issue #40 ownership invariants)
@@ -7987,6 +7985,56 @@ struct whitenoise_macTests {
 
         #expect(state.resolvedNewChatRecipient?.accountIdHex == fastId)
         #expect(state.resolvedNewChatRecipient?.title == "Fast Recipient")
+    }
+
+    @MainActor
+    @Test func newChatLookupQueryEditedMidFlightClearsSpinnerWithoutCommitting() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let slowId = "1111111111111111111111111111111111111111111111111111111111111111"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installNormalizedMemberRef(query: "npub1slow", accountIdHex: slowId, npub: "npub1slow")
+        runtime.installProfile(
+            accountIdHex: slowId,
+            profile: UserProfileMetadataFfi(
+                name: "slow",
+                displayName: "Slow Recipient",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.profileRefreshDelaysByAccountId[slowId] = 150_000_000
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatQuery = "npub1slow"
+        let slowLookup = Task { @MainActor in
+            await state.resolveNewChatQueryIfReady()
+        }
+        let slowLookupStarted = await waitFor {
+            runtime.refreshedProfileIds.contains(slowId)
+        }
+        #expect(slowLookupStarted)
+        #expect(state.isResolvingNewChat)
+
+        // Edit the query mid-flight WITHOUT starting a newer lookup: the in-flight
+        // lookup still owns the generation, so when it resumes its defer must clear
+        // the spinner (keyed on generation ownership) even though the stricter
+        // generation+query commit guard now fails and blocks the stale result.
+        state.newChatQuery = "npub1edited"
+        await slowLookup.value
+
+        #expect(!state.isResolvingNewChat)
+        #expect(state.resolvedNewChatRecipient == nil)
+        #expect(state.lastError == nil)
     }
 
     @MainActor


### PR DESCRIPTION
Closes #255

## Summary
- Adds generation-only `ownsNewChatLookup` ownership for the new-chat lookup spinner.
- Clears `isResolvingNewChat` from `resolveNewChatQuery` using generation ownership, while preserving the stricter generation+query guard for committing `newChatRecipient` and `lastError`.
- Adds/updates tests covering generation ownership after query edits and the mid-flight edited-query spinner regression.

## Verification
- `git diff --check` — pass
- conflict-marker scan over changed files — pass
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` — not run: `xcodebuild` is not available on this Linux host

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/258">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->