### PR TITLE
fix: cache audio waveform presentation bars

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -952,6 +952,7 @@ nonisolated enum MediaWaveformAnalyzer {
     }
 
     static let sampleCount = 36
+    static let fallbackSamples: [CGFloat] = fallback()
     static let chunkFrameCapacityCeiling: AVAudioFrameCount = 65_536
     static let maxChunkBytes: Int = 4 * 1024 * 1024
     static let maxChannelCount: AVAudioChannelCount = 32

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -309,6 +309,7 @@ nonisolated struct ComposerAudioWaveformBar: Equatable {
 
 nonisolated enum ComposerAudioWaveformPresentation {
     static let amplitudeCurveExponent: Double = 0.45
+    static let fallbackPlaybackBars = bars(for: MediaWaveformAnalyzer.fallbackSamples, mode: .playback)
 
     static func bars(
         for samples: [CGFloat],
@@ -338,15 +339,40 @@ nonisolated enum ComposerAudioWaveformPresentation {
 }
 
 struct ComposerAudioWaveformView: View {
-    let samples: [CGFloat]
+    let bars: [ComposerAudioWaveformBar]
     let progress: CGFloat
     let barColor: Color
     let playedColor: Color
-    var mode: ComposerAudioWaveformMode = .playback
+
+    init(
+        samples: [CGFloat],
+        progress: CGFloat,
+        barColor: Color,
+        playedColor: Color,
+        mode: ComposerAudioWaveformMode = .playback
+    ) {
+        self.init(
+            bars: ComposerAudioWaveformPresentation.bars(for: samples, mode: mode),
+            progress: progress,
+            barColor: barColor,
+            playedColor: playedColor
+        )
+    }
+
+    init(
+        bars: [ComposerAudioWaveformBar],
+        progress: CGFloat,
+        barColor: Color,
+        playedColor: Color
+    ) {
+        self.bars = bars
+        self.progress = progress
+        self.barColor = barColor
+        self.playedColor = playedColor
+    }
 
     var body: some View {
         GeometryReader { geometry in
-            let bars = ComposerAudioWaveformPresentation.bars(for: samples, mode: mode)
             let spacing: CGFloat = 2
             let barCount = max(1, bars.count)
             let availableWidth = geometry.size.width - spacing * CGFloat(max(0, barCount - 1))

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -311,6 +311,14 @@ nonisolated enum ComposerAudioWaveformPresentation {
     static let amplitudeCurveExponent: Double = 0.45
     static let fallbackPlaybackBars = bars(for: MediaWaveformAnalyzer.fallbackSamples, mode: .playback)
 
+    static func visiblePlaybackBars(
+        loadedBars: [ComposerAudioWaveformBar],
+        metadataPayloadID: String?,
+        currentPayloadID: String
+    ) -> [ComposerAudioWaveformBar] {
+        metadataPayloadID == currentPayloadID ? loadedBars : fallbackPlaybackBars
+    }
+
     static func bars(
         for samples: [CGFloat],
         mode: ComposerAudioWaveformMode,
@@ -324,6 +332,8 @@ nonisolated enum ComposerAudioWaveformPresentation {
                 .map(displayAmplitude)
                 .map { ComposerAudioWaveformBar(amplitude: $0) }
         case .liveRecording:
+            // Live recordings grow while the user speaks, so this path intentionally
+            // recomputes from the current samples instead of caching a stale snapshot.
             let visibleSamples = samples.suffix(targetCount)
                 .map(displayAmplitude)
                 .map { ComposerAudioWaveformBar(amplitude: $0) }
@@ -344,6 +354,8 @@ struct ComposerAudioWaveformView: View {
     let barColor: Color
     let playedColor: Color
 
+    // Convenience path for one-shot previews and live recording. Playback rows pass
+    // precomputed bars so progress ticks only recolor already-prepared amplitudes.
     init(
         samples: [CGFloat],
         progress: CGFloat,

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -715,6 +715,7 @@ struct MessageAudioAttachmentPlayer: View {
     @State private var playbackProgress: CGFloat = 0
     @State private var metadata: MediaWaveformAnalyzer.Metadata?
     @State private var metadataPayloadID: String?
+    @State private var waveformBars = ComposerAudioWaveformPresentation.fallbackPlaybackBars
     @State private var playbackMonitor: Task<Void, Never>?
     @State private var audioPlayerDelegate = MessageAudioPlayerDelegate()
 
@@ -745,7 +746,7 @@ struct MessageAudioAttachmentPlayer: View {
 
                 HStack(spacing: 8) {
                     ComposerAudioWaveformView(
-                        samples: visibleMetadata?.samples ?? MediaWaveformAnalyzer.fallback(),
+                        bars: visibleWaveformBars,
                         progress: playbackProgress,
                         barColor: isOutgoing ? Color.white.opacity(0.42) : Color.secondary.opacity(0.55),
                         playedColor: isOutgoing ? Color.white.opacity(0.9) : Color.accentColor
@@ -775,16 +776,28 @@ struct MessageAudioAttachmentPlayer: View {
             let payloadID = download.payload.id
             if metadataPayloadID != payloadID {
                 metadata = nil
+                waveformBars = ComposerAudioWaveformPresentation.fallbackPlaybackBars
             }
             let loaded = await MessageAudioMetadataCache.shared.metadata(for: download)
+            let loadedWaveformBars = ComposerAudioWaveformPresentation.bars(
+                for: loaded.samples,
+                mode: .playback
+            )
             guard !Task.isCancelled else { return }
             metadata = loaded
             metadataPayloadID = payloadID
+            waveformBars = loadedWaveformBars
         }
     }
 
     private var visibleMetadata: MediaWaveformAnalyzer.Metadata? {
         metadataPayloadID == download.payload.id ? metadata : nil
+    }
+
+    private var visibleWaveformBars: [ComposerAudioWaveformBar] {
+        metadataPayloadID == download.payload.id
+            ? waveformBars
+            : ComposerAudioWaveformPresentation.fallbackPlaybackBars
     }
 
     private var durationLabel: String {

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -795,9 +795,11 @@ struct MessageAudioAttachmentPlayer: View {
     }
 
     private var visibleWaveformBars: [ComposerAudioWaveformBar] {
-        metadataPayloadID == download.payload.id
-            ? waveformBars
-            : ComposerAudioWaveformPresentation.fallbackPlaybackBars
+        ComposerAudioWaveformPresentation.visiblePlaybackBars(
+            loadedBars: waveformBars,
+            metadataPayloadID: metadataPayloadID,
+            currentPayloadID: download.payload.id
+        )
     }
 
     private var durationLabel: String {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -47,6 +47,37 @@ struct PureValueTests {
         )
     }
 
+    @Test func composerAudioWaveformSelectsLoadedBarsForMatchingPayload() async throws {
+        // The metadata-loaded path stores bars once, then playback progress should only
+        // recolor those loaded bars. Stale or missing metadata keeps showing fallback.
+        let loadedBars = ComposerAudioWaveformPresentation.bars(
+            for: [0.15, 0.35, 0.65, 1.0],
+            mode: .playback
+        )
+
+        #expect(
+            ComposerAudioWaveformPresentation.visiblePlaybackBars(
+                loadedBars: loadedBars,
+                metadataPayloadID: "payload-a",
+                currentPayloadID: "payload-a"
+            ) == loadedBars
+        )
+        #expect(
+            ComposerAudioWaveformPresentation.visiblePlaybackBars(
+                loadedBars: loadedBars,
+                metadataPayloadID: nil,
+                currentPayloadID: "payload-a"
+            ) == ComposerAudioWaveformPresentation.fallbackPlaybackBars
+        )
+        #expect(
+            ComposerAudioWaveformPresentation.visiblePlaybackBars(
+                loadedBars: loadedBars,
+                metadataPayloadID: "payload-a",
+                currentPayloadID: "payload-b"
+            ) == ComposerAudioWaveformPresentation.fallbackPlaybackBars
+        )
+    }
+
     @Test func mediaDurationLabelClampsNonFiniteAndOversizedDurations() async throws {
         // Regression for whitenoise-mac#253: the audio duration is peer-derived
         // (MediaWaveformAnalyzer -> AVAudioFile.length / sampleRate), so it may be

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -32,6 +32,21 @@ struct PureValueTests {
         #expect(DisappearingMessageOption.custom(oversizedSeconds).label == "9223372036854775808 seconds")
     }
 
+    @Test func composerAudioWaveformUsesPrecomputedFallbackBars() async throws {
+        // Regression for whitenoise-mac#292: fallback waveform samples/bars are used
+        // while metadata loads, including during playback-progress repaint ticks. Keep
+        // the default fallback and its display bars as precomputed values so progress
+        // updates can recolor an already-prepared waveform instead of regenerating it.
+        #expect(MediaWaveformAnalyzer.fallbackSamples == MediaWaveformAnalyzer.fallback())
+        #expect(
+            ComposerAudioWaveformPresentation.fallbackPlaybackBars
+                == ComposerAudioWaveformPresentation.bars(
+                    for: MediaWaveformAnalyzer.fallbackSamples,
+                    mode: .playback
+                )
+        )
+    }
+
     @Test func mediaDurationLabelClampsNonFiniteAndOversizedDurations() async throws {
         // Regression for whitenoise-mac#253: the audio duration is peer-derived
         // (MediaWaveformAnalyzer -> AVAudioFile.length / sampleRate), so it may be


### PR DESCRIPTION
## Summary
- Hoists audio waveform display bars out of the playback-progress render path.
- Adds precomputed fallback samples/bars for the metadata-loading state.
- Keeps playback-progress ticks to choosing colors from already-prepared bars.

## Test Plan
- `git diff --check`
- Python delimiter-balance check over changed Swift files
- Working-tree conflict-marker scan
- Not run: `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` (`xcodebuild` is unavailable on this Linux worker)

Closes #292


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/299">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->