### PR TITLE
fix: clean corrupt media cache entries after account purge

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -687,9 +687,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 using: symmetricKey,
                 authenticatedBy: metadataAAD(for: cacheID)
             ),
-            let metadata = try? JSONDecoder().decode(Metadata.self, from: metadataPlaintext),
-            metadata.version == 1
+            let metadata = try? JSONDecoder().decode(Metadata.self, from: metadataPlaintext)
         else { return .corrupt }
+        guard metadata.version == 1 else {
+            // A decryptable, decodable record with a different version may belong to a
+            // newer cache format. Skip it instead of reclaiming it account-agnostically.
+            return .unavailable
+        }
         return .readable(metadata)
     }
 

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -322,6 +322,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 root: root,
                 symmetricKey: symmetricKey
             )
+            // Keep account matching separate from corrupt-entry reclamation. The first
+            // pass only removes entries it can attribute to the target account; this
+            // second pass is account-agnostic and deletes entries no account can read.
+            Self.removeUnreadableEntries(root: root, symmetricKey: symmetricKey)
         }
         await task.task.value
         finishPurge(task)
@@ -449,6 +453,12 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private struct CacheFootprint {
         let entryCount: Int
         let byteCount: UInt64
+    }
+
+    private enum MetadataStatus {
+        case readable(Metadata)
+        case corrupt
+        case unavailable
     }
 
     private static func readDownload(
@@ -607,27 +617,80 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 )
             else { continue }
 
-            for entryDirectory in entryDirectories {
-                let cacheID = entryDirectory.lastPathComponent
-                let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
-                guard let metadataData = try? Data(contentsOf: metadataURL),
-                    let metadataPlaintext = try? open(
-                        metadataData,
-                        using: symmetricKey,
-                        authenticatedBy: metadataAAD(for: cacheID)
-                    ),
-                    let metadata = try? JSONDecoder().decode(Metadata.self, from: metadataPlaintext)
+            for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
+                guard
+                    case .readable(let metadata) = metadataStatus(
+                        in: entryDirectory,
+                        symmetricKey: symmetricKey
+                    )
                 else {
                     // A per-account purge cannot prove an unreadable entry belongs to the
-                    // target account. Skip it instead of deleting unrelated account caches
-                    // because of a transient read/decrypt failure.
+                    // target account. Skip it here; the account-agnostic cleanup pass owns
+                    // corrupt-entry reclamation.
                     continue
                 }
                 if metadata.accountDigest == accountDigest {
                     try? FileManager.default.removeItem(at: entryDirectory)
+                    removeEmptyDirectory(shardDirectory)
                 }
             }
         }
