### PR TITLE
fix: allow media cache declared size mismatch

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -423,13 +423,12 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 using: symmetricKey,
                 authenticatedBy: payloadAAD(for: key.cacheID)
             )
-            // AES-GCM `open` above already authenticates the payload against its key
-            // and AAD, so a full SHA-256 re-hash of the plaintext on every read would
-            // be redundant tamper detection. Keep only the cheap length sanity check.
-            guard UInt64(plaintext.count) == metadata.sizeBytes else {
-                try? FileManager.default.removeItem(at: entryDirectory)
-                return nil
-            }
+            // AES-GCM `open` above already authenticates the payload against its key and
+            // AAD, and the store path verifies the plaintext SHA-256 before writing, so the
+            // bytes on disk are cryptographically bound to this entry. `metadata.sizeBytes`
+            // is the FFI-reported size, which is not guaranteed to equal the decrypted
+            // length (e.g. a declared imeta size); comparing them here would self-delete a
+            // valid entry on every read whenever they diverge (#313), so we don't.
 
             return MessageMediaDownload(
                 payload: DownloadedMediaPayload(id: key.payloadID, data: plaintext),

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1322,6 +1322,41 @@ struct whitenoise_macTests {
         }
     }
 
+    @Test func messageMediaDiskCacheReadsEntryWhenDeclaredSizeDiffersFromPlaintext() async throws {
+        // #313: `sizeBytes` is the FFI-reported/declared size and is not guaranteed to equal
+        // the decrypted plaintext length. A valid, cryptographically authenticated entry must
+        // survive repeated reads even when the two diverge, rather than self-deleting.
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(root: root)
+        let plaintext = Data("bytes whose declared size lies".utf8)
+        let reference = mediaDiskCacheReference(plaintext: plaintext)
+        let key = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: reference)
+        let declaredSize = UInt64(plaintext.count) + 999
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "photo.png",
+            mediaType: "image/png",
+            sizeBytes: declaredSize,
+            payloadId: "network-download"
+        )
+
+        await cache.store(download, for: key)
+        let entryDirectory = try #require(cache.entryDirectory(for: key))
+
+        let firstRead = try #require(await cache.cachedDownload(for: key))
+        #expect(firstRead.data == plaintext)
+        #expect(firstRead.sizeBytes == declaredSize)
+        #expect(fileManager.fileExists(atPath: entryDirectory.path))
+
+        let secondRead = try #require(await cache.cachedDownload(for: key))
+        #expect(secondRead.data == plaintext)
+        #expect(fileManager.fileExists(atPath: entryDirectory.path))
+    }
+
     @Test func messageMediaDiskCacheEvictsCorruptEntries() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
Closes #313

## Summary
- Removed the read-time `plaintext.count == metadata.sizeBytes` invalidation guard from `MessageMediaDiskCache`.
- Kept the FFI-reported `sizeBytes` persisted and returned for display consistency; cache validity now relies on AES-GCM authentication on read plus the existing plaintext SHA-256 check before store.
- Added a regression test proving a cache entry remains readable when declared size differs from decrypted plaintext length.

## Verification
- `git diff --check` — passed.
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- . ':!Vendored'` — no conflict markers found.
- `command -v xcrun`, `command -v xcodebuild`, `command -v swift` — unavailable on this Linux host (`Linux vault 6.12.86+deb13-amd64 x86_64 GNU/Linux`).
- CI-equivalent macOS checks from `.github/workflows/mac-ci.yml` were not runnable locally because they require macOS/Xcode:
  - `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests`
  - `scripts/ci/macos-sanity-checks.sh` (calls `xcodebuild`/PlistBuddy)
  - `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination platform=macOS -resultBundlePath TestResults.xcresult -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO`
  - `xcodebuild build -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -configuration Release -destination platform=macOS ARCHS=arm64 ONLY_ACTIVE_ARCH=NO CODE_SIGNING_ALLOWED=NO`
  - `xcodebuild analyze -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -configuration Debug -destination platform=macOS CODE_SIGNING_ALLOWED=NO`

## Sensitive paths
- `whitenoise-mac/Core/MessageMediaDiskCache.swift` — crypto-adjacent media disk-cache read path using AES-GCM authentication/integrity checks.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/324">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media cache reads so items are no longer removed when the declared size differs from the decrypted content length.
  * Preserved cached media integrity during repeated reads, even when size metadata does not exactly match the stored data.
* **Tests**
  * Added coverage for reading cached media with mismatched declared and actual sizes to ensure entries remain available after access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->