### PR TITLE
fix: avoid redundant media cache invalidation

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -259,10 +259,6 @@ extension WorkspaceState {
         }
         guard !upsertRecords.isEmpty || !removalIds.isEmpty else { return }
 
-        if upsertRecords.contains(where: { timelineRecordMayContainMediaAttachment($0) }) {
-            clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: groupIdHex)
-        }
-
         // Resolve senders for just the changed records (the common case is an all-cached
         // lookup) and map only those records — not the entire window.
         let senderProfiles = await TimelineSignpost.mapping.asyncInterval(
@@ -301,6 +297,25 @@ extension WorkspaceState {
         // does. Existing rows still update in place (edits, reactions, delivery state).
         let anchored = !paging.hasMoreAfter
         let timelineStore = ensureMessageTimelineStore(for: groupIdHex)
+
+        // Only invalidate the per-group media-reference resolution cache when a projection
+        // actually introduces new or changed media attachments. A single media send emits a
+        // burst of projection deltas (new row, delivery-state transitions, relay echo,
+        // per-relay acks) that re-carry the same media fields; clearing on every one of those
+        // re-runs full media resolution for visible `sourceEpoch == 0` tiles. Comparing the
+        // mapped `MessageItem.mediaAttachments` against the current store entry (still
+        // pre-mutation here — `applyProjection` mutates it below) skips the clear for those
+        // pure delivery-state/projection ticks. Read against `timelineStore.lookup` because it
+        // holds the current pre-mutation entry for any message already in the rendered window.
+        let introducesMediaChange = mappedUpserts.contains { upsert in
+            let currentAttachments = timelineStore.lookup[upsert.id]?.mediaAttachments ?? []
+            guard !currentAttachments.isEmpty || !upsert.mediaAttachments.isEmpty else { return false }
+            return currentAttachments != upsert.mediaAttachments
+        }
+        if introducesMediaChange {
+            clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: groupIdHex)
+        }
+
         let result = TimelineSignpost.store.interval(
             "applyProjection", count: mappedUpserts.count + removalIds.count
         ) {
@@ -323,12 +338,6 @@ extension WorkspaceState {
             )
         )
         await markLatestVisibleMessageRead(groupIdHex: groupIdHex, account: account, client: client)
-    }
-
-    private func timelineRecordMayContainMediaAttachment(_ record: TimelineMessageRecordFfi) -> Bool {
-        if !record.media.isEmpty { return true }
-        if record.mediaJson?.isEmpty == false { return true }
-        return record.tags.contains { $0.values.first == "imeta" }
     }
 
     func startReply(to message: MessageItem) {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3352,6 +3352,149 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func timelineMediaProjectionKeepsMediaReferenceCacheForUnchangedMediaTick() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let accountItem = AccountItem(summary: account)
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let chat = ChatItem(
+            id: "group",
+            title: "Test Group",
+            subtitle: "Group message",
+            preview: "Attachment",
+            updatedAt: nil,
+            avatarSeed: "group",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let state = WorkspaceState(
+            accounts: [accountItem],
+            chatsByAccount: [accountItem.id: [chat]],
+            messagesByChat: ["group": []],
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
+        state.activeAccountId = accountItem.id
+        state.selection = .chat("group")
+        let timelineReference = mediaAttachmentReference(
+            sourceEpoch: 0,
+            mediaType: "image/png",
+            fileName: "inbound.png",
+            ciphertextSha256: String(repeating: "e", count: 64),
+            plaintextSha256: String(repeating: "f", count: 64)
+        )
+
+        // Seed the store with the media message. This first projection is a genuine new-media
+        // event, so it is *expected* to invalidate the (empty) cache.
+        let mediaJsonPayload = mediaJson(for: timelineReference)
+        await state.applyTimelineProjection(
+            TimelineProjectionUpdateFfi(
+                groupIdHex: "group",
+                messages: [],
+                changes: [
+                    .upsert(
+                        trigger: .newMessage,
+                        message: timelineMessage(
+                            id: "inbound-media-message",
+                            groupIdHex: "group",
+                            sender: "alice",
+                            plaintext: "",
+                            recordedAt: 1_700_000_001,
+                            mediaJson: mediaJsonPayload
+                        ))
+                ],
+                chatListRow: nil,
+                chatListTrigger: .newLastMessage
+            ),
+            groupIdHex: "group",
+            account: accountItem,
+            client: runtime
+        )
+
+        // Prime the resolution cache with a miss for the unresolved (sourceEpoch == 0) ref.
+        let initial = try await state.resolvedMediaReference(
+            timelineReference,
+            accountId: accountItem.id,
+            accountRef: accountItem.accountRef,
+            groupIdHex: "group",
+            client: runtime
+        )
+        #expect(initial.sourceEpoch == 0)
+        #expect(runtime.listMediaCallCount == 1)
+
+        // Install a now-resolvable record: if the delivery-state tick were to wrongly clear the
+        // cache, the follow-up resolve would rebuild the index and surface this full reference.
+        let fullReference = mediaAttachmentReference(
+            sourceEpoch: 11,
+            mediaType: "image/png",
+            fileName: "inbound.png",
+            ciphertextSha256: timelineReference.ciphertextSha256,
+            plaintextSha256: timelineReference.plaintextSha256
+        )
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "inbound-media-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: fullReference,
+                caption: nil,
+                recordedAt: 1_700_000_001,
+                receivedAt: 1_700_000_001
+            ),
+            download: MediaDownloadResultFfi(
+                plaintext: Data([0x05, 0x06, 0x07, 0x08]),
+                fileName: "inbound.png",
+                mediaType: "image/png",
+                sizeBytes: 4
+            )
+        )
+
+        // A pure delivery-state tick for the same message re-carries the identical media
+        // fields, so the mapped `mediaAttachments` are unchanged and the cache must be kept.
+        await state.applyTimelineProjection(
+            TimelineProjectionUpdateFfi(
+                groupIdHex: "group",
+                messages: [],
+                changes: [
+                    .upsert(
+                        trigger: .deliveryOrSendStateChanged,
+                        message: timelineMessage(
+                            id: "inbound-media-message",
+                            groupIdHex: "group",
+                            sender: "alice",
+                            plaintext: "",
+                            recordedAt: 1_700_000_001,
+                            mediaJson: mediaJsonPayload
+                        ))
+                ],
+                chatListRow: nil,
+                chatListTrigger: .newLastMessage
+            ),
+            groupIdHex: "group",
+            account: accountItem,
+            client: runtime
+        )
+
+        let stillCachedMiss = try await state.resolvedMediaReference(
+            timelineReference,
+            accountId: accountItem.id,
+            accountRef: accountItem.accountRef,
+            groupIdHex: "group",
+            client: runtime
+        )
+        #expect(stillCachedMiss.sourceEpoch == 0)
+        #expect(runtime.listMediaCallCount == 1)
+    }
+
+    @MainActor
     @Test func workspaceCoalescesAndCachesSourceEpochZeroMediaReferenceResolution() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
Fixes #365

## Summary
- Move timeline media-reference cache invalidation to after projection records are mapped to `MessageItem`s.
- Compare each mapped upsert's `mediaAttachments` against the pre-mutation timeline store entry, so known delivery-state/projection ticks that re-carry unchanged media fields do not clear the cache.
- Keep invalidation for new media message ids and media attachment changes, and add a regression test for the unchanged delivery-state tick path.

## Verification
- `git diff --check` ✅
- conflict-marker grep ✅
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` not run: `xcrun` is not installed on this Linux host.
- `scripts/ci/macos-sanity-checks.sh` not run: requires `xcodebuild`, not installed on this Linux host.
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` not run: `xcodebuild` is not installed on this Linux host.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/368">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->