### PR TITLE
fix: preserve chat list enrichment on reload

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -75,9 +75,14 @@ extension WorkspaceState {
 
             let rows = try await runOffMain { subscription.snapshot() }
             guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
-            await applyChatRows(rows, account: activeAccount)
-            guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
+            // Start the listener before applying the snapshot rows. `startChatListListener`
+            // tears down the previous listener (which cancels any in-flight enrichment), so it
+            // must run before `applyChatRows` starts the fresh full-snapshot enrichment task —
+            // otherwise the listener-start teardown cancels that enrichment before its body ever
+            // runs on the main actor, leaving non-selected direct chats on their raw fallback.
             startChatListListener(account: activeAccount, subscription: subscription)
+            guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
+            await applyChatRows(rows, account: activeAccount)
 
             guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
             await selectMostRecentChatIfNeeded()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4304,6 +4304,77 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func bootstrapEnrichesNonSelectedDirectChatWithBlockingListener() async throws {
+        // Issue #281: the full-snapshot enrichment started by `applyChatRows` during
+        // bootstrap/reload must survive listener startup. The listener reuses the snapshot's
+        // subscription, so `nextUpdate()` blocks forever (no forced reconnect to run its own
+        // snapshot/enrichment). A non-selected direct chat must still resolve to its peer
+        // display name / avatar / isDirect instead of staying on its raw group-id fallback.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        // A more-recent message group is auto-selected on bootstrap, leaving the direct chat
+        // non-selected so its enrichment is driven only by the full-snapshot pass.
+        runtime.installDirectGroup(
+            directGroup(),
+            alongside: [messageGroup()],
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: "https://example.com/alice.png",
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "group-latest",
+                    groupIdHex: "group",
+                    sender: aliceId,
+                    plaintext: "Most recent group message.",
+                    kind: 9,
+                    recordedAt: 1_700_000_900
+                )
+            ], groupIdHex: "group")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+
+        let didEnrichDirectChat = await waitFor(attempts: 300) {
+            state.activeChats.first { $0.id == "direct-group" }?.title == "Alice Actual"
+        }
+
+        let directChat = state.activeChats.first { $0.id == "direct-group" }
+        if !didEnrichDirectChat {
+            Issue.record(
+                """
+                Expected non-selected direct chat to be enriched by the full-snapshot pass. \
+                title=\(directChat?.title ?? "nil") isDirect=\(directChat?.isDirect ?? false) \
+                pictureURL=\(directChat?.pictureURL ?? "nil") selection=\(String(describing: state.selection))
+                """
+            )
+        }
+        #expect(didEnrichDirectChat)
+        #expect(directChat?.isDirect == true)
+        #expect(directChat?.pictureURL == "https://example.com/alice.png")
+        // The listener reuses the snapshot's subscription; no forced reconnect masks the bug.
+        #expect(runtime.chatListSubscriptionCount == 1)
+        // The direct chat must not have been auto-selected (older than the group chat).
+        #expect(state.selection == .chat("group"))
+    }
+
+    @MainActor
     @Test func concurrentReloadChatsForSameAccountCoalesces() async throws {
         // Issue #210: reloadChats() is reachable from independently-spawned Tasks. Two overlapping
         // same-account reloads must share one in-flight subscription/snapshot pass instead of
@@ -11307,6 +11378,43 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         otherProfile: UserProfileMetadataFfi
     ) {
         groups = [group]
+        registerDirectGroupDetails(
+            group,
+            selfAccountIdHex: selfAccountIdHex,
+            otherAccountIdHex: otherAccountIdHex,
+            otherDisplayName: otherDisplayName,
+            otherProfile: otherProfile
+        )
+    }
+
+    /// Install a direct group *alongside* the supplied companion groups (which stay raw group
+    /// chats) instead of replacing the whole group set. Lets a test keep the direct chat
+    /// non-selected while another, more-recent chat is auto-selected on bootstrap.
+    func installDirectGroup(
+        _ group: AppGroupRecordFfi,
+        alongside companions: [AppGroupRecordFfi],
+        selfAccountIdHex: String,
+        otherAccountIdHex: String,
+        otherDisplayName: String,
+        otherProfile: UserProfileMetadataFfi
+    ) {
+        installGroups(companions + [group])
+        registerDirectGroupDetails(
+            group,
+            selfAccountIdHex: selfAccountIdHex,
+            otherAccountIdHex: otherAccountIdHex,
+            otherDisplayName: otherDisplayName,
+            otherProfile: otherProfile
+        )
+    }
+
+    private func registerDirectGroupDetails(
+        _ group: AppGroupRecordFfi,
+        selfAccountIdHex: String,
+        otherAccountIdHex: String,
+        otherDisplayName: String,
+        otherProfile: UserProfileMetadataFfi
+    ) {
         profilesByAccountId[otherAccountIdHex] = otherProfile
         let details = GroupDetailsFfi(
             group: group,


### PR DESCRIPTION
Closes #281

## Summary
- Start the chat-list listener before applying a reload snapshot so listener teardown happens before the fresh full-snapshot enrichment task is created.
- Preserve the existing reload generation guards and avoid adding new lifecycle state.
- Add a regression test for a non-selected direct chat with a blocking reused subscription, proving bootstrap/reload enrichment resolves peer title/avatar/isDirect without relying on listener reconnect.

## Verification
- `git diff --check` — pass.
- Python line-length/trailing-whitespace audit for changed Swift files — pass (`line_length_over_120: 0`, `trailing_whitespace: 0`).
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — not runnable on this Linux host (`xcrun: command not found`).
- `scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host (`xcodebuild: command not found`).
- `xcodebuild test ...`, `xcodebuild build ...`, `xcodebuild analyze ...` — not runnable on this Linux host (`xcodebuild: command not found`).

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/308">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->