### PR TITLE
fix: classify incoming SVG media as files

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -307,17 +307,7 @@ nonisolated struct MessageMediaAttachment: Identifiable, Hashable {
     }
 
     var kind: MessageMediaKind {
-        let normalized = mediaType.lowercased()
-        if normalized.hasPrefix("image/") {
-            return .image
-        }
-        if normalized.hasPrefix("audio/") {
-            return .audio
-        }
-        if normalized.hasPrefix("video/") {
-            return .video
-        }
-        return .file
+        OutgoingMediaAttachmentPolicy.kind(mediaType: mediaType, fileName: fileName)
     }
 
     var previewLabel: String {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2735,6 +2735,33 @@ struct whitenoise_macTests {
         #expect(!attachmentOnly.canCopyText)
     }
 
+    @MainActor
+    @Test func incomingNonDecodableImageAttachmentIsClassifiedAsFileNotVisualMedia() async throws {
+        let svg = MessageMediaAttachment(
+            id: "svg",
+            reference: mediaAttachmentReference(mediaType: "image/svg+xml", fileName: "diagram.svg")
+        )
+        let png = MessageMediaAttachment(
+            id: "png",
+            reference: mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        )
+
+        #expect(svg.kind == .file)
+        #expect(png.kind == .image)
+
+        let message = MessageItem(
+            id: "svg-media",
+            senderName: "Bob",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_800_000_002),
+            isOutgoing: false,
+            mediaAttachments: [svg, png]
+        )
+
+        #expect(message.visualMediaAttachments.map(\.id) == ["png"])
+        #expect(message.nonvisualMediaAttachments.map(\.id) == ["svg"])
+    }
+
     @Test func pendingMediaAttachmentDurationLabelFormatsSubhourHourBoundaryAndClampsNegative() {
         let longAttachment = PendingMediaAttachment(
             fileName: "long.m4a",


### PR DESCRIPTION
Fixes #337

## Summary
- Route incoming `MessageMediaAttachment.kind` through `OutgoingMediaAttachmentPolicy.kind(mediaType:fileName:)` instead of raw MIME-prefix matching.
- Keep decodable image/video/audio behavior intact while classifying `image/svg+xml` as `.file`, so it lands in the downloadable attachment row instead of the visual media grid.
- Add a regression test covering incoming SVG vs PNG partitioning.

## Verification
- `git diff --check origin/master...HEAD` — passed.
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed.
- `scripts/ci/macos-sanity-checks.sh` — blocked on this Linux host: `xcodebuild: command not found`.
- macOS/Xcode CI commands (`xcrun swift-format`, `xcodebuild test/build/analyze`) not run locally because `xcodebuild`, `xcrun`, `swift`, `swift-format`, and `swiftformat` are not installed on this host.

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/347">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->