### PR TITLE
fix: cache file importer allowed types

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -526,7 +526,7 @@ nonisolated enum OutgoingMediaAttachmentPolicy {
         "xlsx",
     ]
 
-    static var fileImporterAllowedTypes: [UTType] {
+    static let fileImporterAllowedTypes: [UTType] = {
         var types: [UTType] = [.image, .movie, .audio, .pdf, .plainText, .rtf, .commaSeparatedText, .json]
         for ext in supportedDocumentExtensions.sorted() {
             if let type = UTType(filenameExtension: ext), !types.contains(type) {
@@ -534,7 +534,7 @@ nonisolated enum OutgoingMediaAttachmentPolicy {
             }
         }
         return types
-    }
+    }()
 
     static func canonicalMediaType(_ mediaType: String) -> String {
         let base =


### PR DESCRIPTION
Closes #293

## Summary
- Converts `OutgoingMediaAttachmentPolicy.fileImporterAllowedTypes` from a computed `static var` into a stored `static let` initialized once.
- Preserves the existing allowed-type construction logic exactly, avoiding repeated `UTType(filenameExtension:)` lookups and duplicate checks during SwiftUI body recomputation.

## Verification
- `git diff --check` — passed.
- Searched for `fileImporterAllowedTypes` references — only the definition and the `MessengerShellView` value consumer exist.
- Searched Swift files for conflict markers — none found.
- `xcodebuild` / `swift` unavailable on this Linux worker, so macOS build/test verification is inspection-only here.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how allowed attachment types are prepared for file importing, so the app reuses the same list instead of rebuilding it repeatedly.
* **Performance**
  * File attachment selection may feel slightly more responsive and efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->