### PR TITLE
fix: avoid repeated media cache eviction scans

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -327,27 +327,51 @@ nonisolated extension MessageItem {
         guard let event else { return nil }
         switch event.systemType {
         case "member_added":
-            if let text = memberAddedText(event, activeAccountIdHex: activeAccountIdHex, senderProfiles: senderProfiles) {
+            if let text = memberAddedText(
+                event,
+                activeAccountIdHex: activeAccountIdHex,
+                senderProfiles: senderProfiles
+            ) {
                 return text
             }
         case "member_removed":
-            if let text = memberRemovedText(event, activeAccountIdHex: activeAccountIdHex, senderProfiles: senderProfiles) {
+            if let text = memberRemovedText(
+                event,
+                activeAccountIdHex: activeAccountIdHex,
+                senderProfiles: senderProfiles
+            ) {
                 return text
             }
         case "member_left":
-            if let text = memberLeftText(event, activeAccountIdHex: activeAccountIdHex, senderProfiles: senderProfiles) {
+            if let text = memberLeftText(
+                event,
+                activeAccountIdHex: activeAccountIdHex,
+                senderProfiles: senderProfiles
+            ) {
                 return text
             }
         case "admin_added":
-            if let text = adminAddedText(event, activeAccountIdHex: activeAccountIdHex, senderProfiles: senderProfiles) {
+            if let text = adminAddedText(
+                event,
+                activeAccountIdHex: activeAccountIdHex,
+                senderProfiles: senderProfiles
+            ) {
                 return text
             }
         case "admin_removed":
-            if let text = adminRemovedText(event, activeAccountIdHex: activeAccountIdHex, senderProfiles: senderProfiles) {
+            if let text = adminRemovedText(
+                event,
+                activeAccountIdHex: activeAccountIdHex,
+                senderProfiles: senderProfiles
+            ) {
                 return text
             }
         case "group_renamed":
-            if let text = groupRenamedText(event, activeAccountIdHex: activeAccountIdHex, senderProfiles: senderProfiles) {
+            if let text = groupRenamedText(
+                event,
+                activeAccountIdHex: activeAccountIdHex,
+                senderProfiles: senderProfiles
+            ) {
                 return text
             }
         case "group_avatar_changed":

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -567,6 +567,11 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         var byteCount: UInt64
     }
 
+    private struct CacheScan {
+        let removableEntries: [CacheEntry]
+        let footprint: CacheFootprint
+    }
+
     private enum MetadataStatus {
         case readable(Metadata)
         case corrupt
@@ -872,11 +877,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 || tracked.byteCount > evictionPolicy.maxTotalBytes
         else { return }
 
-        var entries = Self.cacheEntries(root: root, symmetricKey: symmetricKey)
-        var totalBytes = entries.reduce(UInt64(0)) { total, entry in
-            Self.addingWithSaturation(total, entry.byteCount)
-        }
-        var remainingCount = entries.count
+        let scan = Self.cacheScan(root: root, symmetricKey: symmetricKey)
+        var entries = scan.removableEntries
+        var totalBytes = scan.footprint.byteCount
+        var remainingCount = scan.footprint.entryCount
 
         guard remainingCount > evictionPolicy.maxEntryCount || totalBytes > evictionPolicy.maxTotalBytes
         else {
@@ -938,16 +942,23 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         return CacheFootprint(entryCount: entryCount, byteCount: byteCount)
     }
 
-    private static func cacheEntries(root: URL, symmetricKey: SymmetricKey) -> [CacheEntry] {
+    private static func cacheScan(root: URL, symmetricKey: SymmetricKey) -> CacheScan {
         guard
             let shardDirectories = try? FileManager.default.contentsOfDirectory(
                 at: root,
                 includingPropertiesForKeys: [.isDirectoryKey],
                 options: [.skipsHiddenFiles]
             )
-        else { return [] }
+        else {
+            return CacheScan(
+                removableEntries: [],
+                footprint: CacheFootprint(entryCount: 0, byteCount: 0)
+            )
+        }
 
         var entries: [CacheEntry] = []
+        var entryCount = 0
+        var byteCount: UInt64 = 0
         for shardDirectory in shardDirectories where shardDirectory.lastPathComponent != "staging" {
             guard isDirectory(shardDirectory),
                 let entryDirectories = try? FileManager.default.contentsOfDirectory(
@@ -958,15 +969,20 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             else { continue }
 
             for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
+                let entryByteCount = entryByteCount(at: entryDirectory)
                 let metadata: Metadata
                 switch metadataStatus(in: entryDirectory, symmetricKey: symmetricKey) {
                 case .readable(let decodedMetadata):
                     metadata = decodedMetadata
+                    entryCount += 1
+                    byteCount = addingWithSaturation(byteCount, entryByteCount)
                 case .corrupt:
                     try? FileManager.default.removeItem(at: entryDirectory)
                     removeEmptyDirectory(shardDirectory)
                     continue
                 case .unavailable:
+                    entryCount += 1
+                    byteCount = addingWithSaturation(byteCount, entryByteCount)
                     continue
                 }
 
@@ -974,12 +990,15 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                     CacheEntry(
                         directory: entryDirectory,
                         cachedAtUnixSeconds: metadata.cachedAtUnixSeconds,
-                        byteCount: entryByteCount(at: entryDirectory)
+                        byteCount: entryByteCount
                     )
                 )
             }
         }
-        return entries
+        return CacheScan(
+            removableEntries: entries,
+            footprint: CacheFootprint(entryCount: entryCount, byteCount: byteCount)
+        )
     }
 
     private static func isDirectory(_ url: URL) -> Bool {

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -484,8 +484,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
 
         let isReplacement = FileManager.default.fileExists(atPath: prepared.finalDirectory.path)
-        let replacedByteCount = isReplacement
-            ? Self.entryByteCount(at: prepared.finalDirectory) : 0
+        let replacedByteCount =
+            isReplacement
+            ? Self.entryByteCount(at: prepared.finalDirectory)
+            : 0
         let committedByteCount = Self.entryByteCount(at: prepared.stagingDirectory)
 
         do {
@@ -853,14 +855,14 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             return
         }
 
-        var tracked = trackedFootprint!
-        if isNewEntry {
-            tracked.entryCount += 1
-        }
+        let tracked = trackedFootprint!
+        let entryCount = isNewEntry ? tracked.entryCount + 1 : tracked.entryCount
         let withoutReplaced =
             tracked.byteCount > replacedByteCount ? tracked.byteCount - replacedByteCount : 0
-        tracked.byteCount = Self.addingWithSaturation(withoutReplaced, committedByteCount)
-        trackedFootprint = tracked
+        trackedFootprint = CacheFootprint(
+            entryCount: entryCount,
+            byteCount: Self.addingWithSaturation(withoutReplaced, committedByteCount)
+        )
     }
 
     private func enforceEvictionPolicy(root: URL, symmetricKey: SymmetricKey) {

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -204,6 +204,9 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private var purgeSequence = 0
     private var purgeTasks: [Int: ActivePurge] = [:]
     private var didSweepStagingDirectories = false
+    // Updated under `fileMutationLock` on commit and eviction; reset or invalidated on purge.
+    // Seeded with one full scan when nil so stores under the cap avoid re-walking the tree every time (#377).
+    private var trackedFootprint: CacheFootprint?
 
     init(
         directoryResolver: @escaping DirectoryResolver = MessageMediaDiskCache.defaultDirectoryURL,
@@ -313,13 +316,14 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     func purgeAll(removeEncryptionKey: Bool = false) async {
         let root = try? directoryResolver()
         let deleteKey = keyDeleter
-        let task = beginPurge(scope: .all) {
+        let task = beginPurge(scope: .all) { [self] in
             if let root {
                 try? FileManager.default.removeItem(at: root)
             }
             if removeEncryptionKey {
                 deleteKey()
             }
+            trackedFootprint = CacheFootprint(entryCount: 0, byteCount: 0)
         }
         await task.task.value
         finishPurge(task)
@@ -343,7 +347,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
 
         let accountDigest = MessageMediaDiskCacheKey.accountDigest(for: accountId)
-        let task = beginPurge(scope: .account(accountDigest)) {
+        let task = beginPurge(scope: .account(accountDigest)) { [self] in
             Self.removeEntries(
                 matchingAccountDigest: accountDigest,
                 root: root,
@@ -353,6 +357,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             // pass only removes entries it can attribute to the target account; this
             // second pass is account-agnostic and deletes entries no account can read.
             Self.removeUnreadableEntries(root: root, symmetricKey: symmetricKey)
+            // Account purges remove an arbitrary subset of entries. Re-seed lazily on the next store.
+            trackedFootprint = nil
         }
         await task.task.value
         finishPurge(task)
@@ -477,6 +483,11 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             return
         }
 
+        let isReplacement = FileManager.default.fileExists(atPath: prepared.finalDirectory.path)
+        let replacedByteCount = isReplacement
+            ? Self.entryByteCount(at: prepared.finalDirectory) : 0
+        let committedByteCount = Self.entryByteCount(at: prepared.stagingDirectory)
+
         do {
             try FileManager.default.createDirectory(
                 at: prepared.finalDirectory.deletingLastPathComponent(),
@@ -484,7 +495,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             )
             try? FileManager.default.removeItem(at: prepared.finalDirectory)
             try FileManager.default.moveItem(at: prepared.stagingDirectory, to: prepared.finalDirectory)
-            Self.enforceEvictionPolicy(evictionPolicy, root: prepared.root, symmetricKey: symmetricKey)
+            updateTrackedFootprintAfterCommit(
+                isNewEntry: !isReplacement,
+                committedByteCount: committedByteCount,
+                replacedByteCount: replacedByteCount,
+                root: prepared.root
+            )
+            enforceEvictionPolicy(root: prepared.root, symmetricKey: symmetricKey)
         } catch {
             try? FileManager.default.removeItem(at: prepared.stagingDirectory)
         }
@@ -544,8 +561,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     }
 
     private struct CacheFootprint {
-        let entryCount: Int
-        let byteCount: UInt64
+        var entryCount: Int
+        var byteCount: UInt64
     }
 
     private enum MetadataStatus {
@@ -825,23 +842,43 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         return .readable(metadata)
     }
 
-    private static func enforceEvictionPolicy(
-        _ policy: EvictionPolicy,
-        root: URL,
-        symmetricKey: SymmetricKey
+    private func updateTrackedFootprintAfterCommit(
+        isNewEntry: Bool,
+        committedByteCount: UInt64,
+        replacedByteCount: UInt64,
+        root: URL
     ) {
-        let footprint = cacheFootprint(root: root)
-        guard footprint.entryCount > policy.maxEntryCount || footprint.byteCount > policy.maxTotalBytes else {
+        if trackedFootprint == nil {
+            trackedFootprint = Self.cacheFootprint(root: root)
             return
         }
 
-        var entries = cacheEntries(root: root, symmetricKey: symmetricKey)
+        var tracked = trackedFootprint!
+        if isNewEntry {
+            tracked.entryCount += 1
+        }
+        let withoutReplaced =
+            tracked.byteCount > replacedByteCount ? tracked.byteCount - replacedByteCount : 0
+        tracked.byteCount = Self.addingWithSaturation(withoutReplaced, committedByteCount)
+        trackedFootprint = tracked
+    }
+
+    private func enforceEvictionPolicy(root: URL, symmetricKey: SymmetricKey) {
+        guard let tracked = trackedFootprint else { return }
+        guard
+            tracked.entryCount > evictionPolicy.maxEntryCount
+                || tracked.byteCount > evictionPolicy.maxTotalBytes
+        else { return }
+
+        var entries = Self.cacheEntries(root: root, symmetricKey: symmetricKey)
         var totalBytes = entries.reduce(UInt64(0)) { total, entry in
-            addingWithSaturation(total, entry.byteCount)
+            Self.addingWithSaturation(total, entry.byteCount)
         }
         var remainingCount = entries.count
 
-        guard remainingCount > policy.maxEntryCount || totalBytes > policy.maxTotalBytes else {
+        guard remainingCount > evictionPolicy.maxEntryCount || totalBytes > evictionPolicy.maxTotalBytes
+        else {
+            trackedFootprint = CacheFootprint(entryCount: remainingCount, byteCount: totalBytes)
             return
         }
 
@@ -853,20 +890,22 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
 
         for entry in entries {
-            guard remainingCount > policy.maxEntryCount || totalBytes > policy.maxTotalBytes else {
-                break
-            }
+            guard
+                remainingCount > evictionPolicy.maxEntryCount
+                    || totalBytes > evictionPolicy.maxTotalBytes
+            else { break }
 
             do {
                 try FileManager.default.removeItem(at: entry.directory)
                 remainingCount -= 1
                 totalBytes = totalBytes > entry.byteCount ? totalBytes - entry.byteCount : 0
-                removeEmptyDirectory(entry.directory.deletingLastPathComponent())
+                Self.removeEmptyDirectory(entry.directory.deletingLastPathComponent())
             } catch {
                 continue
             }
         }
-        removeEmptyDirectory(root)
+        Self.removeEmptyDirectory(root)
+        trackedFootprint = CacheFootprint(entryCount: remainingCount, byteCount: totalBytes)
     }
 
     private static func cacheFootprint(root: URL) -> CacheFootprint {
@@ -891,13 +930,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
             for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
                 entryCount += 1
-                byteCount = addingWithSaturation(
-                    byteCount,
-                    addingWithSaturation(
-                        fileByteCount(at: entryDirectory.appendingPathComponent(metadataFileName)),
-                        fileByteCount(at: entryDirectory.appendingPathComponent(payloadFileName))
-                    )
-                )
+                byteCount = addingWithSaturation(byteCount, entryByteCount(at: entryDirectory))
             }
         }
         return CacheFootprint(entryCount: entryCount, byteCount: byteCount)
@@ -923,8 +956,6 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             else { continue }
 
             for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
-                let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
-                let payloadURL = entryDirectory.appendingPathComponent(payloadFileName)
                 let metadata: Metadata
                 switch metadataStatus(in: entryDirectory, symmetricKey: symmetricKey) {
                 case .readable(let decodedMetadata):
@@ -941,10 +972,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                     CacheEntry(
                         directory: entryDirectory,
                         cachedAtUnixSeconds: metadata.cachedAtUnixSeconds,
-                        byteCount: addingWithSaturation(
-                            fileByteCount(at: metadataURL),
-                            fileByteCount(at: payloadURL)
-                        )
+                        byteCount: entryByteCount(at: entryDirectory)
                     )
                 )
             }
@@ -954,6 +982,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
     private static func isDirectory(_ url: URL) -> Bool {
         (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+    }
+
+    private static func entryByteCount(at entryDirectory: URL) -> UInt64 {
+        addingWithSaturation(
+            fileByteCount(at: entryDirectory.appendingPathComponent(metadataFileName)),
+            fileByteCount(at: entryDirectory.appendingPathComponent(payloadFileName))
+        )
     }
 
     private static func fileByteCount(at url: URL) -> UInt64 {

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -234,7 +234,11 @@ struct MessagesWindowBackground: View {
 
     var body: some View {
         Rectangle()
-            .fill(colorScheme == .dark ? Color(red: 0.055, green: 0.055, blue: 0.058) : Color(red: 0.975, green: 0.975, blue: 0.965))
+            .fill(
+                colorScheme == .dark
+                    ? Color(red: 0.055, green: 0.055, blue: 0.058)
+                    : Color(red: 0.975, green: 0.975, blue: 0.965)
+            )
             .ignoresSafeArea()
     }
 }
@@ -244,7 +248,11 @@ struct MessagesTranscriptBackground: View {
 
     var body: some View {
         Rectangle()
-            .fill(colorScheme == .dark ? Color(red: 0.055, green: 0.055, blue: 0.058) : Color(nsColor: .textBackgroundColor))
+            .fill(
+                colorScheme == .dark
+                    ? Color(red: 0.055, green: 0.055, blue: 0.058)
+                    : Color(nsColor: .textBackgroundColor)
+            )
             .ignoresSafeArea()
     }
 }
@@ -288,7 +296,11 @@ struct MessagesHeaderBackground: View {
 
     var body: some View {
         Rectangle()
-            .fill(colorScheme == .dark ? Color(red: 0.055, green: 0.055, blue: 0.058) : Color(nsColor: .textBackgroundColor))
+            .fill(
+                colorScheme == .dark
+                    ? Color(red: 0.055, green: 0.055, blue: 0.058)
+                    : Color(nsColor: .textBackgroundColor)
+            )
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1820,6 +1820,112 @@ struct whitenoise_macTests {
         #expect(cacheFiles.filter { $0.hasSuffix("payload.bin") }.count == 2)
     }
 
+    @Test func messageMediaDiskCacheReplaceEntryDoesNotEvictOthersAtEntryLimit() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cachedAtCounter = AtomicCounter()
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 2, maxTotalBytes: UInt64.max),
+            timestampProvider: { TimeInterval(cachedAtCounter.increment()) }
+        )
+        let firstPlaintext = Data("first cached media".utf8)
+        let secondPlaintext = Data("second cached media".utf8)
+        let firstKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: firstPlaintext, ciphertextByte: 0xa1)
+        )
+        let secondKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: secondPlaintext, ciphertextByte: 0xa2)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: firstPlaintext,
+                fileName: "first.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(firstPlaintext.count),
+                payloadId: "first"
+            ),
+            for: firstKey
+        )
+        await cache.store(
+            MessageMediaDownload(
+                data: secondPlaintext,
+                fileName: "second.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(secondPlaintext.count),
+                payloadId: "second"
+            ),
+            for: secondKey
+        )
+        await cache.store(
+            MessageMediaDownload(
+                data: firstPlaintext,
+                fileName: "first-renamed.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(firstPlaintext.count),
+                payloadId: "first-renamed"
+            ),
+            for: firstKey
+        )
+
+        #expect(try #require(await cache.cachedDownload(for: firstKey)).fileName == "first-renamed.jpg")
+        #expect(try #require(await cache.cachedDownload(for: secondKey)).data == secondPlaintext)
+
+        let cacheFiles = try fileManager.subpathsOfDirectory(atPath: root.path)
+        #expect(cacheFiles.filter { $0.hasSuffix("payload.bin") }.count == 2)
+    }
+
+    @Test func messageMediaDiskCacheEvictsAfterManyStoresUnderCap() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cachedAtCounter = AtomicCounter()
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 4, maxTotalBytes: UInt64.max),
+            timestampProvider: { TimeInterval(cachedAtCounter.increment()) }
+        )
+        var keys: [MessageMediaDiskCacheKey] = []
+        for index in 0..<5 {
+            let plaintext = Data("cached media \(index)".utf8)
+            let key = MessageMediaDiskCacheKey(
+                accountId: "account-a",
+                groupIdHex: "group-a",
+                reference: mediaDiskCacheReference(plaintext: plaintext, ciphertextByte: UInt8(0xb0 + index))
+            )
+            keys.append(key)
+            await cache.store(
+                MessageMediaDownload(
+                    data: plaintext,
+                    fileName: "photo-\(index).jpg",
+                    mediaType: "image/jpeg",
+                    sizeBytes: UInt64(plaintext.count),
+                    payloadId: "photo-\(index)"
+                ),
+                for: key
+            )
+        }
+
+        #expect(await cache.cachedDownload(for: keys[0]) == nil)
+        for index in 1..<5 {
+            let restored = try #require(await cache.cachedDownload(for: keys[index]))
+            #expect(restored.data == Data("cached media \(index)".utf8))
+        }
+
+        let cacheFiles = try fileManager.subpathsOfDirectory(atPath: root.path)
+        #expect(cacheFiles.filter { $0.hasSuffix("payload.bin") }.count == 4)
+    }
+
     @Test func messageMediaDiskCacheEvictsEntryWhenByteLimitExceeded() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
Fixes #377

## Summary
- Added an in-memory `trackedFootprint` for `MessageMediaDiskCache` so normal stores update entry/byte counts incrementally instead of running `cacheFootprint(root:)` on every successful commit.
- Eviction now runs the full entry walk only after the tracked count or byte total exceeds the policy cap, and it refreshes the tracked total after eviction.
- Purge-all resets the tracked total; account purge invalidates it so the next store performs a one-time rescan before returning to incremental accounting.
- Added regression coverage for replacement-at-cap and incremental multi-store eviction behavior.

## Verification
- `git diff --check` — pass.
- conflict-marker scan over Swift files — pass.
- `swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — not run: `swift-format` unavailable on this Linux host.
- `scripts/ci/macos-sanity-checks.sh` — attempted; blocked because `xcodebuild` is unavailable on this Linux host.
- `xcodebuild test/build/analyze` — not run: Xcode/macOS toolchain unavailable on this Linux host.

## Sensitive paths
None. Changed disk-cache eviction bookkeeping and tests only; no MLS/CGKA, key-handling, trust-anchor, auth, or generated MarmotKit code.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/380">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media cache overwrite behavior to ensure unrelated cached items aren’t evicted when updating an existing entry.
  * Refined eviction enforcement so the cache reliably stays within configured entry/size limits while retaining the newest payloads.
  * Improved cache size/footprint accounting after purge, eviction, and cleanup operations for more consistent reliability.
* **Tests**
  * Added regression coverage for overwrite-at-limit and long-run eviction-down-to-limit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->