### PR TITLE
fix: reclaim orphaned media cache staging entries

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -182,6 +182,9 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private let keyDeleter: KeyDeleter
     private let timestampProvider: TimestampProvider
     private let evictionPolicy: EvictionPolicy
+    // Staging directories older than this cache instance were left by a previous process and
+    // are safe to discard; same-session staging may still be an in-flight store.
+    private let sessionStartedAtUnixSeconds: TimeInterval
     private let lock = NSLock()
     // Serializes the filesystem create/remove/move work of commits and purges so a slow
     // commit never blocks generation reads or purge bookkeeping (which stay on `lock`).
@@ -194,19 +197,22 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private var generation = 0
     private var purgeTask: Task<Void, Never>?
     private var purgeGeneration: Int?
+    private var didSweepStagingDirectories = false
 
     init(
         directoryResolver: @escaping DirectoryResolver = MessageMediaDiskCache.defaultDirectoryURL,
         keyProvider: @escaping KeyProvider = MessageMediaDiskCacheKeychain.symmetricKey,
         keyDeleter: @escaping KeyDeleter = MessageMediaDiskCacheKeychain.deleteKey,
         timestampProvider: @escaping TimestampProvider = { Date().timeIntervalSince1970 },
-        evictionPolicy: EvictionPolicy = .standard
+        evictionPolicy: EvictionPolicy = .standard,
+        sessionStartedAtUnixSeconds: TimeInterval = Date().timeIntervalSince1970
     ) {
         self.directoryResolver = directoryResolver
         self.keyProvider = keyProvider
         self.keyDeleter = keyDeleter
         self.timestampProvider = timestampProvider
         self.evictionPolicy = evictionPolicy
+        self.sessionStartedAtUnixSeconds = sessionStartedAtUnixSeconds
     }
 
     static func defaultDirectoryURL() throws -> URL {
@@ -234,6 +240,11 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         let symmetricKey: SymmetricKey
         do {
             root = try directoryResolver()
+        } catch {
+            return nil
+        }
+        sweepStaleStagingDirectoriesIfNeeded(root: root)
+        do {
             symmetricKey = try keyProvider()
         } catch {
             return nil
@@ -261,6 +272,11 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         let symmetricKey: SymmetricKey
         do {
             root = try directoryResolver()
+        } catch {
+            return
+        }
+        sweepStaleStagingDirectoriesIfNeeded(root: root)
+        do {
             symmetricKey = try keyProvider()
         } catch {
             return
@@ -310,6 +326,11 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         let symmetricKey: SymmetricKey
         do {
             root = try directoryResolver()
+        } catch {
+            return
+        }
+        sweepStaleStagingDirectoriesIfNeeded(root: root)
+        do {
             symmetricKey = try keyProvider()
         } catch {
             return
@@ -349,6 +370,22 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return generation
+    }
+
+    private func sweepStaleStagingDirectoriesIfNeeded(root: URL) {
+        fileMutationLock.lock()
+        defer { fileMutationLock.unlock() }
+
+        lock.lock()
+        if didSweepStagingDirectories {
+            lock.unlock()
+            return
+        }
+        didSweepStagingDirectories = true
+        let cutoff = sessionStartedAtUnixSeconds
+        lock.unlock()
+
+        Self.removeStaleStagingDirectories(root: root, olderThanUnixSeconds: cutoff)
     }
 
     private func beginStore() -> StoreHandle? {
@@ -569,6 +606,41 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         try? FileManager.default.removeItem(at: stagingDirectory)
         removeEmptyDirectory(stagingDirectory.deletingLastPathComponent())
         removeEmptyDirectory(root)
+    }
+
+    private static func removeStaleStagingDirectories(root: URL, olderThanUnixSeconds cutoff: TimeInterval) {
+        let stagingRoot = root.appendingPathComponent("staging", isDirectory: true)
+        guard
+            let stagingDirectories = try? FileManager.default.contentsOfDirectory(
+                at: stagingRoot,
+                includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey, .creationDateKey],
+                options: [.skipsHiddenFiles]
+            )
+        else { return }
+
+        for stagingDirectory in stagingDirectories {
+            guard isDirectory(stagingDirectory),
+                isStaleStagingDirectory(stagingDirectory, olderThanUnixSeconds: cutoff)
+            else { continue }
+            try? FileManager.default.removeItem(at: stagingDirectory)
+        }
+        removeEmptyDirectory(stagingRoot)
+        removeEmptyDirectory(root)
+    }
+
+    private static func isStaleStagingDirectory(_ directory: URL, olderThanUnixSeconds cutoff: TimeInterval) -> Bool {
+        guard
+            let values = try? directory.resourceValues(forKeys: [
+                .contentModificationDateKey,
+                .creationDateKey,
+            ])
+        else {
+            return true
+        }
+        guard let modifiedAt = values.contentModificationDate ?? values.creationDate else {
+            return true
+        }
+        return modifiedAt.timeIntervalSince1970 < cutoff
     }
 
     private static func removeEmptyDirectory(_ directory: URL) {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1813,6 +1813,40 @@ struct whitenoise_macTests {
         #expect(fileManager.fileExists(atPath: unreadableEntryDirectory.path))
     }
 
+    @Test func messageMediaDiskCacheAccountPurgeSweepsCrashOrphanedStagingEntries() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let stagingRoot = root.appendingPathComponent("staging", isDirectory: true)
+        let staleStagingDirectory = stagingRoot.appendingPathComponent("crash-orphan", isDirectory: true)
+        let inSessionStagingDirectory = stagingRoot.appendingPathComponent("in-session", isDirectory: true)
+        try fileManager.createDirectory(at: staleStagingDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: inSessionStagingDirectory, withIntermediateDirectories: true)
+        try Data("orphaned encrypted payload".utf8).write(
+            to: staleStagingDirectory.appendingPathComponent("payload.bin")
+        )
+        try Data("active encrypted payload".utf8).write(
+            to: inSessionStagingDirectory.appendingPathComponent("payload.bin")
+        )
+        try fileManager.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: staleStagingDirectory.path
+        )
+        try fileManager.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2_000)],
+            ofItemAtPath: inSessionStagingDirectory.path
+        )
+
+        let cache = messageMediaDiskCache(root: root, sessionStartedAtUnixSeconds: 1_000)
+
+        await cache.purgeAccount("account-a")
+
+        #expect(!fileManager.fileExists(atPath: staleStagingDirectory.path))
+        #expect(fileManager.fileExists(atPath: inSessionStagingDirectory.path))
+    }
+
     @Test func messageMediaDiskCachePurgesByAccountAndFullWipeDeletesKey() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
