### PR TITLE
fix: prevent media drafts from dropping replies

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -416,6 +416,9 @@ extension WorkspaceState {
         }
         attachments.append(attachment)
         pendingMediaAttachmentsByConversation[draftKey] = attachments
+        // Media uploads cannot carry a reply target yet, so reply and pending media are
+        // mutually exclusive — staging media drops any active reply banner.
+        replyDraftContextByConversation[draftKey] = nil
         if attachment.kind == .audio {
             draftTextByConversation[draftKey] = nil
         }

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -435,6 +435,11 @@ extension WorkspaceState {
 
     func startReply(to message: MessageItem) {
         guard message.supportsChatActions else { return }
+        // Media uploads cannot carry a reply target yet, so reply and pending media are
+        // mutually exclusive — starting a reply drops any staged attachments.
+        if let draftKey = selectedComposerDraftKey {
+            pendingMediaAttachmentsByConversation[draftKey] = nil
+        }
         replyDraftContext = MessageReplyContext(
             targetMessageId: message.id,
             senderName: message.senderName,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7549,6 +7549,91 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func replyContextAndPendingMediaAreMutuallyExclusive() async throws {
+        // Issue #399: FFI media uploads carry no reply target. The composer must never
+        // keep both a visible reply banner and pending media, regardless of which one
+        // the user starts first, because sendDraft() can only route to one send path.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        let attachment = PendingMediaAttachment(
+            fileName: "notes.txt",
+            mediaType: "text/plain",
+            data: Data("hello media".utf8),
+            dim: nil
+        )
+        let parent = MessageItem(
+            id: "parent",
+            senderName: "Alice",
+            body: "The launch plan is ready.",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false
+        )
+
+        await state.bootstrap()
+        guard let draftKey = state.selectedComposerDraftKey else {
+            Issue.record("Expected a composer draft key")
+            return
+        }
+
+        state.startReply(to: parent)
+        state.appendPendingMediaAttachment(attachment, for: draftKey)
+        state.draftText = "Photo caption"
+
+        #expect(state.replyDraftContext == nil)
+        #expect(state.pendingMediaAttachments.count == 1)
+
+        await state.sendDraft()
+
+        #expect(runtime.uploadMediaCallCount == 1)
+        #expect(runtime.replyToMessageCallCount == 0)
+        #expect(runtime.repliedMessage == nil)
+        #expect(runtime.uploadedMedia?.request.caption == "Photo caption")
+        #expect(state.pendingMediaAttachments.isEmpty)
+
+        state.appendPendingMediaAttachment(attachment, for: draftKey)
+        #expect(state.pendingMediaAttachments.count == 1)
+
+        state.startReply(to: parent)
+        state.draftText = "Text reply only"
+
+        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(state.replyDraftContext?.targetMessageId == "parent")
+
+        await state.sendDraft()
+
+        #expect(runtime.uploadMediaCallCount == 1)
+        #expect(runtime.replyToMessageCallCount == 1)
+        #expect(
+            runtime.repliedMessage
+                == SentReply(
+                    groupIdHex: "direct-group",
+                    targetMessageId: "parent",
+                    text: "Text reply only"
+                ))
+    }
+
+    @MainActor
     @Test func messageActionsPublishReactionAndDelete() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
Fixes #399

## Summary
- Make reply context and pending media mutually exclusive in the composer while media uploads cannot carry a reply target.
- Staging media now clears any active reply banner before send.
- Starting a reply now clears staged attachments, so `sendDraft()` cannot silently discard a visible reply context.
- Added a regression test covering both orderings.

## Verification
- `git diff --check` — passed.
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed.
- Conflict-marker sweep over committed Swift files — passed.
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — not runnable on this Linux host: `xcrun: command not found`.
- `scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host: `xcodebuild: command not found`.
- `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' ...` — not runnable on this Linux host: `xcodebuild: command not found`.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/413">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->