### PR TITLE
fix: let system appearance follow macOS

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -10,12 +10,11 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(WorkspaceState.self) private var workspace
-    @State private var effectiveColorScheme: ColorScheme?
 
     var body: some View {
         MessengerShellView()
             .frame(minWidth: 940, minHeight: 620)
-            .preferredColorScheme(effectiveColorScheme)
+            .preferredColorScheme(workspace.preferredColorScheme)
             .environment(\.locale, workspace.preferredLocale)
             .environment(
                 \.openURL,
@@ -33,13 +32,6 @@ struct ContentView: View {
             }
             .onChange(of: workspace.appearancePreference) { _, preference in
                 applyAppearance(preference)
-            }
-            .onReceive(
-                DistributedNotificationCenter.default().publisher(
-                    for: Notification.Name("AppleInterfaceThemeChangedNotification")
-                )
-            ) { _ in
-                refreshSystemAppearance()
             }
             .onReceive(
                 NotificationCenter.default.publisher(
@@ -77,16 +69,6 @@ struct ContentView: View {
 
     private func applyAppearance(_ preference: AppearancePreference) {
         NativeAppearanceController.apply(preference)
-        effectiveColorScheme = NativeAppearanceController.preferredColorScheme(for: preference)
-
-        DispatchQueue.main.async {
-            effectiveColorScheme = NativeAppearanceController.preferredColorScheme(for: preference)
-        }
-    }
-
-    private func refreshSystemAppearance() {
-        guard workspace.appearancePreference == .system else { return }
-        effectiveColorScheme = NativeAppearanceController.preferredColorScheme(for: .system)
     }
 }
 

--- a/whitenoise-mac/Core/NativeAppearanceController.swift
+++ b/whitenoise-mac/Core/NativeAppearanceController.swift
@@ -1,5 +1,4 @@
 import AppKit
-import SwiftUI
 
 @MainActor
 enum NativeAppearanceController {
@@ -12,25 +11,6 @@ enum NativeAppearanceController {
             window.contentView?.appearance = appearance
             window.displayIfNeeded()
         }
-    }
-
-    static func preferredColorScheme(for preference: AppearancePreference) -> ColorScheme {
-        switch preference {
-        case .system:
-            systemColorScheme
-        case .light:
-            .light
-        case .dark:
-            .dark
-        }
-    }
-
-    private static var systemColorScheme: ColorScheme {
-        let appearance =
-            NSApp.keyWindow?.effectiveAppearance
-            ?? NSApp.mainWindow?.effectiveAppearance
-            ?? NSApp.effectiveAppearance
-        return appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .dark : .light
     }
 
     private static func nsAppearance(for preference: AppearancePreference) -> NSAppearance? {


### PR DESCRIPTION
## Summary
- Leave SwiftUI's preferred color scheme unset while Appearance is set to System.
- Remove the manual `NSApp.effectiveAppearance` color-scheme resolution path that could latch a stale Light/Dark value during live macOS theme changes.
- Keep explicit Light/Dark preferences wired through the existing `WorkspaceState.preferredColorScheme` mapping.

## Test Plan
- `git diff --check`
- Static grep confirmed the stale `effectiveColorScheme` / `refreshSystemAppearance` / `NativeAppearanceController.preferredColorScheme(for:)` path is gone.
- `xcodebuild` unavailable on this Linux host, so macOS build/tests were not run locally.

Fixes #312


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->