### PR TITLE
fix: avoid force-activating for queued deep links

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+DeepLinks.swift
+++ b/whitenoise-mac/Core/WorkspaceState+DeepLinks.swift
@@ -23,7 +23,7 @@ extension WorkspaceState {
         guard phase == .ready, client != nil else {
             // Cold start: .onOpenURL fires before bootstrap() finishes, and the link may
             // also arrive while signed out. Queue the reference; every path to `.ready`
-            // funnels through activateReadyState(), which flushes it.
+            // funnels through activateReadyState(), which flushes it without activating.
             pendingDeepLinkProfileReference = reference
             if phase == .onboarding {
                 backgroundStatus = L10n.string("Sign in to start a chat from this link.")
@@ -40,6 +40,8 @@ extension WorkspaceState {
             let reference = pendingDeepLinkProfileReference
         else { return }
         pendingDeepLinkProfileReference = nil
+        // Queued links came from an earlier untrusted URL event. Handle them once ready,
+        // but do not foreground the app later as a delayed side effect.
         Task { await openProfileReference(reference) }
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState+DeepLinks.swift
+++ b/whitenoise-mac/Core/WorkspaceState+DeepLinks.swift
@@ -6,7 +6,6 @@
 //  (kAEGetURL). Registered via CFBundleURLTypes in Config/Info.plist.
 //
 
-import AppKit
 import Foundation
 
 @MainActor
@@ -21,8 +20,6 @@ extension WorkspaceState {
             return
         }
 
-        NSApplication.shared.activate(ignoringOtherApps: true)
-
         guard phase == .ready, client != nil else {
             // Cold start: .onOpenURL fires before bootstrap() finishes, and the link may
             // also arrive while signed out. Queue the reference; every path to `.ready`
@@ -34,6 +31,7 @@ extension WorkspaceState {
             return
         }
 
+        appActivationHandler(false)
         Task { await openProfileReference(reference) }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -683,6 +683,7 @@ final class WorkspaceState {
     let clientFactory: @MainActor () throws -> any MarmotRuntime
     let localNotificationCenter: any LocalNotificationCenter
     let appActivityProvider: @MainActor () -> Bool
+    let appActivationHandler: @MainActor (_ ignoringOtherApps: Bool) -> Void
     let conversationWindowVisibilityProvider: @MainActor () -> Bool
     let copyTextHandler: @MainActor (String, Bool) -> Void
     let telemetryBuildConfigProvider: @MainActor () -> TelemetryBuildConfig
@@ -1081,6 +1082,9 @@ final class WorkspaceState {
         messagesByChat: [String: [MessageItem]] = [:],
         localNotificationCenter: (any LocalNotificationCenter)? = nil,
         appActivityProvider: @escaping @MainActor () -> Bool = { NSApplication.shared.isActive },
+        appActivationHandler: @escaping @MainActor (_ ignoringOtherApps: Bool) -> Void = {
+            NSApplication.shared.activate(ignoringOtherApps: $0)
+        },
         conversationWindowVisibilityProvider: @escaping @MainActor () -> Bool = {
             WorkspaceState.defaultConversationWindowVisibilityProvider()
         },
@@ -1099,6 +1103,7 @@ final class WorkspaceState {
         self.cachedMessageChatIds = Set(messagesByChat.keys)
         self.localNotificationCenter = localNotificationCenter ?? MacLocalNotificationCenter()
         self.appActivityProvider = appActivityProvider
+        self.appActivationHandler = appActivationHandler
         self.conversationWindowVisibilityProvider = conversationWindowVisibilityProvider
         self.copyTextHandler = copyTextHandler
         self.telemetryBuildConfigProvider = telemetryBuildConfigProvider

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11406,11 +11406,16 @@ struct whitenoise_macTests {
         let routedQuery = "nostr:npub1alice"
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: aliceId, npub: "npub1alice")
-        let state = WorkspaceState(clientFactory: { runtime })
+        let activationRecorder = AppActivationRecorder()
+        let state = WorkspaceState(
+            appActivationHandler: activationRecorder.record,
+            clientFactory: { runtime }
+        )
 
         state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alice?from=qr")!)
         #expect(state.pendingDeepLinkProfileReference == "npub1alice")
         #expect(state.resolvedNewChatRecipient == nil)
+        #expect(activationRecorder.requests.isEmpty)
 
         await state.bootstrap()
         let resolved = await waitFor {
@@ -11420,6 +11425,7 @@ struct whitenoise_macTests {
         #expect(resolved)
         #expect(state.isNewChatComposerVisible)
         #expect(state.pendingDeepLinkProfileReference == nil)
+        #expect(activationRecorder.requests.isEmpty)
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -134,6 +134,15 @@ private final class ObservationInvalidationFlag: @unchecked Sendable {
     }
 }
 
+@MainActor
+private final class AppActivationRecorder {
+    private(set) var requests: [Bool] = []
+
+    func record(ignoringOtherApps: Bool) {
+        requests.append(ignoringOtherApps)
+    }
+}
+
 private final class AtomicCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var storedValue = 0
@@ -11350,7 +11359,11 @@ struct whitenoise_macTests {
         let routedQuery = "nostr:npub1alice"
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: aliceId, npub: "npub1alice")
-        let state = WorkspaceState(clientFactory: { runtime })
+        let activationRecorder = AppActivationRecorder()
+        let state = WorkspaceState(
+            appActivationHandler: activationRecorder.record,
+            clientFactory: { runtime }
+        )
 
         await state.bootstrap()
         state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alice?from=qr")!)
@@ -11362,6 +11375,26 @@ struct whitenoise_macTests {
         #expect(state.isNewChatComposerVisible)
         #expect(state.pendingDeepLinkProfileReference == nil)
         #expect(state.resolvedNewChatRecipient?.npub == "npub1alice")
+        #expect(activationRecorder.requests == [false])
+    }
+
+    @MainActor
+    @Test func marmotDeepLinkWhenSignedOutQueuesWithoutActivatingApp() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [])
+        let activationRecorder = AppActivationRecorder()
+        let state = WorkspaceState(
+            appActivationHandler: activationRecorder.record,
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alice?from=qr")!)
+
+        #expect(state.phase == .onboarding)
+        #expect(state.pendingDeepLinkProfileReference == "npub1alice")
+        #expect(state.backgroundStatus == "Sign in to start a chat from this link.")
+        #expect(!state.isNewChatComposerVisible)
+        #expect(activationRecorder.requests.isEmpty)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Gate OS-level `marmot://profile/...` app activation until `WorkspaceState` is ready and has a client.
- Switch handled ready-state deep-link activation to the non-aggressive `ignoringOtherApps: false` path.
- Add regression coverage for ready-state activation policy and signed-out deep-link queuing without activation.

## Test Plan
- `git diff --check`
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` not run: `xcodebuild` is unavailable on this Linux host.

Fixes #402


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->