### PR TITLE
fix: reject private markdown link hosts

### DIFF
--- a/whitenoise-mac/Core/MarkdownLinkPolicy.swift
+++ b/whitenoise-mac/Core/MarkdownLinkPolicy.swift
@@ -37,6 +37,13 @@ nonisolated enum MarkdownLinkPolicy {
             return false
         }
         guard let host = url.host, !host.isEmpty else { return false }
+        // Peer-controlled links must not point at literal private/loopback/link-local
+        // destinations. Reuse the SSRF host check already implemented for avatar image URLs so
+        // a Markdown link to a LAN/loopback address is suppressed symmetrically with images
+        // (whitenoise-mac#249). Public http/https hosts still pass; the same DNS-rebinding
+        // limitation documented on `RemoteImageURLPolicy` applies (a public-looking hostname can
+        // still resolve to a private IP).
+        guard !RemoteImageURLPolicy.isDisallowedHost(host) else { return false }
         return true
     }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -276,6 +276,34 @@ struct PureValueTests {
         }
     }
 
+    @Test func markdownLinkPolicyRejectsPrivateAndLoopbackHosts() async throws {
+        // whitenoise-mac#249: peer-controlled Markdown links to literal private/loopback/
+        // link-local destinations must be suppressed symmetrically with avatar image URLs,
+        // even though the scheme is an otherwise-allowed http/https.
+        for raw in [
+            "http://192.168.0.1/admin/reboot",
+            "https://[::1]:9000/",
+            "http://127.0.0.1:8080/",
+            "https://10.0.0.5/x",
+            "http://169.254.169.254/latest/meta-data",
+            "https://[fe80::1]/",
+            "http://localhost/admin",
+            "https://printer.local/status",
+            // Obfuscated loopback literal (decimal form of 127.0.0.1).
+            "http://2130706433/",
+        ] {
+            #expect(
+                MarkdownLinkPolicy.sanitizedURL(from: raw) == nil,
+                "expected rejection for \(String(reflecting: raw))"
+            )
+        }
+
+        // Public http/https hosts and internal nostr links still pass.
+        #expect(MarkdownLinkPolicy.sanitizedURL(from: "https://example.com/path") != nil)
+        #expect(MarkdownLinkPolicy.sanitizedURL(from: "http://cdn.example.com/a") != nil)
+        #expect(MarkdownLinkPolicy.sanitizedURL(from: "nostr:nprofile1alice") != nil)
+    }
+
     @Test func markdownInlineBuilderDropsUnsafeMarkdownLinks() async throws {
         let safe = MarkdownDisplayInlineBuilder.attributedString(
             from: [


### PR DESCRIPTION
Closes #249

## Summary
- Reuses `RemoteImageURLPolicy.isDisallowedHost` in `MarkdownLinkPolicy.isAllowedExternalURL` so peer-controlled Markdown http/https links to private, loopback, link-local, localhost, `.local`, and obfuscated IP literals are suppressed.
- Keeps public http/https links and internal `nostr:` links allowed.
- Adds pure regression coverage for private/loopback/local Markdown link destinations.

## Verification
- `git diff --check` ✅
- `scripts/ci/macos-sanity-checks.sh` attempted on Linux; failed immediately because `xcodebuild` is unavailable.
- CI-exact macOS checks (`xcrun swift-format`, `xcodebuild test/build/analyze`) are unavailable on this Linux host and must run in GitHub macOS CI.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/263">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link safety by blocking external web links that resolve to private, loopback, link-local, or other unsafe hosts.
  * Continued allowing valid public `http`/`https` links and `nostr:` profile links as before.

* **Tests**
  * Added coverage for unsafe host handling, including IPv4, IPv6, localhost, and numeric loopback forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->