### PR TITLE
fix: clear image cache on account sign-out

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -256,14 +256,14 @@ extension WorkspaceState {
                 || !accounts.contains(where: { $0.id == activeAccountId })
             let needsActiveReset = wasActive || activeAccountInvalid
 
-            // Decoded peer/group avatars derive from account contacts' attacker-controlled
-            // `picture` URLs. The decoded-image cache is process-lifetime and global rather than
-            // account-partitioned, so evict it after every successful account removal, including
-            // removing a non-active identity from Settings. See #177.
-            RemoteImageLoader.shared.clearCache()
-
             if needsActiveReset {
                 resetActiveAccountUIState()
+            } else {
+                // Decoded peer/group avatars derive from account contacts' attacker-controlled
+                // `picture` URLs. The decoded-image cache is process-lifetime and global rather than
+                // account-partitioned, so evict it after every successful background-account removal.
+                // Active-account removal clears it through `resetActiveAccountUIState()`. See #177.
+                RemoteImageLoader.shared.clearCache()
             }
 
             if accounts.isEmpty {
@@ -307,6 +307,9 @@ extension WorkspaceState {
         mediaDownloads.removeAll()
         peerProfileFFICache.removeAll()
         clearGroupMemberCache()
+        // Active-account teardown must evict decoded peer/group avatars held in the
+        // process-lifetime image cache; profile metadata alone is not enough. See #177/#288.
+        RemoteImageLoader.shared.clearCache()
         timelinePagingByChat.removeAll()
         accountUnreadByIdHex.removeAll()
         // Read markers are keyed by groupIdHex; leaving them behind both retains a

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -541,6 +541,63 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func signOutActiveAccountClearsDecodedImageCache() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+
+        RemoteImageLoader.shared.clearCache()
+        defer { RemoteImageLoader.shared.clearCache() }
+        let cacheKey = "signed-out-active-account-avatar"
+        let imageData = try Self.testPNGData(width: 64, height: 64)
+        let decoded = try #require(
+            await RemoteImageLoader.shared.image(
+                for: imageData,
+                cacheKey: cacheKey,
+                maxPixelSize: 32
+            )
+        )
+        let cachedBeforeSignOut = try #require(
+            await RemoteImageLoader.shared.image(
+                for: Data([0x00]),
+                cacheKey: cacheKey,
+                maxPixelSize: 32
+            )
+        )
+        #expect(cachedBeforeSignOut.nsImage === decoded.nsImage)
+
+        let desktopAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+        await state.signOutAccount(desktopAccount)
+
+        #expect(runtime.signedOutAccountRefs == ["Desktop Account"])
+        #expect(state.accounts.first { $0.id == "Desktop Account" }?.signedOut == true)
+        #expect(state.activeAccountId == "Backup Account")
+        #expect(
+            await RemoteImageLoader.shared.image(
+                for: Data([0x00]),
+                cacheKey: cacheKey,
+                maxPixelSize: 32
+            ) == nil
+        )
+    }
+
+    @MainActor
     @Test func removingBackgroundAccountSelectedMidFlightRecoversActiveAccount() async throws {
         // Regression for the account-switch/remove race: if the user selects the
         // background account that is currently being removed while removal is in flight,
@@ -11815,6 +11872,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func signOut(accountRef: String, deleteKeyPackages: Bool) async throws -> SignOutOutcomeFfi {
         signOutCallCount += 1
         signedOutAccountRefs.append(accountRef)
+        if let index = storedAccounts.firstIndex(where: { $0.label == accountRef }) {
+            storedAccounts[index].signedOut = true
+            storedAccounts[index].running = false
+        }
         return SignOutOutcomeFfi(
             keyPackagesDeleted: 0,
             keyPackageFailures: [],


### PR DESCRIPTION
## Summary
- Clear the shared decoded image cache during active-account UI teardown so sign-out evicts previously-active contact/group avatars.
- Preserve the existing background-account removal cache eviction path.
- Add a regression test covering active account sign-out and decoded image cache eviction.

## Test Plan
- `git diff --check`
- GitHub Mac CI `PR Checks` pass
- GitHub Mac CI `Static Analysis` pass
- Local `xcodebuild -version` unavailable on this Linux worker: `xcodebuild: command not found`
- Local `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` unavailable on this Linux worker: `xcrun: command not found`

Closes #288
