### PR TITLE
fix: scope hover text selection to message bubbles

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -21,16 +21,60 @@ import SwiftUI
 /// fit in the cost-bounded decoded-image cache.
 private let mediaThumbnailOversample: CGFloat = 1.5
 
+/// Per-conversation hover-selection gate. Bubbles register a local `isSelectable` binding;
+/// `activate` flips only the previous and newly active bubble so hover does not invalidate
+/// the non-lazy transcript `ForEach` parent (whitenoise-mac#397). SwiftUI calls this from
+/// main-thread view lifecycle / hover callbacks; it intentionally publishes no observable
+/// state back to `ConversationView`.
+final class ConversationHoverSelectionCoordinator {
+    private var activeMessageID: String?
+    private var registrations: [String: Binding<Bool>] = [:]
+
+    func register(messageID: String, isSelectable: Binding<Bool>) {
+        registrations[messageID] = isSelectable
+        isSelectable.wrappedValue = activeMessageID == messageID
+    }
+
+    func unregister(messageID: String) {
+        if activeMessageID == messageID {
+            activeMessageID = nil
+        }
+        registrations.removeValue(forKey: messageID)
+    }
+
+    func activate(messageID: String) {
+        guard activeMessageID != messageID else { return }
+        if let previousID = activeMessageID {
+            registrations[previousID]?.wrappedValue = false
+        }
+        activeMessageID = messageID
+        registrations[messageID]?.wrappedValue = true
+    }
+
+    func reset() {
+        if let activeMessageID {
+            registrations[activeMessageID]?.wrappedValue = false
+        }
+        activeMessageID = nil
+    }
+}
+
+private struct ConversationHoverSelectionCoordinatorKey: EnvironmentKey {
+    static let defaultValue = ConversationHoverSelectionCoordinator()
+}
+
+extension EnvironmentValues {
+    var conversationHoverSelectionCoordinator: ConversationHoverSelectionCoordinator {
+        get { self[ConversationHoverSelectionCoordinatorKey.self] }
+        set { self[ConversationHoverSelectionCoordinatorKey.self] = newValue }
+    }
+}
+
 struct ConversationMessageRow: View, Equatable {
     let message: MessageItem
-    /// Whether this row is the currently text-selectable bubble (drives `.textSelection`).
-    /// Passed by value so value-diffing only re-runs the rows whose selectability flipped.
-    var isSelectable: Bool = false
     /// Keep the debug toggle as a row input so `.equatable()` still updates rows when the
-    /// diagnostics presentation changes, while ordinary hover/selection churn skips rows
-    /// whose value inputs are unchanged.
+    /// diagnostics presentation changes, while hover/selection churn is scoped below the row.
     var showsDebugMetadata = false
-    let onActivateSelection: (String) -> Void
     let onOpenImageGallery: (MessageImageGalleryPresentation) -> Void
 
     // Receives the resolved MessageItem by value (not via a shared @Observable lookup),
@@ -40,9 +84,7 @@ struct ConversationMessageRow: View, Equatable {
         if message.presentation.isChatBubble {
             MessageBubble(
                 message: message,
-                isSelectable: isSelectable,
                 showsDebugMetadata: showsDebugMetadata,
-                onActivateSelection: onActivateSelection,
                 onOpenImageGallery: onOpenImageGallery
             )
         } else {
@@ -52,7 +94,6 @@ struct ConversationMessageRow: View, Equatable {
 
     static func == (lhs: ConversationMessageRow, rhs: ConversationMessageRow) -> Bool {
         lhs.message == rhs.message
-            && lhs.isSelectable == rhs.isSelectable
             && lhs.showsDebugMetadata == rhs.showsDebugMetadata
     }
 }
@@ -108,13 +149,12 @@ struct TimelineNoticeRow: View {
 
 struct MessageBubble: View {
     @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.conversationHoverSelectionCoordinator) private var hoverSelectionCoordinator
     @State private var isHovering = false
     @State private var isInlineActionPresentationActive = false
+    @State private var isSelectable = false
     let message: MessageItem
-    /// Whether this bubble's text is selectable right now (only the active bubble is).
-    var isSelectable: Bool = false
     let showsDebugMetadata: Bool
-    let onActivateSelection: (String) -> Void
     let onOpenImageGallery: (MessageImageGalleryPresentation) -> Void
 
     var body: some View {
@@ -216,12 +256,18 @@ struct MessageBubble: View {
         .contextMenu {
             MessageContextMenuItems(message: message)
         }
+        .onAppear {
+            hoverSelectionCoordinator.register(messageID: message.id, isSelectable: $isSelectable)
+        }
+        .onDisappear {
+            hoverSelectionCoordinator.unregister(messageID: message.id)
+        }
         .onHover { hovering in
             isHovering = hovering
             // Make this the active (selectable) bubble on hover-enter; do NOT clear on
             // exit, so the selection survives moving the cursor toward ⌘C / the menu bar.
             if hovering {
-                onActivateSelection(message.id)
+                hoverSelectionCoordinator.activate(messageID: message.id)
             }
         }
     }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -282,11 +282,10 @@ private struct ConversationView: View {
     @State private var isFileImporterPresented = false
     @State private var isFileDropTargeted = false
     @State private var imageGallery: MessageImageGalleryPresentation?
-    /// The single message bubble that is currently text-selectable. Set on hover and kept
-    /// until another bubble is hovered or the chat changes, so at most one bubble is ever
-    /// backed by a selection NSView — avoiding the mass-platform-view layout hang that
-    /// blanket `.textSelection(.enabled)` caused (whitenoise-mac#205).
-    @State private var activeSelectionMessageID: String?
+    /// Hover-scoped text-selection gate for chat bubbles. Not read by `body` — bubbles
+    /// register local `isSelectable` state so hover only updates the previous and active row
+    /// (whitenoise-mac#397).
+    @State private var hoverSelectionCoordinator = ConversationHoverSelectionCoordinator()
     /// True while the ScrollView is in any non-idle phase. Drives `.allowsHitTesting` on the
     /// transcript so per-frame hover/hit-test/tracking work is skipped during a fling and
     /// restored the moment scrolling settles.
@@ -332,16 +331,13 @@ private struct ConversationView: View {
                             ForEach(messages) { message in
                                 ConversationMessageRow(
                                     message: message,
-                                    isSelectable: activeSelectionMessageID == message.id,
-                                    showsDebugMetadata: workspace.streamingDebugEnabled,
-                                    onActivateSelection: { messageId in
-                                        activeSelectionMessageID = messageId
-                                    }
+                                    showsDebugMetadata: workspace.streamingDebugEnabled
                                 ) { gallery in
                                     imageGallery = gallery
                                 }
                                 .equatable()
                             }
+                            .environment(\.conversationHoverSelectionCoordinator, hoverSelectionCoordinator)
 
                             if paging.hasMoreAfter {
                                 TimelinePageLoadingRow(isLoading: paging.isLoadingAfter)
@@ -387,7 +383,7 @@ private struct ConversationView: View {
                     pendingPrependAnchorId = nil
                     pendingAppendAnchorId = nil
                     isPinnedToBottom = true
-                    activeSelectionMessageID = nil
+                    hoverSelectionCoordinator.reset()
                 }
                 .onChange(of: messageIDs.last) { _, newMessageId in
                     switch timelineNewestMessageScrollAction(

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1130,6 +1130,102 @@ struct PureValueTests {
             disappearingMessageSecs: 0
         )
     }
+
+    @MainActor
+    @Test func hoverSelectionCoordinatorOnlyTogglesAffectedBubbles() async throws {
+        let coordinator = ConversationHoverSelectionCoordinator()
+        var firstSelectable = false
+        var secondSelectable = false
+        var thirdSelectable = false
+        var firstChangeCount = 0
+        var secondChangeCount = 0
+        var thirdChangeCount = 0
+        coordinator.register(
+            messageID: "first",
+            isSelectable: Binding(
+                get: { firstSelectable },
+                set: {
+                    firstSelectable = $0
+                    firstChangeCount += 1
+                }
+            )
+        )
+        coordinator.register(
+            messageID: "second",
+            isSelectable: Binding(
+                get: { secondSelectable },
+                set: {
+                    secondSelectable = $0
+                    secondChangeCount += 1
+                }
+            )
+        )
+        coordinator.register(
+            messageID: "third",
+            isSelectable: Binding(
+                get: { thirdSelectable },
+                set: {
+                    thirdSelectable = $0
+                    thirdChangeCount += 1
+                }
+            )
+        )
+        firstChangeCount = 0
+        secondChangeCount = 0
+        thirdChangeCount = 0
+
+        coordinator.activate(messageID: "first")
+        #expect(firstSelectable)
+        #expect(!secondSelectable)
+        #expect(!thirdSelectable)
+        #expect(firstChangeCount == 1)
+        #expect(secondChangeCount == 0)
+        #expect(thirdChangeCount == 0)
+
+        firstChangeCount = 0
+        secondChangeCount = 0
+        thirdChangeCount = 0
+        coordinator.activate(messageID: "third")
+        #expect(!firstSelectable)
+        #expect(!secondSelectable)
+        #expect(thirdSelectable)
+        #expect(firstChangeCount == 1)
+        #expect(secondChangeCount == 0)
+        #expect(thirdChangeCount == 1)
+
+        firstChangeCount = 0
+        secondChangeCount = 0
+        thirdChangeCount = 0
+        coordinator.activate(messageID: "third")
+        #expect(thirdSelectable)
+        #expect(firstChangeCount == 0)
+        #expect(secondChangeCount == 0)
+        #expect(thirdChangeCount == 0)
+
+        coordinator.reset()
+        #expect(!firstSelectable)
+        #expect(!secondSelectable)
+        #expect(!thirdSelectable)
+    }
+
+    @MainActor
+    @Test func hoverSelectionCoordinatorRegistersLateJoinerAsInactive() async throws {
+        let coordinator = ConversationHoverSelectionCoordinator()
+        var firstSelectable = false
+        coordinator.register(
+            messageID: "first",
+            isSelectable: Binding(get: { firstSelectable }, set: { firstSelectable = $0 })
+        )
+        coordinator.activate(messageID: "first")
+
+        var secondSelectable = false
+        coordinator.register(
+            messageID: "second",
+            isSelectable: Binding(get: { secondSelectable }, set: { secondSelectable = $0 })
+        )
+        #expect(firstSelectable)
+        #expect(!secondSelectable)
+    }
 }
 
 @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -188,9 +188,7 @@ private struct TranscriptPerformanceRows: View {
             ForEach(messages) { message in
                 ConversationMessageRow(
                     message: message,
-                    isSelectable: false,
-                    showsDebugMetadata: false,
-                    onActivateSelection: { _ in }
+                    showsDebugMetadata: false
                 ) { _ in }
                 .equatable()
             }


### PR DESCRIPTION
Fixes #397

## Summary
- Moved hover text-selection state out of `ConversationView.body` so hover transitions no longer rebuild the whole non-lazy transcript `ForEach`.
- Added `ConversationHoverSelectionCoordinator`, injected as a stable environment value, so each `MessageBubble` registers local `isSelectable` state and only the previously active and newly active bubbles are toggled on hover.
- Added coordinator regression coverage and updated the transcript performance harness for the narrower row initializer.

## Verification
- `git diff --check origin/master...HEAD` — passed.
- Static added-line security scan for hardcoded secrets / eval / shell / SQL patterns — passed.
- Independent pre-commit review subagent — passed; no blocking security or logic findings.
- `bash scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host: `xcodebuild: command not found`.
- CI-exact Xcode gates (`xcrun swift-format lint`, `xcodebuild test/build/analyze`) — not runnable on this Linux host: `xcrun`, `xcodebuild`, `swift`, and `swift-format` are unavailable.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/415">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->