### PR TITLE
fix: preserve valid media JSON locators

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -654,9 +654,10 @@ private nonisolated enum MessageMediaParser {
     }
 
     private static func locators(fromJSONObject value: Any?) -> [MediaLocatorFfi] {
-        guard let locators = value as? [[String: Any]] else { return [] }
+        guard let locators = value as? [Any] else { return [] }
         return locators.compactMap { locator in
-            guard let kind = string(locator, keys: ["kind"]),
+            guard let locator = locator as? [String: Any],
+                let kind = string(locator, keys: ["kind"]),
                 let value = string(locator, keys: ["value"])
             else { return nil }
             return MediaLocatorFfi(kind: kind, value: value)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2772,6 +2772,48 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func directMediaJSONLocatorKeepsValidSiblingsWhenMalformedElementPresent() async throws {
+        // Regression for whitenoise-mac#364: a single malformed locator sibling must not
+        // make the direct-reference JSON parser drop every valid locator in the array.
+        let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "mixed-locator-elements",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJSONString(fromJSONObject: [
+                        "ciphertext_sha256": reference.ciphertextSha256,
+                        "plaintext_sha256": reference.plaintextSha256,
+                        "nonce": reference.nonceHex,
+                        "file_name": reference.fileName,
+                        "media_type": reference.mediaType,
+                        "version": reference.version,
+                        "locators": [
+                            ["kind": "blossom", "value": "https://blob.example/valid"],
+                            0,
+                        ] as [Any],
+                    ])
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+        let attachment = try #require(message.mediaAttachments.first)
+        let locator = try #require(attachment.reference.locators.first)
+
+        #expect(message.mediaAttachments.count == 1)
+        #expect(attachment.reference.locators.count == 1)
+        #expect(locator.kind == "blossom")
+        #expect(locator.value == "https://blob.example/valid")
+    }
+
+    @MainActor
     @Test func booleanMediaJSONStringAliasValuesFallThroughAndBadLocatorsAreDropped() async throws {
         // `string(_:keys:)` searches aliases in order. A boolean at an earlier alias
         // should be treated as malformed for that key, not as "1" and not as a reason


### PR DESCRIPTION
## Summary
- Parse direct-reference media JSON locator arrays per element instead of casting the whole array all-or-nothing.
- Keep valid download locators when malformed sibling elements are present.
- Add a regression test for a mixed locator array.

Fixes #364

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' HEAD -- . || true`
- Not run: `xcodebuild` unit tests; `xcodebuild` is unavailable on this Linux host.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/369">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->