### PR TITLE
fix: preserve media cache entries on read IO failure

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -587,24 +587,46 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
         let payloadURL = entryDirectory.appendingPathComponent(payloadFileName)
 
+        let metadataData: Data
         do {
-            let metadataData = try Data(contentsOf: metadataURL)
+            metadataData = try Data(contentsOf: metadataURL)
+        } catch {
+            // A raw filesystem read failure may be transient; preserve the entry
+            // just like the purge path's `.unavailable` metadata status.
+            return nil
+        }
+
+        let metadata: Metadata
+        do {
             let metadataPlaintext = try open(
                 metadataData,
                 using: symmetricKey,
                 authenticatedBy: metadataAAD(for: key.cacheID)
             )
-            let metadata = try JSONDecoder().decode(Metadata.self, from: metadataPlaintext)
-            guard metadata.version == 1,
-                metadata.accountDigest == key.accountDigest,
-                metadata.ciphertextSha256 == key.ciphertextSha256,
-                metadata.plaintextSha256 == key.plaintextSha256
-            else {
-                try? FileManager.default.removeItem(at: entryDirectory)
-                return nil
-            }
+            metadata = try JSONDecoder().decode(Metadata.self, from: metadataPlaintext)
+        } catch {
+            try? FileManager.default.removeItem(at: entryDirectory)
+            return nil
+        }
+        guard metadata.version == 1,
+            metadata.accountDigest == key.accountDigest,
+            metadata.ciphertextSha256 == key.ciphertextSha256,
+            metadata.plaintextSha256 == key.plaintextSha256
+        else {
+            try? FileManager.default.removeItem(at: entryDirectory)
+            return nil
+        }
 
-            let payloadData = try Data(contentsOf: payloadURL)
+        let payloadData: Data
+        do {
+            payloadData = try Data(contentsOf: payloadURL)
+        } catch {
+            // A raw payload filesystem read failure may be transient; keep the entry
+            // until decrypt/auth failure proves the payload is corrupt.
+            return nil
+        }
+
+        do {
             let plaintext = try open(
                 payloadData,
                 using: symmetricKey,
@@ -624,9 +646,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 sizeBytes: metadata.sizeBytes
             )
         } catch {
-            if FileManager.default.fileExists(atPath: entryDirectory.path) {
-                try? FileManager.default.removeItem(at: entryDirectory)
-            }
+            try? FileManager.default.removeItem(at: entryDirectory)
             return nil
         }
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1750,6 +1750,96 @@ struct whitenoise_macTests {
         #expect(!fileManager.fileExists(atPath: entryDirectory.path))
     }
 
+    @Test func messageMediaDiskCacheEvictsCorruptMetadata() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(root: root)
+        let plaintext = Data("media whose metadata will be corrupted".utf8)
+        let reference = mediaDiskCacheReference(plaintext: plaintext)
+        let key = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: reference)
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "photo.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(plaintext.count),
+            payloadId: "network-download"
+        )
+
+        await cache.store(download, for: key)
+        let entryDirectory = try #require(cache.entryDirectory(for: key))
+        try Data("not sealed metadata".utf8).write(to: entryDirectory.appendingPathComponent("metadata.bin"))
+
+        #expect(await cache.cachedDownload(for: key) == nil)
+        #expect(!fileManager.fileExists(atPath: entryDirectory.path))
+    }
+
+    @Test func messageMediaDiskCachePreservesEntryWhenMetadataCannotBeRead() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(root: root)
+        let plaintext = Data("media with temporarily unreadable metadata".utf8)
+        let reference = mediaDiskCacheReference(plaintext: plaintext)
+        let key = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: reference)
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "photo.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(plaintext.count),
+            payloadId: "network-download"
+        )
+
+        await cache.store(download, for: key)
+        let entryDirectory = try #require(cache.entryDirectory(for: key))
+        let metadataURL = entryDirectory.appendingPathComponent("metadata.bin")
+        let payloadURL = entryDirectory.appendingPathComponent("payload.bin")
+        try fileManager.removeItem(at: metadataURL)
+        try fileManager.createDirectory(at: metadataURL, withIntermediateDirectories: false)
+
+        #expect(await cache.cachedDownload(for: key) == nil)
+        var metadataIsDirectory = ObjCBool(false)
+        #expect(fileManager.fileExists(atPath: metadataURL.path, isDirectory: &metadataIsDirectory))
+        #expect(metadataIsDirectory.boolValue)
+        #expect(fileManager.fileExists(atPath: payloadURL.path))
+    }
+
+    @Test func messageMediaDiskCachePreservesEntryWhenPayloadCannotBeRead() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(root: root)
+        let plaintext = Data("media with temporarily unreadable payload".utf8)
+        let reference = mediaDiskCacheReference(plaintext: plaintext)
+        let key = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: reference)
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "photo.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(plaintext.count),
+            payloadId: "network-download"
+        )
+
+        await cache.store(download, for: key)
+        let entryDirectory = try #require(cache.entryDirectory(for: key))
+        let metadataURL = entryDirectory.appendingPathComponent("metadata.bin")
+        let payloadURL = entryDirectory.appendingPathComponent("payload.bin")
+        try fileManager.removeItem(at: payloadURL)
+        try fileManager.createDirectory(at: payloadURL, withIntermediateDirectories: false)
+
+        #expect(await cache.cachedDownload(for: key) == nil)
+        #expect(fileManager.fileExists(atPath: metadataURL.path))
+        var payloadIsDirectory = ObjCBool(false)
+        #expect(fileManager.fileExists(atPath: payloadURL.path, isDirectory: &payloadIsDirectory))
+        #expect(payloadIsDirectory.boolValue)
+    }
+
     @Test func messageMediaDiskCacheEvictsOldestEntriesWhenEntryLimitExceeded() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
## Summary
- Preserve media cache entries when `readDownload` hits a raw metadata/payload file read failure.
- Keep deleting entries for genuine corruption: metadata decrypt/decode failures, metadata mismatches, and payload authentication failures.
- Add regression tests for unreadable metadata and unreadable payload files on the read path.

## Test Plan
- `git diff --check`
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` (blocked locally: `xcodebuild: command not found` on this Linux worker)

Fixes #400


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/411">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->