### PR TITLE
fix: bound encrypted media disk cache

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -149,6 +149,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     typealias DirectoryResolver = @Sendable () throws -> URL
     typealias KeyProvider = @Sendable () throws -> SymmetricKey
     typealias KeyDeleter = @Sendable () -> Void
+    typealias TimestampProvider = @Sendable () -> TimeInterval
 
     struct EvictionPolicy: Sendable {
         static let standard = EvictionPolicy(
@@ -157,9 +158,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         )
 
         let maxEntryCount: Int
+        // Filesystem footprint cap for encrypted cache records. Uses allocated bytes when
+        // available so sparse/block-rounded files count the way they affect Application Support.
         let maxTotalBytes: UInt64
 
         init(maxEntryCount: Int, maxTotalBytes: UInt64) {
+            // Keep the policy total: a zero entry cap is meaningful for tests and callers that
+            // want every stored record evicted immediately.
             self.maxEntryCount = Swift.max(0, maxEntryCount)
             self.maxTotalBytes = maxTotalBytes
         }
@@ -175,6 +180,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private let directoryResolver: DirectoryResolver
     private let keyProvider: KeyProvider
     private let keyDeleter: KeyDeleter
+    private let timestampProvider: TimestampProvider
     private let evictionPolicy: EvictionPolicy
     private let lock = NSLock()
     // Serializes the filesystem create/remove/move work of commits and purges so a slow
@@ -193,11 +199,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         directoryResolver: @escaping DirectoryResolver = MessageMediaDiskCache.defaultDirectoryURL,
         keyProvider: @escaping KeyProvider = MessageMediaDiskCacheKeychain.symmetricKey,
         keyDeleter: @escaping KeyDeleter = MessageMediaDiskCacheKeychain.deleteKey,
+        timestampProvider: @escaping TimestampProvider = { Date().timeIntervalSince1970 },
         evictionPolicy: EvictionPolicy = .standard
     ) {
         self.directoryResolver = directoryResolver
         self.keyProvider = keyProvider
         self.keyDeleter = keyDeleter
+        self.timestampProvider = timestampProvider
         self.evictionPolicy = evictionPolicy
     }
 
@@ -260,13 +268,15 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         guard !Task.isCancelled, currentGeneration() == start.generation else { return }
 
         let plaintext = download.payload.data
+        let cachedAtUnixSeconds = timestampProvider()
         let prepared = await Task.detached(priority: .utility) {
             Self.prepareStagedEntry(
                 download: download,
                 plaintext: plaintext,
                 for: key,
                 root: root,
-                symmetricKey: symmetricKey
+                symmetricKey: symmetricKey,
+                cachedAtUnixSeconds: cachedAtUnixSeconds
             )
         }.value
 
@@ -436,6 +446,11 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         let byteCount: UInt64
     }
 
+    private struct CacheFootprint {
+        let entryCount: Int
+        let byteCount: UInt64
+    }
+
     private static func readDownload(
         for key: MessageMediaDiskCacheKey,
         root: URL,
@@ -494,7 +509,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         plaintext: Data,
         for key: MessageMediaDiskCacheKey,
         root: URL,
-        symmetricKey: SymmetricKey
+        symmetricKey: SymmetricKey,
+        cachedAtUnixSeconds: TimeInterval
     ) -> PreparedEntry? {
         guard hexSHA256(plaintext) == key.plaintextSha256 else { return nil }
 
@@ -511,7 +527,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             fileName: download.fileName,
             mediaType: download.mediaType,
             sizeBytes: download.sizeBytes,
-            cachedAtUnixSeconds: Date().timeIntervalSince1970
+            cachedAtUnixSeconds: cachedAtUnixSeconds
         )
 
         do {
@@ -619,6 +635,11 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         root: URL,
         symmetricKey: SymmetricKey
     ) {
+        let footprint = cacheFootprint(root: root)
+        guard footprint.entryCount > policy.maxEntryCount || footprint.byteCount > policy.maxTotalBytes else {
+            return
+        }
+
         var entries = cacheEntries(root: root, symmetricKey: symmetricKey)
         var totalBytes = entries.reduce(UInt64(0)) { total, entry in
             addingWithSaturation(total, entry.byteCount)
@@ -651,6 +672,40 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             }
         }
         removeEmptyDirectory(root)
