### PR TITLE
fix: run timeline mapping off main actor

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -103,7 +103,14 @@ extension ChatItem {
     }
 }
 
-extension MessageItem {
+// The whole timeline record → view-model transformation is pure (it only reads the
+// `Sendable` FFI record and the resolved sender-profile map) and is deliberately run
+// off the main actor while mapping a window/projection so the attributed-string /
+// Markdown-AST build and media-JSON parse do not block the UI thread. `nonisolated`
+// opts these out of the module's default main-actor isolation
+// (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`) so they can be called from the
+// `@Sendable` off-main closure in `WorkspaceState+Timeline`. See whitenoise-mac#285.
+nonisolated extension MessageItem {
     private init(
         record: TimelineMessageRecordFfi,
         activeAccountIdHex: String?,
@@ -403,7 +410,7 @@ extension MessageItem {
     }
 }
 
-private enum MarmotTimelineKind {
+private nonisolated enum MarmotTimelineKind {
     static let chat: UInt64 = 9
     static let agentStreamStart: UInt64 = 1200
     static let agentActivity: UInt64 = 1201
@@ -695,7 +702,7 @@ private nonisolated enum MessageMediaParser {
     }
 }
 
-private struct TimelinePayload: Decodable {
+private nonisolated struct TimelinePayload: Decodable {
     let text: String?
     let status: String?
     let eventType: String?
@@ -726,7 +733,7 @@ private extension String {
     }
 }
 
-private extension MessageReaction {
+private nonisolated extension MessageReaction {
     static func summarize(_ summary: TimelineReactionSummaryFfi, activeAccountIdHex: String?) -> [MessageReaction] {
         summary.byEmoji
             .map { reaction in

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -165,18 +165,25 @@ extension WorkspaceState {
         }
         guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
 
-        let currentPaging = timelinePagingByChat[groupIdHex]
         // Maps every record in the window and builds each bubble's Markdown display model
-        // (attributed strings + block ids) eagerly — historically the dominant scroll-back cost.
-        let mappedMessages = TimelineSignpost.mapping.interval(
+        // (attributed strings + block ids) eagerly — historically the dominant scroll-back
+        // cost. Run off the main actor so this pure transformation does not block the UI
+        // thread during the window replace, then re-check the selection guard after the
+        // await before mutating timeline state (whitenoise-mac#285). Capture the plain
+        // `accountIdHex` value before hopping off-main to avoid capturing actor state.
+        let activeAccountIdHex = account.accountIdHex
+        let mappedMessages = await TimelineSignpost.mapping.asyncInterval(
             "mapWindow", count: page.messages.count
         ) {
-            MessageItem.timeline(
-                from: page,
-                activeAccountIdHex: account.accountIdHex,
+            await Self.mapTimelineOffMain(
+                page: page,
+                activeAccountIdHex: activeAccountIdHex,
                 senderProfiles: senderProfiles
             )
         }
+        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+
+        let currentPaging = timelinePagingByChat[groupIdHex]
         TimelineSignpost.store.interval("replaceMessages", count: mappedMessages.count) {
             replaceMessages(
                 mappedMessages,
@@ -265,15 +272,22 @@ extension WorkspaceState {
             )
         }
         guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
-        let mappedUpserts = TimelineSignpost.mapping.interval(
+        // Map only the changed records off the main actor (same pure transformation as the
+        // window path), then re-check the selection guard after the await before mutating
+        // the store (whitenoise-mac#285). Capture the plain `accountIdHex` before hopping
+        // off-main to avoid capturing actor state.
+        let activeAccountIdHex = account.accountIdHex
+        let upsertPage = TimelinePageFfi(messages: upsertRecords, hasMoreBefore: false, hasMoreAfter: false)
+        let mappedUpserts = await TimelineSignpost.mapping.asyncInterval(
             "mapProjection", count: upsertRecords.count
         ) {
-            MessageItem.timeline(
-                from: TimelinePageFfi(messages: upsertRecords, hasMoreBefore: false, hasMoreAfter: false),
-                activeAccountIdHex: account.accountIdHex,
+            await Self.mapTimelineOffMain(
+                page: upsertPage,
+                activeAccountIdHex: activeAccountIdHex,
                 senderProfiles: senderProfiles
             )
         }
+        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
 
         let paging = timelinePagingByChat[groupIdHex] ?? .empty
         // The window is "anchored" to the live head while there is no newer history to

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -822,6 +822,27 @@ final class WorkspaceState {
         attributes: .concurrent
     )
 
+    /// Runs the pure timeline record → view-model transformation off the main actor.
+    /// This uses the same queue as blocking FFI work because `WorkspaceState` is
+    /// `@MainActor` while Markdown/attributed-string/media-JSON mapping can be expensive.
+    nonisolated static func mapTimelineOffMain(
+        page: TimelinePageFfi,
+        activeAccountIdHex: String?,
+        senderProfiles: [String: ChatPeerProfile]
+    ) async -> [MessageItem] {
+        await withCheckedContinuation { (continuation: CheckedContinuation<[MessageItem], Never>) in
+            Self.ffiQueue.async {
+                continuation.resume(
+                    returning: MessageItem.timeline(
+                        from: page,
+                        activeAccountIdHex: activeAccountIdHex,
+                        senderProfiles: senderProfiles
+                    )
+                )
+            }
+        }
+    }
+
     /// Cached raw output of the per-sender profile FFI lookups.
     struct ResolvedPeerFFI: Sendable {
         var profileDisplayName: String?

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -106,7 +106,12 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     }
 }
 
-struct ChatPeerProfile: Hashable {
+// `Sendable` so the timeline window/projection mapping can capture the resolved
+// sender-profile map in the off-main `MessageItem.timeline(...)` closure
+// (whitenoise-mac#285). All stored properties are value types, so the conformance is
+// checked; `nonisolated` opts the value type out of the module's default main-actor
+// isolation (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`), a prerequisite for `Sendable`.
+nonisolated struct ChatPeerProfile: Hashable, Sendable {
     let accountIdHex: String
     let displayName: String?
     let pictureURL: String?
@@ -175,7 +180,7 @@ enum GroupDetailsHeaderAvatar {
     }
 }
 
-struct MessageReaction: Identifiable, Hashable {
+nonisolated struct MessageReaction: Identifiable, Hashable {
     let emoji: String
     let count: Int
     let isOwn: Bool
@@ -199,7 +204,7 @@ struct MessageReaction: Identifiable, Hashable {
     }
 }
 
-struct MessageReplyContext: Hashable {
+nonisolated struct MessageReplyContext: Hashable {
     let targetMessageId: String
     let senderName: String
     let body: String
@@ -225,7 +230,7 @@ nonisolated enum MessageMediaKind: Hashable, Sendable {
     }
 }
 
-struct MessageMediaAttachment: Identifiable, Hashable {
+nonisolated struct MessageMediaAttachment: Identifiable, Hashable {
     let id: String
     let reference: MediaAttachmentReferenceFfi
 
@@ -1261,7 +1266,7 @@ nonisolated private enum TemporaryOutgoingMediaFile {
     }
 }
 
-enum MessagePresentation: Hashable {
+nonisolated enum MessagePresentation: Hashable {
     case chat
     case agentStreamStart
     case agentActivity
@@ -1340,7 +1345,10 @@ struct MessageItem: Identifiable, Hashable {
     /// Whether the bubble should render the parsed Markdown AST instead of plain text.
     var rendersMarkdown: Bool { contentMarkdown != nil }
 
-    init(
+    // `nonisolated` so the timeline record → view-model mapping (`MessageItem.timeline`)
+    // can build items in the off-main window/projection closure (whitenoise-mac#285)
+    // without inheriting the module's default main-actor isolation.
+    nonisolated init(
         id: String,
         groupIdHex: String = "",
         senderAccountIdHex: String? = nil,
@@ -1418,7 +1426,7 @@ struct MessageItem: Identifiable, Hashable {
         self.metadataLabel = statusLabel.map { "\(timeLabel)  \($0)" } ?? timeLabel
     }
 
-    private static func partitionMediaAttachments(_ attachments: [MessageMediaAttachment]) -> (
+    nonisolated private static func partitionMediaAttachments(_ attachments: [MessageMediaAttachment]) -> (
         visual: [MessageMediaAttachment], nonvisual: [MessageMediaAttachment]
     ) {
         var visual: [MessageMediaAttachment] = []


### PR DESCRIPTION
Closes #285

## Summary
- Moves timeline window and projection `MessageItem.timeline(...)` mapping off the main actor, while preserving the existing mapping signpost names/counts.
- Re-checks the active account/chat guard after the off-main await before replacing or mutating the timeline store.
- Marks the pure timeline mapping surface/value models as `nonisolated` where needed under the repo's default MainActor isolation, and makes `ChatPeerProfile` `Sendable` so the sender profile map can cross the off-main boundary.

## Verification
- `git diff --check` — passed.
- Static regression check: confirmed the old synchronous `TimelineSignpost.mapping.interval("mapWindow"/"mapProjection")` call sites are gone and both mapping paths now use `TimelineSignpost.mapping.asyncInterval(...)` around the off-main hop — passed.
- Toolchain probe: `xcodebuild`, `xcrun`, `swift`, `swift-format`, `swiftformat`, and `swiftlint` are not installed on this Linux host, so xcodebuild/Swift format/unit test verification could not be run locally.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/306">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->