### PR TITLE
fix: tear down hidden chat drawer

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -20,15 +20,14 @@ struct MessengerShellView: View {
                     AccountRailView()
                     GlassSeparator()
 
-                    ChatListDrawerView()
-                        .frame(width: 300, alignment: .leading)
-                        .frame(width: workspace.isChatListVisible ? 300 : 0, alignment: .leading)
-                        .opacity(workspace.isChatListVisible ? 1 : 0)
-                        .clipped()
-                        .allowsHitTesting(workspace.isChatListVisible)
+                    if workspace.isChatListVisible {
+                        ChatListDrawerView()
+                            .frame(width: 300, alignment: .leading)
+                            .transition(.move(edge: .leading).combined(with: .opacity))
 
-                    GlassSeparator()
-                        .opacity(workspace.isChatListVisible ? 1 : 0)
+                        GlassSeparator()
+                            .transition(.opacity)
+                    }
                     DetailPaneView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }


### PR DESCRIPTION
Fixes #401

## Summary
- Gates `ChatListDrawerView` on `workspace.isChatListVisible` so the collapsed chat drawer is removed from the SwiftUI tree instead of rendered behind a 0-width clipped frame.
- Moves the trailing drawer separator into the same visibility gate and keeps lightweight transitions for the drawer/separator while the shell's existing animation handles the layout change.

## Verification
- `git diff --check` — passed
- source-shape check: asserted `ChatListDrawerView()` is under `if workspace.isChatListVisible`, transition modifiers are present, and the old zero-width/opacity/allowsHitTesting hiding path is gone — passed
- `xcodebuild` / `xcrun` / `swift` probes — unavailable on this Linux worker, so macOS CI checks were not runnable locally

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/410">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->