### PR TITLE
fix: coalesce concurrent timeline loads

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -84,6 +84,7 @@ extension WorkspaceState {
     ) {
         leaveActiveConversation()
         stopTimelineListener()
+        cancelTimelineLoad()
         cancelChatListReload()
         stopChatListListener()
         clearEnteredLoginIdentity()
@@ -244,6 +245,7 @@ extension WorkspaceState {
         do {
             if wasActive {
                 stopTimelineListener()
+                cancelTimelineLoad()
                 cancelChatListReload()
                 stopChatListListener()
             }
@@ -307,6 +309,7 @@ extension WorkspaceState {
     /// drafts, settings snapshots). Shared by account removal and sign-out.
     func resetActiveAccountUIState() {
         stopTimelineListener()
+        cancelTimelineLoad()
         cancelChatListReload()
         stopChatListListener()
         cachedMessageChatIds.removeAll()
@@ -350,6 +353,7 @@ extension WorkspaceState {
         do {
             if wasActive {
                 stopTimelineListener()
+                cancelTimelineLoad()
                 cancelChatListReload()
                 stopChatListListener()
             }

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -17,6 +17,32 @@ import UserNotifications
 @MainActor
 extension WorkspaceState {
     func loadMessages(groupIdHex: String) async {
+        if timelineTaskGroupId == groupIdHex, ensureMessageTimelineStore(for: groupIdHex).isLoaded {
+            finishTimelineInitialLoad(groupIdHex: groupIdHex)
+            return
+        }
+
+        if let existing = timelineLoadTask, timelineLoadGroupId == groupIdHex {
+            await existing.value
+            return
+        }
+
+        timelineLoadTask?.cancel()
+        let task = Task<Void, Never> { [weak self] in
+            await self?.performTimelineLoad(groupIdHex: groupIdHex)
+        }
+        timelineLoadTask = task
+        timelineLoadGroupId = groupIdHex
+
+        await task.value
+
+        if timelineLoadTask == task {
+            timelineLoadTask = nil
+            timelineLoadGroupId = nil
+        }
+    }
+
+    func performTimelineLoad(groupIdHex: String) async {
         guard let client, let activeAccount else {
             finishTimelineInitialLoad(groupIdHex: groupIdHex)
             return
@@ -77,6 +103,8 @@ extension WorkspaceState {
             guard timelineTaskGroupId == groupIdHex else { return }
             activeTimelineSubscription = subscription
             activeTimelineGroupId = groupIdHex
+        } catch is CancellationError {
+            return
         } catch {
             lastError = error.localizedDescription
         }

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -22,47 +22,88 @@ extension WorkspaceState {
             return
         }
 
-        if let existing = timelineLoadTask, timelineLoadGroupId == groupIdHex {
+        guard client != nil, let activeAccount else {
+            cancelTimelineLoad()
+            finishTimelineInitialLoad(groupIdHex: groupIdHex)
+            return
+        }
+        let accountId = activeAccount.id
+
+        if let existing = timelineLoadTask,
+            timelineLoadGroupId == groupIdHex,
+            timelineLoadAccountId == accountId
+        {
+            // Same-account duplicate loads join the owner task; its defer clears the spinner.
             await existing.value
             return
         }
 
         timelineLoadTask?.cancel()
+        timelineLoadGeneration &+= 1
+        let generation = timelineLoadGeneration
         let task = Task<Void, Never> { [weak self] in
-            await self?.performTimelineLoad(groupIdHex: groupIdHex)
+            await self?.performTimelineLoad(
+                groupIdHex: groupIdHex,
+                accountId: accountId,
+                generation: generation
+            )
         }
         timelineLoadTask = task
         timelineLoadGroupId = groupIdHex
+        timelineLoadAccountId = accountId
 
         await task.value
 
         if timelineLoadTask == task {
             timelineLoadTask = nil
             timelineLoadGroupId = nil
+            timelineLoadAccountId = nil
         }
     }
 
-    func performTimelineLoad(groupIdHex: String) async {
-        guard let client, let activeAccount else {
-            finishTimelineInitialLoad(groupIdHex: groupIdHex)
+    func performTimelineLoad(groupIdHex: String, accountId: String, generation: UInt64) async {
+        guard let client, let activeAccount, activeAccount.id == accountId else {
+            if ownsTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex) {
+                finishTimelineInitialLoad(groupIdHex: groupIdHex)
+            }
+            return
+        }
+        guard canContinueTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex) else {
             return
         }
         if timelineTaskGroupId == groupIdHex, ensureMessageTimelineStore(for: groupIdHex).isLoaded {
+            // `loadMessages` checks this before spawning, but the store may become loaded while
+            // this task waits for the main actor; keep the defensive in-task short-circuit.
             finishTimelineInitialLoad(groupIdHex: groupIdHex)
             return
         }
         stopTimelineListener()
-        guard selectedChat?.id == groupIdHex else {
-            finishTimelineInitialLoad(groupIdHex: groupIdHex)
+        guard canContinueTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex),
+            selectedChat?.id == groupIdHex
+        else {
+            if ownsTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex) {
+                finishTimelineInitialLoad(groupIdHex: groupIdHex)
+            }
             return
         }
         beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
-        defer { finishTimelineInitialLoad(groupIdHex: groupIdHex) }
+        defer {
+            if ownsTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex) {
+                finishTimelineInitialLoad(groupIdHex: groupIdHex)
+            }
+        }
         do {
             let accountRef = activeAccount.accountRef
             if let row = try await runOffMain({
                 try client.initializeChatReadState(accountRef: accountRef, groupIdHex: groupIdHex)
             }) {
+                guard
+                    canContinueTimelineLoad(
+                        generation: generation,
+                        accountId: accountId,
+                        groupIdHex: groupIdHex
+                    )
+                else { return }
                 // `initializeChatReadState` may race a live chat-list delta. Do not let an
                 // older read-state row roll back a newer preview/timestamp already applied
                 // by the subscription listener while the FFI call was in flight.
@@ -79,12 +120,13 @@ extension WorkspaceState {
                 groupIdHex: groupIdHex,
                 limit: Self.timelinePageLimit
             )
-            guard activeAccountId == activeAccount.id, selectedChat?.id == groupIdHex else { return }
+            guard canContinueTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex),
+                selectedChat?.id == groupIdHex
+            else { return }
 
             let snapshot = try await runOffMain { subscription.snapshot() }
-            guard activeAccountId == activeAccount.id,
-                selectedChat?.id == groupIdHex,
-                !Task.isCancelled
+            guard canContinueTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex),
+                selectedChat?.id == groupIdHex
             else { return }
             let page =
                 snapshot
@@ -100,14 +142,37 @@ extension WorkspaceState {
             // while we awaited above); only record the subscription when it actually started,
             // otherwise we leak a live handle with no `next()` loop draining it.
             startTimelineListener(groupIdHex: groupIdHex, account: activeAccount, subscription: subscription)
-            guard timelineTaskGroupId == groupIdHex else { return }
+            guard canContinueTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex),
+                timelineTaskGroupId == groupIdHex
+            else { return }
             activeTimelineSubscription = subscription
             activeTimelineGroupId = groupIdHex
         } catch is CancellationError {
             return
         } catch {
+            guard ownsTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex) else { return }
             lastError = error.localizedDescription
         }
+    }
+
+    func ownsTimelineLoad(generation: UInt64, accountId: String, groupIdHex: String) -> Bool {
+        timelineLoadGeneration == generation
+            && timelineLoadAccountId == accountId
+            && timelineLoadGroupId == groupIdHex
+            && activeAccountId == accountId
+    }
+
+    func canContinueTimelineLoad(generation: UInt64, accountId: String, groupIdHex: String) -> Bool {
+        ownsTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
+            && !Task.isCancelled
+    }
+
+    func cancelTimelineLoad() {
+        timelineLoadTask?.cancel()
+        timelineLoadTask = nil
+        timelineLoadGroupId = nil
+        timelineLoadAccountId = nil
+        timelineLoadGeneration &+= 1
     }
 
     func loadOlderMessages(groupIdHex: String) async {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -739,10 +739,14 @@ final class WorkspaceState {
     var timelineTaskGroupId: String?
     /// Single-owner coalescing for initial timeline loads (issue #332). `loadMessages` can be
     /// reached from overlapping unstructured navigation tasks; concurrent requests for the same
-    /// group should await the in-flight subscription/snapshot pass instead of opening a duplicate
-    /// live subscription and immediately orphaning the first listener handle.
+    /// account+group should await the in-flight subscription/snapshot pass instead of opening a
+    /// duplicate live subscription and immediately orphaning the first listener handle. Requests for
+    /// a different account or group supersede the stale owner; the generation token prevents a stale
+    /// task from applying rows, starting a listener, or clearing newer load state if it resumes later.
     var timelineLoadTask: Task<Void, Never>?
     var timelineLoadGroupId: String?
+    var timelineLoadAccountId: String?
+    var timelineLoadGeneration: UInt64 = 0
     /// The live timeline subscription for the open conversation. It owns the
     /// authoritative, bounded, materialized window; scroll-back/forward pagination and
     /// live updates all flow through it (`paginateBackwards` / `paginateForwards` / `next`).

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -737,6 +737,12 @@ final class WorkspaceState {
     var notificationSettingsGeneration: UInt64 = 0
     var timelineTask: Task<Void, Never>?
     var timelineTaskGroupId: String?
+    /// Single-owner coalescing for initial timeline loads (issue #332). `loadMessages` can be
+    /// reached from overlapping unstructured navigation tasks; concurrent requests for the same
+    /// group should await the in-flight subscription/snapshot pass instead of opening a duplicate
+    /// live subscription and immediately orphaning the first listener handle.
+    var timelineLoadTask: Task<Void, Never>?
+    var timelineLoadGroupId: String?
     /// The live timeline subscription for the open conversation. It owns the
     /// authoritative, bounded, materialized window; scroll-back/forward pagination and
     /// live updates all flow through it (`paginateBackwards` / `paginateForwards` / `next`).

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5401,6 +5401,70 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func concurrentSameChatTimelineLoadsShareInFlightSubscription() async throws {
+        let accountSummary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let account = AccountItem(
+            id: accountSummary.label,
+            accountRef: accountSummary.label,
+            displayName: accountSummary.label,
+            accountIdHex: accountSummary.accountIdHex
+        )
+        let chat = ChatItem(
+            row: chatListRow(
+                groupIdHex: "group",
+                title: "General",
+                preview: "Initial message",
+                sender: accountSummary.accountIdHex,
+                timelineAt: 1_700_000_000
+            ),
+            activeAccountIdHex: accountSummary.accountIdHex
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountSummary])
+        runtime.installGroup(messageGroup())
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "message",
+                    groupIdHex: "group",
+                    sender: accountSummary.accountIdHex,
+                    plaintext: "Initial message",
+                    kind: 9,
+                    recordedAt: 1_700_000_000
+                )
+            ],
+            groupIdHex: "group"
+        )
+        runtime.timelineSubscriptionDelayNanoseconds = 50_000_000
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [chat]],
+            clientFactory: { runtime }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(chat.id)
+        state.client = runtime
+
+        async let firstLoad: Void = state.loadMessages(groupIdHex: chat.id)
+        let didStartFirstLoad = await waitFor {
+            runtime.timelineSubscriptionCount == 1
+        }
+        #expect(didStartFirstLoad)
+        async let duplicateLoad: Void = state.loadMessages(groupIdHex: chat.id)
+
+        _ = await (firstLoad, duplicateLoad)
+
+        #expect(runtime.timelineSubscriptionCount == 1)
+        #expect(state.messagesByChat[chat.id]?.map(\.id) == ["message"])
+        #expect(!state.selectedTimelineIsLoadingInitialPage)
+    }
+
+    @MainActor
     @Test func initialTimelineLoadClearsWhenRuntimeIsUnavailable() async throws {
         let account = AccountItem(
             id: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5465,6 +5465,101 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func switchedAccountTimelineLoadDoesNotJoinStaleSameGroupLoad() async throws {
+        // The load coalescing key must include account ownership. Two local identities can share
+        // the same MLS group id; after switching accounts, the new account must not await the
+        // old account's still-in-flight subscription and return without opening its own timeline.
+        let primarySummary = AccountSummaryFfi(
+            label: "Primary Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let backupSummary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let primaryAccount = AccountItem(
+            id: primarySummary.label,
+            accountRef: primarySummary.label,
+            displayName: primarySummary.label,
+            accountIdHex: primarySummary.accountIdHex
+        )
+        let backupAccount = AccountItem(
+            id: backupSummary.label,
+            accountRef: backupSummary.label,
+            displayName: backupSummary.label,
+            accountIdHex: backupSummary.accountIdHex
+        )
+        let sharedGroup = "group"
+        let primaryChat = ChatItem(
+            row: chatListRow(
+                groupIdHex: sharedGroup,
+                title: "Shared Group",
+                preview: "Primary message",
+                sender: primarySummary.accountIdHex,
+                timelineAt: 1_700_000_000
+            ),
+            activeAccountIdHex: primarySummary.accountIdHex
+        )
+        let backupChat = ChatItem(
+            row: chatListRow(
+                groupIdHex: sharedGroup,
+                title: "Shared Group",
+                preview: "Backup message",
+                sender: backupSummary.accountIdHex,
+                timelineAt: 1_700_000_010
+            ),
+            activeAccountIdHex: backupSummary.accountIdHex
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primarySummary, backupSummary])
+        runtime.installGroup(messageGroup())
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "backup-message",
+                    groupIdHex: sharedGroup,
+                    sender: backupSummary.accountIdHex,
+                    plaintext: "Backup account history",
+                    kind: 9,
+                    recordedAt: 1_700_000_010
+                )
+            ],
+            groupIdHex: sharedGroup
+        )
+        runtime.timelineSubscriptionDelayNanoseconds = 50_000_000
+        let state = WorkspaceState(
+            accounts: [primaryAccount, backupAccount],
+            chatsByAccount: [
+                primaryAccount.id: [primaryChat],
+                backupAccount.id: [backupChat],
+            ],
+            clientFactory: { runtime }
+        )
+        state.activeAccountId = primaryAccount.id
+        state.selection = .chat(sharedGroup)
+        state.client = runtime
+
+        async let stalePrimaryLoad: Void = state.loadMessages(groupIdHex: sharedGroup)
+        let didStartPrimaryLoad = await waitFor {
+            runtime.timelineSubscriptionCount == 1
+        }
+        #expect(didStartPrimaryLoad)
+
+        state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
+        state.selection = .chat(sharedGroup)
+        await state.loadMessages(groupIdHex: sharedGroup)
+        _ = await stalePrimaryLoad
+
+        #expect(runtime.timelineSubscriptionAccountRefs == [primaryAccount.accountRef, backupAccount.accountRef])
+        #expect(state.messagesByChat[sharedGroup]?.map(\.id) == ["backup-message"])
+    }
+
+    @MainActor
     @Test func initialTimelineLoadClearsWhenRuntimeIsUnavailable() async throws {
         let account = AccountItem(
             id: "Desktop Account",
@@ -12682,6 +12777,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var chatListSubscriptionCount = 0
     private(set) var notificationSubscriptionCount = 0
     private(set) var timelineSubscriptionCount = 0
+    private(set) var timelineSubscriptionAccountRefs: [String] = []
     private(set) var lastTimelineSubscription: FakeTimelineMessagesSubscription?
     var chatListStreamEndsAfterUpdates = false
     /// Simulates async relay/runtime latency before a chat-list subscription is ready.
@@ -13812,6 +13908,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         -> TimelineMessagesSubscription
     {
         timelineSubscriptionCount += 1
+        timelineSubscriptionAccountRefs.append(accountRef)
         if timelineSubscriptionDelayNanoseconds > 0 {
             try await Task.sleep(nanoseconds: timelineSubscriptionDelayNanoseconds)
         }


### PR DESCRIPTION
## Summary
- Coalesce overlapping `loadMessages(groupIdHex:)` calls for the same chat onto one in-flight timeline load.
- Move the actual subscription/snapshot pass into a single-owner task and cancel only superseded different-chat loads.
- Add a regression test that starts a duplicate same-chat load while the first subscription is suspended.

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' HEAD -- . ':!Vendored'` (no conflict markers)
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` (not run: `xcodebuild` is unavailable on this Linux worker)

Fixes #332


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->