### PR TITLE
fix: recompute detached timeline head after removals

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -305,7 +305,6 @@ final class MessageTimelineStore {
         anchoredToNewest: Bool,
         windowLimit: Int
     ) -> ProjectionApplyResult {
-        let newestKey = messages.last.map(TimelineSortKey.init)
         var didChange = false
 
         if !removalIds.isEmpty {
@@ -316,6 +315,11 @@ final class MessageTimelineStore {
                 rebuildIndexes()
             }
         }
+
+        // Recompute the head *after* removals: a delta that drops the current newest row lowers
+        // the detached window's real head, and an upsert newer than that post-removal head must
+        // not grow a new head into a scrolled-back window.
+        let newestKey = messages.last.map(TimelineSortKey.init)
 
         for item in upserts {
             if let existingIndex = indexById[item.id] {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -244,6 +244,44 @@ struct PureValueTests {
     }
 
     @MainActor
+    @Test func detachedWindowSuppressesUpsertNewerThanPostRemovalHead() async throws {
+        // Regression for whitenoise-mac#331: applyProjection must recompute the window head
+        // *after* removals. In a detached (scrolled-back) window, a delta that removes the
+        // current newest row and upserts a row newer than the post-removal head must suppress
+        // that upsert — a detached window must not grow a new head — matching the runtime's
+        // apply_projection_to_window.
+        func message(id: String, timelineAt: UInt64) -> MessageItem {
+            MessageItem(
+                id: id,
+                senderName: "sender",
+                body: id,
+                sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+                timelineAt: timelineAt,
+                isOutgoing: false
+            )
+        }
+
+        // Window (oldest→newest): L(95), M(100). We are scrolled back, so anchoredToNewest == false.
+        let store = MessageTimelineStore.loaded(with: [
+            message(id: "L", timelineAt: 95),
+            message(id: "M", timelineAt: 100),
+        ])
+
+        // The delta removes the current newest row M and upserts N(98). After M is gone the true
+        // head is L(95); N(98) is strictly newer and must not become a new head.
+        let result = store.applyProjection(
+            upserts: [message(id: "N", timelineAt: 98)],
+            removals: ["M"],
+            anchoredToNewest: false,
+            windowLimit: 10
+        )
+
+        #expect(store.messages.map(\.id) == ["L"])
+        #expect(!store.containsMessage(id: "N"))
+        #expect(result.didChange)
+    }
+
+    @MainActor
     @Test func workspaceChatSnapshotsDeduplicateDuplicateChatIds() async throws {
         // Regression for whitenoise-mac#309: full-list chat snapshots must not leave duplicate
         // ChatItem.id values in the observed arrays that feed SwiftUI ForEach and later


### PR DESCRIPTION
Fixes #331

## Summary
- Recompute `MessageTimelineStore.applyProjection`'s detached-window head after applying removals, so a delta that removes the current newest row cannot admit an upsert newer than the true post-removal head.
- Add a Swift Testing regression covering a detached window where `M(100)` is removed and `N(98)` is suppressed because the remaining head is `L(95)`.

## Verification
- `git diff --check` — passed.
- Conflict marker sweep with `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' HEAD` — none.
- Tool availability probe — `xcodebuild`, `xcrun`, `swift`, `swiftc`, and `swift-format` are not installed on this Linux host, so macOS build/test/format checks could not be run locally. Expected for this worker; macOS CI must run the xcodebuild gates.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/352">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->