### PR TITLE
fix: render QR images off the main actor

### DIFF
--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -476,6 +476,10 @@ struct PublicIdentityQRCodeSheet: View {
     }
 }
 
+private nonisolated struct RenderedQRCodeImage: @unchecked Sendable {
+    let nsImage: NSImage
+}
+
 struct QRCodeImageView: View {
     let payload: String
 
@@ -499,16 +503,16 @@ struct QRCodeImageView: View {
             }
         }
         .task(id: payload) {
-            let image = await Task.detached(priority: .userInitiated) {
+            let image = await Task.detached(priority: .utility) {
                 Self.image(for: payload)
             }.value
             guard !Task.isCancelled else { return }
-            renderedImage = image
+            renderedImage = image?.nsImage
             renderedPayload = payload
         }
     }
 
-    nonisolated private static func image(for payload: String) -> NSImage? {
+    nonisolated private static func image(for payload: String) -> RenderedQRCodeImage? {
         guard !payload.isEmpty,
             let filter = CIFilter(name: "CIQRCodeGenerator")
         else { return nil }
@@ -521,7 +525,7 @@ struct QRCodeImageView: View {
         let representation = NSCIImageRep(ciImage: scaledImage)
         let image = NSImage(size: representation.size)
         image.addRepresentation(representation)
-        return image
+        return RenderedQRCodeImage(nsImage: image)
     }
 }
 

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -499,12 +499,16 @@ struct QRCodeImageView: View {
             }
         }
         .task(id: payload) {
-            renderedImage = Self.image(for: payload)
+            let image = await Task.detached(priority: .userInitiated) {
+                Self.image(for: payload)
+            }.value
+            guard !Task.isCancelled else { return }
+            renderedImage = image
             renderedPayload = payload
         }
     }
 
-    private static func image(for payload: String) -> NSImage? {
+    nonisolated private static func image(for payload: String) -> NSImage? {
         guard !payload.isEmpty,
             let filter = CIFilter(name: "CIQRCodeGenerator")
         else { return nil }


### PR DESCRIPTION
## Summary
- Move QR code rendering into a user-initiated detached task.
- Keep state assignment on the SwiftUI task after cancellation check.
- Mark the renderer helper nonisolated so CIFilter/rasterization is not main-actor-bound.

## Test plan
- git diff --check
- conflict marker sweep with git grep
- xcodebuild unavailable on this Linux worker

Closes #244


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->