### PR TITLE
Refactor media auto-download handling

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -271,25 +271,23 @@ private extension View {
     func autoDownloadMediaAttachment(
         _ downloadState: MediaDownloadStateStore,
         attachment: MessageMediaAttachment,
-        message: MessageItem,
-        in workspace: WorkspaceState
+        message: MessageItem
     ) -> some View {
         modifier(
             AutomaticMediaDownloadModifier(
                 downloadState: downloadState,
                 attachment: attachment,
-                message: message,
-                workspace: workspace
+                message: message
             )
         )
     }
 }
 
 private struct AutomaticMediaDownloadModifier: ViewModifier {
+    @Environment(WorkspaceState.self) private var workspace
     let downloadState: MediaDownloadStateStore
     let attachment: MessageMediaAttachment
     let message: MessageItem
-    let workspace: WorkspaceState
 
     func body(content: Content) -> some View {
         content
@@ -433,7 +431,6 @@ struct MessageVisualMediaGrid: View {
 }
 
 struct MessageVisualMediaTile: View {
-    @Environment(WorkspaceState.self) private var workspace
     @Environment(\.displayScale) private var displayScale
     let downloadState: MediaDownloadStateStore
     let message: MessageItem
@@ -460,8 +457,7 @@ struct MessageVisualMediaTile: View {
         .autoDownloadMediaAttachment(
             downloadState,
             attachment: attachment,
-            message: message,
-            in: workspace
+            message: message
         )
         .onTapGesture {
             if attachment.kind == .image,
@@ -560,8 +556,7 @@ struct MessageMediaAttachmentView: View {
         .autoDownloadMediaAttachment(
             downloadState,
             attachment: attachment,
-            message: message,
-            in: workspace
+            message: message
         )
         .accessibilityIdentifier("message.media.attachment.\(attachment.id)")
     }
@@ -1250,8 +1245,7 @@ struct MessageImageGalleryContent: View {
         .autoDownloadMediaAttachment(
             downloadState,
             attachment: attachment,
-            message: message,
-            in: workspace
+            message: message
         )
     }
 }

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -267,6 +267,49 @@ private extension View {
             self
         }
     }
+
+    func autoDownloadMediaAttachment(
+        _ downloadState: MediaDownloadStateStore,
+        attachment: MessageMediaAttachment,
+        message: MessageItem,
+        in workspace: WorkspaceState
+    ) -> some View {
+        modifier(
+            AutomaticMediaDownloadModifier(
+                downloadState: downloadState,
+                attachment: attachment,
+                message: message,
+                workspace: workspace
+            )
+        )
+    }
+}
+
+private struct AutomaticMediaDownloadModifier: ViewModifier {
+    let downloadState: MediaDownloadStateStore
+    let attachment: MessageMediaAttachment
+    let message: MessageItem
+    let workspace: WorkspaceState
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                startAutomaticDownloadIfNeeded()
+            }
+            .onChange(of: attachment.id) { _, _ in
+                startAutomaticDownloadIfNeeded()
+            }
+            .onChange(of: downloadState.shouldStartAutomaticDownload) { _, shouldStart in
+                if shouldStart {
+                    startAutomaticDownloadIfNeeded()
+                }
+            }
+    }
+
+    private func startAutomaticDownloadIfNeeded() {
+        guard downloadState.shouldStartAutomaticDownload else { return }
+        Task { await workspace.loadMediaAttachment(attachment, for: message) }
+    }
 }
 
 /// The chat-bubble shape: a rounded rectangle with the trailing/leading bottom corner
@@ -414,14 +457,12 @@ struct MessageVisualMediaTile: View {
         .frame(width: sideLength, height: sideLength)
         .contentShape(Rectangle())
         .clipped()
-        .onAppear {
-            startAutomaticDownloadIfNeeded()
-        }
-        .onChange(of: downloadState.shouldStartAutomaticDownload) { _, shouldStart in
-            if shouldStart {
-                startAutomaticDownloadIfNeeded()
-            }
-        }
+        .autoDownloadMediaAttachment(
+            downloadState,
+            attachment: attachment,
+            message: message,
+            in: workspace
+        )
         .onTapGesture {
             if attachment.kind == .image,
                 let gallery = MessageImageGalleryPresentation(message: message, initialAttachment: attachment)
@@ -430,11 +471,6 @@ struct MessageVisualMediaTile: View {
             }
         }
         .accessibilityIdentifier("message.media.visualTile.\(attachment.id)")
-    }
-
-    private func startAutomaticDownloadIfNeeded() {
-        guard downloadState.shouldStartAutomaticDownload else { return }
-        Task { await workspace.loadMediaAttachment(attachment, for: message) }
     }
 
     @ViewBuilder
@@ -521,20 +557,13 @@ struct MessageMediaAttachmentView: View {
                 }
             }
         }
-        .onAppear {
-            startAutomaticDownloadIfNeeded()
-        }
-        .onChange(of: downloadState.shouldStartAutomaticDownload) { _, shouldStart in
-            if shouldStart {
-                startAutomaticDownloadIfNeeded()
-            }
-        }
+        .autoDownloadMediaAttachment(
+            downloadState,
+            attachment: attachment,
+            message: message,
+            in: workspace
+        )
         .accessibilityIdentifier("message.media.attachment.\(attachment.id)")
-    }
-
-    private func startAutomaticDownloadIfNeeded() {
-        guard downloadState.shouldStartAutomaticDownload else { return }
-        Task { await workspace.loadMediaAttachment(attachment, for: message) }
     }
 
     @ViewBuilder
@@ -1218,22 +1247,12 @@ struct MessageImageGalleryContent: View {
                 DownsampledMessageGalleryImage(download: download, attachment: attachment)
             }
         }
-        .onAppear {
-            startAutomaticDownloadIfNeeded()
-        }
-        .onChange(of: attachment.id) { _, _ in
-            startAutomaticDownloadIfNeeded()
-        }
-        .onChange(of: downloadState.shouldStartAutomaticDownload) { _, shouldStart in
-            if shouldStart {
-                startAutomaticDownloadIfNeeded()
-            }
-        }
-    }
-
-    private func startAutomaticDownloadIfNeeded() {
-        guard downloadState.shouldStartAutomaticDownload else { return }
-        Task { await workspace.loadMediaAttachment(attachment, for: message) }
+        .autoDownloadMediaAttachment(
+            downloadState,
+            attachment: attachment,
+            message: message,
+            in: workspace
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Add one shared `autoDownloadMediaAttachment` view modifier for media attachment auto-download lifecycle handling.
- Replace the three per-view `startAutomaticDownloadIfNeeded` implementations in visual tiles, attachment rows, and gallery content.
- Keep the attachment-id retrigger in the shared modifier so gallery attachment swaps still re-check idle downloads.

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' HEAD -- whitenoise-mac/Views/MessageMediaViews.swift`
- Not run: `xcodebuild` / Swift compiler checks unavailable on this Linux host.

Closes #294


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/297">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->