### PR TITLE
fix: tear down recordings on notification chat switches

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -74,6 +74,9 @@ extension WorkspaceState {
             switchedAccounts = false
         }
 
+        if !switchedAccounts {
+            leaveActiveConversation()
+        }
         selection = .chat(groupIdHex)
         isChatListVisible = true
         if !switchedAccounts {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10085,6 +10085,56 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func activeAccountNotificationResponseStopsInProgressVoiceRecordingBeforeChatSwitch() async throws {
+        // #374: tapping a same-account notification is an implicit chat switch. It must run
+        // the same conversation teardown as `selectChat` before the composer belongs to the
+        // notified chat, or a live recording/transcript export from chat A can continue under
+        // chat B.
+        let state = WorkspaceState.preview()
+        let account = try #require(state.activeAccount)
+        let currentChatId = try #require(state.selectedChat?.id)
+        let targetChat = try #require(state.activeChats.first { $0.id != currentChatId })
+        let url = try armInProgressVoiceRecording(on: state)
+        let transcriptExportTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        state.groupTranscriptExportTask = transcriptExportTask
+        defer { transcriptExportTask.cancel() }
+
+        state.handleNotificationResponse([
+            "groupIdHex": targetChat.id,
+            "accountIdHex": account.accountIdHex,
+            "accountRef": account.accountRef,
+        ])
+
+        #expect(state.selection == .chat(targetChat.id))
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+        #expect(transcriptExportTask.isCancelled)
+        await transcriptExportTask.value
+    }
+
+    @MainActor
+    @Test func unresolvableAccountNotificationResponseStopsInProgressVoiceRecordingForActiveChat() throws {
+        // The fallback path for stale/missing notification account metadata still allows a chat
+        // owned by the active account. That same-account switch must not bypass teardown either.
+        let state = WorkspaceState.preview()
+        let currentChatId = try #require(state.selectedChat?.id)
+        let targetChat = try #require(state.activeChats.first { $0.id != currentChatId })
+        let url = try armInProgressVoiceRecording(on: state)
+
+        state.handleNotificationResponse(["groupIdHex": targetChat.id])
+
+        #expect(state.selection == .chat(targetChat.id))
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
     @Test func removeSelectedChatStopsInProgressVoiceRecordingBeforeAutoReselection() async throws {
         // #362: subscription deltas can remove the selected chat and auto-select a different
         // conversation. That implicit navigation must tear down active conversation resources


### PR DESCRIPTION
## Summary
- Run the shared active-conversation teardown before same-account notification chat switches.
- Add regression coverage for active-account and missing-account-metadata notification taps so voice recordings/transcript exports are stopped before selection moves to the notified chat.

Fixes #374

## Test Plan
- `git diff --check`
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` (not run: `xcodebuild` is unavailable on this Linux host)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/385">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->