### PR TITLE
fix: skip chat-list enrichment for metadata-invariant deltas

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -214,10 +214,28 @@ extension WorkspaceState {
         switch update {
         case .row(let trigger, let row):
             invalidateGroupMemberDetailsCacheIfNeeded(trigger: trigger, groupIdHex: row.groupIdHex)
-            await applyChatRow(row, account: account)
+            // Metadata-invariant deltas (last-message/read-state/pending-confirmation) do not
+            // change the metadata enrichment resolves (direct-chat title/avatar/isDirect), so
+            // skip the per-row FFI fan-out and preserve the already-resolved metadata. This is
+            // the same fast path the Timeline read-state call sites use (issue #170); re-sorting
+            // still happens via `upsertChat` inside `applyChatRow` (issue #251).
+            await applyChatRow(row, account: account, shouldEnrich: chatListTriggerRequiresEnrichment(trigger))
         case .removeRow(trigger: _, let groupIdHex):
             invalidateGroupMembers(for: groupIdHex)
             removeChat(groupIdHex: groupIdHex, account: account)
+        }
+    }
+
+    /// Whether a live chat-list delta can change the metadata enrichment resolves
+    /// (direct-chat title/avatar/`isDirect`). Metadata-invariant triggers only carry
+    /// unread/preview/timestamp/pending-confirmation changes, so they take the
+    /// `shouldEnrich: false` fast path and never trigger the per-row FFI fan-out.
+    func chatListTriggerRequiresEnrichment(_ trigger: ChatListUpdateTriggerFfi) -> Bool {
+        switch trigger {
+        case .newLastMessage, .lastMessageDeleted, .pendingConfirmationChanged, .unreadChanged:
+            return false
+        case .newGroup, .archiveChanged, .membershipChanged, .snapshotRefresh, .removed:
+            return true
         }
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5678,11 +5678,12 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func incrementalChatRowUpdateEnrichesDirectChatTitle() async throws {
-        // Regression for #40: single-row chat-list deltas go through the incremental
-        // enrichment path (startChatListEnrichment(replacingCurrent: false)). After the fix
-        // these tasks are tracked and coalesced per group, but the happy path must still
-        // enrich the row — verify a `.row` delta for a direct chat resolves the peer profile.
+    @Test func newLastMessageChatRowPreservesDirectChatMetadataWithoutReenrichment() async throws {
+        // Regression for #40/#251: a `.newLastMessage` single-row delta is metadata-invariant,
+        // so it takes the `shouldEnrich: false` fast path (no per-row FFI fan-out). The
+        // already-resolved direct-chat metadata (title/avatar/isDirect) must be preserved while
+        // the fresh last-message preview is applied — verify the row still shows the resolved
+        // peer profile without re-querying group details.
         let account = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -5720,28 +5721,49 @@ struct whitenoise_macTests {
         let state = WorkspaceState(clientFactory: { runtime })
 
         await state.bootstrap()
-        let didEnrichIncrementally = await waitFor(attempts: 300) {
+        let didPreserveMetadata = await waitFor(attempts: 300) {
             state.activeChats.first?.title == "Alice Actual"
                 && state.activeChats.first?.preview == "See you soon."
         }
 
-        if !didEnrichIncrementally {
+        if !didPreserveMetadata {
             let chat = state.activeChats.first
             Issue.record(
                 """
-                Expected incremental direct-chat enrichment. \
+                Expected direct-chat metadata preservation. \
                 title=\(chat?.title ?? "nil") preview=\(chat?.preview ?? "nil") \
                 pictureURL=\(chat?.pictureURL ?? "nil") \
                 detailsCalls=\(runtime.groupDetailsCallCounts["direct-group"] ?? 0)
                 """
             )
         }
-        #expect(didEnrichIncrementally)
+        #expect(didPreserveMetadata)
         #expect(state.activeChats.first?.isDirect == true)
         #expect(state.activeChats.first?.pictureURL == "https://example.com/alice.png")
         // The incremental row reuses the initial membership lookup for non-membership triggers;
         // it must not re-query group details just to refresh the last-message preview (#9).
         #expect((runtime.groupDetailsCallCounts["direct-group"] ?? 0) == 1)
+    }
+
+    @MainActor
+    @Test func chatListTriggerEnrichmentGatingMatchesMetadataInvariance() {
+        // The enrichment gate must skip exactly the metadata-invariant triggers and enrich the
+        // rest, so read-state-only deltas never pay for the per-row FFI fan-out (#251).
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+
+        let metadataInvariant: [ChatListUpdateTriggerFfi] = [
+            .newLastMessage, .lastMessageDeleted, .pendingConfirmationChanged, .unreadChanged,
+        ]
+        for trigger in metadataInvariant {
+            #expect(!state.chatListTriggerRequiresEnrichment(trigger))
+        }
+
+        let metadataChanging: [ChatListUpdateTriggerFfi] = [
+            .newGroup, .archiveChanged, .membershipChanged, .snapshotRefresh, .removed,
+        ]
+        for trigger in metadataChanging {
+            #expect(state.chatListTriggerRequiresEnrichment(trigger))
+        }
     }
 
     @Test func chatListOrderingUpdatesSingleRowWithoutResortingWholeList() {


### PR DESCRIPTION
Closes #251

## Summary
- Gates live chat-list `.row` subscription updates by `ChatListUpdateTriggerFfi` before calling `applyChatRow`.
- Skips per-row enrichment for metadata-invariant triggers (`.newLastMessage`, `.lastMessageDeleted`, `.pendingConfirmationChanged`, `.unreadChanged`) so the existing `shouldEnrich: false` path preserves title/avatar/isDirect while applying unread/preview/timestamp changes.
- Keeps metadata-changing triggers on the enrichment path and updates chat-list tests to cover the gating decision and the preserved direct-chat metadata behavior.

## Verification
- `git diff --check` — pass
- Static gate check over edited Swift files — pass (trigger helper covers all enum cases and subscription path calls the helper)
- Conflict-marker scan over edited Swift files — pass
- GitHub PR Checks — pass (run 28548761582)
- GitHub Static Analysis — pass (run 28548761582)

## Review notes
- This is the clean replacement for superseded PR #260, which was closed because it had red CI history on an earlier discarded commit.
- CodeRabbit posted a rate-limit notice, not actionable review findings; there are no inline CodeRabbit comments.

## Sensitive paths
None. Changes are limited to macOS client chat-list state and tests.