+    }
+
+    private static func cacheFootprint(root: URL) -> CacheFootprint {
+        guard
+            let shardDirectories = try? FileManager.default.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else { return CacheFootprint(entryCount: 0, byteCount: 0) }
+
+        var entryCount = 0
+        var byteCount: UInt64 = 0
+        for shardDirectory in shardDirectories where shardDirectory.lastPathComponent != "staging" {
+            guard isDirectory(shardDirectory),
+                let entryDirectories = try? FileManager.default.contentsOfDirectory(
+                    at: shardDirectory,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+            else { continue }
+
+            for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
+                entryCount += 1
+                byteCount = addingWithSaturation(
+                    byteCount,
+                    addingWithSaturation(
+                        fileByteCount(at: entryDirectory.appendingPathComponent(metadataFileName)),
+                        fileByteCount(at: entryDirectory.appendingPathComponent(payloadFileName))
+                    )
+                )
+            }
+        }
+        return CacheFootprint(entryCount: entryCount, byteCount: byteCount)
     }
 
     private static func cacheEntries(root: URL, symmetricKey: SymmetricKey) -> [CacheEntry] {

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -150,6 +150,21 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     typealias KeyProvider = @Sendable () throws -> SymmetricKey
     typealias KeyDeleter = @Sendable () -> Void
 
+    struct EvictionPolicy: Sendable {
+        static let standard = EvictionPolicy(
+            maxEntryCount: 2_048,
+            maxTotalBytes: 512 * 1024 * 1024
+        )
+
+        let maxEntryCount: Int
+        let maxTotalBytes: UInt64
+
+        init(maxEntryCount: Int, maxTotalBytes: UInt64) {
+            self.maxEntryCount = Swift.max(0, maxEntryCount)
+            self.maxTotalBytes = maxTotalBytes
+        }
+    }
+
     static let shared = MessageMediaDiskCache()
 
     private static let directoryName = "WhiteNoiseMediaCache"
@@ -160,6 +175,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private let directoryResolver: DirectoryResolver
     private let keyProvider: KeyProvider
     private let keyDeleter: KeyDeleter
+    private let evictionPolicy: EvictionPolicy
     private let lock = NSLock()
     // Serializes the filesystem create/remove/move work of commits and purges so a slow
     // commit never blocks generation reads or purge bookkeeping (which stay on `lock`).
@@ -176,11 +192,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     init(
         directoryResolver: @escaping DirectoryResolver = MessageMediaDiskCache.defaultDirectoryURL,
         keyProvider: @escaping KeyProvider = MessageMediaDiskCacheKeychain.symmetricKey,
-        keyDeleter: @escaping KeyDeleter = MessageMediaDiskCacheKeychain.deleteKey
+        keyDeleter: @escaping KeyDeleter = MessageMediaDiskCacheKeychain.deleteKey,
+        evictionPolicy: EvictionPolicy = .standard
     ) {
         self.directoryResolver = directoryResolver
         self.keyProvider = keyProvider
         self.keyDeleter = keyDeleter
+        self.evictionPolicy = evictionPolicy
     }
 
     static func defaultDirectoryURL() throws -> URL {
@@ -257,7 +275,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             Self.discardPreparedEntry(prepared)
             return
         }
-        commitPreparedEntry(prepared, startGeneration: start.generation)
+        commitPreparedEntry(prepared, startGeneration: start.generation, symmetricKey: symmetricKey)
     }
 
     func purgeAll(removeEncryptionKey: Bool = false) async {
@@ -355,7 +373,11 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         lock.unlock()
     }
 
-    private func commitPreparedEntry(_ prepared: PreparedEntry, startGeneration: Int) {
+    private func commitPreparedEntry(
+        _ prepared: PreparedEntry,
+        startGeneration: Int,
+        symmetricKey: SymmetricKey
+    ) {
         // Hold only the narrow filesystem-mutation lock across the slow create/remove/move
         // so generation reads and purge bookkeeping (on `lock`) never block on this commit.
         // The generation re-check happens under `fileMutationLock`: a purge bumps the
@@ -376,6 +398,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             )
             try? FileManager.default.removeItem(at: prepared.finalDirectory)
             try FileManager.default.moveItem(at: prepared.stagingDirectory, to: prepared.finalDirectory)
+            Self.enforceEvictionPolicy(evictionPolicy, root: prepared.root, symmetricKey: symmetricKey)
         } catch {
             try? FileManager.default.removeItem(at: prepared.stagingDirectory)
         }
@@ -405,6 +428,12 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private struct PurgeHandle {
         let task: Task<Void, Never>
         let generation: Int
+    }
+
+    private struct CacheEntry {
+        let directory: URL
+        let cachedAtUnixSeconds: TimeInterval
+        let byteCount: UInt64
     }
 
     private static func readDownload(
@@ -583,6 +612,119 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 }
             }
         }
