### PR TITLE
fix: stop voice recording when leaving chats

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -79,7 +79,7 @@ extension WorkspaceState {
         to account: AccountItem,
         preservingMessageCacheFor groupIdHex: String?
     ) {
-        cancelVoiceRecording()
+        leaveActiveConversation()
         stopTimelineListener()
         cancelChatListReload()
         stopChatListListener()
@@ -419,6 +419,9 @@ extension WorkspaceState {
         defer { isDeletingAllData = false }
 
         do {
+            // Stop any in-progress voice recording before the wipe so the mic is not left hot
+            // (and no plaintext audio keeps being written) while local data is deleted (#311).
+            leaveActiveConversation()
             stopNotificationListener()
             cancelChatListReload()
             stopChatListListener()
@@ -496,6 +499,7 @@ extension WorkspaceState {
     }
 
     func resetToNewInstallState(storageRootPath: String) {
+        leaveActiveConversation()
         accounts = []
         resetChats()
         cachedMessageChatIds = []

--- a/whitenoise-mac/Core/WorkspaceState+Navigation.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Navigation.swift
@@ -16,8 +16,17 @@ import UserNotifications
 
 @MainActor
 extension WorkspaceState {
-    func selectChat(_ chat: ChatItem) {
+    /// Releases live, conversation-scoped resources whose only stop/cancel UI lives in the
+    /// conversation composer. Any navigation path that removes that composer from the hierarchy
+    /// (selecting another chat, opening Settings/new-chat, switching accounts, wiping data) must
+    /// run this so the microphone can never stay hot with no visible way to stop it (#311).
+    /// Centralizing the teardown keeps the cancellation from being silently omitted on new paths.
+    func leaveActiveConversation() {
         cancelVoiceRecording()
+    }
+
+    func selectChat(_ chat: ChatItem) {
+        leaveActiveConversation()
         stopTimelineListener()
         clearEnteredLoginIdentity()
         selection = .chat(chat.id)
@@ -28,6 +37,7 @@ extension WorkspaceState {
     }
 
     func showNewChat() {
+        leaveActiveConversation()
         isNewChatComposerVisible = true
         lastError = nil
         resetNewChatComposer()
@@ -39,6 +49,7 @@ extension WorkspaceState {
     }
 
     func showSettings(_ page: SettingsPage = .profile) {
+        leaveActiveConversation()
         stopTimelineListener()
         clearEnteredLoginIdentity()
         selection = .settings(page)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -8588,6 +8588,89 @@ struct whitenoise_macTests {
         #expect(state.draftText == "half-written message")
     }
 
+    /// Puts `state` into an in-progress voice-recording state (mic "hot", metering task running,
+    /// plaintext temp file on disk) without needing real mic hardware, mirroring what
+    /// `startVoiceRecording()` sets up. Returns the temp file URL so tests can assert the
+    /// recording was torn down and the plaintext audio purged. See #311.
+    @MainActor
+    private func armInProgressVoiceRecording(on state: WorkspaceState) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-recording-teardown-\(UUID().uuidString).m4a")
+        try Data("plaintext audio".utf8).write(to: url)
+
+        state.voiceRecordingURL = url
+        state.isRecordingVoiceMessage = true
+        state.voiceRecordingSamples = [0.4, 0.6]
+        state.voiceRecordingDurationSeconds = 1.5
+        state.startVoiceRecordingMetering()
+        #expect(state.voiceRecordingMeterTask != nil)
+        return url
+    }
+
+    @MainActor
+    @Test func showSettingsStopsInProgressVoiceRecording() throws {
+        // #311: navigating to Settings removes the composer (its Stop/Cancel buttons) from the
+        // hierarchy; it must also stop the recorder so the mic is not left hot with no control.
+        let state = WorkspaceState.preview()
+        let url = try armInProgressVoiceRecording(on: state)
+
+        state.showSettings(.profile)
+
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecorder == nil)
+        #expect(state.voiceRecordingURL == nil)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(state.voiceRecordingSamples.isEmpty)
+        #expect(state.voiceRecordingDurationSeconds == 0)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
+    @Test func showNewChatStopsInProgressVoiceRecording() throws {
+        // #311: opening the new-chat composer also swaps out the conversation composer, so the
+        // recorder must be torn down on this path too.
+        let state = WorkspaceState.preview()
+        let url = try armInProgressVoiceRecording(on: state)
+
+        state.showNewChat()
+
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
+    @Test func selectChatStopsInProgressVoiceRecording() throws {
+        // Regression guard for the existing `selectChat` cancellation now routed through the
+        // shared `leaveActiveConversation()` teardown (#311).
+        let state = WorkspaceState.preview()
+        let url = try armInProgressVoiceRecording(on: state)
+        guard let otherChat = state.activeChats.first(where: { $0.id != state.selectedChat?.id }) else {
+            Issue.record("Expected a second chat to switch to")
+            return
+        }
+
+        state.selectChat(otherChat)
+
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
+    @Test func resetToNewInstallStateStopsInProgressVoiceRecording() throws {
+        // #311: the full local-data teardown must also release the recorder so a wipe cannot
+        // leave the microphone active or plaintext audio writes running in the old state.
+        let state = WorkspaceState.preview()
+        let url = try armInProgressVoiceRecording(on: state)
+
+        state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-reset-test")
+
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
     @MainActor
     @Test func startingNewChatCreatesAndSelectsConversation() async throws {
         let account = AccountSummaryFfi(


### PR DESCRIPTION
Closes #311

## Summary
- Added a shared `leaveActiveConversation()` teardown for conversation-scoped live resources and routed chat selection, Settings navigation, new-chat navigation, account switching, and local-data reset through it.
- Stop any in-progress voice recording before `deleteAllData()` wipes local data so the mic cannot stay hot and plaintext recording output cannot keep being written during the wipe.
- Added Swift Testing coverage for Settings, new-chat, chat switching, and reset-to-new-install teardown paths using a synthetic in-progress recording state.

## Verification
- `git diff --check` — passed.
- `command -v xcodebuild`, `command -v swift`, `command -v swiftc` — all missing on this Linux host; AGENTS.md xcodebuild build/test commands could not be run here.
- `git grep -n -E 'cancelVoiceRecording|leaveActiveConversation' -- '*.swift'` — verified navigation-away paths route through `leaveActiveConversation()`; the composer Cancel button still intentionally calls `cancelVoiceRecording` directly.
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .` and same against `HEAD` — no conflict markers.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/325">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->