### PR TITLE
fix: narrow media cache commit locking

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -161,6 +161,14 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private let keyProvider: KeyProvider
     private let keyDeleter: KeyDeleter
     private let lock = NSLock()
+    // Serializes the filesystem create/remove/move work of commits and purges so a slow
+    // commit never blocks generation reads or purge bookkeeping (which stay on `lock`).
+    // A commit holds this lock while it re-reads the generation and moves the final entry
+    // into place; a purge holds it while it deletes on disk. Because `beginPurge()` bumps
+    // the generation under `lock` before its filesystem work runs, a commit that observes
+    // an unchanged generation while holding this lock is guaranteed no purge deletion can
+    // interleave with its move, so an older store can never resurrect a purged entry.
+    private let fileMutationLock = NSLock()
     private var generation = 0
     private var purgeTask: Task<Void, Never>?
     private var purgeGeneration: Int?
@@ -326,7 +334,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         lock.lock()
         generation += 1
         let activeGeneration = generation
+        let fileMutationLock = self.fileMutationLock
         let task = Task.detached(priority: .utility) {
+            fileMutationLock.lock()
+            defer { fileMutationLock.unlock() }
             work()
         }
         purgeTask = task
@@ -345,10 +356,15 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     }
 
     private func commitPreparedEntry(_ prepared: PreparedEntry, startGeneration: Int) {
-        lock.lock()
-        defer { lock.unlock() }
+        // Hold only the narrow filesystem-mutation lock across the slow create/remove/move
+        // so generation reads and purge bookkeeping (on `lock`) never block on this commit.
+        // The generation re-check happens under `fileMutationLock`: a purge bumps the
+        // generation under `lock` before acquiring `fileMutationLock` for its deletion, so
+        // an unchanged generation observed here means no purge deletion can interleave.
+        fileMutationLock.lock()
+        defer { fileMutationLock.unlock() }
 
-        guard generation == startGeneration else {
+        guard currentGeneration() == startGeneration else {
             Self.discardPreparedEntry(prepared)
             return
         }


### PR DESCRIPTION
Fixes #335

## Summary
- Adds a narrow filesystem-mutation lock for `MessageMediaDiskCache` commits and purge work.
- Keeps the existing state lock limited to generation/purge bookkeeping so slow entry commits no longer block cache generation reads or purge initiation.
- Preserves purge correctness by bumping generation before purge filesystem work and serializing purge deletion against commit move operations.

## Verification
- `git diff --check` — pass
- line-length scan for `whitenoise-mac/Core/MessageMediaDiskCache.swift` > 120 chars — pass
- trailing-whitespace scan for `whitenoise-mac/Core/MessageMediaDiskCache.swift` — pass
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — not run on Linux: `xcrun: command not found`
- `scripts/ci/macos-sanity-checks.sh` — not run on Linux: `xcodebuild: command not found`
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO` — not run on Linux: `xcodebuild: command not found`

## Sensitive paths
- `whitenoise-mac/Core/MessageMediaDiskCache.swift` contains media cache crypto/keychain code, but this PR changes only concurrency/locking around filesystem commit and purge operations. No crypto, keychain, sealing/opening, AAD, or auth logic changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/349">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->