### PR TITLE
fix: purge unreadable media cache metadata

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -556,10 +556,14 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                         using: symmetricKey,
                         authenticatedBy: metadataAAD(for: cacheID)
                     ),
-                    let metadata = try? JSONDecoder().decode(Metadata.self, from: metadataPlaintext),
-                    metadata.accountDigest == accountDigest
-                else { continue }
-                try? FileManager.default.removeItem(at: entryDirectory)
+                    let metadata = try? JSONDecoder().decode(Metadata.self, from: metadataPlaintext)
+                else {
+                    try? FileManager.default.removeItem(at: entryDirectory)
+                    continue
+                }
+                if metadata.accountDigest == accountDigest {
+                    try? FileManager.default.removeItem(at: entryDirectory)
+                }
             }
         }
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1163,6 +1163,61 @@ struct whitenoise_macTests {
         #expect(!fileManager.fileExists(atPath: entryDirectory.path))
     }
 
+    @Test func messageMediaDiskCacheAccountPurgeDeletesUnreadableEntries() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(root: root)
+        let corruptPlaintext = Data("account media with unreadable metadata".utf8)
+        let preservedPlaintext = Data("other account media".utf8)
+        let corruptKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: corruptPlaintext, ciphertextByte: 0xaa)
+        )
+        let preservedKey = MessageMediaDiskCacheKey(
+            accountId: "account-b",
+            groupIdHex: "group-b",
+            reference: mediaDiskCacheReference(plaintext: preservedPlaintext, ciphertextByte: 0xbb)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: corruptPlaintext,
+                fileName: "corrupt.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(corruptPlaintext.count),
+                payloadId: "corrupt"
+            ),
+            for: corruptKey
+        )
+        await cache.store(
+            MessageMediaDownload(
+                data: preservedPlaintext,
+                fileName: "preserved.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(preservedPlaintext.count),
+                payloadId: "preserved"
+            ),
+            for: preservedKey
+        )
+
+        let corruptEntryDirectory = try #require(cache.entryDirectory(for: corruptKey))
+        let preservedEntryDirectory = try #require(cache.entryDirectory(for: preservedKey))
+        try Data("not sealed metadata".utf8).write(
+            to: corruptEntryDirectory.appendingPathComponent("metadata.bin")
+        )
+
+        await cache.purgeAccount("account-a")
+
+        #expect(!fileManager.fileExists(atPath: corruptEntryDirectory.path))
+        #expect(await cache.cachedDownload(for: corruptKey) == nil)
+        #expect(fileManager.fileExists(atPath: preservedEntryDirectory.path))
+        #expect(try #require(await cache.cachedDownload(for: preservedKey)).data == preservedPlaintext)
+    }
+
     @Test func messageMediaDiskCachePurgesByAccountAndFullWipeDeletesKey() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
## Summary
- delete media-cache entries whose metadata cannot be decrypted/decoded during per-account purge
- keep the existing accountDigest check for readable metadata so other accounts' healthy cache entries survive
- add regression coverage for unreadable metadata alongside a preserved other-account entry

Closes #248

## Test plan
- `git diff --check`
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` (fails locally: `xcodebuild` is not installed on this Linux host)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/273">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->