@@ -15815,6 +15849,7 @@ private func messageMediaDiskCache(
     keyData: Data = Data(repeating: 0x42, count: 32),
     evictionPolicy: MessageMediaDiskCache.EvictionPolicy = .standard,
     timestampProvider: @escaping MessageMediaDiskCache.TimestampProvider = { Date().timeIntervalSince1970 },
+    sessionStartedAtUnixSeconds: TimeInterval = Date().timeIntervalSince1970,
     keyDeleter: @escaping @Sendable () -> Void = {}
 ) -> MessageMediaDiskCache {
     MessageMediaDiskCache(
@@ -15822,7 +15857,8 @@ private func messageMediaDiskCache(
         keyProvider: { SymmetricKey(data: keyData) },
         keyDeleter: keyDeleter,
         timestampProvider: timestampProvider,
-        evictionPolicy: evictionPolicy
+        evictionPolicy: evictionPolicy,
+        sessionStartedAtUnixSeconds: sessionStartedAtUnixSeconds
     )
 }
 


### PR DESCRIPTION
## Summary
- sweep stale `WhiteNoiseMediaCache/v1/staging/*` directories that predate the current cache session before reads, stores, and per-account purges
- preserve same-session staging directories so in-flight writes are not deleted
- add regression coverage for per-account purge reclaiming a crash-orphaned staging entry

## Test Plan
- `git diff --check HEAD^ HEAD`
- line-length check for changed Swift files (<= 120 columns)
- Not run: `xcrun swift-format lint`, `xcodebuild test`, `xcodebuild build`, `xcodebuild analyze` (Linux worker lacks Xcode/xcrun/swift)

Fixes #376


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->