### PR TITLE
fix: clear account read state on sign-out

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -309,6 +309,14 @@ extension WorkspaceState {
         clearGroupMemberCache()
         timelinePagingByChat.removeAll()
         accountUnreadByIdHex.removeAll()
+        // Read markers are keyed by groupIdHex; leaving them behind both retains a
+        // record of which messages the signed-out identity read and lets a recurring
+        // group id suppress the first legitimate read-mark advance after re-login. The
+        // delivered-notification keys are likewise account-scoped residue. See #241.
+        lastMarkedReadMarkers.removeAll()
+        lastConfirmedReadMarkers.removeAll()
+        deliveredNotificationKeys.removeAll()
+        deliveredNotificationKeyOrder.removeAll()
         profileDraft = ProfileDraft()
         keyPackages = []
         auditLogFiles = []

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -690,6 +690,39 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func resetActiveAccountUIStateClearsReadMarkersAndDeliveredNotificationKeys() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+
+        let marker = ReadMarker(
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            messageId: "m0"
+        )
+        state.lastMarkedReadMarkers["group-a"] = marker
+        state.lastConfirmedReadMarkers["group-a"] = marker
+        state.deliveredNotificationKeys.insert("notif-1")
+        state.deliveredNotificationKeyOrder.append("notif-1")
+
+        state.resetActiveAccountUIState()
+
+        // Sign-out and active-account removal share this reset path; per-group read
+        // markers and delivered-notification keys must not survive it. See #241.
+        #expect(state.lastMarkedReadMarkers.isEmpty)
+        #expect(state.lastConfirmedReadMarkers.isEmpty)
+        #expect(state.deliveredNotificationKeys.isEmpty)
+        #expect(state.deliveredNotificationKeyOrder.isEmpty)
+    }
+
+    @MainActor
     @Test func removeNonActiveAccountClearsItsUnreadBadge() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
Closes #241

## Summary
- Clear account-scoped read marker caches and delivered-notification dedupe keys in `resetActiveAccountUIState()`, the shared sign-out/account-removal teardown path.
- Add regression coverage that seeds both read marker maps and delivered-notification key stores, then verifies the reset clears all four.

## Verification
- `git diff --check` — passed.
- Conflict-marker sweep over touched files — passed.
- Source grep sanity confirmed the reset clears all four fields and the regression asserts them empty.
- `xcodebuild`, `xcrun`, `swift`, and `swift-format` are unavailable on this Linux host, so macOS CI must run the repository's Xcode checks.

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+Account.swift` — account sign-out/removal UI-state teardown path; no crypto/MLS/key material changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/269">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->