### PR TITLE
feat: surface self-membership state for left/removed groups

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -16,6 +16,19 @@ extension AccountItem {
     }
 }
 
+extension ChatSelfMembership {
+    nonisolated init(_ membership: SelfMembershipFfi) {
+        switch membership {
+        case .member:
+            self = .member
+        case .left:
+            self = .left
+        case .removed:
+            self = .removed
+        }
+    }
+}
+
 extension ChatItem {
     init(
         row: ChatListRowFfi,
@@ -61,7 +74,8 @@ extension ChatItem {
             unreadCount: Int(clamping: row.unreadCount),
             unreadMentionCount: Int(clamping: row.unreadMentionCount),
             isDirect: directPeer != nil,
-            pendingConfirmation: row.pendingConfirmation
+            pendingConfirmation: row.pendingConfirmation,
+            selfMembership: ChatSelfMembership(row.selfMembership)
         )
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -208,8 +208,18 @@ extension WorkspaceState {
         clearComposerDrafts(for: Array(removedChatIds), accountId: account.id)
         setChats(sortedChatItems(chatItems), forAccountId: account.id)
         dismissGroupImagePickerIfSelectedChatUnavailable()
+        cancelVoiceRecordingIfSelectedMembershipEnded()
         ensureSelectedMessageTimelineStore()
         startChatListEnrichment(rows: rows, account: account)
+    }
+
+    /// A membership flip to left/removed swaps the selected chat's composer (its recording
+    /// Stop/Cancel controls included) for the membership-ended notice, so any chat-list
+    /// update that can carry that flip must also tear down an in-progress recorder — the
+    /// microphone must never stay hot with no visible way to stop it (#311).
+    func cancelVoiceRecordingIfSelectedMembershipEnded() {
+        guard isRecordingVoiceMessage, selectedChat?.isNoLongerMember == true else { return }
+        cancelVoiceRecording()
     }
 
     func applyChatListSubscriptionUpdate(
@@ -275,6 +285,7 @@ extension WorkspaceState {
         let needsInitialMetadata = !shouldEnrich && readStateRowNeedsMetadataEnrichment(row, current: current)
 
         upsertChat(chat, forAccountId: account.id)
+        cancelVoiceRecordingIfSelectedMembershipEnded()
         ensureSelectedMessageTimelineStore()
         if shouldEnrich {
             startChatListEnrichment(rows: [row], account: account, replacingCurrent: false)
@@ -418,7 +429,8 @@ extension WorkspaceState {
                 unreadCount: current.unreadCount,
                 unreadMentionCount: current.unreadMentionCount,
                 isDirect: enrichedItem.isDirect,
-                pendingConfirmation: current.pendingConfirmation
+                pendingConfirmation: current.pendingConfirmation,
+                selfMembership: current.selfMembership
             )
             guard next != current else { continue }
             if incremental {

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -369,7 +369,11 @@ extension WorkspaceState {
     }
 
     func canBeginMediaAttachmentSelection() -> Bool {
-        guard client != nil, selectedChat != nil else { return false }
+        // An ended membership must also refuse new attachments/recordings: the drop
+        // target and file importer stay reachable even while the composer is replaced
+        // by the membership-ended notice, and anything collected here could otherwise
+        // accumulate invisibly (the pending-media strip is hidden) and never be sent.
+        guard client != nil, selectedChat?.isNoLongerMember == false else { return false }
         guard remainingMediaAttachmentSlots > 0 else {
             presentMaxMediaAttachmentWarning()
             return false

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -424,6 +424,9 @@ extension WorkspaceState {
         guard let client,
             let activeAccount,
             let selectedChat,
+            // Mirrors `canSend`: the core rejects sends to a group the local
+            // account left or was removed from (`invalid_transition`).
+            !selectedChat.isNoLongerMember,
             let draftKey = selectedComposerDraftKey,
             !text.isEmpty || !mediaAttachments.isEmpty,
             !isSending

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -155,7 +155,8 @@ nonisolated struct ChatListOrdering {
             unreadCount: chat.unreadCount,
             unreadMentionCount: chat.unreadMentionCount,
             isDirect: current.isDirect,
-            pendingConfirmation: chat.pendingConfirmation
+            pendingConfirmation: chat.pendingConfirmation,
+            selfMembership: chat.selfMembership
         )
     }
 
@@ -1269,8 +1270,11 @@ final class WorkspaceState {
     }
 
     var canSend: Bool {
+        // The core rejects sends to a group the local account left or was removed
+        // from (`invalid_transition`), so an ended membership disables sending
+        // even though the chat stays selectable for reading history.
         client != nil
-            && selectedChat != nil
+            && selectedChat?.isNoLongerMember == false
             && (!draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || !pendingMediaAttachments.isEmpty)
             && !isSending
@@ -1357,6 +1361,7 @@ final class WorkspaceState {
             adminIds: details.group.admins,
             archived: details.group.archived,
             pendingConfirmation: details.group.pendingConfirmation,
+            selfMembership: ChatSelfMembership(details.group.selfMembership),
             members: members,
             isSelfAdmin: managementState.isSelfAdmin,
             isLastAdmin: managementState.isLastAdmin,

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -49,6 +49,53 @@ struct AccountItem: Identifiable, Hashable {
     }
 }
 
+/// Whether the local account is still a member of a group, and if not, whether it
+/// left voluntarily or was removed. Mirrors the FFI's `SelfMembershipFfi`: ended
+/// chats stay in the list so the history remains readable, but the core rejects
+/// sends to them (`invalid_transition`), so the composer must not offer to send.
+nonisolated enum ChatSelfMembership: Hashable {
+    case member
+    case left
+    case removed
+
+    /// Short badge label for sidebar rows, `nil` while still a member.
+    var sidebarBadgeLabel: String? {
+        switch self {
+        case .member:
+            return nil
+        case .left:
+            return L10n.string("Left")
+        case .removed:
+            return L10n.string("Removed")
+        }
+    }
+
+    /// One-line explanation of the ended membership, used by the sidebar badge
+    /// tooltip and the composer notice. `nil` while still a member.
+    var endedDescription: String? {
+        switch self {
+        case .member:
+            return nil
+        case .left:
+            return L10n.string("You left this group")
+        case .removed:
+            return L10n.string("You were removed from this group")
+        }
+    }
+
+    /// SF Symbol shown alongside the ended state, `nil` while still a member.
+    var endedSymbolName: String? {
+        switch self {
+        case .member:
+            return nil
+        case .left:
+            return "rectangle.portrait.and.arrow.right"
+        case .removed:
+            return "person.fill.xmark"
+        }
+    }
+}
+
 nonisolated struct ChatItem: Identifiable, Hashable {
     let id: String
     let title: String
@@ -64,12 +111,16 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     let unreadMentionCount: Int
     let isDirect: Bool
     let pendingConfirmation: Bool
+    let selfMembership: ChatSelfMembership
     /// Precomputed once from `updatedAt` (which is immutable for a given value) to
     /// avoid re-formatting the date on every chat-row render.
     let timestampLabel: String
 
     /// Whether this chat has at least one unread @-mention of the active account.
     var hasMention: Bool { unreadMentionCount > 0 }
+
+    /// True when the local account left or was removed from this group.
+    var isNoLongerMember: Bool { selfMembership != .member }
 
     init(
         id: String,
@@ -83,7 +134,8 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         unreadCount: Int,
         unreadMentionCount: Int = 0,
         isDirect: Bool = false,
-        pendingConfirmation: Bool = false
+        pendingConfirmation: Bool = false,
+        selfMembership: ChatSelfMembership = .member
     ) {
         self.id = id
         self.title = title
@@ -98,6 +150,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         self.unreadMentionCount = unreadMentionCount
         self.isDirect = isDirect
         self.pendingConfirmation = pendingConfirmation
+        self.selfMembership = selfMembership
         if let updatedAt {
             self.timestampLabel = DisplayText.relativeTimestamp(for: updatedAt)
         } else {
@@ -158,6 +211,7 @@ struct GroupDetailsSnapshot: Hashable {
     let adminIds: [String]
     let archived: Bool
     let pendingConfirmation: Bool
+    let selfMembership: ChatSelfMembership
     let members: [GroupMemberItem]
     let isSelfAdmin: Bool
     let isLastAdmin: Bool

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -94,6 +94,12 @@ nonisolated enum ChatSelfMembership: Hashable {
             return "person.fill.xmark"
         }
     }
+
+    /// Secondary line shown under `endedDescription` wherever the ended state is
+    /// explained (composer notice, group details).
+    static var endedHistoryExplanation: String {
+        L10n.string("You can keep reading the history, but new messages can't be sent.")
+    }
 }
 
 nonisolated struct ChatItem: Identifiable, Hashable {

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -502,7 +502,7 @@ struct MembershipEndedComposerNotice: View {
                 Text(membership.endedDescription ?? "")
                     .font(.callout.weight(.semibold))
 
-                Text("You can keep reading the history, but new messages can't be sent.")
+                Text(ChatSelfMembership.endedHistoryExplanation)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -486,6 +486,36 @@ struct ReplyComposerContextView: View {
     }
 }
 
+/// Replaces the composer for a group the local account left or was removed from:
+/// the transcript stays readable, but the core would reject any send
+/// (`invalid_transition`), so no input is offered.
+struct MembershipEndedComposerNotice: View {
+    let membership: ChatSelfMembership
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: membership.endedSymbolName ?? "")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(membership.endedDescription ?? "")
+                    .font(.callout.weight(.semibold))
+
+                Text("You can keep reading the history, but new messages can't be sent.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .glassCard()
+        .accessibilityIdentifier("composer.membershipEnded")
+    }
+}
+
 struct NewChatColumnView: View {
     @Environment(WorkspaceState.self) private var workspace
     @FocusState private var isSearchFocused: Bool
@@ -821,7 +851,9 @@ struct ConversationHeader: View {
                 .help("Decline invite")
             }
 
-            if !chat.isDirect {
+            // Changing the group image is a send (commit) under the hood, which the
+            // core rejects once the local account is no longer a member.
+            if !chat.isDirect && !chat.isNoLongerMember {
                 Button {
                     workspace.showGroupImagePicker(for: chat)
                 } label: {

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -114,6 +114,25 @@ struct GroupDetailsSheet: View {
                         }
                     }
 
+                    if let endedDescription = snapshot.selfMembership.endedDescription {
+                        Section("Membership") {
+                            Label {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(endedDescription)
+                                        .font(.callout.weight(.semibold))
+
+                                    Text("You can keep reading the history, but new messages can't be sent.")
+                                        .font(.callout)
+                                        .foregroundStyle(.secondary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            } icon: {
+                                Image(systemName: snapshot.selfMembership.endedSymbolName ?? "")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+
                     Section("Profile") {
                         TextField("Group name", text: $workspace.groupProfileDraftName)
                             .textFieldStyle(.roundedBorder)
@@ -323,6 +342,10 @@ struct GroupDetailsSheet: View {
                             GroupDiagnosticsValueRow(
                                 title: "Pending confirmation",
                                 value: snapshot.pendingConfirmation ? L10n.string("Yes") : L10n.string("No"),
+                                copyable: false)
+                            GroupDiagnosticsValueRow(
+                                title: "Self membership",
+                                value: snapshot.selfMembership.sidebarBadgeLabel ?? L10n.string("Member"),
                                 copyable: false)
                         }
                     }

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -121,7 +121,7 @@ struct GroupDetailsSheet: View {
                                     Text(endedDescription)
                                         .font(.callout.weight(.semibold))
 
-                                    Text("You can keep reading the history, but new messages can't be sent.")
+                                    Text(ChatSelfMembership.endedHistoryExplanation)
                                         .font(.callout)
                                         .foregroundStyle(.secondary)
                                         .fixedSize(horizontal: false, vertical: true)
@@ -167,6 +167,9 @@ struct GroupDetailsSheet: View {
                             .disabled(!hasProfileChanges || workspace.isSavingGroupProfile)
                         }
                     }
+                    // Profile edits publish a group commit, which the core rejects for a
+                    // non-member the same way it rejects sends (`invalid_transition`).
+                    .disabled(snapshot.selfMembership != .member)
 
                     Section("Members") {
                         if snapshot.members.isEmpty {
@@ -200,7 +203,11 @@ struct GroupDetailsSheet: View {
                         } label: {
                             Label("Auto-delete after", systemImage: "timer")
                         }
-                        .disabled(workspace.isUpdatingDisappearingMessages)
+                        // Retention changes are group commits — rejected for non-members.
+                        // "Delete expired now" below stays enabled: it is a local prune.
+                        .disabled(
+                            workspace.isUpdatingDisappearingMessages || snapshot.selfMembership != .member
+                        )
 
                         if snapshot.disappearingMessagesEnabled {
                             Button {
@@ -213,7 +220,7 @@ struct GroupDetailsSheet: View {
                         }
                     }
 
-                    if snapshot.canInvite {
+                    if snapshot.canInvite && snapshot.selfMembership == .member {
                         Section("Invite") {
                             HStack(spacing: 10) {
                                 TextField(

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -447,83 +447,13 @@ private struct ConversationView: View {
             GlassSeparator(axis: .horizontal)
 
             VStack(spacing: 8) {
-                if let replyDraftContext = workspace.replyDraftContext {
-                    ReplyComposerContextView(context: replyDraftContext) {
-                        workspace.cancelReply()
-                    }
-                }
-
-                if !workspace.pendingMediaAttachments.isEmpty {
-                    PendingMediaDraftStrip(
-                        attachments: workspace.pendingMediaAttachments,
-                        onRemove: workspace.removePendingMediaAttachment
-                    )
-                }
-
-                if workspace.isRecordingVoiceMessage {
-                    VoiceRecordingComposerView(
-                        samples: workspace.voiceRecordingSamples,
-                        durationSeconds: workspace.voiceRecordingDurationSeconds,
-                        onCancel: workspace.cancelVoiceRecording,
-                        onStop: {
-                            Task { await workspace.finishVoiceRecording() }
-                        }
-                    )
+                // The core rejects sends to a group the local account left or was
+                // removed from (`invalid_transition`), so the whole composer —
+                // reply/media drafts included — gives way to an explanatory notice.
+                if chat.isNoLongerMember {
+                    MembershipEndedComposerNotice(membership: chat.selfMembership)
                 } else {
-                    HStack(alignment: .bottom, spacing: 8) {
-                        Button {
-                            isFileImporterPresented = true
-                        } label: {
-                            Image(systemName: "paperclip")
-                                .font(.system(size: 18, weight: .medium))
-                                .frame(width: 30, height: 30)
-                                .background {
-                                    MessagesCircleControlBackground()
-                                }
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(workspace.isSending)
-                        .help("Attach files")
-
-                        TextField("Message", text: $workspace.draftText, axis: .vertical)
-                            .textFieldStyle(.plain)
-                            .lineLimit(1...5)
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 8)
-                            .background {
-                                MessagesComposerFieldBackground()
-                            }
-                            .accessibilityIdentifier("composer.message")
-
-                        Button {
-                            Task { await workspace.toggleVoiceRecording() }
-                        } label: {
-                            Image(systemName: "mic.fill")
-                                .font(.system(size: 14, weight: .semibold))
-                                .frame(width: 32, height: 32)
-                                .background {
-                                    MessagesCircleControlBackground()
-                                }
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(workspace.isSending)
-                        .help("Voice message")
-
-                        Button {
-                            Task { await workspace.sendDraft() }
-                        } label: {
-                            Image(systemName: "paperplane.fill")
-                                .font(.system(size: 14, weight: .semibold))
-                                .frame(width: 32, height: 32)
-                                .background {
-                                    MessagesSendButtonBackground(isEnabled: workspace.canSend)
-                                }
-                        }
-                        .buttonStyle(.plain)
-                        .keyboardShortcut(.return, modifiers: .command)
-                        .disabled(!workspace.canSend)
-                        .help("Send")
-                    }
+                    composerControls
                 }
             }
             .padding(.horizontal, 16)
@@ -594,6 +524,90 @@ private struct ConversationView: View {
             imageGallery = nil
             if workspace.isGroupDetailsPresented {
                 workspace.closeGroupDetails()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var composerControls: some View {
+        @Bindable var workspace = workspace
+
+        if let replyDraftContext = workspace.replyDraftContext {
+            ReplyComposerContextView(context: replyDraftContext) {
+                workspace.cancelReply()
+            }
+        }
+
+        if !workspace.pendingMediaAttachments.isEmpty {
+            PendingMediaDraftStrip(
+                attachments: workspace.pendingMediaAttachments,
+                onRemove: workspace.removePendingMediaAttachment
+            )
+        }
+
+        if workspace.isRecordingVoiceMessage {
+            VoiceRecordingComposerView(
+                samples: workspace.voiceRecordingSamples,
+                durationSeconds: workspace.voiceRecordingDurationSeconds,
+                onCancel: workspace.cancelVoiceRecording,
+                onStop: {
+                    Task { await workspace.finishVoiceRecording() }
+                }
+            )
+        } else {
+            HStack(alignment: .bottom, spacing: 8) {
+                Button {
+                    isFileImporterPresented = true
+                } label: {
+                    Image(systemName: "paperclip")
+                        .font(.system(size: 18, weight: .medium))
+                        .frame(width: 30, height: 30)
+                        .background {
+                            MessagesCircleControlBackground()
+                        }
+                }
+                .buttonStyle(.plain)
+                .disabled(workspace.isSending)
+                .help("Attach files")
+
+                TextField("Message", text: $workspace.draftText, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1...5)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background {
+                        MessagesComposerFieldBackground()
+                    }
+                    .accessibilityIdentifier("composer.message")
+
+                Button {
+                    Task { await workspace.toggleVoiceRecording() }
+                } label: {
+                    Image(systemName: "mic.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(width: 32, height: 32)
+                        .background {
+                            MessagesCircleControlBackground()
+                        }
+                }
+                .buttonStyle(.plain)
+                .disabled(workspace.isSending)
+                .help("Voice message")
+
+                Button {
+                    Task { await workspace.sendDraft() }
+                } label: {
+                    Image(systemName: "paperplane.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .frame(width: 32, height: 32)
+                        .background {
+                            MessagesSendButtonBackground(isEnabled: workspace.canSend)
+                        }
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.return, modifiers: .command)
+                .disabled(!workspace.canSend)
+                .help("Send")
             }
         }
     }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -488,10 +488,15 @@ private struct ConversationView: View {
             }
         }
         .dropDestination(for: URL.self) { urls, _ in
+            // Refuse drops once membership ended: the pending-media strip is hidden
+            // behind the membership-ended notice, so accepted files would accumulate
+            // invisibly and could never be sent. `addMediaAttachments` re-checks via
+            // `canBeginMediaAttachmentSelection()` as defense in depth.
+            guard !chat.isNoLongerMember else { return false }
             Task { await workspace.addMediaAttachments(from: urls) }
             return !urls.isEmpty
         } isTargeted: { isTargeted in
-            isFileDropTargeted = isTargeted
+            isFileDropTargeted = isTargeted && !chat.isNoLongerMember
         }
         .overlay {
             if isFileDropTargeted {

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -350,6 +350,9 @@ struct ChatRowContent: View {
                     if chat.pendingConfirmation {
                         PendingInviteBadge()
                     }
+                    if chat.isNoLongerMember {
+                        MembershipEndedBadge(membership: chat.selfMembership)
+                    }
                     Spacer(minLength: 8)
                     Text(chat.timestampLabel)
                         .font(.caption)
@@ -403,5 +406,25 @@ struct PendingInviteBadge: View {
             .foregroundStyle(.secondary)
             .background(.quaternary, in: Capsule())
             .help(L10n.string("Group invite pending"))
+    }
+}
+
+/// "Left" / "Removed" capsule on rows for groups the local account is no longer a
+/// member of; the chat stays listed so the history remains readable.
+struct MembershipEndedBadge: View {
+    let membership: ChatSelfMembership
+
+    var body: some View {
+        Label(
+            membership.sidebarBadgeLabel ?? "",
+            systemImage: membership.endedSymbolName ?? ""
+        )
+        .font(.caption2.weight(.semibold))
+        .labelStyle(.titleAndIcon)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .foregroundStyle(.secondary)
+        .background(.quaternary, in: Capsule())
+        .help(membership.endedDescription ?? "")
     }
 }

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -347,11 +347,13 @@ struct ChatRowContent: View {
                     Text(chat.title)
                         .font(.system(size: 14, weight: .semibold))
                         .lineLimit(1)
-                    if chat.pendingConfirmation {
-                        PendingInviteBadge()
-                    }
+                    // An ended membership supersedes a pending invite: show a single
+                    // badge rather than a contradictory "Invite" + "Removed" pair if
+                    // the FFI ever delivers both flags together.
                     if chat.isNoLongerMember {
                         MembershipEndedBadge(membership: chat.selfMembership)
+                    } else if chat.pendingConfirmation {
+                        PendingInviteBadge()
                     }
                     Spacer(minLength: 8)
                     Text(chat.timestampLabel)

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -331,6 +331,65 @@ struct PureValueTests {
         #expect(member.canDemote)
     }
 
+    @MainActor
+    @Test func groupDetailsSnapshotMapsSelfMembershipVariants() async throws {
+        let variants: [(SelfMembershipFfi, ChatSelfMembership)] = [
+            (.member, .member),
+            (.left, .left),
+            (.removed, .removed),
+        ]
+        let state = WorkspaceState(
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+
+        for (ffiMembership, expected) in variants {
+            let group = AppGroupRecordFfi(
+                groupIdHex: "group",
+                endpoint: "",
+                name: "Test Group",
+                description: "",
+                admins: [],
+                relays: [],
+                nostrGroupIdHex: "",
+                avatarUrl: nil,
+                avatarDim: nil,
+                avatarThumbhash: nil,
+                encryptedMedia: AppGroupEncryptedMediaComponentFfi(
+                    componentId: 0,
+                    component: "",
+                    required: false,
+                    mediaFormat: "",
+                    allowedLocatorKinds: [],
+                    defaultBlobEndpoints: []
+                ),
+                disappearingMessageSecs: 0,
+                archived: false,
+                pendingConfirmation: false,
+                selfMembership: ffiMembership,
+                welcomerAccountIdHex: nil,
+                viaWelcomeMessageIdHex: nil
+            )
+            let managementState = GroupManagementStateFfi(
+                myAccountIdHex: "self",
+                isSelfAdmin: false,
+                isLastAdmin: false,
+                canInvite: false,
+                canLeave: false,
+                requiresSelfDemoteBeforeLeave: false,
+                memberActions: []
+            )
+
+            let snapshot = state.groupDetailsSnapshot(
+                from: GroupDetailsFfi(group: group, members: []),
+                managementState: managementState
+            )
+
+            #expect(snapshot.selfMembership == expected)
+        }
+    }
+
     @Test func remoteImageSanitizedURLRejectsPrivateHosts() async throws {
         // The string entry point used by the UI must also reject internal destinations.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://192.168.1.1/x.png") == nil)
@@ -857,6 +916,7 @@ struct PureValueTests {
             adminIds: [],
             archived: false,
             pendingConfirmation: false,
+            selfMembership: .member,
             members: [],
             isSelfAdmin: false,
             isLastAdmin: false,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1741,6 +1741,43 @@ struct whitenoise_macTests {
         #expect(chat.pendingConfirmation)
         #expect(chat.subtitle == "Planning")
         #expect(chat.preview == "Alice: Welcome in")
+        #expect(chat.selfMembership == .member)
+        #expect(!chat.isNoLongerMember)
+    }
+
+    @MainActor
+    @Test func chatRowMapsSelfMembershipVariantsIntoChatItem() async throws {
+        let sender = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let variants: [(SelfMembershipFfi, ChatSelfMembership)] = [
+            (.member, .member),
+            (.left, .left),
+            (.removed, .removed),
+        ]
+
+        for (ffiMembership, expected) in variants {
+            let row = chatListRow(
+                groupIdHex: "group",
+                title: "Planning",
+                preview: "hello",
+                sender: sender,
+                timelineAt: 1_700_000_000,
+                selfMembership: ffiMembership
+            )
+            let chat = ChatItem(row: row, activeAccountIdHex: "self")
+
+            #expect(chat.selfMembership == expected)
+            #expect(chat.isNoLongerMember == (expected != .member))
+        }
+    }
+
+    @MainActor
+    @Test func selfMembershipPresentationLabelsDescribeEndedStates() async throws {
+        #expect(ChatSelfMembership.member.sidebarBadgeLabel == nil)
+        #expect(ChatSelfMembership.member.endedDescription == nil)
+        #expect(ChatSelfMembership.left.sidebarBadgeLabel == "Left")
+        #expect(ChatSelfMembership.left.endedDescription == "You left this group")
+        #expect(ChatSelfMembership.removed.sidebarBadgeLabel == "Removed")
+        #expect(ChatSelfMembership.removed.endedDescription == "You were removed from this group")
     }
 
     @MainActor
@@ -5772,6 +5809,40 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func endedMembershipDisablesSendingWhileChatStaysListed() async throws {
+        // A group the local account was removed from stays in the chat list so the
+        // history remains readable, but the core rejects sends to it
+        // (`invalid_transition`), so both `canSend` and `sendDraft` must gate on it.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        var removedGroup = messageGroup()
+        removedGroup.selfMembership = .removed
+        runtime.installGroups([removedGroup])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+
+        let chat = try #require(state.selectedChat)
+        #expect(chat.id == "group")
+        #expect(chat.selfMembership == .removed)
+        #expect(chat.isNoLongerMember)
+
+        state.draftText = "still there?"
+        #expect(!state.canSend)
+
+        await state.sendDraft()
+
+        #expect(runtime.sendTextCallCount == 0)
+        #expect(state.draftText == "still there?")
+    }
+
+    @MainActor
     @Test func preparedMediaAttachmentIsDiscardedWhenSelectionChangesDuringPrep() async throws {
         // Issue #245: media/voice prep captures the composer draft key before an async prep
         // step. If the user switches chats while prep is in flight, the finished attachment
@@ -6738,7 +6809,8 @@ struct whitenoise_macTests {
             pictureURL: nil,
             unreadCount: 0,
             isDirect: false,
-            pendingConfirmation: true
+            pendingConfirmation: true,
+            selfMembership: .removed
         )
 
         let merged = ChatListOrdering.preservingResolvedMetadata(in: readState, from: current)
@@ -6752,6 +6824,9 @@ struct whitenoise_macTests {
         #expect(merged.updatedAt == Date(timeIntervalSince1970: 200))
         #expect(merged.unreadCount == 0)
         #expect(merged.pendingConfirmation)
+        // Membership state rides the incoming row, like pendingConfirmation — it
+        // is not part of the enrichment-resolved metadata being preserved.
+        #expect(merged.selfMembership == .removed)
     }
 
     @MainActor
@@ -8706,6 +8781,35 @@ struct whitenoise_macTests {
 
         state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-reset-test")
 
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
+    @Test func endedMembershipRowUpdateStopsInProgressVoiceRecording() async throws {
+        // A removal can land while the user is recording in that very chat. The
+        // membership-ended notice then replaces the composer (and its Stop/Cancel
+        // controls), so the chat-list row update must also tear down the recorder —
+        // the mic must never stay hot with no visible way to stop it (#311).
+        let state = WorkspaceState.preview()
+        let account = AccountItem.samples[0]
+        let selectedChatId = try #require(state.selectedChat?.id)
+        let url = try armInProgressVoiceRecording(on: state)
+
+        await state.applyChatRow(
+            chatListRow(
+                groupIdHex: selectedChatId,
+                title: "Marmot Design",
+                preview: "you were removed",
+                sender: "alice1234567890alice1234567890alice1234567890alice1234567890",
+                timelineAt: 1_700_000_000,
+                selfMembership: .removed
+            ),
+            account: account
+        )
+
+        #expect(state.selectedChat?.selfMembership == .removed)
         #expect(!state.isRecordingVoiceMessage)
         #expect(state.voiceRecordingMeterTask == nil)
         #expect(!FileManager.default.fileExists(atPath: url.path))
@@ -12882,7 +12986,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
             lastReadMessageIdHex: nil,
             lastReadTimelineAt: latest?.timelineAt,
             updatedAt: latest?.timelineAt ?? 0,
-            selfMembership: .member
+            selfMembership: group.selfMembership
         )
     }
 }
@@ -13514,7 +13618,8 @@ private func chatListRow(
     preview: String,
     sender: String,
     timelineAt: UInt64,
-    kind: UInt64 = 9
+    kind: UInt64 = 9,
+    selfMembership: SelfMembershipFfi = .member
 ) -> ChatListRowFfi {
     ChatListRowFfi(
         groupIdHex: groupIdHex,
@@ -13542,7 +13647,7 @@ private func chatListRow(
         lastReadMessageIdHex: nil,
         lastReadTimelineAt: nil,
         updatedAt: timelineAt,
-        selfMembership: .member
+        selfMembership: selfMembership
     )
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5840,6 +5840,21 @@ struct whitenoise_macTests {
 
         #expect(runtime.sendTextCallCount == 0)
         #expect(state.draftText == "still there?")
+
+        // Attachments arriving via drag-and-drop / file import bypass the hidden
+        // composer, so the state-level gate must refuse them too — otherwise they
+        // accumulate invisibly behind the membership-ended notice.
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let attachmentURL = directory.appendingPathComponent("notes.txt")
+        try Data("dropped file".utf8).write(to: attachmentURL)
+
+        await state.addMediaAttachments(from: [attachmentURL])
+
+        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(!state.canSend)
     }
 
     @MainActor
@@ -8806,6 +8821,35 @@ struct whitenoise_macTests {
                 timelineAt: 1_700_000_000,
                 selfMembership: .removed
             ),
+            account: account
+        )
+
+        #expect(state.selectedChat?.selfMembership == .removed)
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
+    @Test func endedMembershipBulkRowsUpdateStopsInProgressVoiceRecording() async throws {
+        // Sibling of the single-row test above for the bulk snapshot/reconnect path
+        // (`applyChatRows`), which also carries membership flips (#311).
+        let state = WorkspaceState.preview()
+        let account = AccountItem.samples[0]
+        let selectedChatId = try #require(state.selectedChat?.id)
+        let url = try armInProgressVoiceRecording(on: state)
+
+        await state.applyChatRows(
+            [
+                chatListRow(
+                    groupIdHex: selectedChatId,
+                    title: "Marmot Design",
+                    preview: "you were removed",
+                    sender: "alice1234567890alice1234567890alice1234567890alice1234567890",
+                    timelineAt: 1_700_000_000,
+                    selfMembership: .removed
+                )
+            ],
             account: account
         )
 


### PR DESCRIPTION
## What

The mdk e712232 bindings (vendored in #341) expose a new `selfMembership: SelfMembershipFfi` (`.member` / `.left` / `.removed`) on both `ChatListRowFfi` and `AppGroupRecordFfi` — whether the local account is still a member of a group, and if not, whether it left voluntarily or was removed. The app previously ignored it. This maps the field through `Core/MarmotMapping.swift` into the view models and surfaces it everywhere the user can act on the chat:

- **Model**: new app-side `ChatSelfMembership` enum with presentation helpers (`sidebarBadgeLabel`, `endedDescription`, `endedSymbolName`); `ChatItem.selfMembership` / `isNoLongerMember` and `GroupDetailsSnapshot.selfMembership`. The field survives both chat-list merge paths the same way `pendingConfirmation` does (fresh-row wins on row updates, current wins during metadata enrichment).
- **Sidebar**: a "Left" / "Removed" capsule badge on chat rows, mirroring the existing `PendingInviteBadge`, with the full explanation as tooltip.
- **Conversation**: for non-member groups the composer (reply/media strips included) is replaced by an explanatory notice — "You left this group" / "You were removed from this group" — since the chat stays listed for reading history but the core rejects sends with `invalid_transition` (see wn-cli changelog). `canSend` and `sendDraft` gate on membership as defense in depth, and the header's "Set group image" button (a commit under the hood) is hidden.
- **Group details**: a "Membership" explanatory section plus a "Self membership" developer-diagnostics row.
- **Edge case** per the #311/#325 "mic must never stay hot without a stop button" rule: a membership flip that lands while recording a voice message in that chat tears the recorder down (`cancelVoiceRecordingIfSelectedMembershipEnded`, hooked into both chat-list update paths).

## Why

Upstream, mdk#724 clears the removed marker when branch selection supersedes a removal, and sends to self-evicted groups fail with `invalid_transition` — without this state the app offered a composer whose sends could only fail, with no explanation of why the group went quiet.

## Reviewer notes

- The fake runtime's `chatListRow(for:)` now derives `selfMembership` from the installed `AppGroupRecordFfi` instead of hardcoding `.member`, so tests can drive the full pipeline.
- Tests (317 total, all passing): FFI→`ChatItem` variant mapping, presentation labels, metadata-merge preservation, `GroupDetailsSnapshot` mapping, an end-to-end bootstrap test proving a `.removed` group stays listed but cannot send, and the recorder-teardown test.
- New user-facing strings are not yet in `Localizable.xcstrings`, matching existing practice for recent keys (e.g. "Group invite pending"); they fall back to English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/343">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->