### PR TITLE
fix: harden media duration label conversion

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -367,13 +367,29 @@ nonisolated enum MessageMediaGridPresentation {
 
 nonisolated enum MediaDurationLabel {
     static func string(for durationSeconds: Double) -> String {
-        let total = max(0, Int(durationSeconds.rounded(.down)))
+        // The duration can be peer-derived (see MediaWaveformAnalyzer), so it may be
+        // NaN, ±Infinity, negative, or larger than Int.max. The trapping Int(_:)
+        // initializer would crash on non-finite or out-of-range values, so clamp the
+        // floored duration into the representable range before converting.
+        let total: Int
+        if durationSeconds.isFinite {
+            let flooredSeconds = durationSeconds.rounded(.down)
+            if flooredSeconds <= 0 {
+                total = 0
+            } else if flooredSeconds >= Double(Int.max) {
+                total = Int.max
+            } else {
+                total = Int(flooredSeconds)
+            }
+        } else {
+            total = 0
+        }
         let hours = total / 3_600
         let minutes = (total % 3_600) / 60
         let seconds = total % 60
 
         if hours > 0 {
-            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+            return "\(hours):" + String(format: "%02d:%02d", minutes, seconds)
         }
         return String(format: "%d:%02d", minutes, seconds)
     }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -32,6 +32,29 @@ struct PureValueTests {
         #expect(DisappearingMessageOption.custom(oversizedSeconds).label == "9223372036854775808 seconds")
     }
 
+    @Test func mediaDurationLabelClampsNonFiniteAndOversizedDurations() async throws {
+        // Regression for whitenoise-mac#253: the audio duration is peer-derived
+        // (MediaWaveformAnalyzer -> AVAudioFile.length / sampleRate), so it may be
+        // NaN, ±Infinity, or larger than Int.max. Int(_:) traps on any of those, so
+        // the label must clamp instead of crashing while rendering an audio row.
+        #expect(MediaDurationLabel.string(for: .nan) == "0:00")
+        #expect(MediaDurationLabel.string(for: .infinity) == "0:00")
+        #expect(MediaDurationLabel.string(for: -.infinity) == "0:00")
+        #expect(MediaDurationLabel.string(for: -1) == "0:00")
+
+        // A crafted header can drive the duration above Int.max; clamping to Int.max
+        // must not trap and must still format as an hours label. Double(Int.max)
+        // rounds up to 2^63, which is > Int.max, so it exercises the clamp path.
+        let expected = "2562047788015215:30:07"
+        #expect(MediaDurationLabel.string(for: 1e19) == expected)
+        #expect(MediaDurationLabel.string(for: Double(Int.max)) == expected)
+        #expect(MediaDurationLabel.string(for: .greatestFiniteMagnitude) == expected)
+
+        // Ordinary values keep formatting exactly as before.
+        #expect(MediaDurationLabel.string(for: 3_599) == "59:59")
+        #expect(MediaDurationLabel.string(for: 3_600) == "1:00:00")
+    }
+
     @Test func remoteImageSanitizedURLRejectsPrivateHosts() async throws {
         // The string entry point used by the UI must also reject internal destinations.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://192.168.1.1/x.png") == nil)


### PR DESCRIPTION
Closes #253

## Summary
- Harden `MediaDurationLabel.string(for:)` before converting peer-derived `Double` durations to `Int`.
- Non-finite and non-positive durations now format as `0:00`; values at or above `Int.max` clamp to `Int.max` before conversion.
- Avoid `%d` for the clamped hours component so an oversized safe value is not truncated by C formatting.
- Add pure regression coverage for NaN, infinities, negative values, `Double(Int.max)`, `1e19`, `.greatestFiniteMagnitude`, and unchanged ordinary labels.

## Verification
- `git diff --check` — passed.
- `git grep -I -n -E '^(<<<<<<<|=======|>>>>>>>)' HEAD -- whitenoise-mac whitenoise-macTests whitenoise-macUITests` — no conflict markers.
- Python logic simulation of the clamp/format branches — passed:
  - `nan`, `inf`, `-inf`, `-1` -> `0:00`
  - `3599` -> `59:59`; `3600` -> `1:00:00`
  - `1e19`, `Double(Int.max)`, `.greatestFiniteMagnitude` -> `2562047788015215:30:07`
- Xcode/Swift checks not run on this Linux worker: `xcodebuild`, `xcrun`, `swift`, and `swiftc` are not installed. CI should run the macOS `swift-format`, sanity, test, build, and analyze jobs.

## Sensitive paths
None. UI/model formatting and pure value test only.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->