### PR TITLE
refactor: share glass circle close button

### DIFF
--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -529,15 +529,9 @@ struct NewChatColumnView: View {
                     .font(.title2.weight(.semibold))
                     .lineLimit(1)
                 Spacer()
-                Button {
+                GlassCircleCloseButton {
                     workspace.closeNewChatComposer()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .semibold))
-                        .frame(width: 28, height: 28)
                 }
-                .nativeGlassCircleButtonStyle()
-                .help("Close")
             }
             .padding(.horizontal, 14)
             .padding(.top, MessagesLayout.sidebarTitlebarTopPadding)

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -58,15 +58,9 @@ struct GroupDetailsSheet: View {
                         .controlSize(.small)
                 }
 
-                Button {
+                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back to chat") {
                     workspace.closeGroupDetails()
-                } label: {
-                    Image(systemName: "chevron.backward")
-                        .font(.system(size: 13, weight: .semibold))
-                        .frame(width: 28, height: 28)
                 }
-                .nativeGlassCircleButtonStyle()
-                .help("Back to chat")
             }
             .padding(20)
 
@@ -609,15 +603,9 @@ struct GroupImagePickerSheet: View {
 
                     Spacer()
 
-                    Button {
+                    GlassCircleCloseButton {
                         workspace.closeGroupImagePicker()
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 12, weight: .bold))
-                            .frame(width: 28, height: 28)
                     }
-                    .nativeGlassCircleButtonStyle()
-                    .help("Close")
                 }
                 .padding(.horizontal, 18)
                 .padding(.vertical, 16)

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -474,3 +474,30 @@ extension View {
         }
     }
 }
+
+/// Shared 28×28 circular glass dismiss/back control for sheet and column chrome.
+struct GlassCircleCloseButton: View {
+    let symbol: String
+    let helpText: String
+    let action: () -> Void
+
+    init(
+        symbol: String = "xmark",
+        help: String = "Close",
+        action: @escaping () -> Void
+    ) {
+        self.symbol = symbol
+        self.helpText = help
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 12, weight: .semibold))
+                .frame(width: 28, height: 28)
+        }
+        .nativeGlassCircleButtonStyle()
+        .help(helpText)
+    }
+}

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -443,15 +443,9 @@ struct PublicIdentityQRCodeSheet: View {
 
                 Spacer()
 
-                Button {
+                GlassCircleCloseButton {
                     dismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 13, weight: .semibold))
-                        .frame(width: 28, height: 28)
                 }
-                .nativeGlassCircleButtonStyle()
-                .help("Close")
             }
 
             ZStack {


### PR DESCRIPTION
Fixes #405

## Summary
- Added a shared `GlassCircleCloseButton` component next to the existing native glass button styles.
- Replaced the duplicated 28×28 circular glass close/back button chrome in the new-chat column, group details sheet, group image picker, and public identity QR sheet.
- Standardized the icon font to 12pt semibold while preserving each action and the back button’s existing help text.

## Verification
- `git diff --check` — pass
- conflict-marker sweep with `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .` — pass
- static call-site check — 5 `GlassCircleCloseButton` mentions across the changed files (1 definition + 4 call sites)
- `xcodebuild` / `xcrun swift-format` / `swift` — not available on this Linux host; macOS CI should run the native Xcode checks

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/406">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized close/back controls across several screens to use a shared circular button style.
  * Improved consistency in the composer, group details, image picker, and QR code sheets.
* **Style**
  * Close and back buttons now have a more uniform look and feel throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->