### PR TITLE
fix: cap fallback media attachments

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -964,7 +964,10 @@ private nonisolated enum UntrustedJSON {
 }
 
 private nonisolated enum MessageMediaParser {
-    private static let maxAttachmentsPerMessage = OutgoingMediaDraftProcessor.maxAttachmentCount
+    // Legacy inbound fallback parsing intentionally mirrors the compose cap for now,
+    // but keeps its own policy name so it can diverge from outgoing media limits.
+    private static let maxFallbackAttachmentsPerMessage =
+        OutgoingMediaDraftProcessor.maxAttachmentCount
     private static let logger = Logger(subsystem: "com.whitenoise.media", category: "MessageMediaParser")
 
     static func attachments(
@@ -982,13 +985,14 @@ private nonisolated enum MessageMediaParser {
         if !resolvedMedia.isEmpty {
             resolvedReferences = resolvedMedia
         } else {
-            let tagReferences =
-                tags
-                .filter { $0.values.first == "imeta" }
-                .compactMap { reference(fromIMetaTag: $0.values, sourceEpoch: 0) }
+            let tagReferences = references(fromIMetaTags: tags)
             let jsonReferences = references(fromMediaJson: mediaJson)
-            let fallbackReferences = jsonReferences.isEmpty ? tagReferences : jsonReferences
-            resolvedReferences = cappedFallbackReferences(fallbackReferences)
+            let fallbackReferences =
+                jsonReferences.references.isEmpty ? tagReferences : jsonReferences
+            if fallbackReferences.wasTruncated {
+                logFallbackOverflow()
+            }
+            resolvedReferences = fallbackReferences.references
         }
 
         return resolvedReferences.enumerated().map { index, reference in
@@ -999,98 +1003,148 @@ private nonisolated enum MessageMediaParser {
         }
     }
 
-    private static func cappedFallbackReferences(
-        _ references: [MediaAttachmentReferenceFfi]
-    ) -> [MediaAttachmentReferenceFfi] {
-        guard references.count > maxAttachmentsPerMessage else { return references }
-
-        let droppedCount = references.count - maxAttachmentsPerMessage
-        logger.notice(
-            "Dropped \(droppedCount) fallback media attachment references over cap \(maxAttachmentsPerMessage)"
-        )
-        return Array(references.prefix(maxAttachmentsPerMessage))
+    private struct FallbackReferenceParseResult {
+        var references: [MediaAttachmentReferenceFfi] = []
+        var wasTruncated = false
     }
 
-    private static func references(fromMediaJson mediaJson: String?) -> [MediaAttachmentReferenceFfi] {
+    private static func references(fromIMetaTags tags: [MessageTagFfi]) -> FallbackReferenceParseResult {
+        var result = FallbackReferenceParseResult()
+        for tag in tags where tag.values.first == "imeta" {
+            guard result.references.count < maxFallbackAttachmentsPerMessage else {
+                result.wasTruncated = true
+                break
+            }
+            if let reference = reference(fromIMetaTag: tag.values, sourceEpoch: 0) {
+                result.references.append(reference)
+            }
+        }
+        return result
+    }
+
+    private static func logFallbackOverflow() {
+        logger.notice(
+            "Dropped fallback media attachment references after reaching cap \(maxFallbackAttachmentsPerMessage)"
+        )
+    }
+
+    private static func references(fromMediaJson mediaJson: String?) -> FallbackReferenceParseResult {
         guard let mediaJson,
             !UntrustedJSON.nestingExceedsLimit(mediaJson),
             let data = mediaJson.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data)
-        else { return [] }
+        else { return FallbackReferenceParseResult() }
 
-        return references(fromJSONObject: root, remainingDepth: UntrustedJSON.maxNestingDepth)
+        var result = FallbackReferenceParseResult()
+        collectReferences(fromJSONObject: root, remainingDepth: UntrustedJSON.maxNestingDepth, into: &result)
+        return result
     }
 
-    private static func references(
+    private static func collectReferences(
         fromJSONObject value: Any,
-        remainingDepth: Int
-    ) -> [MediaAttachmentReferenceFfi] {
-        guard remainingDepth >= 0 else { return [] }
+        remainingDepth: Int,
+        into result: inout FallbackReferenceParseResult
+    ) {
+        guard remainingDepth >= 0, !result.wasTruncated else { return }
 
         if let dictionary = value as? [String: Any] {
             // Branches are mutually exclusive in precedence order so a single object
             // carrying multiple shapes (e.g. both `imeta` and the flat direct-reference
             // keys) cannot emit duplicate references for the same logical attachment.
             if let imeta = dictionary["imeta"] {
-                // Safe without its own depth counter because the raw JSON pre-scan rejects
                 // any object graph deeper than UntrustedJSON.maxNestingDepth before parsing.
-                let imetaReferences = references(
+                let beforeCount = result.references.count
+                collectReferences(
                     fromIMetaValue: imeta,
-                    sourceEpoch: unsignedInteger(dictionary["source_epoch"] ?? dictionary["sourceEpoch"])
+                    sourceEpoch: unsignedInteger(dictionary["source_epoch"] ?? dictionary["sourceEpoch"]),
+                    into: &result
                 )
-                if !imetaReferences.isEmpty {
-                    return imetaReferences
+                if result.wasTruncated || result.references.count > beforeCount {
+                    return
                 }
             }
             if let media = dictionary["media"] {
-                let mediaReferences = references(fromJSONObject: media, remainingDepth: remainingDepth - 1)
-                if !mediaReferences.isEmpty {
-                    return mediaReferences
+                let beforeCount = result.references.count
+                collectReferences(
+                    fromJSONObject: media,
+                    remainingDepth: remainingDepth - 1,
+                    into: &result
+                )
+                if result.wasTruncated || result.references.count > beforeCount {
+                    return
                 }
             }
             if let direct = reference(fromJSONObject: dictionary) {
-                return [direct]
+                append(direct, into: &result)
             }
-
-            return []
+            return
         }
 
         if let array = value as? [Any] {
-            if let tagReferences = references(fromIMetaArray: array, sourceEpoch: nil), !tagReferences.isEmpty {
-                return tagReferences
+            let stringArray = array.compactMap { $0 as? String }
+            if stringArray.count == array.count, stringArray.first == "imeta" {
+                if let reference = reference(fromIMetaTag: stringArray, sourceEpoch: 0) {
+                    append(reference, into: &result)
+                }
+                return
             }
-            return array.flatMap { references(fromJSONObject: $0, remainingDepth: remainingDepth - 1) }
+
+            for item in array {
+                guard result.references.count < maxFallbackAttachmentsPerMessage else {
+                    result.wasTruncated = true
+                    return
+                }
+                collectReferences(fromJSONObject: item, remainingDepth: remainingDepth - 1, into: &result)
+                if result.wasTruncated { return }
+            }
         }
-
-        return []
     }
 
-    private static func references(fromIMetaValue value: Any, sourceEpoch: UInt64?) -> [MediaAttachmentReferenceFfi] {
-        guard let array = value as? [Any],
-            let references = references(fromIMetaArray: array, sourceEpoch: sourceEpoch)
-        else { return [] }
-        return references
+    private static func collectReferences(
+        fromIMetaValue value: Any,
+        sourceEpoch: UInt64?,
+        into result: inout FallbackReferenceParseResult
+    ) {
+        guard let array = value as? [Any] else { return }
+        collectReferences(fromIMetaArray: array, sourceEpoch: sourceEpoch, into: &result)
     }
 
-    private static func references(fromIMetaArray array: [Any], sourceEpoch: UInt64?) -> [MediaAttachmentReferenceFfi]?
-    {
+    private static func collectReferences(
+        fromIMetaArray array: [Any],
+        sourceEpoch: UInt64?,
+        into result: inout FallbackReferenceParseResult
+    ) {
         let stringArray = array.compactMap { $0 as? String }
         if stringArray.count == array.count, stringArray.first == "imeta" {
-            return reference(fromIMetaTag: stringArray, sourceEpoch: sourceEpoch ?? 0).map { [$0] } ?? []
+            if let reference = reference(fromIMetaTag: stringArray, sourceEpoch: sourceEpoch ?? 0) {
+                append(reference, into: &result)
+            }
+            return
         }
 
-        var references: [MediaAttachmentReferenceFfi] = []
-        var sawTag = false
         for item in array {
             guard let tagArray = item as? [Any] else { continue }
             let tag = tagArray.compactMap { $0 as? String }
             guard tag.count == tagArray.count, tag.first == "imeta" else { continue }
-            sawTag = true
+            guard result.references.count < maxFallbackAttachmentsPerMessage else {
+                result.wasTruncated = true
+                return
+            }
             if let reference = reference(fromIMetaTag: tag, sourceEpoch: sourceEpoch ?? 0) {
-                references.append(reference)
+                result.references.append(reference)
             }
         }
-        return sawTag ? references : nil
+    }
+
+    private static func append(
+        _ reference: MediaAttachmentReferenceFfi,
+        into result: inout FallbackReferenceParseResult
+    ) {
+        guard result.references.count < maxFallbackAttachmentsPerMessage else {
+            result.wasTruncated = true
+            return
+        }
+        result.references.append(reference)
     }
 
     private static func reference(fromJSONObject dictionary: [String: Any]) -> MediaAttachmentReferenceFfi? {

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MarmotKit
+import OSLog
 
 extension AccountItem {
     nonisolated init(summary: AccountSummaryFfi) {
@@ -963,6 +964,8 @@ private nonisolated enum UntrustedJSON {
 }
 
 private nonisolated enum MessageMediaParser {
+    private static let maxAttachmentsPerMessage = OutgoingMediaDraftProcessor.maxAttachmentCount
+    private static let logger = Logger(subsystem: "com.whitenoise.media", category: "MessageMediaParser")
 
     static func attachments(
         resolvedMedia: [MediaAttachmentReferenceFfi],
@@ -984,7 +987,8 @@ private nonisolated enum MessageMediaParser {
                 .filter { $0.values.first == "imeta" }
                 .compactMap { reference(fromIMetaTag: $0.values, sourceEpoch: 0) }
             let jsonReferences = references(fromMediaJson: mediaJson)
-            resolvedReferences = jsonReferences.isEmpty ? tagReferences : jsonReferences
+            let fallbackReferences = jsonReferences.isEmpty ? tagReferences : jsonReferences
+            resolvedReferences = cappedFallbackReferences(fallbackReferences)
         }
 
         return resolvedReferences.enumerated().map { index, reference in
@@ -993,6 +997,18 @@ private nonisolated enum MessageMediaParser {
                 reference: reference
             )
         }
+    }
+
+    private static func cappedFallbackReferences(
+        _ references: [MediaAttachmentReferenceFfi]
+    ) -> [MediaAttachmentReferenceFfi] {
+        guard references.count > maxAttachmentsPerMessage else { return references }
+
+        let droppedCount = references.count - maxAttachmentsPerMessage
+        logger.notice(
+            "Dropped \(droppedCount) fallback media attachment references over cap \(maxAttachmentsPerMessage)"
+        )
+        return Array(references.prefix(maxAttachmentsPerMessage))
     }
 
     private static func references(fromMediaJson mediaJson: String?) -> [MediaAttachmentReferenceFfi] {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3373,6 +3373,40 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func fallbackMediaJSONCapsWideAttachmentArrays() async throws {
+        // Regression for whitenoise-mac#404: the depth guard bounds nesting only. A flat
+        // legacy `mediaJson` array must also be capped so one message cannot allocate and
+        // render an unbounded number of fallback attachment tiles.
+        let cap = OutgoingMediaDraftProcessor.maxAttachmentCount
+        let references = (0..<(cap + 15)).map { index in
+            mediaAttachmentReference(mediaType: "image/png", fileName: "wide-\(index).png")
+        }
+        let mediaObjects: [[String: Any]] = references.map { reference in
+            ["imeta": [mediaIMetaTag(for: reference).values]]
+        }
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "wide-media-json",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJSONString(fromJSONObject: mediaObjects)
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+
+        #expect(message.mediaAttachments.count == cap)
+        #expect(message.mediaAttachments.map(\.reference.fileName) == Array(references.prefix(cap)).map(\.fileName))
+    }
+
+    @MainActor
     @Test func mediaOnlyChatPreviewShowsAttachmentLabelInsteadOfUnsupported() async throws {
         // Regression for whitenoise-mac#175: `ChatListMessagePreviewFfi` carries no media
         // payload, so a media-only chat message arrives with empty plaintext. The chat-list

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3407,6 +3407,43 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func resolvedMediaBypassesFallbackAttachmentCap() async throws {
+        // The fallback cap is intentionally local to legacy `mediaJson`/`imeta` parsing.
+        // Non-empty core-resolved media is already validated upstream and remains intact.
+        let cap = OutgoingMediaDraftProcessor.maxAttachmentCount
+        let resolvedReferences = (0..<(cap + 2)).map { index in
+            mediaAttachmentReference(mediaType: "image/png", fileName: "resolved-\(index).png")
+        }
+        let fallbackReferences = (0..<(cap + 15)).map { index in
+            mediaAttachmentReference(mediaType: "image/png", fileName: "fallback-\(index).png")
+        }
+        let mediaObjects: [[String: Any]] = fallbackReferences.map { reference in
+            ["imeta": [mediaIMetaTag(for: reference).values]]
+        }
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "resolved-media",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJSONString(fromJSONObject: mediaObjects),
+                    media: resolvedReferences
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+
+        #expect(message.mediaAttachments.count == resolvedReferences.count)
+        #expect(message.mediaAttachments.map(\.reference.fileName) == resolvedReferences.map(\.fileName))
+    }
+
+    @MainActor
     @Test func mediaOnlyChatPreviewShowsAttachmentLabelInsteadOfUnsupported() async throws {
         // Regression for whitenoise-mac#175: `ChatListMessagePreviewFfi` carries no media
         // payload, so a media-only chat message arrives with empty plaintext. The chat-list
@@ -16217,6 +16254,7 @@ private func timelineMessage(
     tags: [MessageTagFfi] = [],
     recordedAt: UInt64,
     mediaJson: String? = nil,
+    media: [MediaAttachmentReferenceFfi] = [],
     agentTextStreamJson: String? = nil,
     groupSystem: GroupSystemEventFfi? = nil,
     replyToMessageIdHex: String? = nil,
@@ -16241,7 +16279,7 @@ private func timelineMessage(
         replyToMessageIdHex: replyToMessageIdHex,
         replyPreview: replyPreview,
         mediaJson: mediaJson,
-        media: [],
+        media: media,
         agentTextStreamJson: agentTextStreamJson,
         groupSystem: groupSystem,
         reactions: reactions,


### PR DESCRIPTION
## Summary
- caps legacy mediaJson/imeta fallback attachments at the existing per-message attachment limit before creating UI tiles
- logs dropped fallback references when a malformed wide payload exceeds the cap
- adds a regression test for a flat mediaJson array wider than the cap

## Test Plan
- `git diff --check`
- conflict-marker sweep on changed Swift files
- not run: `xcodebuild` (unavailable on Linux host)

Fixes #404


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/407">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy media attachments are now capped when parsing older message data, preventing oversized attachment lists.
  * Fallback parsing now logs when extra references are dropped, improving visibility into truncated media handling.
  * Messages with directly resolved media continue to keep all available attachments without being limited by the legacy fallback path.

* **Tests**
  * Added coverage for capped legacy attachment parsing and for preserving fully resolved media attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->