+    }
+
+    private static func enforceEvictionPolicy(
+        _ policy: EvictionPolicy,
+        root: URL,
+        symmetricKey: SymmetricKey
+    ) {
+        var entries = cacheEntries(root: root, symmetricKey: symmetricKey)
+        var totalBytes = entries.reduce(UInt64(0)) { total, entry in
+            addingWithSaturation(total, entry.byteCount)
+        }
+        var remainingCount = entries.count
+
+        guard remainingCount > policy.maxEntryCount || totalBytes > policy.maxTotalBytes else {
+            return
+        }
+
+        entries.sort {
+            if $0.cachedAtUnixSeconds == $1.cachedAtUnixSeconds {
+                return $0.directory.path < $1.directory.path
+            }
+            return $0.cachedAtUnixSeconds < $1.cachedAtUnixSeconds
+        }
+
+        for entry in entries {
+            guard remainingCount > policy.maxEntryCount || totalBytes > policy.maxTotalBytes else {
+                break
+            }
+
+            do {
+                try FileManager.default.removeItem(at: entry.directory)
+                remainingCount -= 1
+                totalBytes = totalBytes > entry.byteCount ? totalBytes - entry.byteCount : 0
+                removeEmptyDirectory(entry.directory.deletingLastPathComponent())
+            } catch {
+                continue
+            }
+        }
+        removeEmptyDirectory(root)
+    }
+
+    private static func cacheEntries(root: URL, symmetricKey: SymmetricKey) -> [CacheEntry] {
+        guard
+            let shardDirectories = try? FileManager.default.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else { return [] }
+
+        var entries: [CacheEntry] = []
+        for shardDirectory in shardDirectories where shardDirectory.lastPathComponent != "staging" {
+            guard isDirectory(shardDirectory),
+                let entryDirectories = try? FileManager.default.contentsOfDirectory(
+                    at: shardDirectory,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+            else { continue }
+
+            for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
+                let cacheID = entryDirectory.lastPathComponent
+                let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
+                let payloadURL = entryDirectory.appendingPathComponent(payloadFileName)
+                guard let metadataData = try? Data(contentsOf: metadataURL),
+                    let metadataPlaintext = try? open(
+                        metadataData,
+                        using: symmetricKey,
+                        authenticatedBy: metadataAAD(for: cacheID)
+                    ),
+                    let metadata = try? JSONDecoder().decode(Metadata.self, from: metadataPlaintext),
+                    metadata.version == 1
+                else {
+                    try? FileManager.default.removeItem(at: entryDirectory)
+                    removeEmptyDirectory(shardDirectory)
+                    continue
+                }
+
+                entries.append(
+                    CacheEntry(
+                        directory: entryDirectory,
+                        cachedAtUnixSeconds: metadata.cachedAtUnixSeconds,
+                        byteCount: addingWithSaturation(
+                            fileByteCount(at: metadataURL),
+                            fileByteCount(at: payloadURL)
+                        )
+                    )
+                )
+            }
+        }
+        return entries
+    }
+
+    private static func isDirectory(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+    }
+
+    private static func fileByteCount(at url: URL) -> UInt64 {
+        guard
+            let values = try? url.resourceValues(forKeys: [
+                .totalFileAllocatedSizeKey,
+                .fileAllocatedSizeKey,
+                .fileSizeKey,
+            ])
+        else { return 0 }
+
+        let byteCount = values.totalFileAllocatedSize ?? values.fileAllocatedSize ?? values.fileSize ?? 0
+        return UInt64(Swift.max(0, byteCount))
+    }
+
+    private static func addingWithSaturation(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? .max : sum
     }
 
     private static func prepareDirectory(_ root: URL) throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1614,6 +1614,109 @@ struct whitenoise_macTests {
         #expect(!fileManager.fileExists(atPath: entryDirectory.path))
     }
 
