### PR TITLE
fix: stop voice recording when removed chat reselects

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -336,6 +336,7 @@ extension WorkspaceState {
             selectedGroupId == groupIdHex
         else { return }
 
+        leaveActiveConversation()
         closeGroupImagePicker()
         let nextChat = mostRecentChat(in: chats)
         selection = nextChat.map { .chat($0.id) }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10020,6 +10020,25 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func removeSelectedChatStopsInProgressVoiceRecordingBeforeAutoReselection() throws {
+        // #362: subscription deltas can remove the selected chat and auto-select a different
+        // conversation. That implicit navigation must tear down the recorder before the composer
+        // belongs to the new chat, or finishing would file chat A's audio under chat B.
+        let state = WorkspaceState.preview()
+        let account = AccountItem.samples[0]
+        let removedChatId = try #require(state.selectedChat?.id)
+        let url = try armInProgressVoiceRecording(on: state)
+
+        state.removeChat(groupIdHex: removedChatId, account: account)
+
+        #expect(state.selection != .chat(removedChatId))
+        #expect(state.selectedChat != nil)
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
     @Test func resetToNewInstallStateStopsInProgressVoiceRecording() throws {
         // #311: the full local-data teardown must also release the recorder so a wipe cannot
         // leave the microphone active or plaintext audio writes running in the old state.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10020,14 +10020,22 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func removeSelectedChatStopsInProgressVoiceRecordingBeforeAutoReselection() throws {
+    @Test func removeSelectedChatStopsInProgressVoiceRecordingBeforeAutoReselection() async throws {
         // #362: subscription deltas can remove the selected chat and auto-select a different
-        // conversation. That implicit navigation must tear down the recorder before the composer
-        // belongs to the new chat, or finishing would file chat A's audio under chat B.
+        // conversation. That implicit navigation must tear down active conversation resources
+        // before the composer belongs to the new chat, or finishing would file chat A's audio
+        // under chat B and transcript export pagination would continue after leaving chat A.
         let state = WorkspaceState.preview()
         let account = AccountItem.samples[0]
         let removedChatId = try #require(state.selectedChat?.id)
         let url = try armInProgressVoiceRecording(on: state)
+        let transcriptExportTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        state.groupTranscriptExportTask = transcriptExportTask
+        defer { transcriptExportTask.cancel() }
 
         state.removeChat(groupIdHex: removedChatId, account: account)
 
@@ -10036,6 +10044,8 @@ struct whitenoise_macTests {
         #expect(!state.isRecordingVoiceMessage)
         #expect(state.voiceRecordingMeterTask == nil)
         #expect(!FileManager.default.fileExists(atPath: url.path))
+        #expect(transcriptExportTask.isCancelled)
+        await transcriptExportTask.value
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- cancel active conversation resources when `removeChat` removes the selected chat before auto-reselecting another chat
- add a regression test for an in-progress voice recording during removeChat auto-reselection

## Test plan
- `git diff --check`
- Not run: `xcodebuild` / Swift tests (xcodebuild, swift, and swiftc are unavailable on this Linux worker)

Fixes #362


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->