### PR TITLE
fix: fail transcript export on stuck cursor

### DIFF
--- a/whitenoise-mac/Core/ConversationTranscriptExport.swift
+++ b/whitenoise-mac/Core/ConversationTranscriptExport.swift
@@ -8,17 +8,18 @@ nonisolated enum ConversationTranscriptExport {
     static let pageLimit: UInt32 = 200
 
     enum ExportError: LocalizedError {
-        /// The FFI reported more history exists (`hasMoreBefore == true`) but returned an
-        /// empty page, so the `before` cursor cannot advance. Surfacing this prevents
-        /// silently truncating the transcript (issue #139).
+        /// The FFI reported more history exists (`hasMoreBefore == true`) but the `before`
+        /// cursor cannot advance — either the page was empty, or its oldest message matched
+        /// the current cursor. Surfacing this prevents silently truncating the transcript
+        /// (issue #139 and its non-empty sibling case).
         case emptyPageWithMoreHistory
 
         var errorDescription: String? {
             switch self {
             case .emptyPageWithMoreHistory:
                 return
-                    "Transcript export stopped early: the timeline reported more history but returned an empty page, "
-                    + "so older messages could not be loaded."
+                    "Transcript export stopped early: the timeline reported more history but the pagination "
+                    + "cursor could not advance, so older messages could not be loaded."
             }
         }
     }
@@ -114,7 +115,12 @@ nonisolated enum ConversationTranscriptExport {
             }
             let nextBefore = oldest.timelineAt
             let nextBeforeMessageId = oldest.messageIdHex
-            guard nextBefore != before || nextBeforeMessageId != beforeMessageId else { break }
+            guard nextBefore != before || nextBeforeMessageId != beforeMessageId else {
+                // `hasMoreBefore` is true but the oldest message matches the current cursor, so
+                // the `before` cursor cannot advance. Fail loudly like the empty-page branch
+                // above instead of silently truncating history (sibling case of #139).
+                throw ExportError.emptyPageWithMoreHistory
+            }
             before = nextBefore
             beforeMessageId = nextBeforeMessageId
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6017,6 +6017,36 @@ struct whitenoise_macTests {
         }
     }
 
+    @Test func conversationTranscriptExportFailsWhenNonEmptyPageDoesNotAdvanceCursor() throws {
+        // Regression for the sibling of #139: a *non-empty* page whose oldest message equals
+        // the current `before` cursor while `hasMoreBefore == true` also cannot advance, so the
+        // export must fail loudly rather than silently truncating older history. The first page
+        // returns one message with more before it; the second page returns that same message
+        // (same `timelineAt` + `messageIdHex`) while still claiming more history exists.
+        let runtime = FakeMarmotRuntime(accounts: [desktopAccount()])
+        let firstId = String(repeating: "1", count: 64)
+        let boundary = timelineMessage(
+            id: firstId,
+            groupIdHex: "group",
+            sender: String(repeating: "a", count: 64),
+            plaintext: "newest",
+            recordedAt: 10
+        )
+        // Every page returns only the boundary message, so after the first page the oldest
+        // message always equals the current cursor and the loop can never make progress.
+        runtime.timelineMessagesHandler = { _ in
+            TimelinePageFfi(messages: [boundary], hasMoreBefore: true, hasMoreAfter: false)
+        }
+
+        #expect(throws: ConversationTranscriptExport.ExportError.self) {
+            try ConversationTranscriptExport.fetchAllMessages(
+                client: runtime,
+                accountRef: "Desktop Account",
+                groupIdHex: "group"
+            )
+        }
+    }
+
     @Test func conversationTranscriptExportStopsCleanlyWhenEmptyPageHasNoMoreHistory() throws {
         // The companion to the regression above: an empty page with `hasMoreBefore == false`
         // is genuinely done and must terminate the loop without throwing.


### PR DESCRIPTION
Closes #289

## Summary
- Added a regression test for the non-empty pagination no-progress case in transcript export.
- Changed `ConversationTranscriptExport.fetchAllMessages` to throw when `hasMoreBefore == true` but the computed `before` cursor cannot advance, instead of silently breaking and returning a truncated transcript.
- Reused the existing `emptyPageWithMoreHistory` error and broadened its message/doc comment to cover both empty-page and stuck-cursor failures.

## Verification
- `git diff --check` ✅
- searched Swift files for conflict markers ✅
- inspected diff and confirmed the new test references existing `FakeMarmotRuntime`, `desktopAccount()`, `timelineMessage(...)`, and `TimelinePageFfi(messages:hasMoreBefore:hasMoreAfter:)` patterns ✅
- `command -v xcodebuild xcrun swift swift-format` → unavailable on this Linux host, so Xcode/macOS CI commands could not be run locally.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/298">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript export so it no longer silently stops when pagination gets stuck, helping prevent incomplete exports.
  * Updated the export error message to better explain cases where more history is available but the next page cannot be reached.
* **Tests**
  * Added regression coverage for exports that fail to advance through pagination, ensuring the issue is detected reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->