### PR TITLE
fix: clear group UI state on account teardown

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -334,10 +334,27 @@ extension WorkspaceState {
         lastConfirmedReadMarkers.removeAll()
         deliveredNotificationKeys.removeAll()
         deliveredNotificationKeyOrder.removeAll()
+        resetAccountScopedGroupAndNewChatUIState()
         profileDraft = ProfileDraft()
         keyPackages = []
         auditLogFiles = []
         auditLogUploadStatus = nil
+    }
+
+    private func resetAccountScopedGroupAndNewChatUIState() {
+        isNewChatComposerVisible = false
+        resetNewChatComposer()
+        isResolvingNewChat = false
+        isCreatingChat = false
+
+        isGroupImagePickerPresented = false
+        groupImageSearchQuery = ""
+        groupImageResults = []
+        invalidateGroupImageSearch()
+        isSavingGroupImage = false
+
+        closeGroupDetails()
+        groupTranscriptExportTask = nil
     }
 
     /// Non-destructive sign-out: retains the account's local data but deactivates
@@ -593,33 +610,7 @@ extension WorkspaceState {
         isDeletingAuditLogFiles = false
         isUploadingAuditLogFiles = false
         deletingKeyPackageId = nil
-        isNewChatComposerVisible = false
-        resetNewChatComposer()
-        isResolvingNewChat = false
-        isCreatingChat = false
-        isGroupImagePickerPresented = false
-        groupImageSearchQuery = ""
-        groupImageResults = []
-        invalidateGroupImageSearch()
-        isSavingGroupImage = false
-        isGroupDetailsPresented = false
-        groupDetailsSnapshot = nil
-        groupProfileDraftName = ""
-        groupProfileDraftDescription = ""
-        groupInviteMemberQuery = ""
-        // Invalidate any in-flight load so a stale completion cannot write into the reset state;
-        // this also clears `isLoadingGroupDetails`. See issue #135.
-        invalidateGroupDetailsLoad()
-        isSavingGroupProfile = false
-        isInvitingGroupMember = false
-        isAcceptingGroupInvite = false
-        isDecliningGroupInvite = false
-        isArchivingGroup = false
-        isLeavingGroup = false
-        isExportingGroupTranscript = false
-        groupTranscriptExportTask = nil
-        groupTranscriptExportStatus = nil
-        mutatingGroupMemberId = nil
+        resetAccountScopedGroupAndNewChatUIState()
         self.storageRootPath = storageRootPath
         timelinePagingByChat = [:]
         timelineInitialLoadGroupId = nil

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1084,6 +1084,72 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func resetActiveAccountUIStateClearsGroupAndNewChatPII() async throws {
+        let primary = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [primary])
+        runtime.installGroup(messageGroup())
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: primary.accountIdHex))
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let groupChat = try #require(state.activeChats.first)
+        await state.showGroupDetails(for: groupChat)
+        #expect(state.groupDetailsSnapshot?.members.count == 3)
+
+        state.groupProfileDraftName = "Private group name"
+        state.groupProfileDraftDescription = "Private group description"
+        state.groupInviteMemberQuery = "npub1privateinvite"
+        state.isGroupImagePickerPresented = true
+        state.groupImageSearchQuery = "private avatar"
+        state.groupImageResults = [
+            GroupImageSearchResult(
+                id: "image-1",
+                title: "Private Avatar",
+                imageURL: "https://example.com/private-avatar.jpg",
+                thumbnailURL: "https://example.com/private-avatar-thumb.jpg",
+                creator: "Private Creator",
+                license: "cc0",
+                attribution: nil,
+                sourceURL: nil,
+                width: 128,
+                height: 128
+            )
+        ]
+        let recipient = NewChatRecipient(
+            sourceQuery: "npub1recipient",
+            memberRef: "npub1recipient",
+            accountIdHex: "recipient1234567890recipient1234567890recipient1234567890recip1",
+            npub: "npub1recipient",
+            displayName: "Private Recipient",
+            pictureURL: "https://example.com/recipient.png"
+        )
+        state.newChatQuery = "npub1recipient"
+        state.newChatName = "Private chat"
+        state.newChatDescription = "Private chat description"
+        state.newChatRecipient = recipient
+        state.newChatRecipients = [recipient]
+
+        state.resetActiveAccountUIState()
+
+        // Sign-out and active-account removal share this reset path; group-scoped
+        // roster/details, invite queries, image-picker results, and new-chat recipients
+        // must not survive account teardown. See #398.
+        #expect(!state.isGroupDetailsPresented)
+        #expect(state.groupDetailsSnapshot == nil)
+        #expect(state.groupProfileDraftName.isEmpty)
+        #expect(state.groupProfileDraftDescription.isEmpty)
+        #expect(state.groupInviteMemberQuery.isEmpty)
+        #expect(!state.isGroupImagePickerPresented)
+        #expect(state.groupImageSearchQuery.isEmpty)
+        #expect(state.groupImageResults.isEmpty)
+        #expect(state.newChatQuery.isEmpty)
+        #expect(state.newChatName.isEmpty)
+        #expect(state.newChatDescription.isEmpty)
+        #expect(state.newChatRecipient == nil)
+        #expect(state.newChatRecipients.isEmpty)
+    }
+
+    @MainActor
     @Test func removeNonActiveAccountClearsItsUnreadBadge() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
## Summary
- Add a shared account teardown helper for group details, group image search, and new-chat composer state.
- Call it from resetActiveAccountUIState so sign-out/account removal clear group roster/draft/invite/new-chat PII.
- Reuse the helper from resetToNewInstallState so delete-all and account teardown stay aligned.

Fixes #398

## Test Plan
- `git diff --check`
- `xcodebuild test -scheme whitenoise-mac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO` (not run: xcodebuild is not available on this Linux host)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/412">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting account state now fully clears group-related and new chat UI details, including open panels, draft fields, search results, and picker state.
  * Sign-out and fresh-install reset flows now use the same cleanup path, helping ensure a more consistent app state.
* **Tests**
  * Added coverage to verify group and new chat UI data is cleared after resetting the active account state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->