### PR TITLE
fix: preserve chat row updatedAt fallback

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -50,7 +50,8 @@ extension ChatItem {
             title = DisplayText.short(directPeer?.accountIdHex ?? row.groupIdHex)
         }
         let preview = row.lastMessage.map { ChatItem.previewText(for: $0, activeAccountIdHex: activeAccountIdHex) }
-        let timestamp = row.lastMessage?.timelineAt ?? row.updatedAt
+        let previewTimestamp = row.lastMessage?.timelineAt ?? 0
+        let timestamp = previewTimestamp > 0 ? previewTimestamp : row.updatedAt
         let updatedAt = timestamp > 0 ? Date(timeIntervalSince1970: TimeInterval(timestamp)) : nil
         let subtitle: String
         if row.archived {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -168,6 +168,45 @@ struct PureValueTests {
         #expect(chat.unreadMentionCount == Int.max)
     }
 
+    @Test func chatListRowFallsBackToUpdatedAtWhenPreviewTimelineIsUnknown() async throws {
+        // Regression for whitenoise-mac#330: a last-message preview with timelineAt == 0
+        // means the preview timestamp is unknown, so the chat row must keep using
+        // updatedAt for sidebar ordering and timestamp display.
+        let fallbackUpdatedAt: UInt64 = 1_800_000_000
+        let row = ChatListRowFfi(
+            groupIdHex: "group",
+            archived: false,
+            pendingConfirmation: false,
+            title: "Planning",
+            groupName: "Planning",
+            avatarUrl: nil,
+            avatar: nil,
+            lastMessage: ChatListMessagePreviewFfi(
+                messageIdHex: "message-1",
+                sender: "alice1234567890alice1234567890alice1234567890alice1234567890",
+                senderDisplayName: "Alice",
+                plaintext: "Queued locally",
+                contentTokens: MarkdownDocumentFfi(blocks: [], truncated: false),
+                kind: 9,
+                timelineAt: 0,
+                deleted: false
+            ),
+            unreadCount: 0,
+            hasUnread: false,
+            unreadMentionCount: 0,
+            unreadMention: false,
+            firstUnreadMessageIdHex: nil,
+            lastReadMessageIdHex: nil,
+            lastReadTimelineAt: nil,
+            updatedAt: fallbackUpdatedAt,
+            selfMembership: .member
+        )
+
+        let chat = ChatItem(row: row, activeAccountIdHex: "self")
+
+        #expect(chat.updatedAt == Date(timeIntervalSince1970: TimeInterval(fallbackUpdatedAt)))
+    }
+
     @Test func messageItemTimelineFallbackClampsPreEpochAndNonFiniteDates() async throws {
         // Regression for whitenoise-mac#247: the timelineAt fallback derives from
         // sentAt via UInt64(_:), which traps on negative (pre-1970) or non-finite


### PR DESCRIPTION
## Summary
- Treat `lastMessage.timelineAt == 0` as an unknown preview timestamp in `ChatItem` mapping.
- Fall back to `row.updatedAt` so affected chats keep their sidebar ordering and timestamp label.
- Add regression coverage for the unknown-preview-timestamp path.

## Test Plan
- `git diff --check`
- Conflict-marker scan over Swift files
- `xcodebuild` unavailable on this Linux host; macOS build/test checks skipped

Fixes #330


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/358">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->