+    }
+
+    private static func removeUnreadableEntries(root: URL, symmetricKey: SymmetricKey) {
+        guard
+            let shardDirectories = try? FileManager.default.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else { return }
+
+        for shardDirectory in shardDirectories where shardDirectory.lastPathComponent != "staging" {
+            guard isDirectory(shardDirectory),
+                let entryDirectories = try? FileManager.default.contentsOfDirectory(
+                    at: shardDirectory,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+            else { continue }
+
+            for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
+                guard case .corrupt = metadataStatus(in: entryDirectory, symmetricKey: symmetricKey) else {
+                    continue
+                }
+                try? FileManager.default.removeItem(at: entryDirectory)
+                removeEmptyDirectory(shardDirectory)
+            }
+        }
+        removeEmptyDirectory(root)
+    }
+
+    private static func metadataStatus(in entryDirectory: URL, symmetricKey: SymmetricKey) -> MetadataStatus {
+        let cacheID = entryDirectory.lastPathComponent
+        let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
+        guard FileManager.default.fileExists(atPath: metadataURL.path) else { return .corrupt }
+
+        let metadataData: Data
+        do {
+            metadataData = try Data(contentsOf: metadataURL)
+        } catch {
+            // Do not reclaim entries whose metadata could not be read at all; a transient
+            // filesystem read failure is exactly what the per-account purge must not turn
+            // into collateral deletion.
+            return .unavailable
+        }
+
+        guard
+            let metadataPlaintext = try? open(
+                metadataData,
+                using: symmetricKey,
+                authenticatedBy: metadataAAD(for: cacheID)
+            ),
+            let metadata = try? JSONDecoder().decode(Metadata.self, from: metadataPlaintext),
+            metadata.version == 1
+        else { return .corrupt }
+        return .readable(metadata)
     }
 
     private static func enforceEvictionPolicy(
@@ -728,20 +791,17 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             else { continue }
 
             for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
-                let cacheID = entryDirectory.lastPathComponent
                 let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
                 let payloadURL = entryDirectory.appendingPathComponent(payloadFileName)
-                guard let metadataData = try? Data(contentsOf: metadataURL),
-                    let metadataPlaintext = try? open(
-                        metadataData,
-                        using: symmetricKey,
-                        authenticatedBy: metadataAAD(for: cacheID)
-                    ),
-                    let metadata = try? JSONDecoder().decode(Metadata.self, from: metadataPlaintext),
-                    metadata.version == 1
-                else {
+                let metadata: Metadata
+                switch metadataStatus(in: entryDirectory, symmetricKey: symmetricKey) {
+                case .readable(let decodedMetadata):
+                    metadata = decodedMetadata
+                case .corrupt:
                     try? FileManager.default.removeItem(at: entryDirectory)
                     removeEmptyDirectory(shardDirectory)
+                    continue
+                case .unavailable:
                     continue
                 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1846,6 +1846,77 @@ struct whitenoise_macTests {
         #expect(fileManager.fileExists(atPath: unavailablePayloadURL.path))
     }
 
+    @Test func messageMediaDiskCacheAccountPurgePreservesFutureMetadataVersions() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let keyData = Data(repeating: 0x42, count: 32)
+        let cache = messageMediaDiskCache(root: root, keyData: keyData)
+        let purgedPlaintext = Data("purged account media".utf8)
+        let futurePlaintext = Data("other account media with future metadata".utf8)
+        let purgedKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: purgedPlaintext, ciphertextByte: 0xaa)
+        )
+        let futureKey = MessageMediaDiskCacheKey(
+            accountId: "account-b",
+            groupIdHex: "group-b",
+            reference: mediaDiskCacheReference(plaintext: futurePlaintext, ciphertextByte: 0xbe)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: purgedPlaintext,
+                fileName: "purged.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(purgedPlaintext.count),
+                payloadId: "purged"
+            ),
+            for: purgedKey
+        )
+        await cache.store(
+            MessageMediaDownload(
+                data: futurePlaintext,
+                fileName: "future.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(futurePlaintext.count),
+                payloadId: "future"
+            ),
+            for: futureKey
+        )
+
+        let purgedEntryDirectory = try #require(cache.entryDirectory(for: purgedKey))
+        let futureEntryDirectory = try #require(cache.entryDirectory(for: futureKey))
+        let futureMetadataURL = futureEntryDirectory.appendingPathComponent("metadata.bin")
+        let futurePayloadURL = futureEntryDirectory.appendingPathComponent("payload.bin")
+        let futureMetadataPlaintext = try JSONSerialization.data(withJSONObject: [
+            "version": 2,
+            "accountDigest": futureKey.accountDigest,
+            "ciphertextSha256": futureKey.ciphertextSha256,
+            "plaintextSha256": futureKey.plaintextSha256,
+            "fileName": "future.jpg",
+            "mediaType": "image/jpeg",
+            "sizeBytes": UInt64(futurePlaintext.count),
+            "cachedAtUnixSeconds": 1_234,
+        ])
+        let futureMetadataBox = try AES.GCM.seal(
+            futureMetadataPlaintext,
+            using: SymmetricKey(data: keyData),
+            authenticating: Data("white-noise-media-cache-metadata-v1|\(futureKey.cacheID)".utf8)
+        )
+        let futureMetadataData = try #require(futureMetadataBox.combined)
+        try futureMetadataData.write(to: futureMetadataURL)
+
+        await cache.purgeAccount("account-a")
+
+        #expect(!fileManager.fileExists(atPath: purgedEntryDirectory.path))
+        #expect(fileManager.fileExists(atPath: futureMetadataURL.path))
+        #expect(fileManager.fileExists(atPath: futurePayloadURL.path))
+    }
+
     @Test func messageMediaDiskCachePurgesByAccountAndFullWipeDeletesKey() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1717,7 +1717,7 @@ struct whitenoise_macTests {
         #expect(!cacheFiles.contains { $0.hasSuffix("payload.bin") })
     }
 
