### PR TITLE
fix: tolerate duplicate FFI ids in index rebuilds

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -7,6 +7,22 @@ import Observation
 import SwiftUI
 import UserNotifications
 
+private func uniquedLastWins<Value, Key: Hashable>(
+    _ values: [Value],
+    by key: (Value) -> Key
+) -> [Value] {
+    var seenKeys = Set<Key>()
+    var result: [Value] = []
+    result.reserveCapacity(values.count)
+
+    for value in values.reversed() {
+        guard seenKeys.insert(key(value)).inserted else { continue }
+        result.append(value)
+    }
+
+    return Array(result.reversed())
+}
+
 struct TimelinePagingState: Equatable {
     var hasMoreBefore: Bool
     var hasMoreAfter: Bool
@@ -225,6 +241,7 @@ final class MessageTimelineStore {
     private(set) var isLoaded: Bool
 
     init(messages: [MessageItem] = [], isLoaded: Bool = false) {
+        let messages = Self.deduplicatedMessages(messages)
         self.messages = messages
         self.messageIDs = messages.map(\.id)
         self.lookup = Dictionary(messages.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
@@ -233,6 +250,10 @@ final class MessageTimelineStore {
             uniquingKeysWith: { _, new in new }
         )
         self.isLoaded = isLoaded
+    }
+
+    private static func deduplicatedMessages(_ messages: [MessageItem]) -> [MessageItem] {
+        uniquedLastWins(messages, by: \.id)
     }
 
     static func loaded(with messages: [MessageItem]) -> MessageTimelineStore {
@@ -311,6 +332,7 @@ final class MessageTimelineStore {
     }
 
     private func rebuildIndexes() {
+        messages = Self.deduplicatedMessages(messages)
         messageIDs = messages.map(\.id)
         lookup = Dictionary(messages.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
         indexById = Dictionary(
@@ -936,7 +958,7 @@ final class WorkspaceState {
         clientFactory: @escaping @MainActor () throws -> any MarmotRuntime = { try MarmotClient() }
     ) {
         self.accounts = accounts
-        self.chatsByAccount = chatsByAccount
+        self.chatsByAccount = chatsByAccount.mapValues { Self.deduplicatedChats($0) }
         self.messageTimelineStores = messagesByChat.mapValues { MessageTimelineStore.loaded(with: $0) }
         self.cachedMessageChatIds = Set(messagesByChat.keys)
         self.localNotificationCenter = localNotificationCenter ?? MacLocalNotificationCenter()
@@ -1000,6 +1022,10 @@ final class WorkspaceState {
         return state
     }
 
+    private static func deduplicatedChats(_ chats: [ChatItem]) -> [ChatItem] {
+        uniquedLastWins(chats, by: \.id)
+    }
+
     var activeAccount: AccountItem? {
         guard let activeAccountId else { return nil }
         return accounts.first { $0.id == activeAccountId }
@@ -1046,7 +1072,7 @@ final class WorkspaceState {
     }
 
     func setChats(_ chats: [ChatItem], forAccountId accountId: String) {
-        chatsByAccount[accountId] = chats
+        chatsByAccount[accountId] = Self.deduplicatedChats(chats)
         rebuildChatIndexes(forAccountId: accountId)
     }
 
@@ -1113,13 +1139,16 @@ final class WorkspaceState {
     func rebuildChatIndexes() {
         chatLookupByAccount = [:]
         chatIndexByAccount = [:]
-        for accountId in chatsByAccount.keys {
+        for accountId in Array(chatsByAccount.keys) {
             rebuildChatIndexes(forAccountId: accountId)
         }
     }
 
     func rebuildChatIndexes(forAccountId accountId: String) {
-        let chats = chatsByAccount[accountId] ?? []
+        let chats = Self.deduplicatedChats(chatsByAccount[accountId] ?? [])
+        if chatsByAccount[accountId] != nil {
+            chatsByAccount[accountId] = chats
+        }
         chatLookupByAccount[accountId] = Dictionary(
             chats.map { ($0.id, $0) },
             uniquingKeysWith: { _, new in new }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -227,8 +227,11 @@ final class MessageTimelineStore {
     init(messages: [MessageItem] = [], isLoaded: Bool = false) {
         self.messages = messages
         self.messageIDs = messages.map(\.id)
-        self.lookup = Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
-        self.indexById = Dictionary(uniqueKeysWithValues: messages.enumerated().map { ($0.element.id, $0.offset) })
+        self.lookup = Dictionary(messages.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
+        self.indexById = Dictionary(
+            messages.enumerated().map { ($0.element.id, $0.offset) },
+            uniquingKeysWith: { _, new in new }
+        )
         self.isLoaded = isLoaded
     }
 
@@ -309,8 +312,11 @@ final class MessageTimelineStore {
 
     private func rebuildIndexes() {
         messageIDs = messages.map(\.id)
-        lookup = Dictionary(uniqueKeysWithValues: messages.map { ($0.id, $0) })
-        indexById = Dictionary(uniqueKeysWithValues: messages.enumerated().map { ($0.element.id, $0.offset) })
+        lookup = Dictionary(messages.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
+        indexById = Dictionary(
+            messages.enumerated().map { ($0.element.id, $0.offset) },
+            uniquingKeysWith: { _, new in new }
+        )
     }
 
     private func insertMessage(_ item: MessageItem, at index: Int) {
@@ -1114,11 +1120,14 @@ final class WorkspaceState {
 
     func rebuildChatIndexes(forAccountId accountId: String) {
         let chats = chatsByAccount[accountId] ?? []
-        chatLookupByAccount[accountId] = Dictionary(uniqueKeysWithValues: chats.map { ($0.id, $0) })
+        chatLookupByAccount[accountId] = Dictionary(
+            chats.map { ($0.id, $0) },
+            uniquingKeysWith: { _, new in new }
+        )
         chatIndexByAccount[accountId] = Dictionary(
-            uniqueKeysWithValues: chats.enumerated().map {
-                ($0.element.id, $0.offset)
-            })
+            chats.enumerated().map { ($0.element.id, $0.offset) },
+            uniquingKeysWith: { _, new in new }
+        )
         bumpChatListGeneration(forAccountId: accountId)
     }
 
@@ -1274,7 +1283,8 @@ final class WorkspaceState {
         managementState: GroupManagementStateFfi
     ) -> GroupDetailsSnapshot {
         let actionByMemberId = Dictionary(
-            uniqueKeysWithValues: managementState.memberActions.map { ($0.memberIdHex, $0) }
+            managementState.memberActions.map { ($0.memberIdHex, $0) },
+            uniquingKeysWith: { _, new in new }
         )
         let members = details.members
             .map { member in

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -181,21 +181,34 @@ struct PureValueTests {
 
         let duplicates = [message(id: "dup", body: "first"), message(id: "dup", body: "second")]
 
-        // init path does not trap and resolves the later item.
+        // init path does not trap, resolves the later item, and keeps observed arrays unique.
         let store = MessageTimelineStore.loaded(with: duplicates)
+        #expect(store.messages.map(\.body) == ["second"])
+        #expect(store.messageIDs == ["dup"])
         #expect(store.lookup["dup"]?.body == "second")
 
         // replace() (rebuildIndexes) path behaves identically.
         let replaced = MessageTimelineStore()
         replaced.replace(with: duplicates)
+        #expect(replaced.messages.map(\.body) == ["second"])
+        #expect(replaced.messageIDs == ["dup"])
         #expect(replaced.lookup["dup"]?.body == "second")
+
+        // Later incremental upserts update the single retained row instead of leaving a stale twin.
+        _ = replaced.applyProjection(
+            upserts: [message(id: "dup", body: "third")],
+            removals: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(replaced.messages.map(\.body) == ["third"])
     }
 
     @MainActor
-    @Test func workspaceChatIndexRebuildToleratesDuplicateChatIds() async throws {
-        // Regression for whitenoise-mac#309: rebuildChatIndexes(forAccountId:) keys the chat
-        // lookup and position index on ChatItem.id, which can collide across FFI updates. The
-        // rebuild must not trap and should resolve the later item (last-wins).
+    @Test func workspaceChatSnapshotsDeduplicateDuplicateChatIds() async throws {
+        // Regression for whitenoise-mac#309: full-list chat snapshots must not leave duplicate
+        // ChatItem.id values in the observed arrays that feed SwiftUI ForEach and later
+        // incremental upsert/remove paths. The snapshot boundary resolves duplicates last-wins.
         func chat(id: String, title: String) -> ChatItem {
             ChatItem(
                 id: id,
@@ -218,11 +231,17 @@ struct PureValueTests {
             conversationWindowVisibilityProvider: { false }
         )
 
-        state.rebuildChatIndexes(forAccountId: accountId)
-
+        #expect(state.chatsByAccount[accountId]?.map(\.title) == ["second"])
         #expect(state.chatLookupByAccount[accountId]?["dup"]?.title == "second")
-        // The position index maps the id to the later element's offset.
-        #expect(state.chatIndexByAccount[accountId]?["dup"] == 1)
+        #expect(state.chatIndexByAccount[accountId]?["dup"] == 0)
+
+        state.setChats(duplicates, forAccountId: accountId)
+        #expect(state.chatsByAccount[accountId]?.map(\.title) == ["second"])
+        #expect(state.chatLookupByAccount[accountId]?["dup"]?.title == "second")
+        #expect(state.chatIndexByAccount[accountId]?["dup"] == 0)
+
+        state.upsertChat(chat(id: "dup", title: "third"), forAccountId: accountId)
+        #expect(state.chatsByAccount[accountId]?.map(\.title) == ["third"])
     }
 
     @MainActor

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -164,6 +164,152 @@ struct PureValueTests {
         #expect(explicit.timelineAt == 42)
     }
 
+    @MainActor
+    @Test func messageTimelineStoreToleratesDuplicateMessageIds() async throws {
+        // Regression for whitenoise-mac#309: full-list index rebuilds keyed on FFI-derived
+        // MessageItem.id must not trap on a duplicate id from runtime/relay/FFI. The store
+        // resolves duplicates last-wins, mirroring applyProjection/upsert semantics.
+        func message(id: String, body: String) -> MessageItem {
+            MessageItem(
+                id: id,
+                senderName: "sender",
+                body: body,
+                sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+                isOutgoing: false
+            )
+        }
+
+        let duplicates = [message(id: "dup", body: "first"), message(id: "dup", body: "second")]
+
+        // init path does not trap and resolves the later item.
+        let store = MessageTimelineStore.loaded(with: duplicates)
+        #expect(store.lookup["dup"]?.body == "second")
+
+        // replace() (rebuildIndexes) path behaves identically.
+        let replaced = MessageTimelineStore()
+        replaced.replace(with: duplicates)
+        #expect(replaced.lookup["dup"]?.body == "second")
+    }
+
+    @MainActor
+    @Test func workspaceChatIndexRebuildToleratesDuplicateChatIds() async throws {
+        // Regression for whitenoise-mac#309: rebuildChatIndexes(forAccountId:) keys the chat
+        // lookup and position index on ChatItem.id, which can collide across FFI updates. The
+        // rebuild must not trap and should resolve the later item (last-wins).
+        func chat(id: String, title: String) -> ChatItem {
+            ChatItem(
+                id: id,
+                title: title,
+                subtitle: "",
+                preview: "",
+                updatedAt: nil,
+                avatarSeed: id,
+                pictureURL: nil,
+                unreadCount: 0
+            )
+        }
+
+        let accountId = "account"
+        let duplicates = [chat(id: "dup", title: "first"), chat(id: "dup", title: "second")]
+        let state = WorkspaceState(
+            chatsByAccount: [accountId: duplicates],
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+
+        state.rebuildChatIndexes(forAccountId: accountId)
+
+        #expect(state.chatLookupByAccount[accountId]?["dup"]?.title == "second")
+        // The position index maps the id to the later element's offset.
+        #expect(state.chatIndexByAccount[accountId]?["dup"] == 1)
+    }
+
+    @MainActor
+    @Test func groupDetailsSnapshotToleratesDuplicateMemberActionIds() async throws {
+        // Regression for whitenoise-mac#309: groupDetailsSnapshot builds actionByMemberId from
+        // FFI GroupMemberActionStateFfi.memberIdHex, which can repeat. The rebuild must not trap
+        // and should apply the later action (last-wins).
+        let memberIdHex = "member1234567890member1234567890member1234567890member1234"
+        let group = AppGroupRecordFfi(
+            groupIdHex: "group",
+            endpoint: "",
+            name: "Test Group",
+            description: "",
+            admins: [memberIdHex],
+            relays: [],
+            nostrGroupIdHex: "",
+            avatarUrl: nil,
+            avatarDim: nil,
+            avatarThumbhash: nil,
+            encryptedMedia: AppGroupEncryptedMediaComponentFfi(
+                componentId: 0,
+                component: "",
+                required: false,
+                mediaFormat: "",
+                allowedLocatorKinds: [],
+                defaultBlobEndpoints: []
+            ),
+            disappearingMessageSecs: 0,
+            archived: false,
+            pendingConfirmation: false,
+            welcomerAccountIdHex: nil,
+            viaWelcomeMessageIdHex: nil
+        )
+        let details = GroupDetailsFfi(
+            group: group,
+            members: [
+                GroupMemberDetailsFfi(
+                    memberIdHex: memberIdHex,
+                    account: "Member",
+                    local: false,
+                    isAdmin: true,
+                    isSelf: false,
+                    npub: "npub1member",
+                    displayName: "Member"
+                )
+            ]
+        )
+        let managementState = GroupManagementStateFfi(
+            myAccountIdHex: memberIdHex,
+            isSelfAdmin: true,
+            isLastAdmin: false,
+            canInvite: true,
+            canLeave: true,
+            requiresSelfDemoteBeforeLeave: false,
+            memberActions: [
+                GroupMemberActionStateFfi(
+                    memberIdHex: memberIdHex,
+                    isSelf: false,
+                    isAdmin: true,
+                    canRemove: false,
+                    canPromote: false,
+                    canDemote: false
+                ),
+                GroupMemberActionStateFfi(
+                    memberIdHex: memberIdHex,
+                    isSelf: false,
+                    isAdmin: true,
+                    canRemove: true,
+                    canPromote: true,
+                    canDemote: true
+                ),
+            ]
+        )
+
+        let state = WorkspaceState(
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+        let snapshot = state.groupDetailsSnapshot(from: details, managementState: managementState)
+
+        let member = try #require(snapshot.members.first { $0.id == memberIdHex })
+        #expect(member.canRemove)
+        #expect(member.canPromote)
+        #expect(member.canDemote)
+    }
+
     @Test func remoteImageSanitizedURLRejectsPrivateHosts() async throws {
         // The string entry point used by the UI must also reject internal destinations.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://192.168.1.1/x.png") == nil)
@@ -634,4 +780,19 @@ struct PureValueTests {
             disappearingMessageSecs: 0
         )
     }
+}
+
+@MainActor
+private final class NoopLocalNotificationCenter: LocalNotificationCenter {
+    func authorizationStatus() async -> LocalNotificationAuthorizationStatus {
+        .notDetermined
+    }
+
+    func requestAuthorization() async throws -> LocalNotificationAuthorizationStatus {
+        .notDetermined
+    }
+
+    func post(_ notification: LocalNotificationRequest) async throws {}
+
+    func setResponseHandler(_ handler: @escaping @MainActor ([String: String]) -> Void) {}
 }


### PR DESCRIPTION
Closes #309

## Summary
- Replace trapping `Dictionary(uniqueKeysWithValues:)` rebuilds in `WorkspaceState` with last-wins `Dictionary(..., uniquingKeysWith:)` construction.
- Covers message timeline lookup/index rebuilds, chat lookup/index rebuilds, and group member action lookup construction.
- Add Swift Testing regressions for duplicate message ids, chat ids, and member action ids.

## Verification
- `git diff --check`
- `git grep -n 'Dictionary(uniqueKeysWithValues:' -- whitenoise-mac/Core/WorkspaceState.swift` returned no matches
- `git grep -nE '^(<<<<<<<|=======|>>>>>>>)' -- .` returned no matches
- `xcodebuild` / `swift` unavailable on this Linux host, so macOS build/test validation is deferred to GitHub CI / reviewer machine

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/326">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->