### PR TITLE
fix: bound timeline payload JSON depth

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -923,8 +923,46 @@ private nonisolated enum MarmotTimelineKind {
     static let groupSystem: UInt64 = 1210
 }
 
+private nonisolated enum UntrustedJSON {
+    static let maxNestingDepth = 32
+
+    static func nestingExceedsLimit(_ json: String, maxDepth: Int = maxNestingDepth) -> Bool {
+        var depth = 0
+        var isInsideString = false
+        var isEscaped = false
+
+        for scalar in json.unicodeScalars {
+            if isInsideString {
+                if isEscaped {
+                    isEscaped = false
+                } else if scalar.value == 0x5C {  // \\
+                    isEscaped = true
+                } else if scalar.value == 0x22 {  // "
+                    isInsideString = false
+                }
+                continue
+            }
+
+            switch scalar.value {
+            case 0x22:  // "
+                isInsideString = true
+            case 0x7B, 0x5B:  // { or [
+                depth += 1
+                if depth > maxDepth {
+                    return true
+                }
+            case 0x7D, 0x5D:  // } or ]
+                depth = max(0, depth - 1)
+            default:
+                continue
+            }
+        }
+
+        return false
+    }
+}
+
 private nonisolated enum MessageMediaParser {
-    private static let maxMediaJSONTraversalDepth = 32
 
     static func attachments(
         resolvedMedia: [MediaAttachmentReferenceFfi],
@@ -959,12 +997,12 @@ private nonisolated enum MessageMediaParser {
 
     private static func references(fromMediaJson mediaJson: String?) -> [MediaAttachmentReferenceFfi] {
         guard let mediaJson,
-            !mediaJSONNestingExceedsLimit(mediaJson, maxDepth: maxMediaJSONTraversalDepth),
+            !UntrustedJSON.nestingExceedsLimit(mediaJson),
             let data = mediaJson.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data)
         else { return [] }
 
-        return references(fromJSONObject: root, remainingDepth: maxMediaJSONTraversalDepth)
+        return references(fromJSONObject: root, remainingDepth: UntrustedJSON.maxNestingDepth)
     }
 
     private static func references(
@@ -979,7 +1017,7 @@ private nonisolated enum MessageMediaParser {
             // keys) cannot emit duplicate references for the same logical attachment.
             if let imeta = dictionary["imeta"] {
                 // Safe without its own depth counter because the raw JSON pre-scan rejects
-                // any object graph deeper than maxMediaJSONTraversalDepth before parsing.
+                // any object graph deeper than UntrustedJSON.maxNestingDepth before parsing.
                 let imetaReferences = references(
                     fromIMetaValue: imeta,
                     sourceEpoch: unsignedInteger(dictionary["source_epoch"] ?? dictionary["sourceEpoch"])
@@ -1009,41 +1047,6 @@ private nonisolated enum MessageMediaParser {
         }
 
         return []
-    }
-
-    private static func mediaJSONNestingExceedsLimit(_ json: String, maxDepth: Int) -> Bool {
-        var depth = 0
-        var isInsideString = false
-        var isEscaped = false
-
-        for scalar in json.unicodeScalars {
-            if isInsideString {
-                if isEscaped {
-                    isEscaped = false
-                } else if scalar.value == 0x5C {  // \\
-                    isEscaped = true
-                } else if scalar.value == 0x22 {  // "
-                    isInsideString = false
-                }
-                continue
-            }
-
-            switch scalar.value {
-            case 0x22:  // "
-                isInsideString = true
-            case 0x7B, 0x5B:  // { or [
-                depth += 1
-                if depth > maxDepth {
-                    return true
-                }
-            case 0x7D, 0x5D:  // } or ]
-                depth = max(0, depth - 1)
-            default:
-                continue
-            }
-        }
-
-        return false
     }
 
     private static func references(fromIMetaValue value: Any, sourceEpoch: UInt64?) -> [MediaAttachmentReferenceFfi] {
@@ -1228,7 +1231,9 @@ private nonisolated struct TimelinePayload: Decodable {
     private static let decoder = JSONDecoder()
 
     static func decode(from text: String) -> TimelinePayload? {
-        guard let data = text.data(using: .utf8) else { return nil }
+        guard !UntrustedJSON.nestingExceedsLimit(text),
+            let data = text.data(using: .utf8)
+        else { return nil }
         return try? decoder.decode(TimelinePayload.self, from: data)
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3832,6 +3832,70 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func deeplyNestedTimelinePayloadJSONFallsBackWithoutDecoding() async throws {
+        // Regression for whitenoise-mac#403: agent/group-system plaintext JSON is peer content.
+        // Overly deep nesting must be rejected before JSONDecoder runs on the timeline path.
+        let deepActivityJSON = timelinePayloadJSONWithNesting(
+            inner: ["v": 1, "text": "Thinking"],
+            objectDepth: 40
+        )
+        let deepOperationJSON = timelinePayloadJSONWithNesting(
+            inner: ["v": 1, "event_type": "tool_call", "preview": "glp-1"],
+            objectDepth: 40
+        )
+        let deepSystemJSON = timelinePayloadJSONWithNesting(
+            inner: ["v": 1, "system_type": "group_renamed", "text": "Group renamed"],
+            objectDepth: 40
+        )
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "deep-activity",
+                    groupIdHex: "group",
+                    sender: "agent",
+                    plaintext: deepActivityJSON,
+                    kind: 1201,
+                    recordedAt: 1_700_000_000
+                ),
+                timelineMessage(
+                    id: "deep-operation",
+                    groupIdHex: "group",
+                    sender: "agent",
+                    plaintext: deepOperationJSON,
+                    kind: 1202,
+                    recordedAt: 1_700_000_001
+                ),
+                timelineMessage(
+                    id: "deep-system",
+                    groupIdHex: "group",
+                    sender: "",
+                    plaintext: deepSystemJSON,
+                    kind: 1210,
+                    recordedAt: 1_700_000_002
+                ),
+                timelineMessage(
+                    id: "shallow-activity",
+                    groupIdHex: "group",
+                    sender: "agent",
+                    plaintext: #"{"v":1,"text":"Thinking"}"#,
+                    kind: 1201,
+                    recordedAt: 1_700_000_003
+                ),
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+
+        #expect(messages.count == 4)
+        #expect(messages[0].body == deepActivityJSON)
+        #expect(messages[1].body == deepOperationJSON)
+        #expect(messages[2].body == deepSystemJSON)
+        #expect(messages[3].body == "Thinking")
+    }
+
+    @MainActor
     @Test func boundedNestedMediaJSONStillProducesAttachments() async throws {
         // Base helper shape is object + imeta array + tag array, so 29 wrappers
         // reaches the current raw nesting limit of 32 without exceeding it.
@@ -16638,6 +16702,14 @@ private func mediaJson(for reference: MediaAttachmentReferenceFfi, arrayDepth de
     var object: Any = ["imeta": [mediaIMetaTag(for: reference).values]]
     for _ in 0..<depth {
         object = [object]
+    }
+    return mediaJSONString(fromJSONObject: object)
+}
+
+private func timelinePayloadJSONWithNesting(inner: [String: Any], objectDepth depth: Int) -> String {
+    var object: Any = inner
+    for _ in 0..<depth {
+        object = ["wrapper": object]
     }
     return mediaJSONString(fromJSONObject: object)
 }


### PR DESCRIPTION
Fixes #403

## Summary
- Hoists the untrusted JSON nesting pre-scan into a shared `UntrustedJSON` helper with the existing depth limit of 32.
- Applies that guard to `TimelinePayload.decode` before `JSONDecoder` handles peer-controlled agent/group-system plaintext JSON.
- Keeps the media JSON path on the same guard and adds a regression test covering deep agent activity, agent operation, and group-system payloads plus a shallow decode case.

## Verification
- `git diff --check` — passed.
- `search_files '^(<<<<<<<|=======|>>>>>>>)'` over Swift files — no conflict markers.
- `command -v swift`, `command -v swiftc`, `command -v xcodebuild` — all missing on this Linux host, so macOS xcodebuild tests were not runnable locally.

## Sensitive paths
None. Client-side timeline/message mapping hardening only; no crypto, MLS, CGKA, key handling, trust anchors, auth flows, or group-state core touched.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/408">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->