### PR TITLE
fix: reject non-public IPv4 image hosts

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -80,18 +80,24 @@ nonisolated enum RemoteImageURLPolicy {
     }
 
     /// Rejects IPv4 literals in non-public ranges: loopback `127.0.0.0/8`, "this host"
-    /// `0.0.0.0/8`, private `10.0.0.0/8` / `172.16.0.0/12` / `192.168.0.0/16`, and
-    /// link-local `169.254.0.0/16`.
+    /// `0.0.0.0/8`, private `10.0.0.0/8` / `172.16.0.0/12` / `192.168.0.0/16`,
+    /// link-local `169.254.0.0/16`, CGNAT `100.64.0.0/10`, and the non-routable top of the
+    /// space: multicast `224.0.0.0/4`, reserved `240.0.0.0/4`, and limited broadcast
+    /// `255.255.255.255` (all covered by first octet `224...255`).
     private static func isPrivateIPv4(_ octets: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
         let (a, b, _, _) = octets
         switch a {
         case 0, 127, 10:
+            return true
+        case 100 where (64...127).contains(b):
             return true
         case 172 where (16...31).contains(b):
             return true
         case 192 where b == 168:
             return true
         case 169 where b == 254:
+            return true
+        case 224...:
             return true
         default:
             return false

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -96,6 +96,13 @@ struct PureValueTests {
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://127.0.0.1:8080/x.png") == nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[::1]/x.png") == nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://localhost/x.png") == nil)
+        // whitenoise-mac#243: broadcast / multicast / reserved / CGNAT are non-public too,
+        // including an obfuscated (decimal) broadcast literal to exercise the parser path.
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://255.255.255.255/x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://224.0.0.1/x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://240.0.0.1/x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://100.64.0.1/x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://4294967295/x.png") == nil)
         // A public host still round-trips.
         #expect(
             RemoteImageURLPolicy.sanitizedURL(from: "https://cdn.example/p.png")?.absoluteString

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7152,6 +7152,22 @@ struct whitenoise_macTests {
             #expect(!RemoteImageURLPolicy.isAllowed(URL(string: s)!), "expected SSRF rejection for \(s)")
         }
 
+        // whitenoise-mac#243: broadcast / multicast / reserved / CGNAT literals are not routable
+        // public destinations and must be rejected too, including an obfuscated (decimal) form so
+        // the parser path is exercised, not just the dotted-quad string.
+        let blockedV4NonPublic = [
+            "https://255.255.255.255/x.png",  // limited broadcast
+            "https://224.0.0.1/x.png",  // multicast 224.0.0.0/4 (low edge)
+            "https://239.255.255.255/x.png",  // multicast 224.0.0.0/4 (high edge)
+            "https://240.0.0.1/x.png",  // reserved 240.0.0.0/4 (low edge)
+            "https://100.64.0.1/x.png",  // CGNAT 100.64.0.0/10 (low edge)
+            "https://100.127.255.255/x.png",  // CGNAT 100.64.0.0/10 (high edge)
+            "https://4294967295/x.png",  // decimal 255.255.255.255 (obfuscated broadcast)
+        ]
+        for s in blockedV4NonPublic {
+            #expect(!RemoteImageURLPolicy.isAllowed(URL(string: s)!), "expected SSRF rejection for \(s)")
+        }
+
         // IPv6 loopback / unspecified / ULA / link-local / IPv4-mapped private.
         let blockedV6 = [
             "https://[::1]/x.png",
@@ -7179,6 +7195,9 @@ struct whitenoise_macTests {
             "https://1.1.1.1/x.png",
             "https://172.32.0.1/x.png",  // just outside 172.16/12
             "https://192.169.0.1/x.png",  // just outside 192.168/16
+            "https://100.63.255.255/x.png",  // just below CGNAT 100.64.0.0/10
+            "https://100.128.0.1/x.png",  // just above CGNAT 100.64.0.0/10
+            "https://223.255.255.255/x.png",  // just below multicast 224.0.0.0/4
             "https://[2606:4700:4700::1111]/x.png",  // public IPv6 (Cloudflare)
             "https://[::ffff:8.8.8.8]/x.png",  // IPv4-mapped public address
         ]


### PR DESCRIPTION
Closes #243

## Summary
- Extend `RemoteImageURLPolicy`'s IPv4 non-public host rejection to cover CGNAT `100.64.0.0/10`.
- Reject multicast/reserved/broadcast IPv4 literals via first octet `224...255`, including `255.255.255.255`.
- Add regression coverage for direct literals, an obfuscated decimal broadcast literal, and adjacent allowed boundary cases.

## Verification
- `git diff --check` — passed.
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' HEAD -- .` — no conflict markers.
- `command -v xcodebuild || true; command -v swift || true; command -v swiftc || true; xcodebuild -version` — `xcodebuild: command not found`; Swift/Xcode toolchain unavailable on this Linux host, so AGENTS.md `xcodebuild` build/test commands could not be run locally.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/267">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->