### PR TITLE
fix: harden message timeline fallback

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1352,7 +1352,26 @@ struct MessageItem: Identifiable, Hashable {
         self.contentMarkdown = contentMarkdown.map(MarkdownDisplayDocument.init(document:))
         self.trimmedBody = trimmedBody
         self.sentAt = sentAt
-        self.timelineAt = timelineAt ?? UInt64(sentAt.timeIntervalSince1970)
+        // `timelineAt` is normally supplied by the core mapping; the fallback derives it from
+        // `sentAt`. A pre-epoch, non-finite, or oversized `sentAt` would trap the `UInt64(_:)`
+        // conversion, so clamp the floored timestamp into the representable range first.
+        let fallbackTimeline = sentAt.timeIntervalSince1970
+        let resolvedTimelineAt: UInt64
+        if let timelineAt = timelineAt {
+            resolvedTimelineAt = timelineAt
+        } else if fallbackTimeline.isFinite {
+            let flooredTimeline = fallbackTimeline.rounded(.down)
+            if flooredTimeline <= 0 {
+                resolvedTimelineAt = 0
+            } else if flooredTimeline >= Double(UInt64.max) {
+                resolvedTimelineAt = UInt64.max
+            } else {
+                resolvedTimelineAt = UInt64(flooredTimeline)
+            }
+        } else {
+            resolvedTimelineAt = 0
+        }
+        self.timelineAt = resolvedTimelineAt
         self.timelineKind = timelineKind
         self.isDeleted = isDeleted
         self.invalidationStatus = invalidationStatus

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -55,6 +55,41 @@ struct PureValueTests {
         #expect(MediaDurationLabel.string(for: 3_600) == "1:00:00")
     }
 
+    @Test func messageItemTimelineFallbackClampsPreEpochAndNonFiniteDates() async throws {
+        // Regression for whitenoise-mac#247: the timelineAt fallback derives from
+        // sentAt via UInt64(_:), which traps on negative (pre-1970) or non-finite
+        // dates. The fallback must clamp instead of crashing the initializer.
+        func timelineAt(for sentAt: Date) -> UInt64 {
+            MessageItem(id: "t", senderName: "s", body: "b", sentAt: sentAt, isOutgoing: false).timelineAt
+        }
+
+        // Pre-epoch dates have a negative timeIntervalSince1970 and clamp to 0.
+        #expect(timelineAt(for: Date(timeIntervalSince1970: -1)) == 0)
+        #expect(timelineAt(for: Date(timeIntervalSince1970: -1_000)) == 0)
+
+        // Non-finite dates also clamp to 0 rather than trapping.
+        #expect(timelineAt(for: Date(timeIntervalSince1970: .nan)) == 0)
+        #expect(timelineAt(for: Date(timeIntervalSince1970: .infinity)) == 0)
+        #expect(timelineAt(for: Date(timeIntervalSince1970: -.infinity)) == 0)
+
+        // Ordinary positive dates floor to their epoch seconds.
+        #expect(timelineAt(for: Date(timeIntervalSince1970: 1_700_000_000.75)) == 1_700_000_000)
+
+        // Oversized finite dates clamp to UInt64.max instead of trapping.
+        #expect(timelineAt(for: Date(timeIntervalSince1970: 1e30)) == UInt64.max)
+
+        // An explicit timelineAt still overrides the fallback entirely.
+        let explicit = MessageItem(
+            id: "t",
+            senderName: "s",
+            body: "b",
+            sentAt: Date(timeIntervalSince1970: -5),
+            timelineAt: 42,
+            isOutgoing: false
+        )
+        #expect(explicit.timelineAt == 42)
+    }
+
     @Test func remoteImageSanitizedURLRejectsPrivateHosts() async throws {
         // The string entry point used by the UI must also reject internal destinations.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://192.168.1.1/x.png") == nil)


### PR DESCRIPTION
Closes #247

## Summary
- Hardened `MessageItem`'s fallback `timelineAt` derivation so pre-epoch, non-finite, and oversized `sentAt` values no longer trap `UInt64(_:)`.
- Added pure-value regression coverage for negative dates, `NaN`, `±Infinity`, oversized finite dates, ordinary flooring, and explicit `timelineAt` override behavior.

## Verification
- `git diff --check` — passed
- Static changed-line check for `swift-format` 120-column limit — passed for touched lines
- Conflict-marker scan for Swift files — passed
- GitHub Actions / Mac CI: `PR Checks` — passed
- GitHub Actions / Mac CI: `Static Analysis` — passed
- CodeRabbit status — passed, but the bot left a rate-limit notice instead of a substantive review; no inline findings were returned.

## Sensitive paths
None. Touched Swift view-model/test code only.
