### PR TITLE
fix: guard redirect hop counter

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -905,8 +905,11 @@ private final class CappedImageDownloadDelegate: NSObject, URLSessionDataDelegat
         newRequest request: URLRequest,
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
-        redirectHopCount += 1
-        if redirectHopCount > 5 {
+        let hopCount = lock.withLock {
+            redirectHopCount += 1
+            return redirectHopCount
+        }
+        if hopCount > 5 {
             completionHandler(nil)
             task.cancel()
             finish(with: nil)


### PR DESCRIPTION
## Summary
- Guard `CappedImageDownloadDelegate` redirect hop accounting with the same delegate lock used for the rest of its mutable state.
- Compare the redirect cap against a locked snapshot instead of reading `redirectHopCount` directly in the redirect callback.

## Test Plan
- `git diff --check`
- Source inspection script: verified the redirect hop increment/read uses `lock.withLock` and no direct `if redirectHopCount > 5` read remains.
- Not run: `xcodebuild` / `swift-format` (unavailable on this Linux worker).

Closes #250


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/271">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->