### PR TITLE
fix: clamp unread FFI counts

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -58,8 +58,8 @@ extension ChatItem {
             updatedAt: updatedAt,
             avatarSeed: directPeer?.accountIdHex ?? row.groupIdHex,
             pictureURL: directPeer?.pictureURL ?? groupAvatarURL,
-            unreadCount: Int(row.unreadCount),
-            unreadMentionCount: Int(row.unreadMentionCount),
+            unreadCount: Int(clamping: row.unreadCount),
+            unreadMentionCount: Int(clamping: row.unreadMentionCount),
             isDirect: directPeer != nil,
             pendingConfirmation: row.pendingConfirmation
         )

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -393,7 +393,7 @@ extension WorkspaceState {
         do {
             let rows = try await runOffMain { try client.accountUnreadSummary() }
             accountUnreadByIdHex = Dictionary(
-                rows.map { ($0.accountIdHex, Int($0.unreadCount)) },
+                rows.map { ($0.accountIdHex, Int(clamping: $0.unreadCount)) },
                 uniquingKeysWith: { lhs, _ in lhs }
             )
         } catch {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -55,6 +55,34 @@ struct PureValueTests {
         #expect(MediaDurationLabel.string(for: 3_600) == "1:00:00")
     }
 
+    @Test func chatListRowClampsOversizedUnreadCounts() async throws {
+        // Regression for whitenoise-mac#242: unread counts cross the FFI boundary as
+        // UInt64, and Int(value) traps above Int.max while mapping the chat list.
+        let row = ChatListRowFfi(
+            groupIdHex: "group",
+            archived: false,
+            pendingConfirmation: false,
+            title: "Planning",
+            groupName: "Planning",
+            avatarUrl: nil,
+            avatar: nil,
+            lastMessage: nil,
+            unreadCount: UInt64(Int.max) + 1,
+            hasUnread: true,
+            unreadMentionCount: UInt64.max,
+            unreadMention: true,
+            firstUnreadMessageIdHex: nil,
+            lastReadMessageIdHex: nil,
+            lastReadTimelineAt: nil,
+            updatedAt: 0
+        )
+
+        let chat = ChatItem(row: row, activeAccountIdHex: nil)
+
+        #expect(chat.unreadCount == Int.max)
+        #expect(chat.unreadMentionCount == Int.max)
+    }
+
     @Test func messageItemTimelineFallbackClampsPreEpochAndNonFiniteDates() async throws {
         // Regression for whitenoise-mac#247: the timelineAt fallback derives from
         // sentAt via UInt64(_:), which traps on negative (pre-1970) or non-finite

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -690,6 +690,32 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func accountUnreadSummaryClampsOversizedUnreadCount() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary])
+        runtime.accountUnreadSummaryRows = [
+            AccountUnreadFfi(
+                accountIdHex: primary.accountIdHex,
+                unreadCount: UInt64(Int.max) + 1,
+                unreadConversations: 1,
+                hasUnread: true
+            )
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.refreshAccountUnreadSummary()
+
+        #expect(state.unreadCount(forAccountIdHex: primary.accountIdHex) == Int.max)
+    }
+
+    @MainActor
     @Test func resetActiveAccountUIStateClearsReadMarkersAndDeliveredNotificationKeys() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
## Summary
- Clamp FFI-supplied chat-list unread counts before mapping them to `ChatItem` badges.
- Clamp account unread summary counts before storing them for the account switcher.
- Add regression coverage for oversized `UInt64` unread counts in both paths.

Closes #242

## Test Plan
- `git diff --check`
- `git grep -n 'Int(row\.unreadCount)\|Int(row\.unreadMentionCount)\|Int(\$0\.unreadCount)' -- '*.swift' || true` (no matches)
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- '*.swift' || true` (no matches)

Not run: `xcodebuild` tests, because this Linux worker host has no `xcodebuild` or Swift toolchain.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/276">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->