### PR TITLE
fix: clear image gallery on chat switch

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -386,7 +386,6 @@ private struct ConversationView: View {
                     pendingAppendAnchorId = nil
                     isPinnedToBottom = true
                     activeSelectionMessageID = nil
-                    imageGallery = nil
                 }
                 .onChange(of: messageIDs.last) { _, newMessageId in
                     switch timelineNewestMessageScrollAction(
@@ -589,9 +588,10 @@ private struct ConversationView: View {
             }
         }
         .animation(.smooth(duration: 0.24), value: workspace.isGroupDetailsPresented)
-        // Switching conversations must not leave the previous chat's info panel
-        // open over a different transcript.
+        // Switching conversations must not leave the previous chat's body-level
+        // overlays open over a different transcript.
         .onChange(of: chat.id) { _, _ in
+            imageGallery = nil
             if workspace.isGroupDetailsPresented {
                 workspace.closeGroupDetails()
             }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -386,6 +386,7 @@ private struct ConversationView: View {
                     pendingAppendAnchorId = nil
                     isPinnedToBottom = true
                     activeSelectionMessageID = nil
+                    imageGallery = nil
                 }
                 .onChange(of: messageIDs.last) { _, newMessageId in
                     switch timelineNewestMessageScrollAction(


### PR DESCRIPTION
## Summary
- Clear the full-screen image gallery presentation when `ConversationView` observes a selected-chat id change.
- Preserve the existing targeted per-chat reset instead of forcing a full `ConversationView` identity reset.

## Test Plan
- `git diff --check`
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':!*.xcstrings'` (no matches)
- `xcodebuild` unavailable on this Linux host

Closes #240


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the image gallery could remain open when switching between conversations.
  * Updated the chat view so the gallery clears automatically when a new conversation is selected, keeping the transcript display correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->