### PR TITLE
fix: scrub telemetry OS build number

### DIFF
--- a/whitenoise-mac/Core/TelemetryBuildConfig.swift
+++ b/whitenoise-mac/Core/TelemetryBuildConfig.swift
@@ -40,7 +40,7 @@ struct TelemetryBuildConfig: Equatable {
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
         processInfo: ProcessInfo = .processInfo,
         environment: [String: String]? = nil,
-        osVersion: String = ProcessInfo.processInfo.operatingSystemVersionString,
+        osVersion: String = TelemetryBuildConfig.marketingOSVersion(),
         deviceModelIdentifier: String? = nil
     ) -> TelemetryBuildConfig {
         let info = infoDictionary ?? [:]
@@ -162,6 +162,18 @@ struct TelemetryBuildConfig: Equatable {
 
     nonisolated private static func isUnresolvedBuildSetting(_ value: String) -> Bool {
         value.hasPrefix("$(") && value.hasSuffix(")")
+    }
+
+    /// Marketing-only OS version formatted as "major.minor.patch".
+    ///
+    /// `ProcessInfo.operatingSystemVersionString` embeds the build number (for
+    /// example "Version 15.5 (Build 24F74)"), a higher-entropy fingerprinting
+    /// signal. This resource is exported to a remote OTLP endpoint, so emit only
+    /// the marketing version drawn from `operatingSystemVersion`.
+    nonisolated static func marketingOSVersion(
+        _ version: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    ) -> String {
+        "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
     }
 
     nonisolated static func deviceModelIdentifier() -> String? {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11102,6 +11102,41 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func telemetryBuildConfigDefaultsToMarketingOnlyOSVersion() async throws {
+        // The default osVersion must be the marketing "major.minor.patch"
+        // string, never the build-bearing operatingSystemVersionString (for
+        // example "Version 15.5 (Build 24F74)") which is a higher-entropy
+        // fingerprint exported to the remote OTLP endpoint.
+        let config = TelemetryBuildConfig.current(
+            infoDictionary: [
+                "CFBundleShortVersionString": "2026.6",
+                "CFBundleVersion": "12",
+            ],
+            environment: [:]
+        )
+
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        let expected = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+        #expect(config.osVersion == expected)
+        #expect(config.osVersion != ProcessInfo.processInfo.operatingSystemVersionString)
+        #expect(!config.osVersion.contains("Build"))
+        #expect(!config.osVersion.contains("Version"))
+        #expect(config.osVersion.allSatisfy { $0.isNumber || $0 == "." })
+
+        let runtimeResource = config.runtimeConfig(installId: "install-id").resource
+        #expect(runtimeResource?.osVersion == expected)
+        #expect(runtimeResource?.osVersion != ProcessInfo.processInfo.operatingSystemVersionString)
+    }
+
+    @MainActor
+    @Test func telemetryBuildConfigFormatsMarketingOSVersionAsMajorMinorPatch() async throws {
+        let formatted = TelemetryBuildConfig.marketingOSVersion(
+            OperatingSystemVersion(majorVersion: 15, minorVersion: 5, patchVersion: 0)
+        )
+        #expect(formatted == "15.5.0")
+    }
+
+    @MainActor
     @Test func telemetryBuildConfigIgnoresUnresolvedBuildSettingsAndUsesEnvironmentFallbacks() async throws {
         let config = TelemetryBuildConfig.current(
             infoDictionary: [
@@ -11179,7 +11214,7 @@ struct whitenoise_macTests {
         #expect(telemetryResource?.deploymentEnvironment == "production")
         #expect(telemetryResource?.tenant == "whitenoise-mac")
         #expect(telemetryResource?.osType == "darwin")
-        #expect(telemetryResource?.osVersion == ProcessInfo.processInfo.operatingSystemVersionString)
+        #expect(telemetryResource?.osVersion == TelemetryBuildConfig.marketingOSVersion())
         #expect(telemetryResource?.deviceModelIdentifier == nil)
         #expect(runtime.auditLogTrackerConfig?.authorizationBearerToken == "audit-token")
         #expect(runtime.auditLogTrackerConfig?.source.deviceLabel == expectedDeviceModelIdentifier())
@@ -15160,7 +15195,7 @@ private func telemetryBuildConfig(
     auditToken: String? = "audit-token",
     environment: String = "production",
     serviceVersion: String = expectedTelemetryServiceVersion(),
-    osVersion: String = ProcessInfo.processInfo.operatingSystemVersionString,
+    osVersion: String = TelemetryBuildConfig.marketingOSVersion(),
     deviceModelIdentifier: String? = expectedDeviceModelIdentifier()
 ) -> TelemetryBuildConfig {
     TelemetryBuildConfig(


### PR DESCRIPTION
Fixes #363

## Summary
- Replace the relay telemetry default OS version source with a marketing-version-only formatter based on `ProcessInfo.operatingSystemVersion`.
- Export `major.minor.patch` in `RelayTelemetryResourceFfi.osVersion` instead of the build-bearing `operatingSystemVersionString`.
- Add regression coverage for the scrubbed default and deterministic formatter behavior.

## Verification
- `git diff --check` — passed.
- line-length check for changed Swift files (<= 120 chars) — passed.
- `scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host: `xcodebuild: command not found`.
- macOS CI-required `xcrun swift-format`, `xcodebuild test/build/analyze`, `plutil`, `/usr/libexec/PlistBuddy` — not available on this Linux host.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/371">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced OS version detail sent in telemetry to a simpler marketing version format, lowering fingerprinting risk.
  * Telemetry now uses a consistent `major.minor.patch` OS version value by default.

* **Tests**
  * Added coverage for the new OS version formatting behavior.
  * Updated existing telemetry assertions to match the revised default format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->