### PR TITLE
fix: scope chat list toggle animation

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Navigation.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Navigation.swift
@@ -65,8 +65,6 @@ extension WorkspaceState {
     }
 
     func toggleChatList() {
-        withAnimation(.smooth(duration: 0.18)) {
-            isChatListVisible.toggle()
-        }
+        isChatListVisible.toggle()
     }
 }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -20,14 +20,21 @@ struct MessengerShellView: View {
                     AccountRailView()
                     GlassSeparator()
 
-                    if workspace.isChatListVisible {
-                        ChatListDrawerView()
-                            .frame(width: 300, alignment: .leading)
-                            .transition(.move(edge: .leading).combined(with: .opacity))
+                    Group {
+                        if workspace.isChatListVisible {
+                            ChatListDrawerView()
+                                .frame(width: 300, alignment: .leading)
+                                .transition(.move(edge: .leading).combined(with: .opacity))
 
-                        GlassSeparator()
-                            .transition(.opacity)
+                            GlassSeparator()
+                                .transition(.opacity)
+                        }
                     }
+                    // Scope the sidebar transition to the drawer. The detail pane
+                    // width should jump once, not animate through every intermediate
+                    // width and force the non-lazy transcript to re-wrap each frame.
+                    .animation(.smooth(duration: 0.18), value: workspace.isChatListVisible)
+
                     DetailPaneView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
@@ -47,7 +54,6 @@ struct MessengerShellView: View {
             MessagesWindowBackground()
         }
         .ignoresSafeArea(.container, edges: ignoredEdges)
-        .animation(.smooth(duration: 0.18), value: workspace.isChatListVisible)
     }
 }
 


### PR DESCRIPTION
## Summary
- scopes the chat-list show/hide animation to the drawer instead of the whole messenger shell
- removes the animated transaction around `toggleChatList()` so the detail pane width changes once instead of interpolating every frame
- keeps the drawer teardown behavior from #401 by leaving `ChatListDrawerView` conditional

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' HEAD -- . ':!*.xcstrings'`
- Not run: `xcodebuild`/Swift compiler are unavailable on this Linux worker (`xcodebuild: not found`, `swift: not found`)

Fixes #396


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->