### PR TITLE
fix: prune media downloads with timeline window

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -246,7 +246,7 @@ extension WorkspaceState {
 
     /// Lazily allocates per-attachment stores from SwiftUI body lookup without observing the
     /// backing dictionary; `mediaDownloads` is `@ObservationIgnored`, and pruning bounds it to
-    /// the active conversation.
+    /// attachments that still belong to the active timeline window.
     func mediaDownloadStateStore(forKey key: String) -> MediaDownloadStateStore {
         if let store = mediaDownloads[key] {
             return store
@@ -484,7 +484,19 @@ extension WorkspaceState {
     }
 
     func mediaDownloadKey(message: MessageItem, attachment: MessageMediaAttachment) -> String {
-        [activeAccountId ?? "", message.groupIdHex, attachment.id].joined(separator: "\u{1F}")
+        mediaDownloadKey(
+            accountId: activeAccountId ?? "",
+            groupIdHex: message.groupIdHex,
+            attachmentId: attachment.id
+        )
+    }
+
+    private func mediaDownloadKey(
+        accountId: String,
+        groupIdHex: String,
+        attachmentId: String
+    ) -> String {
+        [accountId, groupIdHex, attachmentId].joined(separator: "\u{1F}")
     }
 
     func pruneMediaDownloadCache(keeping groupIdHex: String?) {
@@ -494,12 +506,31 @@ extension WorkspaceState {
         }
 
         let prefix = [activeAccountId, groupIdHex, ""].joined(separator: "\u{1F}")
-        let removedKeys = mediaDownloads.keys.filter { !$0.hasPrefix(prefix) }
+        let retainedKeys = retainedMediaDownloadKeys(groupIdHex: groupIdHex, accountId: activeAccountId)
+        let removedKeys = mediaDownloads.keys.filter { key in
+            guard key.hasPrefix(prefix) else { return true }
+            return !retainedKeys.contains(key)
+        }
         for key in removedKeys {
             // Notify any lingering per-attachment observers before dropping the store.
             mediaDownloads[key]?.update(.idle)
             mediaDownloads[key] = nil
         }
+    }
+
+    private func retainedMediaDownloadKeys(groupIdHex: String, accountId: String) -> Set<String> {
+        guard let timelineStore = messageTimelineStores[groupIdHex] else { return [] }
+        return Set(
+            timelineStore.messages.flatMap { message in
+                message.mediaAttachments.map { attachment in
+                    mediaDownloadKey(
+                        accountId: accountId,
+                        groupIdHex: message.groupIdHex,
+                        attachmentId: attachment.id
+                    )
+                }
+            }
+        )
     }
 
     func resetMediaDownloadStateStores() {

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -186,7 +186,14 @@ extension WorkspaceState {
         )
 
         if let cachedDownload = await mediaDiskCache.cachedDownload(for: cacheKey) {
-            guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
+            guard
+                canPublishMediaDownloadState(
+                    forKey: key,
+                    stateStore: stateStore,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else {
                 stateStore.update(.idle)
                 return
             }
@@ -201,6 +208,17 @@ extension WorkspaceState {
         if case .loaded = stateStore.state {
             return
         }
+        guard
+            canPublishMediaDownloadState(
+                forKey: key,
+                stateStore: stateStore,
+                accountId: accountId,
+                groupIdHex: groupIdHex
+            )
+        else {
+            stateStore.update(.idle)
+            return
+        }
 
         do {
             let reference = try await resolvedMediaReference(
@@ -210,12 +228,30 @@ extension WorkspaceState {
                 groupIdHex: groupIdHex,
                 client: client
             )
+            guard
+                canPublishMediaDownloadState(
+                    forKey: key,
+                    stateStore: stateStore,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else {
+                stateStore.update(.idle)
+                return
+            }
             let download = try await client.downloadMedia(
                 accountRef: accountRef,
                 groupIdHex: groupIdHex,
                 reference: reference
             )
-            guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
+            guard
+                canPublishMediaDownloadState(
+                    forKey: key,
+                    stateStore: stateStore,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else {
                 stateStore.update(.idle)
                 return
             }
@@ -236,7 +272,14 @@ extension WorkspaceState {
                 storeGuard: storeGuard
             )
         } catch {
-            guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
+            guard
+                canPublishMediaDownloadState(
+                    forKey: key,
+                    stateStore: stateStore,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else {
                 stateStore.update(.idle)
                 return
             }
@@ -254,6 +297,16 @@ extension WorkspaceState {
         let store = MediaDownloadStateStore()
         mediaDownloads[key] = store
         return store
+    }
+
+    private func canPublishMediaDownloadState(
+        forKey key: String,
+        stateStore: MediaDownloadStateStore,
+        accountId: String,
+        groupIdHex: String
+    ) -> Bool {
+        isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex)
+            && mediaDownloads[key] === stateStore
     }
 
     func addMediaAttachments(from urls: [URL]) async {
@@ -525,7 +578,7 @@ extension WorkspaceState {
                 message.mediaAttachments.map { attachment in
                     mediaDownloadKey(
                         accountId: accountId,
-                        groupIdHex: message.groupIdHex,
+                        groupIdHex: groupIdHex,
                         attachmentId: attachment.id
                     )
                 }

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -428,7 +428,10 @@ extension WorkspaceState {
                 hasMoreAfter: paging.hasMoreAfter,
                 isLoadingBefore: paging.isLoadingBefore,
                 isLoadingAfter: paging.isLoadingAfter
-            )
+            ),
+            pruneMediaDownloads: result.didRemoveMessages
+                || result.didTrimOlderMessages
+                || introducesMediaChange
         )
         await markLatestVisibleMessageRead(groupIdHex: groupIdHex, account: account, client: client)
     }
@@ -746,7 +749,8 @@ extension WorkspaceState {
 
     func finalizeTimelineStoreMutation(
         groupIdHex: String,
-        paging: TimelinePagingState
+        paging: TimelinePagingState,
+        pruneMediaDownloads: Bool
     ) {
         let timelineStore = ensureMessageTimelineStore(for: groupIdHex)
         for (storeGroupId, store) in messageTimelineStores where storeGroupId != groupIdHex {
@@ -756,7 +760,9 @@ extension WorkspaceState {
         messageTimelineStores = [groupIdHex: timelineStore]
         timelinePagingByChat = [groupIdHex: paging]
         finishTimelineInitialLoad(groupIdHex: groupIdHex)
-        pruneMediaDownloadCache(keeping: groupIdHex)
+        if pruneMediaDownloads {
+            pruneMediaDownloadCache(keeping: groupIdHex)
+        }
     }
 
     func refreshSelectedTimelineAfterSend(

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -741,6 +741,7 @@ extension WorkspaceState {
             timelinePagingByChat = [groupIdHex: nextPaging]
         }
         finishTimelineInitialLoad(groupIdHex: groupIdHex)
+        pruneMediaDownloadCache(keeping: groupIdHex)
     }
 
     func finalizeTimelineStoreMutation(
@@ -755,6 +756,7 @@ extension WorkspaceState {
         messageTimelineStores = [groupIdHex: timelineStore]
         timelinePagingByChat = [groupIdHex: paging]
         finishTimelineInitialLoad(groupIdHex: groupIdHex)
+        pruneMediaDownloadCache(keeping: groupIdHex)
     }
 
     func refreshSelectedTimelineAfterSend(

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -248,6 +248,7 @@ final class MediaDownloadStateStore {
 final class MessageTimelineStore {
     struct ProjectionApplyResult: Equatable {
         let didChange: Bool
+        let didRemoveMessages: Bool
         let didTrimOlderMessages: Bool
     }
 
@@ -306,12 +307,14 @@ final class MessageTimelineStore {
         windowLimit: Int
     ) -> ProjectionApplyResult {
         var didChange = false
+        var didRemoveMessages = false
 
         if !removalIds.isEmpty {
             let originalCount = messages.count
             messages.removeAll { removalIds.contains($0.id) }
-            didChange = messages.count != originalCount
-            if didChange {
+            didRemoveMessages = messages.count != originalCount
+            didChange = didRemoveMessages
+            if didRemoveMessages {
                 rebuildIndexes()
             }
         }
@@ -353,7 +356,11 @@ final class MessageTimelineStore {
         if didChange {
             isLoaded = true
         }
-        return ProjectionApplyResult(didChange: didChange, didTrimOlderMessages: didTrimOlderMessages)
+        return ProjectionApplyResult(
+            didChange: didChange,
+            didRemoveMessages: didRemoveMessages,
+            didTrimOlderMessages: didTrimOlderMessages
+        )
     }
 
     private func rebuildIndexes() {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -285,6 +285,80 @@ struct PureValueTests {
     }
 
     @MainActor
+    @Test func replacingTimelineWindowEvictsMediaDownloadsOutsideWindow() async throws {
+        // Regression for whitenoise-mac#394: decrypted attachment payloads for messages that
+        // leave the selected timeline window must be released instead of staying resident until
+        // the user switches conversations.
+        let account = AccountItem.samples[0]
+        let chat = ChatItem.samples[0]
+        let staleAttachment = MessageMediaAttachment(
+            id: "stale-attachment",
+            reference: mediaReference(fileName: "stale.png", mediaType: "image/png")
+        )
+        let retainedAttachment = MessageMediaAttachment(
+            id: "retained-attachment",
+            reference: mediaReference(fileName: "retained.png", mediaType: "image/png")
+        )
+        let staleMessage = MessageItem(
+            id: "stale-message",
+            groupIdHex: chat.id,
+            senderName: "Alice",
+            body: "Scrolled away",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            mediaAttachments: [staleAttachment]
+        )
+        let retainedMessage = MessageItem(
+            id: "retained-message",
+            groupIdHex: chat.id,
+            senderName: "Alice",
+            body: "Still visible",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_001),
+            isOutgoing: false,
+            mediaAttachments: [retainedAttachment]
+        )
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [chat]],
+            messagesByChat: [chat.id: [staleMessage, retainedMessage]],
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(chat.id)
+
+        let staleKey = state.mediaDownloadKey(message: staleMessage, attachment: staleAttachment)
+        let retainedKey = state.mediaDownloadKey(message: retainedMessage, attachment: retainedAttachment)
+        let staleStore = mediaDownloadStore(
+            plaintext: Data("stale decrypted plaintext".utf8),
+            fileName: "stale.png",
+            payloadId: "stale-payload"
+        )
+        let retainedStore = mediaDownloadStore(
+            plaintext: Data("retained decrypted plaintext".utf8),
+            fileName: "retained.png",
+            payloadId: "retained-payload"
+        )
+        state.mediaDownloads[staleKey] = staleStore
+        state.mediaDownloads[retainedKey] = retainedStore
+
+        state.replaceMessages([retainedMessage], groupIdHex: chat.id)
+
+        #expect(state.mediaDownloads[staleKey] == nil)
+        #expect(staleStore.state == .idle)
+        let retained = try #require(state.mediaDownloads[retainedKey])
+        #expect(retained === retainedStore)
+        let retainedData: Data?
+        if case .loaded(let download) = retained.state {
+            retainedData = download.data
+        } else {
+            retainedData = nil
+        }
+        #expect(retainedData == Data("retained decrypted plaintext".utf8))
+    }
+
+    @MainActor
     @Test func detachedWindowSuppressesUpsertNewerThanPostRemovalHead() async throws {
         // Regression for whitenoise-mac#331: applyProjection must recompute the window head
         // *after* removals. In a detached (scrolled-back) window, a delta that removes the
@@ -1093,6 +1167,42 @@ struct PureValueTests {
             sourceURL: nil,
             width: nil,
             height: nil
+        )
+    }
+
+    @MainActor
+    private func mediaDownloadStore(
+        plaintext: Data,
+        fileName: String,
+        payloadId: String
+    ) -> MediaDownloadStateStore {
+        let store = MediaDownloadStateStore()
+        store.update(
+            .loaded(
+                MessageMediaDownload(
+                    data: plaintext,
+                    fileName: fileName,
+                    mediaType: "image/png",
+                    sizeBytes: UInt64(plaintext.count),
+                    payloadId: payloadId
+                )
+            )
+        )
+        return store
+    }
+
+    private func mediaReference(fileName: String, mediaType: String) -> MediaAttachmentReferenceFfi {
+        MediaAttachmentReferenceFfi(
+            locators: [MediaLocatorFfi(kind: "blossom", value: "https://media.example/\(fileName)")],
+            ciphertextSha256: "ciphertext-\(fileName)",
+            plaintextSha256: "plaintext-\(fileName)",
+            nonceHex: "00",
+            fileName: fileName,
+            mediaType: mediaType,
+            version: "1",
+            sourceEpoch: 1,
+            dim: nil,
+            thumbhash: nil
         )
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4640,22 +4640,33 @@ struct whitenoise_macTests {
         )
         await state.bootstrap()
         let chat = try #require(state.activeChats.first)
-        state.selectChat(chat)
-        let message = MessageItem(
-            id: "late-after-failed-delete-message",
-            groupIdHex: "group",
-            senderName: "Alice",
-            body: "",
-            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
-            isOutgoing: false,
-            mediaAttachments: [
-                MessageMediaAttachment(
-                    id: "late-after-failed-delete-message#0#\(reference.plaintextSha256)",
-                    reference: reference
+        state.selection = .chat(chat.id)
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "late-after-failed-delete-message",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJson(for: reference)
                 )
-            ]
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+        runtime.installTimelinePage(page, groupIdHex: "group")
+        let message = try #require(
+            MessageItem.timeline(
+                from: page,
+                activeAccountIdHex: AccountItem(summary: account).id
+            ).first
         )
         let attachment = try #require(message.mediaAttachments.first)
+        state.replaceMessages([message], groupIdHex: "group")
+        // `deleteAllData()` recovery reloads the selected timeline after a failed wipe. Keep this
+        // fixture message in that recovered window so the test continues to model a visible tile
+        // whose late download is still allowed to publish.
         let stateStore = state.mediaDownloadStateStore(for: message, attachment: attachment)
         let cacheKey = MessageMediaDiskCacheKey(
             accountId: AccountItem(summary: account).id,
@@ -4681,6 +4692,107 @@ struct whitenoise_macTests {
             return
         }
         #expect(loaded.data == plaintext)
+        #expect(state.mediaDiskStoreTasks.isEmpty)
+        #expect(await mediaDiskCache.cachedDownload(for: cacheKey) == nil)
+    }
+
+    @MainActor
+    @Test func mediaDownloadFinishingAfterTimelinePruneDoesNotPublishPlaintext() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: false
+        )
+        let plaintext = Data([0x70, 0x71, 0x72, 0x73])
+        let reference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "image/png",
+            fileName: "pruned-late.png",
+            plaintextSha256: hexSHA256(plaintext)
+        )
+        let download = MediaDownloadResultFfi(
+            plaintext: plaintext,
+            fileName: "pruned-late.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(plaintext.count)
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "pruned-late-media-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: reference,
+                caption: nil,
+                recordedAt: 1_700_000_000,
+                receivedAt: 1_700_000_000
+            ),
+            download: download
+        )
+        let mediaDiskCache = messageMediaDiskCache(root: root)
+        let state = WorkspaceState(
+            mediaDiskCache: mediaDiskCache,
+            clientFactory: { runtime }
+        )
+        await state.bootstrap()
+        let chat = try #require(state.activeChats.first)
+        state.selection = .chat(chat.id)
+        let message = MessageItem(
+            id: "pruned-late-media-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "pruned-late-media-message#0#\(reference.plaintextSha256)",
+                    reference: reference
+                )
+            ]
+        )
+        let attachment = try #require(message.mediaAttachments.first)
+        state.replaceMessages([message], groupIdHex: "group")
+        let key = state.mediaDownloadKey(message: message, attachment: attachment)
+        let stateStore = state.mediaDownloadStateStore(for: message, attachment: attachment)
+        let cacheKey = MessageMediaDiskCacheKey(
+            accountId: AccountItem(summary: account).id,
+            groupIdHex: "group",
+            reference: reference
+        )
+
+        runtime.mediaDownloadGateEnabled = true
+        async let load: Void = state.loadMediaAttachment(attachment, for: message)
+        while !runtime.didReachMediaDownloadGate {
+            await Task.yield()
+        }
+
+        state.replaceMessages([], groupIdHex: "group")
+        #expect(state.mediaDownloads[key] == nil)
+        #expect(stateStore.state == .idle)
+
+        runtime.releaseMediaDownloadGate()
+        await load
+        for _ in 0..<20 where !state.mediaDiskStoreTasks.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(state.mediaDownloads[key] == nil)
+        #expect(stateStore.state == .idle)
         #expect(state.mediaDiskStoreTasks.isEmpty)
         #expect(await mediaDiskCache.cachedDownload(for: cacheKey) == nil)
     }
@@ -14361,6 +14473,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func installMessages(_ messages: [AppMessageRecordFfi], groupIdHex: String) {
         messagesByGroupId[groupIdHex] = messages
         timelinePagesByGroupId[groupIdHex] = projectedTimeline(from: messages)
+    }
+
+    func installTimelinePage(_ page: TimelinePageFfi, groupIdHex: String) {
+        timelinePagesByGroupId[groupIdHex] = page
     }
 
     func installGroup(_ group: AppGroupRecordFfi) {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3905,17 +3905,7 @@ struct whitenoise_macTests {
         )
         let state = WorkspaceState(clientFactory: { runtime })
         await state.bootstrap()
-        state.selectChat(
-            ChatItem(
-                id: "group",
-                title: "Test Group",
-                subtitle: "Group message",
-                preview: "Attachment",
-                updatedAt: nil,
-                avatarSeed: "group",
-                pictureURL: nil,
-                unreadCount: 0
-            ))
+        state.selection = .chat("group")
         let message = MessageItem(
             id: "media-message",
             groupIdHex: "group",
@@ -3931,6 +3921,7 @@ struct whitenoise_macTests {
             ]
         )
         let attachment = try #require(message.mediaAttachments.first)
+        state.replaceMessages([message], groupIdHex: "group")
 
         await state.loadMediaAttachment(attachment, for: message)
         let stateAfterFirstLoad = state.mediaDownloadState(for: message, attachment: attachment)
@@ -4563,7 +4554,7 @@ struct whitenoise_macTests {
         )
         await state.bootstrap()
         let chat = try #require(state.activeChats.first)
-        state.selectChat(chat)
+        state.selection = .chat(chat.id)
         let message = MessageItem(
             id: "suppressed-cached-message",
             groupIdHex: "group",
@@ -4579,6 +4570,7 @@ struct whitenoise_macTests {
             ]
         )
         let attachment = try #require(message.mediaAttachments.first)
+        state.replaceMessages([message], groupIdHex: chat.id)
 
         state.suppressAllMediaDiskStores()
         await state.loadMediaAttachment(attachment, for: message)


### PR DESCRIPTION
## Summary
- prune `mediaDownloads` to the attachment keys still present in the active timeline window
- run that pruning after full timeline window replacement and incremental projection mutations
- add regression coverage for stale plaintext eviction and update existing media download tests to seed their synthetic messages into the active window

## Test plan
- `git diff --check`
- conflict marker scan with `search_files` over Swift sources
- GitHub Mac CI: `Static Analysis` pass, `PR Checks` pass
- not run locally: `xcodebuild` / Swift tests (xcodebuild, swift, and swiftformat are not installed on this Linux host)

Fixes #394