-    @Test func messageMediaDiskCacheAccountPurgeSkipsUnreadableEntries() async throws {
+    @Test func messageMediaDiskCacheAccountPurgeCleansUnreadableEntriesAfterAccountPass() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
@@ -1726,6 +1726,7 @@ struct whitenoise_macTests {
         let cache = messageMediaDiskCache(root: root)
         let purgedPlaintext = Data("purged account media".utf8)
         let unreadablePlaintext = Data("other account media with unreadable metadata".utf8)
+        let preservedPlaintext = Data("other account readable media".utf8)
         let purgedKey = MessageMediaDiskCacheKey(
             accountId: "account-a",
             groupIdHex: "group-a",
@@ -1735,6 +1736,11 @@ struct whitenoise_macTests {
             accountId: "account-b",
             groupIdHex: "group-b",
             reference: mediaDiskCacheReference(plaintext: unreadablePlaintext, ciphertextByte: 0xbb)
+        )
+        let preservedKey = MessageMediaDiskCacheKey(
+            accountId: "account-b",
+            groupIdHex: "group-b",
+            reference: mediaDiskCacheReference(plaintext: preservedPlaintext, ciphertextByte: 0xbc)
         )
 
         await cache.store(
@@ -1757,6 +1763,16 @@ struct whitenoise_macTests {
             ),
             for: unreadableKey
         )
+        await cache.store(
+            MessageMediaDownload(
+                data: preservedPlaintext,
+                fileName: "preserved.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(preservedPlaintext.count),
+                payloadId: "preserved"
+            ),
+            for: preservedKey
+        )
 
         let purgedEntryDirectory = try #require(cache.entryDirectory(for: purgedKey))
         let unreadableEntryDirectory = try #require(cache.entryDirectory(for: unreadableKey))
@@ -1767,9 +1783,10 @@ struct whitenoise_macTests {
         await cache.purgeAccount("account-a")
 
         #expect(!fileManager.fileExists(atPath: purgedEntryDirectory.path))
-        // Do not assert via cachedDownload(for:): reading this intentionally
-        // unreadable entry would trigger corrupt-entry read repair and delete it.
-        #expect(fileManager.fileExists(atPath: unreadableEntryDirectory.path))
+        // The corrupt-entry cleanup is account-agnostic: readable entries for other
+        // accounts survive, while entries whose metadata no account can decode are removed.
+        #expect(!fileManager.fileExists(atPath: unreadableEntryDirectory.path))
+        #expect(try #require(await cache.cachedDownload(for: preservedKey)).data == preservedPlaintext)
     }
 
     @Test func messageMediaDiskCachePurgesByAccountAndFullWipeDeletesKey() async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1789,6 +1789,63 @@ struct whitenoise_macTests {
         #expect(try #require(await cache.cachedDownload(for: preservedKey)).data == preservedPlaintext)
     }
 
+    @Test func messageMediaDiskCacheAccountPurgePreservesEntriesWhenMetadataCannotBeRead() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(root: root)
+        let purgedPlaintext = Data("purged account media".utf8)
+        let unavailablePlaintext = Data("other account media with unavailable metadata".utf8)
+        let purgedKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: purgedPlaintext, ciphertextByte: 0xaa)
+        )
+        let unavailableKey = MessageMediaDiskCacheKey(
+            accountId: "account-b",
+            groupIdHex: "group-b",
+            reference: mediaDiskCacheReference(plaintext: unavailablePlaintext, ciphertextByte: 0xbd)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: purgedPlaintext,
+                fileName: "purged.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(purgedPlaintext.count),
+                payloadId: "purged"
+            ),
+            for: purgedKey
+        )
+        await cache.store(
+            MessageMediaDownload(
+                data: unavailablePlaintext,
+                fileName: "unavailable.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(unavailablePlaintext.count),
+                payloadId: "unavailable"
+            ),
+            for: unavailableKey
+        )
+
+        let purgedEntryDirectory = try #require(cache.entryDirectory(for: purgedKey))
+        let unavailableEntryDirectory = try #require(cache.entryDirectory(for: unavailableKey))
+        let unavailableMetadataURL = unavailableEntryDirectory.appendingPathComponent("metadata.bin")
+        let unavailablePayloadURL = unavailableEntryDirectory.appendingPathComponent("payload.bin")
+        try fileManager.removeItem(at: unavailableMetadataURL)
+        try fileManager.createDirectory(at: unavailableMetadataURL, withIntermediateDirectories: false)
+
+        await cache.purgeAccount("account-a")
+
+        #expect(!fileManager.fileExists(atPath: purgedEntryDirectory.path))
+        var metadataIsDirectory = ObjCBool(false)
+        #expect(fileManager.fileExists(atPath: unavailableMetadataURL.path, isDirectory: &metadataIsDirectory))
+        #expect(metadataIsDirectory.boolValue)
+        #expect(fileManager.fileExists(atPath: unavailablePayloadURL.path))
+    }
+
     @Test func messageMediaDiskCachePurgesByAccountAndFullWipeDeletesKey() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
## Summary
- run an account-agnostic corrupt metadata cleanup pass after per-account media cache purge
- keep the per-account purge guard: entries with metadata that cannot be read at all are skipped instead of treated as target-account matches
- update the media disk cache regression to prove readable entries for other accounts survive while corrupt metadata entries are reclaimed

## Test Plan
- `git diff --check`
- GitHub: PR Checks pass
- GitHub: Static Analysis pass
- GitHub: CodeRabbit status success, but the posted comment says review was rate-limited and no actionable findings were produced
- Local `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` unavailable on this Linux host (`xcodebuild: command not found`)
- Local `swift --version` unavailable on this Linux host (`swift: command not found`)

Fixes #356


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account-based cache cleanup to remove leftover corrupted media entries during purge.
  * Ensured valid media from other accounts remains available after clearing one account’s cache.
  * Better handling of unreadable cache data so it no longer lingers in storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->