### PR TITLE
fix: prevent transcript export task orphaning

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -51,9 +51,6 @@ extension WorkspaceState {
         guard groupTranscriptExportTask == nil, !isExportingGroupTranscript else { return }
         groupTranscriptExportTask = Task { [weak self] in
             await self?.copySelectedGroupTranscriptJSON()
-            await MainActor.run {
-                self?.groupTranscriptExportTask = nil
-            }
         }
     }
 
@@ -62,6 +59,8 @@ extension WorkspaceState {
     }
 
     func copySelectedGroupTranscriptJSON() async {
+        defer { groupTranscriptExportTask = nil }
+
         guard !isExportingGroupTranscript,
             let client,
             let activeAccount,
@@ -72,10 +71,7 @@ extension WorkspaceState {
         lastError = nil
         groupTranscriptExportStatus = nil
         isExportingGroupTranscript = true
-        defer {
-            isExportingGroupTranscript = false
-            groupTranscriptExportTask = nil
-        }
+        defer { isExportingGroupTranscript = false }
 
         do {
             let accountRef = activeAccount.accountRef


### PR DESCRIPTION
Fixes #379

## Summary
- Removed the redundant trailing `MainActor.run` cleanup from the transcript export wrapper task.
- Moved `groupTranscriptExportTask` cleanup into a single synchronous defer in `copySelectedGroupTranscriptJSON()` so early exits still release the handle without a later suspension that can orphan a restarted export.

## Verification
- `git diff --check` — passed.
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed.
- Python structural check — passed: no outer `MainActor.run` clear remains; exactly one task-slot clear remains in `copySelectedGroupTranscriptJSON()` before early-return guards; exporting-state defer remains.
- macOS/Xcode checks not run on this Linux host: `xcrun`, `swift-format`, `xcodebuild`, `plutil`, `/usr/libexec/PlistBuddy`, and `swift` are unavailable.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/381">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->