### PR TITLE
fix: bound remote image download duration

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -31,6 +31,14 @@ nonisolated enum RemoteImageURLPolicy {
     /// otherwise serve an arbitrarily large response. 8 MiB is generous for an avatar/preview.
     static let maxResponseBytes: Int64 = 8 * 1024 * 1024
 
+    /// Maximum idle gap between received response chunks. `URLSession` resets this timer on
+    /// progress, so it bounds a stalled peer but is not a total download-duration ceiling.
+    static let downloadStallTimeout: TimeInterval = 15
+
+    /// Hard wall-clock ceiling for one remote image fetch, even if a peer keeps slow-dripping
+    /// bytes under the response-size cap and never trips the per-request stall timeout.
+    static let downloadResourceTimeout: TimeInterval = 60
+
     /// Returns true if `url` is safe to fetch: `https` scheme with a non-empty, public host.
     ///
     /// "Public host" means the host is not a literal private/loopback/link-local/unspecified
@@ -546,6 +554,8 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
             diskCapacity: 0,
             diskPath: nil
         )
+        config.timeoutIntervalForRequest = RemoteImageURLPolicy.downloadStallTimeout
+        config.timeoutIntervalForResource = RemoteImageURLPolicy.downloadResourceTimeout
         config.requestCachePolicy = .useProtocolCachePolicy
         return config
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -9216,6 +9216,9 @@ struct whitenoise_macTests {
         // writes directly, so pin the privacy invariant that prevents them for the default loader.
         #expect(urlCache.memoryCapacity > 0)
         #expect(urlCache.diskCapacity == 0)
+        #expect(config.timeoutIntervalForRequest == RemoteImageURLPolicy.downloadStallTimeout)
+        #expect(config.timeoutIntervalForResource == RemoteImageURLPolicy.downloadResourceTimeout)
+        #expect(config.timeoutIntervalForResource > config.timeoutIntervalForRequest)
         #expect(config.requestCachePolicy == .useProtocolCachePolicy)
     }
 


### PR DESCRIPTION
## Summary
- add explicit stall and wall-clock timeouts to the RemoteImageLoader URLSession
- expose the timeout values as policy constants next to the existing response byte cap
- pin the timeout defaults in the RemoteImageLoader session configuration invariant test

## Test Plan
- `git diff --check`
- conflict-marker sweep for changed Swift files
- `xcodebuild` not run: unavailable on this Linux host

Fixes #336


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/351">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote image downloads now have built-in limits for both stalled connections and total download duration, helping prevent images from hanging indefinitely on slow networks.
  * Improved default networking behavior for remote image loading so requests fail more predictably when transfers take too long.
* **Tests**
  * Added coverage to verify the default remote image timeout settings are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->