### PR TITLE
fix: cap chat unread badge count

### DIFF
--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -10,6 +10,10 @@
 import AppKit
 import SwiftUI
 
+private func unreadBadgeLabel(for count: Int) -> String {
+    count > 99 ? "99+" : "\(count)"
+}
+
 struct AccountRailView: View {
     @Environment(WorkspaceState.self) private var workspace
 
@@ -127,7 +131,7 @@ private struct AccountRailAvatar: View {
                 .foregroundStyle(.secondary)
                 .background(Circle().fill(Color(nsColor: .windowBackgroundColor)))
         } else if unread > 0 {
-            Text(unread > 99 ? "99+" : "\(unread)")
+            Text(unreadBadgeLabel(for: unread))
                 .font(.caption2.weight(.bold))
                 .foregroundStyle(.white)
                 .padding(.horizontal, 5)
@@ -372,7 +376,7 @@ struct ChatRowContent: View {
                             .background(Circle().fill(Color.accentColor))
                             .help(L10n.string("You were mentioned"))
                     }
-                    Text("\(chat.unreadCount)")
+                    Text(unreadBadgeLabel(for: chat.unreadCount))
                         .font(.caption2.weight(.bold))
                         .foregroundStyle(.white)
                         .frame(minWidth: 18, minHeight: 18)


### PR DESCRIPTION
## Summary
- Share unread badge label formatting between the account rail and chat rows.
- Cap chat-list unread badges at `99+` instead of rendering oversized raw counts.

## Test plan
- `git diff --check`
- Verified `Text("\\(chat.unreadCount)")` no longer appears in `SidebarViews.swift`.
- Not run: `xcodebuild`/Swift are unavailable on this Linux host.

Closes #278


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/280">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->