### PR TITLE
fix: bound automatic media downloads

### DIFF
--- a/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
+++ b/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
@@ -1,0 +1,45 @@
+//
+//  MediaAttachmentDownloadLimiter.swift
+//  whitenoise-mac
+//
+
+import Foundation
+
+/// Bounds concurrent attachment downloads so opening a media-heavy chat cannot spawn
+/// unbounded FFI `downloadMedia` calls.
+enum MediaAttachmentDownloadConcurrency {
+    static let maxConcurrentDownloads = 4
+}
+
+actor MediaAttachmentDownloadLimiter {
+    static let shared = MediaAttachmentDownloadLimiter(
+        maxConcurrent: MediaAttachmentDownloadConcurrency.maxConcurrentDownloads
+    )
+
+    private let maxConcurrent: Int
+    private var inFlight = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(maxConcurrent: Int) {
+        self.maxConcurrent = max(1, maxConcurrent)
+    }
+
+    func acquire() async {
+        if inFlight < maxConcurrent {
+            inFlight += 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        if let waiter = waiters.first {
+            waiters.removeFirst()
+            waiter.resume()
+        } else {
+            inFlight -= 1
+        }
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -194,6 +194,14 @@ extension WorkspaceState {
             return
         }
 
+        await MediaAttachmentDownloadLimiter.shared.acquire()
+        defer {
+            Task { await MediaAttachmentDownloadLimiter.shared.release() }
+        }
+        if case .loaded = stateStore.state {
+            return
+        }
+
         do {
             let reference = try await resolvedMediaReference(
                 attachment.reference,

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -274,13 +274,15 @@ private extension View {
     func autoDownloadMediaAttachment(
         _ downloadState: MediaDownloadStateStore,
         attachment: MessageMediaAttachment,
-        message: MessageItem
+        message: MessageItem,
+        requiresScrollVisibility: Bool = true
     ) -> some View {
         modifier(
             AutomaticMediaDownloadModifier(
                 downloadState: downloadState,
                 attachment: attachment,
-                message: message
+                message: message,
+                requiresScrollVisibility: requiresScrollVisibility
             )
         )
     }
@@ -291,20 +293,42 @@ private struct AutomaticMediaDownloadModifier: ViewModifier {
     let downloadState: MediaDownloadStateStore
     let attachment: MessageMediaAttachment
     let message: MessageItem
+    let requiresScrollVisibility: Bool
+    @State private var isVisibleInScrollView = false
 
     func body(content: Content) -> some View {
-        content
-            .onAppear {
+        Group {
+            if requiresScrollVisibility {
+                content
+                    // A tiny non-zero threshold means eager, non-lazy transcript rows do not
+                    // auto-download until at least part of the tile intersects the ScrollView.
+                    .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+                        isVisibleInScrollView = isVisible
+                        if isVisible {
+                            startAutomaticDownloadIfNeeded()
+                        }
+                    }
+            } else {
+                content
+                    .onAppear {
+                        startAutomaticDownloadIfNeeded()
+                    }
+            }
+        }
+        .onChange(of: attachment.id) { _, _ in
+            if shouldStartForCurrentVisibility {
                 startAutomaticDownloadIfNeeded()
             }
-            .onChange(of: attachment.id) { _, _ in
+        }
+        .onChange(of: downloadState.shouldStartAutomaticDownload) { _, shouldStart in
+            if shouldStart, shouldStartForCurrentVisibility {
                 startAutomaticDownloadIfNeeded()
             }
-            .onChange(of: downloadState.shouldStartAutomaticDownload) { _, shouldStart in
-                if shouldStart {
-                    startAutomaticDownloadIfNeeded()
-                }
-            }
+        }
+    }
+
+    private var shouldStartForCurrentVisibility: Bool {
+        !requiresScrollVisibility || isVisibleInScrollView
     }
 
     private func startAutomaticDownloadIfNeeded() {
@@ -1293,7 +1317,8 @@ struct MessageImageGalleryContent: View {
         .autoDownloadMediaAttachment(
             downloadState,
             attachment: attachment,
-            message: message
+            message: message,
+            requiresScrollVisibility: false
         )
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -136,6 +136,32 @@ private final class AtomicCounter: @unchecked Sendable {
         return value
     }
 
+    @discardableResult
+    func decrement() -> Int {
+        lock.lock()
+        storedValue -= 1
+        let value = storedValue
+        lock.unlock()
+        return value
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
+    }
+}
+
+private final class AtomicMax: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue = 0
+
+    func record(_ value: Int) {
+        lock.lock()
+        storedValue = max(storedValue, value)
+        lock.unlock()
+    }
+
     var value: Int {
         lock.lock()
         defer { lock.unlock() }
@@ -4205,6 +4231,28 @@ struct whitenoise_macTests {
         #expect(!store.shouldStartAutomaticDownload)
         store.update(.idle)
         #expect(store.shouldStartAutomaticDownload)
+    }
+
+    @Test func mediaAttachmentDownloadLimiterCapsConcurrentAcquires() async {
+        let limiter = MediaAttachmentDownloadLimiter(maxConcurrent: 2)
+        let inFlight = AtomicCounter()
+        let maxInFlight = AtomicMax()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    await limiter.acquire()
+                    let current = inFlight.increment()
+                    maxInFlight.record(current)
+                    try? await Task.sleep(nanoseconds: 5_000_000)
+                    inFlight.decrement()
+                    await limiter.release()
+                }
+            }
+        }
+
+        #expect(maxInFlight.value <= 2)
+        #expect(inFlight.value == 0)
     }
 
     @Test func messageAudioMetadataCacheHitPerformanceGuard() async throws {


### PR DESCRIPTION
Fixes #375

## Summary
- Replaces transcript media auto-download `.onAppear` triggering with SwiftUI scroll-visibility gating, so the non-lazy transcript no longer starts downloads for off-screen rows on chat open.
- Keeps image-gallery loading opt-in to appear-based behavior because the gallery is outside the transcript `ScrollView`.
- Adds a shared media download limiter and applies it after disk-cache misses so FFI media downloads are capped at four concurrent requests.
- Adds a concurrency regression test for the limiter.

## Verification
- `git diff --check` — passed.
- `bash scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux worker; exits 127 because `xcodebuild` is not installed.
- `command -v swift swift-format xcodebuild xcrun` — none available on this Linux worker, so Xcode build/tests were not run locally.
- `search_files` conflict-marker sweep over Swift files — no conflict markers found.

## Sensitive paths
none

## Notes
Needs normal macOS CI/Xcode validation for the SwiftUI `.onScrollVisibilityChange` behavior and the new Swift test target compile.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/384">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->