### PR TITLE
fix: guard prepared media attachments against stale selection

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -247,7 +247,7 @@ extension WorkspaceState {
             }
             do {
                 let attachment = try await OutgoingMediaDraftProcessor.preparedAttachment(fromFileURL: url)
-                appendPendingMediaAttachment(attachment, for: draftKey)
+                guard appendPendingMediaAttachmentIfSelectionUnchanged(attachment, for: draftKey) else { return }
             } catch is CancellationError {
                 return
             } catch {
@@ -337,7 +337,9 @@ extension WorkspaceState {
                     waveformSamples: samples
                 )
             )
-            appendPendingMediaAttachment(attachment, for: draftKey)
+            // `preparedVoiceAttachment` already removes the recording temp file in a defer, so
+            // nothing leaks when the stale-selection guard discards the prepared attachment.
+            appendPendingMediaAttachmentIfSelectionUnchanged(attachment, for: draftKey)
         } catch is CancellationError {
             return
         } catch {
@@ -355,6 +357,21 @@ extension WorkspaceState {
             presentMaxMediaAttachmentWarning()
             return false
         }
+        return true
+    }
+
+    /// Appends a freshly prepared attachment only if the live composer selection still matches
+    /// the draft captured before the async media-preparation step. If the user switched
+    /// chats/accounts during preparation the attachment is discarded rather than filed under the
+    /// stale conversation, preventing private-content misdirection (whitenoise-mac#245). Returns
+    /// whether the selection still matched and the append was attempted.
+    @discardableResult
+    func appendPendingMediaAttachmentIfSelectionUnchanged(
+        _ attachment: PendingMediaAttachment,
+        for draftKey: ComposerDraftKey
+    ) -> Bool {
+        guard selectedComposerDraftKey == draftKey else { return false }
+        appendPendingMediaAttachment(attachment, for: draftKey)
         return true
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5114,6 +5114,62 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func preparedMediaAttachmentIsDiscardedWhenSelectionChangesDuringPrep() async throws {
+        // Issue #245: media/voice prep captures the composer draft key before an async prep
+        // step. If the user switches chats while prep is in flight, the finished attachment
+        // must be discarded rather than filed under the chat they just left. The append is
+        // gated by `appendPendingMediaAttachmentIfSelectionUnchanged`, which discards when the
+        // live selection no longer matches the captured key.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        guard let chatA = state.activeChats.first(where: { $0.id == "group" }),
+            let chatB = state.activeChats.first(where: { $0.id == "direct-group" })
+        else {
+            Issue.record("Expected both test chats")
+            return
+        }
+
+        state.selectChat(chatA)
+        guard let staleKey = state.selectedComposerDraftKey else {
+            Issue.record("Expected a composer draft key for chat A")
+            return
+        }
+
+        let attachment = PendingMediaAttachment(
+            fileName: "notes.txt",
+            mediaType: "text/plain",
+            data: Data("hello media".utf8),
+            dim: nil
+        )
+
+        // Simulate the user switching to chat B while prep is in flight, then the prep
+        // completing with chat A's captured key.
+        state.selectChat(chatB)
+        let appended = state.appendPendingMediaAttachmentIfSelectionUnchanged(attachment, for: staleKey)
+
+        #expect(!appended)
+        // Nothing lands in the chat the user left, nor in the chat they are now viewing.
+        #expect(state.pendingMediaAttachmentsByConversation[staleKey] == nil)
+        #expect(state.pendingMediaAttachments.isEmpty)
+
+        // Sanity check the positive path: with selection unchanged the attachment is appended.
+        state.selectChat(chatA)
+        let appendedAgain = state.appendPendingMediaAttachmentIfSelectionUnchanged(attachment, for: staleKey)
+        #expect(appendedAgain)
+        #expect(state.pendingMediaAttachments.map(\.fileName) == ["notes.txt"])
+    }
+
+    @MainActor
     @Test func mediaSendRefreshesSelectedTimelineImmediately() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
Closes #245

## Summary
- Revalidates the live composer draft key after async media/voice preparation and before appending the prepared attachment.
- Discards prepared attachments when the user switched chats/accounts during preparation, instead of filing them under the stale captured conversation.
- Adds regression coverage for the stale-selection guard and the unchanged-selection positive path.

## Verification
- `git diff --check` — passed
- Conflict marker sweep with `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' HEAD -- . ':!Vendored'` — passed
- Python line-length check for changed Swift files (120 chars) — passed
- `scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host: `xcodebuild: command not found` (exit 127)
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — not runnable on this Linux host: `xcrun: command not found` (exit 127)
- `xcodebuild` test/build/analyze commands — not runnable on this Linux host: `xcodebuild: command not found` (exit 127)

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/266">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->