### PR TITLE
fix: protect voice recording scratch files

### DIFF
--- a/whitenoise-mac/Core/MediaPlaybackTempStore.swift
+++ b/whitenoise-mac/Core/MediaPlaybackTempStore.swift
@@ -1,8 +1,8 @@
 import CryptoKit
 import Foundation
 
-/// Manages on-disk scratch files used to hand decrypted attachment plaintext to
-/// macOS playback/open APIs (`AVPlayer`, `NSWorkspace.open`) that require a file URL.
+/// Manages on-disk scratch files used to hand attachment plaintext to macOS APIs
+/// (`AVPlayer`, `NSWorkspace.open`, `AVAudioRecorder`) that require a file URL.
 ///
 /// For an E2EE messenger, decrypted media must not linger on disk after it has been
 /// viewed. The previous implementation wrote plaintext into the shared OS temp
@@ -21,10 +21,11 @@ import Foundation
 ///   a file as soon as the consuming action finishes and so launch/"Delete All Local
 ///   Data" can wipe the whole directory.
 ///
-/// All file-system inputs are injectable to keep the logic unit-testable without a real
-/// `AVPlayer`/`NSWorkspace`.
+/// All file-system inputs are injectable to keep the logic unit-testable without real
+/// playback/recording APIs.
 nonisolated enum MediaPlaybackTempStore {
     private static let directoryName = "WhiteNoiseMediaPlayback"
+    private static let voiceRecordingsDirectoryName = "WhiteNoiseVoiceRecordings"
 
     /// Resolves the playback scratch directory inside the app container.
     ///
@@ -46,9 +47,27 @@ nonisolated enum MediaPlaybackTempStore {
     }
 
     static func directoryURL(baseURL: URL) -> URL {
-        baseURL
-            .appendingPathComponent("White Noise", isDirectory: true)
-            .appendingPathComponent(directoryName, isDirectory: true)
+        scratchDirectoryURL(baseURL: baseURL, directoryName: directoryName)
+    }
+
+    /// Resolves the outgoing voice-recording scratch directory inside the app container.
+    static func voiceRecordingsDirectoryURL(
+        fileManager: FileManager = .default,
+        applicationSupportDirectory: (FileManager) throws -> URL = { fileManager in
+            try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        }
+    ) throws -> URL {
+        let base = try applicationSupportDirectory(fileManager)
+        return voiceRecordingsDirectoryURL(baseURL: base)
+    }
+
+    static func voiceRecordingsDirectoryURL(baseURL: URL) -> URL {
+        scratchDirectoryURL(baseURL: baseURL, directoryName: voiceRecordingsDirectoryName)
     }
 
     /// The legacy pre-fix location that used the shared OS temp directory. Purges keep
@@ -56,6 +75,25 @@ nonisolated enum MediaPlaybackTempStore {
     /// a launch or "Delete All Local Data".
     static func legacySharedTemporaryDirectory(fileManager: FileManager = .default) -> URL {
         fileManager.temporaryDirectory.appendingPathComponent(directoryName, isDirectory: true)
+    }
+
+    /// The legacy outgoing voice-recording location that used the shared OS temp
+    /// directory. Purges keep deleting it so already-orphaned microphone plaintext
+    /// from older app versions does not survive launch or "Delete All Local Data".
+    static func legacySharedVoiceRecordingsDirectory(fileManager: FileManager = .default) -> URL {
+        fileManager.temporaryDirectory.appendingPathComponent(voiceRecordingsDirectoryName, isDirectory: true)
+    }
+
+    /// Reserves a protected file for `AVAudioRecorder` to write an outgoing voice note.
+    static func prepareVoiceRecordingFile(
+        in directory: URL,
+        uniqueID: UUID = UUID(),
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try prepareDirectory(directory, fileManager: fileManager)
+        let url = directory.appendingPathComponent("voice-\(uniqueID.uuidString).m4a")
+        try Data().write(to: url, options: [.atomic, .completeFileProtection])
+        return url
     }
 
     /// Writes `data` to a per-consumer scratch file for `id`/`fileName` and returns its URL.
@@ -86,8 +124,8 @@ nonisolated enum MediaPlaybackTempStore {
         try? fileManager.removeItem(at: url)
     }
 
-    /// Removes the entire playback scratch directory. Used on launch and when the user
-    /// deletes all local data. Missing directories are treated as success.
+    /// Removes playback and voice-recording scratch directories. Used on launch and
+    /// when the user deletes all local data. Missing directories are treated as success.
     static func purge(
         fileManager: FileManager = .default,
         applicationSupportDirectory: (FileManager) throws -> URL = { fileManager in
@@ -97,29 +135,45 @@ nonisolated enum MediaPlaybackTempStore {
                 appropriateFor: nil,
                 create: true
             )
+        },
+        legacyPlaybackDirectory: (FileManager) -> URL = { fileManager in
+            MediaPlaybackTempStore.legacySharedTemporaryDirectory(fileManager: fileManager)
+        },
+        legacyVoiceRecordingsDirectory: (FileManager) -> URL = { fileManager in
+            MediaPlaybackTempStore.legacySharedVoiceRecordingsDirectory(fileManager: fileManager)
         }
     ) {
-        guard
-            let directory = try? directoryURL(
-                fileManager: fileManager,
-                applicationSupportDirectory: applicationSupportDirectory
-            )
-        else {
-            purge(directory: legacySharedTemporaryDirectory(fileManager: fileManager), fileManager: fileManager)
+        let legacyDirectories = [
+            legacyPlaybackDirectory(fileManager),
+            legacyVoiceRecordingsDirectory(fileManager),
+        ]
+        guard let base = try? applicationSupportDirectory(fileManager) else {
+            purge(directories: legacyDirectories, fileManager: fileManager)
             return
         }
         purge(
-            directory: directory,
-            legacyDirectory: legacySharedTemporaryDirectory(fileManager: fileManager),
+            directories: [
+                directoryURL(baseURL: base),
+                voiceRecordingsDirectoryURL(baseURL: base),
+            ] + legacyDirectories,
             fileManager: fileManager
         )
     }
 
     static func purge(directory: URL, legacyDirectory: URL? = nil, fileManager: FileManager = .default) {
-        purgeSingleDirectory(directory, fileManager: fileManager)
-        if let legacyDirectory {
-            purgeSingleDirectory(legacyDirectory, fileManager: fileManager)
+        purge(directories: [directory] + [legacyDirectory].compactMap { $0 }, fileManager: fileManager)
+    }
+
+    static func purge(directories: [URL], fileManager: FileManager = .default) {
+        for directory in directories {
+            purgeSingleDirectory(directory, fileManager: fileManager)
         }
+    }
+
+    private static func scratchDirectoryURL(baseURL: URL, directoryName: String) -> URL {
+        baseURL
+            .appendingPathComponent("White Noise", isDirectory: true)
+            .appendingPathComponent(directoryName, isDirectory: true)
     }
 
     private static func prepareDirectory(_ directory: URL, fileManager: FileManager) throws {

--- a/whitenoise-mac/Core/MediaPlaybackTempStore.swift
+++ b/whitenoise-mac/Core/MediaPlaybackTempStore.swift
@@ -92,7 +92,7 @@ nonisolated enum MediaPlaybackTempStore {
     ) throws -> URL {
         try prepareDirectory(directory, fileManager: fileManager)
         let url = directory.appendingPathComponent("voice-\(uniqueID.uuidString).m4a")
-        try Data().write(to: url, options: [.atomic, .completeFileProtection])
+        try writeProtectedData(Data(), to: url, fileManager: fileManager)
         return url
     }
 
@@ -114,7 +114,7 @@ nonisolated enum MediaPlaybackTempStore {
         try prepareDirectory(directory, fileManager: fileManager)
         let sanitized = sanitizedFileName(fileName, fallbackExtension: fallbackExtension)
         let url = directory.appendingPathComponent("\(stableStem(for: id))-\(uniqueID.uuidString)-\(sanitized)")
-        try data.write(to: url, options: [.atomic, .completeFileProtection])
+        try writeProtectedData(data, to: url, fileManager: fileManager)
         return url
     }
 
@@ -182,6 +182,16 @@ nonisolated enum MediaPlaybackTempStore {
         var values = URLResourceValues()
         values.isExcludedFromBackup = true
         try directoryURL.setResourceValues(values)
+    }
+
+    private static func writeProtectedData(_ data: Data, to url: URL, fileManager: FileManager) throws {
+        try data.write(to: url, options: [.atomic, .completeFileProtection])
+        // Some macOS volumes downgrade or reject explicit protection changes; keep the
+        // scratch write usable, but request the strongest class when the volume accepts it.
+        try? fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.complete],
+            ofItemAtPath: url.path
+        )
     }
 
     private static func purgeSingleDirectory(_ directory: URL, fileManager: FileManager) {

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -284,6 +284,7 @@ extension WorkspaceState {
         do {
             let directory = try MediaPlaybackTempStore.voiceRecordingsDirectoryURL()
             let url = try MediaPlaybackTempStore.prepareVoiceRecordingFile(in: directory)
+            voiceRecordingURL = url
             let settings: [String: Any] = [
                 AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
                 AVSampleRateKey: 44_100,
@@ -297,7 +298,6 @@ extension WorkspaceState {
             }
 
             voiceRecorder = recorder
-            voiceRecordingURL = url
             voiceRecordingSamples = []
             voiceRecordingDurationSeconds = 0
             isRecordingVoiceMessage = true

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -281,12 +281,9 @@ extension WorkspaceState {
             return
         }
 
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("WhiteNoiseVoiceRecordings", isDirectory: true)
         do {
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-            let fileName = "voice-\(Int(Date().timeIntervalSince1970)).m4a"
-            let url = directory.appendingPathComponent(fileName)
+            let directory = try MediaPlaybackTempStore.voiceRecordingsDirectoryURL()
+            let url = try MediaPlaybackTempStore.prepareVoiceRecordingFile(in: directory)
             let settings: [String: Any] = [
                 AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
                 AVSampleRateKey: 44_100,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -972,6 +972,10 @@ struct whitenoise_macTests {
         )
 
         #expect(fileManager.fileExists(atPath: url.path))
+        let fileAttributes = try fileManager.attributesOfItem(atPath: url.path)
+        if let protection = fileAttributes[.protectionKey] as? FileProtectionType {
+            #expect(protection == .complete || protection == .completeUntilFirstUserAuthentication)
+        }
         #expect(url.lastPathComponent == "voice-\(uniqueID.uuidString).m4a")
         #expect(url.deletingLastPathComponent().path == directory.path)
         let values = try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -948,6 +948,36 @@ struct whitenoise_macTests {
         #expect(!directory.path.contains(FileManager.default.temporaryDirectory.path))
     }
 
+    @Test func mediaPlaybackTempStoreVoiceRecordingsLiveInsideAppContainerNotSharedTemp() {
+        let base = URL(fileURLWithPath: "/Container", isDirectory: true)
+        let directory = MediaPlaybackTempStore.voiceRecordingsDirectoryURL(baseURL: base)
+
+        #expect(
+            directory.path == "/Container/White Noise/WhiteNoiseVoiceRecordings"
+        )
+        #expect(!directory.path.contains(FileManager.default.temporaryDirectory.path))
+    }
+
+    @Test func mediaPlaybackTempStorePreparesVoiceRecordingFile() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-voice-recording-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let uniqueID = UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
+        let url = try MediaPlaybackTempStore.prepareVoiceRecordingFile(
+            in: directory,
+            uniqueID: uniqueID,
+            fileManager: fileManager
+        )
+
+        #expect(fileManager.fileExists(atPath: url.path))
+        #expect(url.lastPathComponent == "voice-\(uniqueID.uuidString).m4a")
+        #expect(url.deletingLastPathComponent().path == directory.path)
+        let values = try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        #expect(values.isExcludedFromBackup == true)
+    }
+
     @Test func mediaPlaybackTempStoreMaterializesIndependentConsumerFiles() throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
@@ -1099,6 +1129,36 @@ struct whitenoise_macTests {
         MediaPlaybackTempStore.purge(directory: directory, legacyDirectory: legacyDirectory)
         #expect(!fileManager.fileExists(atPath: directory.path))
         #expect(!fileManager.fileExists(atPath: legacyDirectory.path))
+    }
+
+    @Test func mediaPlaybackTempStorePurgesVoiceRecordingDirectories() throws {
+        let fileManager = FileManager.default
+        let sandbox = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-purge-tests-\(UUID().uuidString)", isDirectory: true)
+        let appSupport = sandbox.appendingPathComponent("ApplicationSupport", isDirectory: true)
+        let legacyPlayback = sandbox.appendingPathComponent("LegacyPlayback", isDirectory: true)
+        let legacyVoiceRecordings = sandbox.appendingPathComponent("LegacyVoiceRecordings", isDirectory: true)
+        defer { try? fileManager.removeItem(at: sandbox) }
+
+        let playback = MediaPlaybackTempStore.directoryURL(baseURL: appSupport)
+        let voiceRecordings = MediaPlaybackTempStore.voiceRecordingsDirectoryURL(baseURL: appSupport)
+        for directory in [playback, voiceRecordings, legacyPlayback, legacyVoiceRecordings] {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data("plaintext".utf8).write(to: directory.appendingPathComponent("left-behind.bin"))
+            #expect(fileManager.fileExists(atPath: directory.path))
+        }
+
+        MediaPlaybackTempStore.purge(
+            fileManager: fileManager,
+            applicationSupportDirectory: { _ in appSupport },
+            legacyPlaybackDirectory: { _ in legacyPlayback },
+            legacyVoiceRecordingsDirectory: { _ in legacyVoiceRecordings }
+        )
+
+        #expect(!fileManager.fileExists(atPath: playback.path))
+        #expect(!fileManager.fileExists(atPath: voiceRecordings.path))
+        #expect(!fileManager.fileExists(atPath: legacyPlayback.path))
+        #expect(!fileManager.fileExists(atPath: legacyVoiceRecordings.path))
     }
 
     @Test func messageMediaDiskCacheRoundTripsEncryptedPayload() async throws {


### PR DESCRIPTION
## Summary
- moves outgoing voice-recording scratch files into the app-container MediaPlaybackTempStore area instead of shared OS temp
- reserves each recording as a `.completeFileProtection` placeholder before AVAudioRecorder writes to it
- extends launch/Delete All Local Data purge coverage to both current and legacy voice-recording scratch directories

## Test Plan
- `git diff --check`
- line-length scan for changed Swift files (<= 120 chars)
- not run: `xcrun swift-format` / `xcodebuild` unavailable on this Linux worker

Closes #252


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/268">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->