### PR TITLE
fix: precompute sanitized avatar URLs

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1277,13 +1277,15 @@ final class WorkspaceState {
                 if lhs.isAdmin != rhs.isAdmin { return lhs.isAdmin }
                 return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
             }
+        let avatarURL = firstNonBlank([details.group.avatarUrl])
 
         return GroupDetailsSnapshot(
             groupIdHex: details.group.groupIdHex,
             endpoint: details.group.endpoint,
             name: firstNonBlank([details.group.name]) ?? L10n.string("Unnamed group"),
             description: details.group.description,
-            avatarURL: firstNonBlank([details.group.avatarUrl]),
+            avatarURL: avatarURL,
+            sanitizedAvatarURL: RemoteImageURLPolicy.sanitizedURL(from: avatarURL),
             avatarDimension: firstNonBlank([details.group.avatarDim]),
             nostrGroupIdHex: details.group.nostrGroupIdHex,
             relays: details.group.relays,

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -13,6 +13,9 @@ struct AccountItem: Identifiable, Hashable {
     let npub: String?
     let initials: String
     let pictureURL: String?
+    /// Pre-sanitized once from the peer-controlled raw URL so avatar render passes only read it.
+    /// The view still gates loading on `WorkspaceState.loadRemoteImages`.
+    let sanitizedPictureURL: URL?
     let localSigning: Bool
     let isRunning: Bool
     /// True when the account has been signed out (non-destructive): local data is
@@ -27,6 +30,7 @@ struct AccountItem: Identifiable, Hashable {
         npub: String? = nil,
         initials: String? = nil,
         pictureURL: String? = nil,
+        sanitizedPictureURL: URL? = nil,
         localSigning: Bool = true,
         isRunning: Bool = true,
         signedOut: Bool = false
@@ -38,6 +42,8 @@ struct AccountItem: Identifiable, Hashable {
         self.npub = npub
         self.initials = initials ?? DisplayText.initials(for: displayName, fallback: accountIdHex)
         self.pictureURL = pictureURL
+        self.sanitizedPictureURL =
+            sanitizedPictureURL ?? RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
         self.localSigning = localSigning
         self.isRunning = isRunning
         self.signedOut = signedOut
@@ -52,6 +58,9 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     let updatedAt: Date?
     let avatarSeed: String
     let pictureURL: String?
+    /// Pre-sanitized once from the peer-controlled raw URL so chat-row render passes only read it.
+    /// The view still gates loading on `WorkspaceState.loadRemoteImages`.
+    let sanitizedPictureURL: URL?
     let unreadCount: Int
     /// Unread messages in this chat that @-mention the active account.
     let unreadMentionCount: Int
@@ -72,6 +81,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         updatedAt: Date?,
         avatarSeed: String,
         pictureURL: String?,
+        sanitizedPictureURL: URL? = nil,
         unreadCount: Int,
         unreadMentionCount: Int = 0,
         isDirect: Bool = false,
@@ -84,6 +94,8 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         self.updatedAt = updatedAt
         self.avatarSeed = avatarSeed
         self.pictureURL = pictureURL
+        self.sanitizedPictureURL =
+            sanitizedPictureURL ?? RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
         self.unreadCount = unreadCount
         self.unreadMentionCount = unreadMentionCount
         self.isDirect = isDirect
@@ -135,6 +147,8 @@ struct GroupDetailsSnapshot: Hashable {
     let name: String
     let description: String
     let avatarURL: String?
+    /// Pre-sanitized once from the group profile avatar URL for details/header rendering.
+    let sanitizedAvatarURL: URL?
     let avatarDimension: String?
     let nostrGroupIdHex: String
     let relays: [String]
@@ -1863,6 +1877,25 @@ struct NewChatRecipient: Equatable {
     let npub: String
     let displayName: String?
     let pictureURL: String?
+    /// Pre-sanitized once from the peer-controlled raw URL so recipient rows only read it.
+    let sanitizedPictureURL: URL?
+
+    init(
+        sourceQuery: String,
+        memberRef: String,
+        accountIdHex: String,
+        npub: String,
+        displayName: String?,
+        pictureURL: String?
+    ) {
+        self.sourceQuery = sourceQuery
+        self.memberRef = memberRef
+        self.accountIdHex = accountIdHex
+        self.npub = npub
+        self.displayName = displayName
+        self.pictureURL = pictureURL
+        self.sanitizedPictureURL = RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
+    }
 
     var title: String {
         guard let displayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -13,8 +13,7 @@ struct AccountItem: Identifiable, Hashable {
     let npub: String?
     let initials: String
     let pictureURL: String?
-    /// Pre-sanitized once from the peer-controlled raw URL so avatar render passes only read it.
-    /// The view still gates loading on `WorkspaceState.loadRemoteImages`.
+    /// Pre-sanitized avatar URL; `ProfileImageAvatarView` still applies `loadRemoteImages`.
     let sanitizedPictureURL: URL?
     let localSigning: Bool
     let isRunning: Bool
@@ -58,8 +57,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     let updatedAt: Date?
     let avatarSeed: String
     let pictureURL: String?
-    /// Pre-sanitized once from the peer-controlled raw URL so chat-row render passes only read it.
-    /// The view still gates loading on `WorkspaceState.loadRemoteImages`.
+    /// Pre-sanitized avatar URL for chat rows/headers; the view still applies `loadRemoteImages`.
     let sanitizedPictureURL: URL?
     let unreadCount: Int
     /// Unread messages in this chat that @-mention the active account.
@@ -169,6 +167,12 @@ struct GroupDetailsSnapshot: Hashable {
     }
 
     var disappearingMessagesEnabled: Bool { disappearingMessageSecs > 0 }
+}
+
+enum GroupDetailsHeaderAvatar {
+    static func sanitizedURL(snapshot: GroupDetailsSnapshot?, fallback chat: ChatItem) -> URL? {
+        snapshot?.sanitizedAvatarURL ?? chat.sanitizedPictureURL
+    }
 }
 
 struct MessageReaction: Identifiable, Hashable {
@@ -1763,12 +1767,35 @@ enum RelaySettingsSection: String, CaseIterable, Identifiable {
 }
 
 struct ProfileDraft: Equatable {
-    var name = ""
-    var displayName = ""
-    var about = ""
-    var picture = ""
-    var nip05 = ""
-    var lud16 = ""
+    var name: String
+    var displayName: String
+    var about: String
+    var picture: String {
+        didSet {
+            guard picture != oldValue else { return }
+            sanitizedPictureURL = RemoteImageURLPolicy.sanitizedURL(from: picture)
+        }
+    }
+    private(set) var sanitizedPictureURL: URL?
+    var nip05: String
+    var lud16: String
+
+    init(
+        name: String = "",
+        displayName: String = "",
+        about: String = "",
+        picture: String = "",
+        nip05: String = "",
+        lud16: String = ""
+    ) {
+        self.name = name
+        self.displayName = displayName
+        self.about = about
+        self.picture = picture
+        self.sanitizedPictureURL = RemoteImageURLPolicy.sanitizedURL(from: picture)
+        self.nip05 = nip05
+        self.lud16 = lud16
+    }
 }
 
 struct RelaySettingsSnapshot: Equatable {

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -631,7 +631,7 @@ struct NewChatRecipientCard: View {
             ProfileImageAvatarView(
                 seed: recipient.accountIdHex,
                 initials: recipient.title,
-                pictureURL: recipient.pictureURL,
+                sanitizedPictureURL: recipient.sanitizedPictureURL,
                 size: 44,
                 isSelected: false
             )
@@ -694,21 +694,14 @@ struct ProfileImageAvatarView: View {
     @Environment(WorkspaceState.self) private var workspace
     let seed: String
     let initials: String
-    let pictureURL: String?
+    /// Already passed through `RemoteImageURLPolicy`; body only checks the user preference.
+    let sanitizedPictureURL: URL?
     let size: CGFloat
     let isSelected: Bool
 
-    /// Only returns a fetchable URL when the user has opted into loading remote images AND the
-    /// URL passes the safety policy (https + valid host). Otherwise nil, so a generated avatar
-    /// is shown and no outbound request is made to a sender-chosen server.
-    private var imageURL: URL? {
-        guard workspace.loadRemoteImages else { return nil }
-        return RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
-    }
-
     var body: some View {
         Group {
-            if let imageURL {
+            if workspace.loadRemoteImages, let imageURL = sanitizedPictureURL {
                 DownsampledAsyncImage(url: imageURL, maxPixelSize: size * 2) { image in
                     image
                         .resizable()
@@ -743,7 +736,7 @@ struct ConversationHeader: View {
                     ProfileImageAvatarView(
                         seed: chat.avatarSeed,
                         initials: chat.title,
-                        pictureURL: chat.pictureURL,
+                        sanitizedPictureURL: chat.sanitizedPictureURL,
                         size: 38,
                         isSelected: false
                     )

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -26,8 +26,7 @@ struct GroupDetailsSheet: View {
     }
 
     private var headerAvatarURL: URL? {
-        guard let snapshot = workspace.groupDetailsSnapshot else { return chat.sanitizedPictureURL }
-        return snapshot.sanitizedAvatarURL
+        GroupDetailsHeaderAvatar.sanitizedURL(snapshot: workspace.groupDetailsSnapshot, fallback: chat)
     }
 
     var body: some View {

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -25,6 +25,11 @@ struct GroupDetailsSheet: View {
                 != snapshot.description
     }
 
+    private var headerAvatarURL: URL? {
+        guard let snapshot = workspace.groupDetailsSnapshot else { return chat.sanitizedPictureURL }
+        return snapshot.sanitizedAvatarURL
+    }
+
     var body: some View {
         @Bindable var workspace = workspace
 
@@ -33,7 +38,7 @@ struct GroupDetailsSheet: View {
                 ProfileImageAvatarView(
                     seed: chat.avatarSeed,
                     initials: chat.title,
-                    pictureURL: workspace.groupDetailsSnapshot?.avatarURL ?? chat.pictureURL,
+                    sanitizedPictureURL: headerAvatarURL,
                     size: 48,
                     isSelected: false
                 )
@@ -559,7 +564,7 @@ struct GroupImagePickerSheet: View {
                     ProfileImageAvatarView(
                         seed: chat.avatarSeed,
                         initials: chat.title,
-                        pictureURL: chat.pictureURL,
+                        sanitizedPictureURL: chat.sanitizedPictureURL,
                         size: 46,
                         isSelected: false
                     )

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -550,8 +550,7 @@ struct ProfileSettingsView: View {
                         ProfileImageAvatarView(
                             seed: account.accountIdHex,
                             initials: profilePreviewName(fallback: account),
-                            sanitizedPictureURL: RemoteImageURLPolicy.sanitizedURL(
-                                from: workspace.profileDraft.picture),
+                            sanitizedPictureURL: workspace.profileDraft.sanitizedPictureURL,
                             size: 56,
                             isSelected: false
                         )

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -297,7 +297,7 @@ struct AccountSettingsRow: View {
                     ProfileImageAvatarView(
                         seed: account.accountIdHex,
                         initials: account.initials,
-                        pictureURL: account.pictureURL,
+                        sanitizedPictureURL: account.sanitizedPictureURL,
                         size: 44,
                         isSelected: false
                     )
@@ -550,7 +550,8 @@ struct ProfileSettingsView: View {
                         ProfileImageAvatarView(
                             seed: account.accountIdHex,
                             initials: profilePreviewName(fallback: account),
-                            pictureURL: workspace.profileDraft.picture,
+                            sanitizedPictureURL: RemoteImageURLPolicy.sanitizedURL(
+                                from: workspace.profileDraft.picture),
                             size: 56,
                             isSelected: false
                         )
@@ -631,7 +632,7 @@ struct IdentityKeysSettingsView: View {
                         ProfileImageAvatarView(
                             seed: account.accountIdHex,
                             initials: account.initials,
-                            pictureURL: account.pictureURL,
+                            sanitizedPictureURL: account.sanitizedPictureURL,
                             size: 52,
                             isSelected: false
                         )

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -87,7 +87,7 @@ private struct AccountRailAvatar: View {
             ProfileImageAvatarView(
                 seed: account.accountIdHex,
                 initials: account.initials,
-                pictureURL: account.pictureURL,
+                sanitizedPictureURL: account.sanitizedPictureURL,
                 size: 42,
                 isSelected: isActive
             )
@@ -259,7 +259,7 @@ struct SettingsListDrawerView: View {
                 ProfileImageAvatarView(
                     seed: account.accountIdHex,
                     initials: account.initials,
-                    pictureURL: account.pictureURL,
+                    sanitizedPictureURL: account.sanitizedPictureURL,
                     size: 34,
                     isSelected: false
                 )
@@ -333,7 +333,7 @@ struct ChatRowContent: View {
             ProfileImageAvatarView(
                 seed: chat.avatarSeed,
                 initials: chat.title,
-                pictureURL: chat.pictureURL,
+                sanitizedPictureURL: chat.sanitizedPictureURL,
                 size: 42,
                 isSelected: false
             )

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -164,6 +164,53 @@ struct PureValueTests {
             pictureURL: "https://cdn.example/recipient.png"
         )
         #expect(recipient.sanitizedPictureURL?.absoluteString == "https://cdn.example/recipient.png")
+
+        let snapshot = groupDetailsSnapshot(
+            avatarURL: "  https://cdn.example/group.png  ",
+            sanitizedAvatarURL: RemoteImageURLPolicy.sanitizedURL(
+                from: "  https://cdn.example/group.png  ")
+        )
+        #expect(snapshot.avatarURL == "  https://cdn.example/group.png  ")
+        #expect(snapshot.sanitizedAvatarURL?.absoluteString == "https://cdn.example/group.png")
+    }
+
+    @Test func groupDetailsHeaderAvatarFallsBackToChatAvatarWhenSnapshotHasNone() async throws {
+        let chat = ChatItem(
+            id: "chat",
+            title: "Chat",
+            subtitle: "Group message",
+            preview: "No messages yet",
+            updatedAt: nil,
+            avatarSeed: "chat",
+            pictureURL: "https://cdn.example/chat.png",
+            unreadCount: 0
+        )
+        let emptySnapshot = groupDetailsSnapshot(avatarURL: nil, sanitizedAvatarURL: nil)
+        let snapshotWithAvatar = groupDetailsSnapshot(
+            avatarURL: "https://cdn.example/group.png",
+            sanitizedAvatarURL: RemoteImageURLPolicy.sanitizedURL(from: "https://cdn.example/group.png")
+        )
+
+        #expect(
+            GroupDetailsHeaderAvatar.sanitizedURL(snapshot: nil, fallback: chat)?.absoluteString
+                == "https://cdn.example/chat.png")
+        #expect(
+            GroupDetailsHeaderAvatar.sanitizedURL(snapshot: emptySnapshot, fallback: chat)?.absoluteString
+                == "https://cdn.example/chat.png")
+        #expect(
+            GroupDetailsHeaderAvatar.sanitizedURL(snapshot: snapshotWithAvatar, fallback: chat)?.absoluteString
+                == "https://cdn.example/group.png")
+    }
+
+    @Test func profileDraftCachesSanitizedPictureURL() async throws {
+        var draft = ProfileDraft(picture: "  https://cdn.example/profile.png  ")
+        #expect(draft.sanitizedPictureURL?.absoluteString == "https://cdn.example/profile.png")
+
+        draft.displayName = "Updated"
+        #expect(draft.sanitizedPictureURL?.absoluteString == "https://cdn.example/profile.png")
+
+        draft.picture = "https://127.0.0.1/profile.png"
+        #expect(draft.sanitizedPictureURL == nil)
     }
 
     @Test func downsampledImageSizingCeilsAndBucketsRequestedPixels() async throws {
@@ -382,5 +429,29 @@ struct PureValueTests {
             }
         }
         return result
+    }
+
+    private func groupDetailsSnapshot(avatarURL: String?, sanitizedAvatarURL: URL?) -> GroupDetailsSnapshot {
+        GroupDetailsSnapshot(
+            groupIdHex: "group",
+            endpoint: "",
+            name: "Group",
+            description: "",
+            avatarURL: avatarURL,
+            sanitizedAvatarURL: sanitizedAvatarURL,
+            avatarDimension: nil,
+            nostrGroupIdHex: "",
+            relays: [],
+            adminIds: [],
+            archived: false,
+            pendingConfirmation: false,
+            members: [],
+            isSelfAdmin: false,
+            isLastAdmin: false,
+            canInvite: false,
+            canLeave: true,
+            requiresSelfDemoteBeforeLeave: false,
+            disappearingMessageSecs: 0
+        )
     }
 }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -131,6 +131,41 @@ struct PureValueTests {
         #expect(sanitized?.absoluteString == "https://cdn.example/p.png")
     }
 
+    @Test func avatarModelsPrecomputeSanitizedPictureURLs() async throws {
+        let account = AccountItem(
+            id: "account",
+            accountRef: "account",
+            displayName: "Account",
+            accountIdHex: "abc123",
+            pictureURL: "  https://cdn.example/account.png  "
+        )
+        #expect(account.pictureURL == "  https://cdn.example/account.png  ")
+        #expect(account.sanitizedPictureURL?.absoluteString == "https://cdn.example/account.png")
+
+        let chat = ChatItem(
+            id: "chat",
+            title: "Chat",
+            subtitle: "Group message",
+            preview: "No messages yet",
+            updatedAt: nil,
+            avatarSeed: "chat",
+            pictureURL: "https://0x7f000001/avatar.png",
+            unreadCount: 0
+        )
+        #expect(chat.pictureURL == "https://0x7f000001/avatar.png")
+        #expect(chat.sanitizedPictureURL == nil)
+
+        let recipient = NewChatRecipient(
+            sourceQuery: "npub1recipient",
+            memberRef: "npub1recipient",
+            accountIdHex: "def456",
+            npub: "npub1recipient",
+            displayName: "Recipient",
+            pictureURL: "https://cdn.example/recipient.png"
+        )
+        #expect(recipient.sanitizedPictureURL?.absoluteString == "https://cdn.example/recipient.png")
+    }
+
     @Test func downsampledImageSizingCeilsAndBucketsRequestedPixels() async throws {
         #expect(DownsampledImageSizing.requestedPixelSize(0) == 1)
         #expect(DownsampledImageSizing.requestedPixelSize(63.1) == 64)


### PR DESCRIPTION
## Summary
- Precompute sanitized avatar image URLs on `AccountItem`, `ChatItem`, `NewChatRecipient`, and group details snapshots.
- Pass the pre-sanitized URLs into `ProfileImageAvatarView` so hot avatar body renders only check `loadRemoteImages` and read a stored `URL?`.
- Add pure value coverage for sanitized avatar URL precomputation and SSRF rejection.

## Test Plan
- `git diff --check`
- Static sweep: `git grep -n 'pictureURL:' -- 'whitenoise-mac/Views/*.swift'` returned no view call sites using raw picture URLs.
- Not run: `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` (`xcodebuild: command not found` on this Linux worker).

Closes #254


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/264">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar image handling across chats, groups, settings, and profile views.
  * Fixed fallback behavior so group headers and related screens show the expected avatar when a group image is unavailable.
  * Added safer handling for image URLs, reducing issues caused by invalid or poorly formatted links.

* **New Features**
  * Avatar rendering now consistently uses preprocessed image URLs for more reliable display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->