+    @Test func messageMediaDiskCacheEvictsOldestEntriesWhenEntryLimitExceeded() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 2, maxTotalBytes: UInt64.max)
+        )
+        let firstPlaintext = Data("first cached media".utf8)
+        let secondPlaintext = Data("second cached media".utf8)
+        let thirdPlaintext = Data("third cached media".utf8)
+        let firstKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: firstPlaintext, ciphertextByte: 0xa1)
+        )
+        let secondKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: secondPlaintext, ciphertextByte: 0xa2)
+        )
+        let thirdKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: thirdPlaintext, ciphertextByte: 0xa3)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: firstPlaintext,
+                fileName: "first.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(firstPlaintext.count),
+                payloadId: "first"
+            ),
+            for: firstKey
+        )
+        usleep(1_000)
+        await cache.store(
+            MessageMediaDownload(
+                data: secondPlaintext,
+                fileName: "second.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(secondPlaintext.count),
+                payloadId: "second"
+            ),
+            for: secondKey
+        )
+        usleep(1_000)
+        await cache.store(
+            MessageMediaDownload(
+                data: thirdPlaintext,
+                fileName: "third.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(thirdPlaintext.count),
+                payloadId: "third"
+            ),
+            for: thirdKey
+        )
+
+        #expect(await cache.cachedDownload(for: firstKey) == nil)
+        #expect(try #require(await cache.cachedDownload(for: secondKey)).data == secondPlaintext)
+        #expect(try #require(await cache.cachedDownload(for: thirdKey)).data == thirdPlaintext)
+
+        let cacheFiles = try fileManager.subpathsOfDirectory(atPath: root.path)
+        #expect(cacheFiles.filter { $0.hasSuffix("payload.bin") }.count == 2)
+    }
+
+    @Test func messageMediaDiskCacheEvictsEntryWhenByteLimitExceeded() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 10, maxTotalBytes: 1)
+        )
+        let plaintext = Data("media larger than the byte cap".utf8)
+        let key = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: plaintext)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: plaintext,
+                fileName: "oversized.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(plaintext.count),
+                payloadId: "oversized"
+            ),
+            for: key
+        )
+
+        #expect(await cache.cachedDownload(for: key) == nil)
+        let cacheFiles = (try? fileManager.subpathsOfDirectory(atPath: root.path)) ?? []
+        #expect(!cacheFiles.contains { $0.hasSuffix("payload.bin") })
+    }
+
     @Test func messageMediaDiskCacheAccountPurgeSkipsUnreadableEntries() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
@@ -15381,12 +15484,14 @@ private func formatMilliseconds(_ milliseconds: Double) -> String {
 private func messageMediaDiskCache(
     root: URL,
     keyData: Data = Data(repeating: 0x42, count: 32),
+    evictionPolicy: MessageMediaDiskCache.EvictionPolicy = .standard,
     keyDeleter: @escaping @Sendable () -> Void = {}
 ) -> MessageMediaDiskCache {
     MessageMediaDiskCache(
         directoryResolver: { root },
         keyProvider: { SymmetricKey(data: keyData) },
-        keyDeleter: keyDeleter
+        keyDeleter: keyDeleter,
+        evictionPolicy: evictionPolicy
     )
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1620,9 +1620,11 @@ struct whitenoise_macTests {
             .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
         defer { try? fileManager.removeItem(at: root) }
 
+        let cachedAtCounter = AtomicCounter()
         let cache = messageMediaDiskCache(
             root: root,
-            evictionPolicy: .init(maxEntryCount: 2, maxTotalBytes: UInt64.max)
+            evictionPolicy: .init(maxEntryCount: 2, maxTotalBytes: UInt64.max),
+            timestampProvider: { TimeInterval(cachedAtCounter.increment()) }
         )
         let firstPlaintext = Data("first cached media".utf8)
         let secondPlaintext = Data("second cached media".utf8)
@@ -1653,7 +1655,6 @@ struct whitenoise_macTests {
             ),
             for: firstKey
         )
-        usleep(1_000)
         await cache.store(
             MessageMediaDownload(
                 data: secondPlaintext,
@@ -1664,7 +1665,6 @@ struct whitenoise_macTests {
             ),
             for: secondKey
         )
-        usleep(1_000)
         await cache.store(
             MessageMediaDownload(
                 data: thirdPlaintext,
@@ -15485,12 +15485,14 @@ private func messageMediaDiskCache(
     root: URL,
     keyData: Data = Data(repeating: 0x42, count: 32),
     evictionPolicy: MessageMediaDiskCache.EvictionPolicy = .standard,
+    timestampProvider: @escaping MessageMediaDiskCache.TimestampProvider = { Date().timeIntervalSince1970 },
     keyDeleter: @escaping @Sendable () -> Void = {}
 ) -> MessageMediaDiskCache {
     MessageMediaDiskCache(
         directoryResolver: { root },
         keyProvider: { SymmetricKey(data: keyData) },
         keyDeleter: keyDeleter,
+        timestampProvider: timestampProvider,
         evictionPolicy: evictionPolicy
     )
 }


### PR DESCRIPTION
## Summary
- add a standard MessageMediaDiskCache eviction policy capped by entry count and total on-disk bytes
- evict oldest cached entries after successful stores using cachedAtUnixSeconds metadata
- cover entry-count eviction and byte-limit eviction in media disk cache tests

## Test Plan
- `git diff --check`
- `xcodebuild`/Swift tests not run: unavailable on this Linux host

Fixes #328


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/359">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->