### PR TITLE
fix: guard audit log file loads

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -576,6 +576,7 @@ extension WorkspaceState {
         isSavingNotifications = false
         isSavingPrivacySecurity = false
         isLoadingAuditLogFiles = false
+        shouldReloadAuditLogFilesAfterCurrentLoad = false
         isDeletingAuditLogFiles = false
         isUploadingAuditLogFiles = false
         deletingKeyPackageId = nil

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -567,21 +567,31 @@ extension WorkspaceState {
     func loadAuditLogFiles() async {
         guard let client else {
             auditLogFiles = []
+            shouldReloadAuditLogFilesAfterCurrentLoad = false
             return
         }
-        guard !isLoadingAuditLogFiles else { return }
+        guard !isLoadingAuditLogFiles else {
+            shouldReloadAuditLogFilesAfterCurrentLoad = true
+            return
+        }
 
         isLoadingAuditLogFiles = true
-        defer { isLoadingAuditLogFiles = false }
-
-        do {
-            auditLogFiles = try await runOffMain {
-                try client.auditLogFiles()
-            }
-        } catch {
-            auditLogFiles = []
-            lastError = error.localizedDescription
+        defer {
+            isLoadingAuditLogFiles = false
+            shouldReloadAuditLogFilesAfterCurrentLoad = false
         }
+
+        repeat {
+            shouldReloadAuditLogFilesAfterCurrentLoad = false
+            do {
+                auditLogFiles = try await runOffMain {
+                    try client.auditLogFiles()
+                }
+            } catch {
+                auditLogFiles = []
+                lastError = error.localizedDescription
+            }
+        } while shouldReloadAuditLogFilesAfterCurrentLoad
     }
 
     func deleteAllAuditLogFiles() async {

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -569,6 +569,7 @@ extension WorkspaceState {
             auditLogFiles = []
             return
         }
+        guard !isLoadingAuditLogFiles else { return }
 
         isLoadingAuditLogFiles = true
         defer { isLoadingAuditLogFiles = false }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -618,6 +618,7 @@ final class WorkspaceState {
     var isSavingNotifications = false
     var isSavingPrivacySecurity = false
     var isLoadingAuditLogFiles = false
+    @ObservationIgnored var shouldReloadAuditLogFilesAfterCurrentLoad = false
     var isDeletingAuditLogFiles = false
     var isUploadingAuditLogFiles = false
     var isDeletingAllData = false

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -305,6 +305,46 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func overlappingAuditLogFileLoadsAreDroppedWhileLoadIsInFlight() async throws {
+        // Regression for #366: loadAuditLogFiles() owns a shared spinner flag. A second
+        // overlapping load must return at entry rather than enqueue another FFI fetch whose
+        // completion can race the first load's defer and clear the spinner early.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        runtime.clearSyncCallThreadRecords()
+        runtime.auditLogFilesGateEnabled = true
+
+        async let firstLoad: Void = state.loadAuditLogFiles()
+        while !(state.isLoadingAuditLogFiles && runtime.didReachAuditLogFilesGate) {
+            await Task.yield()
+        }
+
+        async let secondLoad: Void = state.loadAuditLogFiles()
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        #expect(state.isLoadingAuditLogFiles)
+        #expect(runtime.syncCallThreadRecord("auditLogFiles").count == 1)
+
+        runtime.releaseAuditLogFilesGate()
+        await firstLoad
+        await secondLoad
+
+        #expect(runtime.syncCallThreadRecord("auditLogFiles").count == 1)
+        #expect(state.isLoadingAuditLogFiles == false)
+    }
+
+    @MainActor
     @Test func addingSecondAccountViaLoginBringsItOnlineWithoutRelaunch() async throws {
         // Regression for #74: the Settings → Add Account flow reuses login()/
         // signUp() while the runtime is already running. The new account must be
@@ -12820,6 +12860,17 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var didReachSetLocalNotificationsGate: Bool {
         setLocalNotificationsGate.didReach
     }
+    /// Issue #366 reentrancy-test support: when armed, the first synchronous
+    /// `auditLogFiles` read blocks on the off-main FFI batch while a test issues
+    /// an overlapping load that must be dropped by WorkspaceState.
+    private let auditLogFilesGate = BlockingFfiGate()
+    var auditLogFilesGateEnabled: Bool {
+        get { auditLogFilesGate.isEnabled }
+        set { auditLogFilesGate.isEnabled = newValue }
+    }
+    var didReachAuditLogFilesGate: Bool {
+        auditLogFilesGate.didReach
+    }
     /// Issue #283 stale-account-test support: when armed, the first synchronous `userProfile` FFI
     /// read blocks on the off-main FFI batch until released, holding `performSettingsLoad`'s profile
     /// fetch in-flight so a test can switch the active account and assert account A's stale profile
@@ -13239,6 +13290,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func auditLogFiles() throws -> [AuditLogFileFfi] {
         recordSyncCall("auditLogFiles")
+        auditLogFilesGate.passIfArmed()
         return storedAuditLogFiles
     }
 
@@ -13317,6 +13369,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func releaseSetLocalNotificationsGate() {
         setLocalNotificationsGate.release()
+    }
+
+    func releaseAuditLogFilesGate() {
+        auditLogFilesGate.release()
     }
 
     func setRelayTelemetryRuntimeConfig(config: RelayTelemetryRuntimeConfigFfi) async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -305,10 +305,11 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func overlappingAuditLogFileLoadsAreDroppedWhileLoadIsInFlight() async throws {
+    @Test func overlappingAuditLogFileLoadsCoalesceWhileLoadIsInFlight() async throws {
         // Regression for #366: loadAuditLogFiles() owns a shared spinner flag. A second
-        // overlapping load must return at entry rather than enqueue another FFI fetch whose
-        // completion can race the first load's defer and clear the spinner early.
+        // overlapping load must not enqueue a concurrent FFI fetch whose completion can race
+        // the first load's defer, but it should request one fresh pass after the current load
+        // so mutation-triggered refreshes are not dropped.
         let account = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -340,7 +341,7 @@ struct whitenoise_macTests {
         await firstLoad
         await secondLoad
 
-        #expect(runtime.syncCallThreadRecord("auditLogFiles").count == 1)
+        #expect(runtime.syncCallThreadRecord("auditLogFiles").count == 2)
         #expect(state.isLoadingAuditLogFiles == false)
     }
 
@@ -12862,7 +12863,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
     /// Issue #366 reentrancy-test support: when armed, the first synchronous
     /// `auditLogFiles` read blocks on the off-main FFI batch while a test issues
-    /// an overlapping load that must be dropped by WorkspaceState.
+    /// an overlapping load that must be coalesced by WorkspaceState.
     private let auditLogFilesGate = BlockingFfiGate()
     var auditLogFilesGateEnabled: Bool {
         get { auditLogFilesGate.isEnabled }


### PR DESCRIPTION
## Summary
- add an entry reentrancy guard to `loadAuditLogFiles()` so overlapping audit-log refreshes return while a load is in flight
- add a gated regression test proving an overlapping load does not enqueue a second audit-log FFI fetch

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- .`
- Not run: `xcodebuild` / Swift tests (`xcodebuild` and `swift` are unavailable on this Linux worker)

Fixes #366


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/367">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->