### PR TITLE
fix: avoid origin-host group image previews

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1647,6 +1647,15 @@ struct GroupImageSearchResult: Identifiable, Hashable, Sendable {
         return "\(width)x\(height)"
     }
 
+    /// The URL used to render the search-result thumbnail. Only the
+    /// Openverse-proxied `thumbnailURL` is used; the arbitrary origin
+    /// `imageURL` is never fetched for previews (whitenoise-mac#315), so a
+    /// result without a usable thumbnail renders the placeholder instead.
+    var previewURL: URL? {
+        guard let thumbnailURL = thumbnailURL?.nilIfBlank else { return nil }
+        return URL(string: thumbnailURL)
+    }
+
     var creditLine: String {
         let creatorText = creator?.trimmingCharacters(in: .whitespacesAndNewlines)
         let licenseText = license?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -724,15 +724,6 @@ struct GroupImageResultTile: View {
     }
 }
 
-private extension GroupImageSearchResult {
-    var previewURL: URL? {
-        if let thumbnailURL, let url = URL(string: thumbnailURL) {
-            return url
-        }
-        return URL(string: imageURL)
-    }
-}
-
 /// Selectable disappearing-message timer presets for a group. `custom` carries a
 /// non-preset value returned by the core so the picker can still display it.
 enum DisappearingMessageOption: Hashable, Identifiable {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -571,6 +571,36 @@ struct PureValueTests {
         #expect(links(in: attributed).map(\.absoluteString) == ["nostr:\(bech32)"])
     }
 
+    @Test func groupImagePreviewURLUsesOpenverseThumbnailOnly() async throws {
+        // Regression for whitenoise-mac#315: search-result tiles must connect only to
+        // the Openverse-proxied thumbnail, never to the arbitrary origin `imageURL`.
+        // Any result without a usable thumbnail renders the placeholder (nil preview).
+        let origin = "https://origin.example/photo.jpg"
+
+        #expect(
+            groupImageResult(imageURL: origin, thumbnailURL: "https://api.openverse.org/thumb.jpg").previewURL
+                == URL(string: "https://api.openverse.org/thumb.jpg")
+        )
+        #expect(groupImageResult(imageURL: origin, thumbnailURL: nil).previewURL == nil)
+        #expect(groupImageResult(imageURL: origin, thumbnailURL: "").previewURL == nil)
+        #expect(groupImageResult(imageURL: origin, thumbnailURL: "   ").previewURL == nil)
+    }
+
+    private func groupImageResult(imageURL: String, thumbnailURL: String?) -> GroupImageSearchResult {
+        GroupImageSearchResult(
+            id: "image-1",
+            title: "Aurora",
+            imageURL: imageURL,
+            thumbnailURL: thumbnailURL,
+            creator: nil,
+            license: nil,
+            attribution: nil,
+            sourceURL: nil,
+            width: nil,
+            height: nil
+        )
+    }
+
     private func links(in attributed: AttributedString) -> [URL] {
         var result: [URL] = []
         for run in attributed.runs {


### PR DESCRIPTION
Closes #315

## Summary
- Removed the group-image preview fallback from Openverse search results to the original `imageURL` origin host.
- Moved preview URL logic onto `GroupImageSearchResult` as a testable thumbnail-only computed property.
- Added a regression test covering valid thumbnail previews and nil/blank thumbnail placeholders.

## Verification
- `git diff --check` — pass
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- ':!*.pbxproj'` — no conflict markers
- `git grep -n 'URL(string: imageURL)' -- '*.swift'` — no origin fallback remains
- `git grep -n 'updateSelectedGroupImage(url: result.imageURL' -- whitenoise-mac/Core/WorkspaceState+Groups.swift` — selection path still saves the chosen origin image URL
- `bash -n scripts/ci/macos-sanity-checks.sh` — pass
- `swift`, `xcodebuild`, and `xcrun` are unavailable on this Linux worker, so macOS Swift format/build/test/analyze checks could not be run locally.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/321">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->