### PR TITLE
refactor: share account removal confirmation

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -23968,9 +23968,6 @@
     "This removes %@ from the group." : {
 
     },
-    "This removes the selected account from this Mac." : {
-
-    },
     "Token fingerprint" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -159,6 +159,51 @@ struct SettingsScaffold<Content: View>: View {
     }
 }
 
+private let removeAccountConfirmationMessage: LocalizedStringKey =
+    "This deletes the private key and local message history for this identity from this Mac. This cannot be undone."
+
+private func removeAccountConfirmationTitle(for account: AccountItem?) -> String {
+    guard let account else { return L10n.string("Remove account?") }
+    return String(format: L10n.string("Remove %@?"), account.displayName)
+}
+
+private struct RemoveAccountConfirmationModifier: ViewModifier {
+    let account: AccountItem?
+    @Binding var isPresented: Bool
+    let onRemove: () -> Void
+
+    func body(content: Content) -> some View {
+        content.confirmationDialog(
+            removeAccountConfirmationTitle(for: account),
+            isPresented: $isPresented,
+            titleVisibility: .visible
+        ) {
+            Button("Remove Account", role: .destructive) {
+                onRemove()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(removeAccountConfirmationMessage)
+        }
+    }
+}
+
+private extension View {
+    func removeAccountConfirmation(
+        account: AccountItem?,
+        isPresented: Binding<Bool>,
+        onRemove: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            RemoveAccountConfirmationModifier(
+                account: account,
+                isPresented: isPresented,
+                onRemove: onRemove
+            )
+        )
+    }
+}
+
 struct AccountsSettingsView: View {
     @Environment(WorkspaceState.self) private var workspace
     @State private var accountPendingRemoval: AccountItem?
@@ -243,23 +288,10 @@ struct AccountsSettingsView: View {
             }
 
         }
-        .confirmationDialog(
-            removeAccountTitle,
-            isPresented: removeConfirmationBinding,
-            titleVisibility: .visible,
-            presenting: accountPendingRemoval
-        ) { account in
-            Button("Remove Account", role: .destructive) {
-                accountPendingRemoval = nil
-                Task { await workspace.removeAccount(account) }
-            }
-            Button("Cancel", role: .cancel) {
-                accountPendingRemoval = nil
-            }
-        } message: { _ in
-            Text(
-                "This deletes the private key and local message history for this identity from this Mac. This cannot be undone."
-            )
+        .removeAccountConfirmation(account: accountPendingRemoval, isPresented: removeConfirmationBinding) {
+            guard let account = accountPendingRemoval else { return }
+            accountPendingRemoval = nil
+            Task { await workspace.removeAccount(account) }
         }
     }
 
@@ -270,13 +302,6 @@ struct AccountsSettingsView: View {
                 if !isPresented { accountPendingRemoval = nil }
             }
         )
-    }
-
-    private var removeAccountTitle: String {
-        if let account = accountPendingRemoval {
-            return String(format: L10n.string("Remove %@?"), account.displayName)
-        }
-        return L10n.string("Remove account?")
     }
 }
 
@@ -729,28 +754,15 @@ struct IdentityKeysSettingsView: View {
             }
 
         }
-        .confirmationDialog(
-            removeAccountTitle,
-            isPresented: $showRemoveAccountConfirmation,
-            titleVisibility: .visible
+        .removeAccountConfirmation(
+            account: workspace.activeAccount,
+            isPresented: $showRemoveAccountConfirmation
         ) {
-            Button("Remove Account", role: .destructive) {
-                Task { await workspace.removeActiveAccount() }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This removes the selected account from this Mac.")
+            Task { await workspace.removeActiveAccount() }
         }
         .sheet(isPresented: $showKeyBackup) {
             PrivateKeyBackupSheet()
         }
-    }
-
-    private var removeAccountTitle: String {
-        if let account = workspace.activeAccount {
-            return String(format: L10n.string("Remove %@?"), account.displayName)
-        }
-        return L10n.string("Remove account?")
     }
 }
 


### PR DESCRIPTION
## Summary
- Extract shared remove-account confirmation title/message/button handling.
- Reuse it from Accounts and Identity Keys settings with only the removal action supplied by each view.
- Intentionally unify the Identity Keys removal dialog on the existing stronger account-removal warning, and remove the now-unused old string-catalog entry.

## Testing
- `python3 -m json.tool whitenoise-mac/Localizable.xcstrings`
- `grep -R "This removes the selected account from this Mac\." -n whitenoise-mac --exclude-dir=.git` (confirmed no matches)
- `git diff --check`
- `bash -n scripts/ci/macos-sanity-checks.sh`
- Python assertion that the two settings call sites use `.removeAccountConfirmation(...)` and no private `removeAccountTitle` helpers remain
- Not run locally: `xcrun swift-format lint` / `xcodebuild` (Xcode toolchain is not installed on this Linux worker)

Closes #318


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Streamlined account removal confirmations into a consistent, reusable dialog experience.
  * Updated account and identity key settings to use the same removal flow and messaging.
* **Bug Fixes**
  * Improved dismissal behavior so closing the confirmation dialog now properly clears pending removal state.
  * Ensured account removal only runs after a valid selection is confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->