### PR TITLE
fix: reject rooted local SSRF hosts

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -55,10 +55,16 @@ nonisolated enum RemoteImageURLPolicy {
     /// a private/loopback/link-local/unspecified literal IP, or a local hostname.
     static func isDisallowedHost(_ host: String) -> Bool {
         // `URL.host` does not lowercase or strip IPv6 brackets in all cases; normalize defensively.
-        let normalized =
-            host
-            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
-            .lowercased()
+        // Strip absolute-FQDN trailing dots so localhost./*.local./127.0.0.1. are checked
+        // against the same local-hostname and literal-IP rules as their unrooted forms.
+        var normalized = host.lowercased()
+        while normalized.hasSuffix(".") {
+            normalized.removeLast()
+        }
+        normalized = normalized.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        while normalized.hasSuffix(".") {
+            normalized.removeLast()
+        }
 
         if normalized.isEmpty { return true }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -170,6 +170,9 @@ struct PureValueTests {
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://127.0.0.1:8080/x.png") == nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[::1]/x.png") == nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://localhost/x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://localhost./x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://printer.local./x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://127.0.0.1./x.png") == nil)
         // whitenoise-mac#243: broadcast / multicast / reserved / CGNAT are non-public too,
         // including an obfuscated (decimal) broadcast literal to exercise the parser path.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://255.255.255.255/x.png") == nil)
@@ -505,11 +508,14 @@ struct PureValueTests {
             "http://192.168.0.1/admin/reboot",
             "https://[::1]:9000/",
             "http://127.0.0.1:8080/",
+            "http://127.0.0.1.:8080/",
             "https://10.0.0.5/x",
             "http://169.254.169.254/latest/meta-data",
             "https://[fe80::1]/",
             "http://localhost/admin",
+            "http://localhost./admin",
             "https://printer.local/status",
+            "https://printer.local./status",
             // Obfuscated loopback literal (decimal form of 127.0.0.1).
             "http://2130706433/",
         ] {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7864,6 +7864,7 @@ struct whitenoise_macTests {
         // IPv4 loopback / private / link-local / "this host".
         let blockedV4 = [
             "https://127.0.0.1/x.png",
+            "https://127.0.0.1./x.png",
             "https://127.1.2.3/x.png",
             "https://10.0.0.5/x.png",
             "https://10.255.255.255/x.png",
@@ -7921,8 +7922,10 @@ struct whitenoise_macTests {
 
         // Local hostnames.
         #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "https://localhost/x.png")!))
+        #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "https://localhost./x.png")!))
         #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "https://LOCALHOST/x.png")!))
         #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "https://printer.local/x.png")!))
+        #expect(!RemoteImageURLPolicy.isAllowed(URL(string: "https://printer.local./x.png")!))
 
         // Allowed: genuine public hosts and public IP literals are not affected.
         let allowed = [


### PR DESCRIPTION
## Summary
- normalize remote-image and Markdown-link hosts by stripping absolute-FQDN trailing dots before SSRF checks
- reject rooted localhost, `.local`, and private IPv4 literals in both avatar URL and peer Markdown policies
- add regression coverage for `localhost.`, `printer.local.`, and `127.0.0.1.` variants

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' HEAD -- whitenoise-mac/Core/RemoteImageLoader.swift whitenoise-macTests/PureValueTests.swift whitenoise-macTests/whitenoise_macTests.swift`
- GitHub Actions: `PR Checks` pass, `Static Analysis` pass
- Not run locally: `xcodebuild` / Swift tests unavailable on this Linux host (`swift` and `xcodebuild` not installed)

## Notes
- CodeRabbit posted a rate-limit notice rather than a substantive review; no inline review comments were present at handoff.

Closes #282
