### PR TITLE
fix: reject relay URLs with userinfo

### DIFF
--- a/whitenoise-mac/Core/RelayURLValidator.swift
+++ b/whitenoise-mac/Core/RelayURLValidator.swift
@@ -71,6 +71,15 @@ nonisolated enum RelayURLValidator {
             return .invalid
         }
 
+        // Reject any embedded userinfo. A relay's identity is its URL string,
+        // so `wss://relay.damus.io@evil-relay.example` parses with
+        // host == "evil-relay.example" but reads as the trusted host to a human
+        // scanning a relay list — a host-confusion attack. Relay URLs have no
+        // legitimate user/password component, so treat any as malformed.
+        guard components.user == nil, components.password == nil else {
+            return .invalid
+        }
+
         switch scheme {
         case "wss":
             return .secure

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -783,6 +783,33 @@ struct PureValueTests {
         #expect(RelayURLValidator.classify("ws://127.0.0.256") == .insecureRejected)
     }
 
+    @Test func relayValidatorRejectsEmbeddedUserinfoHostConfusion() async throws {
+        // Issue #327: a relay's identity is its URL string. An entry like
+        // `wss://relay.damus.io@evil-relay.example` parses with
+        // host == "evil-relay.example" (user == "relay.damus.io"), so a human
+        // scanning a relay list reads the trusted leading host while the client
+        // connects to the attacker. Any userinfo makes the URL invalid before
+        // scheme classification, so it can never be accepted or flagged secure.
+        for url in [
+            // Deceptive trusted-host-as-userinfo cases (the core attack).
+            "wss://relay.damus.io@evil-relay.example",
+            "wss://trusted@evil",
+            "wss://relay.example.com@evil.com/relay",
+            // Loopback host smuggled behind userinfo must not become loopback.
+            "ws://localhost@evil.com",
+            "ws://127.0.0.1@evil.com",
+            // Explicit user:password userinfo variants.
+            "wss://user:pass@evil.com",
+            "wss://:pass@evil.com",
+            "wss://user@relay.example.com",
+        ] {
+            #expect(RelayURLValidator.classify(url) == .invalid, "expected invalid for \(url)")
+            #expect(!RelayURLValidator.isAcceptable(url), "expected not acceptable for \(url)")
+            #expect(!RelayURLValidator.isInsecure(url), "expected no insecure flag for \(url)")
+            #expect(!RelayURLValidator.isCleartext(url), "expected not cleartext for \(url)")
+        }
+    }
+
     @Test func markdownLinkPolicyAllowsOnlyWebAndNostrSchemes() async throws {
         let httpsURL = MarkdownLinkPolicy.sanitizedURL(from: "https://example.com/path")
         #expect(httpsURL?.absoluteString == "https://example.com/path")


### PR DESCRIPTION
Fixes #327

## Summary
- Reject relay URLs with embedded userinfo (`user` or `password`) before scheme classification.
- Add a Swift Testing regression covering deceptive `wss://trusted@evil` relay URLs, loopback-smuggling userinfo, and explicit `user:password` variants.

## Verification
- `git diff --check` — pass.
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .` — pass, no conflict markers.
- `command -v xcodebuild xcrun swift swift-format` — all missing on this Linux host, so macOS/Xcode CI commands could not be run locally.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/355">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->