### PR TITLE
fix: bound media playback scratch filenames

### DIFF
--- a/whitenoise-mac/Core/MediaPlaybackTempStore.swift
+++ b/whitenoise-mac/Core/MediaPlaybackTempStore.swift
@@ -27,6 +27,12 @@ nonisolated enum MediaPlaybackTempStore {
     private static let directoryName = "WhiteNoiseMediaPlayback"
     private static let voiceRecordingsDirectoryName = "WhiteNoiseVoiceRecordings"
 
+    /// Upper bound, in UTF-8 bytes, for the scratch filename component built by `materialize`.
+    ///
+    /// APFS allows 255 UTF-8 bytes per path component. Keeping our component below that leaves
+    /// room for filesystem normalization differences while still preserving useful peer filenames.
+    static let maxScratchFileComponentBytes = 240
+
     /// Resolves the playback scratch directory inside the app container.
     ///
     /// Mirrors `MarmotStorageRoot`'s Application Support location but lives in a
@@ -112,8 +118,10 @@ nonisolated enum MediaPlaybackTempStore {
         fileManager: FileManager = .default
     ) throws -> URL {
         try prepareDirectory(directory, fileManager: fileManager)
-        let sanitized = sanitizedFileName(fileName, fallbackExtension: fallbackExtension)
-        let url = directory.appendingPathComponent("\(stableStem(for: id))-\(uniqueID.uuidString)-\(sanitized)")
+        let prefix = "\(stableStem(for: id))-\(uniqueID.uuidString)-"
+        let byteLimit = max(1, maxScratchFileComponentBytes - prefix.utf8.count)
+        let sanitized = sanitizedFileName(fileName, fallbackExtension: fallbackExtension, byteLimit: byteLimit)
+        let url = directory.appendingPathComponent("\(prefix)\(sanitized)")
         try writeProtectedData(data, to: url, fileManager: fileManager)
         return url
     }
@@ -215,13 +223,52 @@ nonisolated enum MediaPlaybackTempStore {
         return "\(prefix)-\(digest)"
     }
 
-    static func sanitizedFileName(_ fileName: String, fallbackExtension: String) -> String {
+    static func sanitizedFileName(_ fileName: String, fallbackExtension: String, byteLimit: Int) -> String {
         let trimmed = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
         let fallback = "attachment.\(fallbackExtension)"
         let rawName = trimmed.isEmpty ? fallback : trimmed
         let illegal = CharacterSet(charactersIn: "/:\\")
         let components = rawName.components(separatedBy: illegal).filter { !$0.isEmpty }
         let sanitized = components.joined(separator: "-").trimmingCharacters(in: .whitespacesAndNewlines)
-        return sanitized.isEmpty ? fallback : sanitized
+        let bounded = boundedFileName(sanitized.isEmpty ? fallback : sanitized, byteLimit: byteLimit)
+        return bounded.isEmpty ? fallback : bounded
+    }
+
+    /// Truncates `name` to at most `byteLimit` UTF-8 bytes, keeping a trailing extension
+    /// intact when possible by shortening the stem first.
+    ///
+    /// A peer-supplied `fileName` can be arbitrarily long; without this bound the full
+    /// `"<stem>-<uuid>-<sanitized>"` path component can exceed APFS' 255-byte limit and make
+    /// `data.write(to:)` throw, silently breaking the attachment open/playback.
+    static func boundedFileName(_ name: String, byteLimit: Int) -> String {
+        guard byteLimit > 0, name.utf8.count > byteLimit else { return name }
+
+        let dotIndex = name.lastIndex(of: ".")
+        let stem = dotIndex.map { String(name[..<$0]) } ?? name
+        // Include the leading dot so an empty stem still yields a usable name.
+        let ext = dotIndex.map { String(name[$0...]) } ?? ""
+
+        // Reserve room for the extension; if it alone overruns the budget, drop it and
+        // truncate the whole name so we never exceed the cap.
+        let stemBudget = byteLimit - ext.utf8.count
+        guard stemBudget > 0 else { return truncatedToUTF8ByteLimit(name, byteLimit: byteLimit) }
+        return truncatedToUTF8ByteLimit(stem, byteLimit: stemBudget) + ext
+    }
+
+    /// Returns the longest prefix of `value` whose UTF-8 encoding fits in `byteLimit`,
+    /// never splitting a multi-byte scalar.
+    private static func truncatedToUTF8ByteLimit(_ value: String, byteLimit: Int) -> String {
+        guard byteLimit > 0 else { return "" }
+        guard value.utf8.count > byteLimit else { return value }
+
+        var result = ""
+        var used = 0
+        for character in value {
+            let width = String(character).utf8.count
+            if used + width > byteLimit { break }
+            result.append(character)
+            used += width
+        }
+        return result
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1082,6 +1082,44 @@ struct whitenoise_macTests {
         #expect(try Data(contentsOf: second) == Data("second".utf8))
     }
 
+    @Test func mediaPlaybackTempStoreBoundsLongPeerFileName() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        // An attacker-controlled attachment name of ~500 characters would otherwise push the
+        // "<stem>-<uuid>-<sanitized>" path component past APFS' 255-byte limit and make the
+        // write throw, silently breaking the open/playback.
+        let longName = String(repeating: "a", count: 500) + ".mp4"
+        let url = try MediaPlaybackTempStore.materialize(
+            data: Data("secret".utf8),
+            id: "attachment-id",
+            fileName: longName,
+            fallbackExtension: "bin",
+            directory: directory,
+            uniqueID: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
+        )
+
+        #expect(fileManager.fileExists(atPath: url.path))
+        // The full scratch-file component stays comfortably below APFS' 255-byte limit.
+        #expect(url.lastPathComponent.utf8.count <= MediaPlaybackTempStore.maxScratchFileComponentBytes)
+        // The original extension survives truncation of the stem.
+        #expect(url.lastPathComponent.hasSuffix(".mp4"))
+        #expect(try Data(contentsOf: url) == Data("secret".utf8))
+    }
+
+    @Test func mediaPlaybackTempStoreBoundsFileNameKeepsMultiByteExtension() throws {
+        // A multi-byte scalar must never be split when truncating to the byte budget.
+        let longStem = String(repeating: "é", count: 400)
+        let byteLimit = 128
+        let bounded = MediaPlaybackTempStore.boundedFileName("\(longStem).pdf", byteLimit: byteLimit)
+        let expectedStemCount = (byteLimit - ".pdf".utf8.count) / "é".utf8.count
+
+        #expect(bounded.utf8.count <= byteLimit)
+        #expect(bounded == String(repeating: "é", count: expectedStemCount) + ".pdf")
+    }
+
     @Test func mediaPlaybackTempStoreExcludesScratchDirectoryFromBackups() throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory


### PR DESCRIPTION
Closes #291

## Summary
- Bound media playback scratch filename components to 240 UTF-8 bytes, accounting for the actual stable-stem/UUID prefix before appending peer-supplied attachment names.
- Truncate sanitized filenames by UTF-8 byte count while preserving normal extensions such as `.mp4`/`.pdf`.
- Added regression coverage for a very long peer filename and multi-byte truncation behavior.

## Verification
- `git diff --check` — passed.
- Static line-length/conflict-marker inspection for changed Swift files — passed.
- Python simulation of the byte-budget regression cases — passed (`ascii_component_bytes=240`, `multibyte_bytes=128`).
- `xcrun`, `xcodebuild`, `swift`, and `swift-format` are not installed on this Linux worker, so macOS/Xcode CI commands were not runnable locally.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->