### PR TITLE
fix: guard unavailable notification targets

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -56,11 +56,19 @@ extension WorkspaceState {
     func handleNotificationResponse(_ userInfo: [String: String]) {
         guard let groupIdHex = userInfo["groupIdHex"] else { return }
 
+        let account = notificationAccount(from: userInfo)
         let switchedAccounts: Bool
-        if let account = notificationAccount(from: userInfo), activeAccountId != account.id {
+        if let account, !account.signedOut, activeAccountId != account.id {
             prepareForActiveAccountSwitch(to: account, preservingMessageCacheFor: groupIdHex)
             switchedAccounts = true
         } else {
+            guard activeAccountContainsNotificationGroup(groupIdHex) else {
+                setBackgroundStatus(
+                    L10n.string("This notification is for an account or chat that is no longer available.")
+                )
+                NSApplication.shared.activate(ignoringOtherApps: true)
+                return
+            }
             switchedAccounts = false
         }
 
@@ -77,6 +85,11 @@ extension WorkspaceState {
             await reloadChats()
             await loadMessages(groupIdHex: groupIdHex)
         }
+    }
+
+    func activeAccountContainsNotificationGroup(_ groupIdHex: String) -> Bool {
+        guard let activeAccountId else { return false }
+        return chatItem(accountId: activeAccountId, chatId: groupIdHex) != nil
     }
 
     func startNotificationListener() {

--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -61,14 +61,16 @@ extension WorkspaceState {
         if let account, !account.signedOut, activeAccountId != account.id {
             prepareForActiveAccountSwitch(to: account, preservingMessageCacheFor: groupIdHex)
             switchedAccounts = true
-        } else {
-            guard activeAccountContainsNotificationGroup(groupIdHex) else {
+        } else if account == nil || account?.signedOut == true {
+            guard activeAccountHasChat(groupIdHex: groupIdHex) else {
                 setBackgroundStatus(
                     L10n.string("This notification is for an account or chat that is no longer available.")
                 )
                 NSApplication.shared.activate(ignoringOtherApps: true)
                 return
             }
+            switchedAccounts = false
+        } else {
             switchedAccounts = false
         }
 
@@ -87,7 +89,7 @@ extension WorkspaceState {
         }
     }
 
-    func activeAccountContainsNotificationGroup(_ groupIdHex: String) -> Bool {
+    func activeAccountHasChat(groupIdHex: String) -> Bool {
         guard let activeAccountId else { return false }
         return chatItem(accountId: activeAccountId, chatId: groupIdHex) != nil
     }

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -23903,6 +23903,65 @@
         }
       }
     },
+    "This notification is for an account or chat that is no longer available." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Benachrichtigung gehört zu einem Konto oder Chat, der nicht mehr verfügbar ist."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta notificación es de una cuenta o chat que ya no está disponible."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette notification concerne un compte ou une discussion qui n’est plus disponible."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questa notifica riguarda un account o una chat che non è più disponibile."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta notificação é de uma conta ou conversa que não está mais disponível."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это уведомление относится к учетной записи или чату, которые больше недоступны."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu bildirim artık kullanılamayan bir hesaba veya sohbete ait."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此通知对应的账号或聊天已不可用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此通知對應的帳號或聊天已不可用。"
+          }
+        }
+      }
+    },
     "This permanently removes every local audit JSONL file on this Mac." : {
 
     },

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -8971,6 +8971,113 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func notificationResponseForUnresolvableAccountDoesNotSelectForeignGroup() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.removeObject(forKey: "whitenoise.mac.activeAccountId")
+
+        let account = AccountSummaryFfi(
+            label: "primary-account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == account.label)
+        #expect(state.selection == .chat("direct-group"))
+
+        runtime.clearTimelineMessageQueries()
+        state.handleNotificationResponse([
+            "groupIdHex": "foreign-group",
+            "accountIdHex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "accountRef": "removed-account",
+        ])
+
+        #expect(state.activeAccountId == account.label)
+        #expect(state.selection == .chat("direct-group"))
+        #expect(
+            state.backgroundStatus
+                == "This notification is for an account or chat that is no longer available."
+        )
+        #expect(runtime.timelineMessageQueries.isEmpty)
+    }
+
+    @MainActor
+    @Test func notificationResponseForSignedOutAccountDoesNotSwitchOrSelectForeignGroup() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.removeObject(forKey: "whitenoise.mac.activeAccountId")
+
+        let primary = AccountSummaryFfi(
+            label: "primary-account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let signedOut = AccountSummaryFfi(
+            label: "signed-out-account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            signedOut: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, signedOut])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: primary.accountIdHex,
+            otherAccountIdHex: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == primary.label)
+        #expect(state.selection == .chat("direct-group"))
+
+        runtime.clearTimelineMessageQueries()
+        state.handleNotificationResponse([
+            "groupIdHex": "foreign-group",
+            "accountIdHex": signedOut.accountIdHex,
+            "accountRef": signedOut.label,
+        ])
+
+        #expect(state.activeAccountId == primary.label)
+        #expect(state.selection == .chat("direct-group"))
+        #expect(
+            state.backgroundStatus
+                == "This notification is for an account or chat that is no longer available."
+        )
+        #expect(runtime.timelineMessageQueries.isEmpty)
+    }
+
+    @MainActor
     @Test func enablingPrivacySecurityTogglesRequireConfiguredTokens() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -8971,6 +8971,59 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func notificationResponseForActiveAccountAllowsUnsyncedGroupBeforeReload() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.removeObject(forKey: "whitenoise.mac.activeAccountId")
+
+        let account = AccountSummaryFfi(
+            label: "primary-account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == account.label)
+
+        // Simulate a notification for an active-account chat that the runtime can return,
+        // but the current chat-list snapshot has not learned about yet. The tap path must
+        // select first and let the reload discover it, not reject it as unavailable.
+        state.setChats([], forAccountId: account.label)
+        state.selection = .settings(.accounts)
+        runtime.clearTimelineMessageQueries()
+
+        state.handleNotificationResponse([
+            "groupIdHex": "direct-group",
+            "accountIdHex": account.accountIdHex,
+            "accountRef": account.label,
+        ])
+
+        #expect(state.selection == .chat("direct-group"))
+        #expect(
+            state.backgroundStatus
+                != "This notification is for an account or chat that is no longer available."
+        )
+    }
+
+    @MainActor
     @Test func notificationResponseForUnresolvableAccountDoesNotSelectForeignGroup() async throws {
         let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
         defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }


### PR DESCRIPTION
## Summary
- Guard notification taps whose account cannot be resolved or is signed out.
- Only select/load the notification chat without an account switch if the active account already owns that chat.
- Surface a background status and bail instead of selecting a foreign group.

## Test Plan
- `git diff --check`
- conflict marker sweep: `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' HEAD -- .` (no matches)
- duplicate Swift function-name heuristic over changed files (no matches)
- not run: `xcodebuild` / Swift tests unavailable on this Linux host

Closes #256


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->