### PR TITLE
fix: time out stalled attachment downloads

### DIFF
--- a/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
+++ b/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
@@ -9,6 +9,114 @@ import Foundation
 /// unbounded FFI `downloadMedia` calls.
 enum MediaAttachmentDownloadConcurrency {
     static let maxConcurrentDownloads = 4
+
+    /// Wall-clock ceiling for one attachment's resolve+download FFI while holding a limiter slot.
+    /// Matches `RemoteImageURLPolicy.downloadResourceTimeout` so stalled relay fetches cannot
+    /// occupy all download slots indefinitely.
+    static let defaultFfiDownloadTimeoutNanoseconds: UInt64 = 60 * 1_000_000_000
+
+    #if DEBUG
+        static var ffiDownloadTimeoutNanoseconds: UInt64 = defaultFfiDownloadTimeoutNanoseconds
+    #else
+        static let ffiDownloadTimeoutNanoseconds: UInt64 = defaultFfiDownloadTimeoutNanoseconds
+    #endif
+}
+
+struct MediaAttachmentDownloadTimeoutError: LocalizedError {
+    var errorDescription: String? {
+        L10n.string("Attachment download timed out")
+    }
+}
+
+func withMediaAttachmentDownloadTimeout<T>(
+    nanoseconds: UInt64 = MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try Task.checkCancellation()
+    let race = MediaAttachmentDownloadTimeoutRace(
+        nanoseconds: nanoseconds,
+        operation: operation
+    )
+    return try await race.value()
+}
+
+private final class MediaAttachmentDownloadTimeoutRace<T>: @unchecked Sendable {
+    private let nanoseconds: UInt64
+    private let operation: @Sendable () async throws -> T
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var finished = false
+    private var operationTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(
+        nanoseconds: UInt64,
+        operation: @escaping @Sendable () async throws -> T
+    ) {
+        self.nanoseconds = nanoseconds
+        self.operation = operation
+    }
+
+    func value() async throws -> T {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                start(continuation)
+            }
+        } onCancel: {
+            finish(.failure(CancellationError()))
+        }
+    }
+
+    private func start(_ continuation: CheckedContinuation<T, Error>) {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        self.continuation = continuation
+        let operationTask = Task { [operation, weak self] in
+            do {
+                self?.finish(.success(try await operation()))
+            } catch {
+                self?.finish(.failure(error))
+            }
+        }
+        let timeoutTask = Task { [nanoseconds, weak self] in
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds)
+                self?.finish(.failure(MediaAttachmentDownloadTimeoutError()))
+            } catch is CancellationError {
+                // Expected when the download wins or the caller is cancelled.
+            } catch {
+                self?.finish(.failure(error))
+            }
+        }
+        self.operationTask = operationTask
+        self.timeoutTask = timeoutTask
+        lock.unlock()
+    }
+
+    private func finish(_ result: Result<T, Error>) {
+        lock.lock()
+        guard !finished else {
+            lock.unlock()
+            return
+        }
+        finished = true
+        let continuation = self.continuation
+        self.continuation = nil
+        let operationTask = self.operationTask
+        let timeoutTask = self.timeoutTask
+        self.operationTask = nil
+        self.timeoutTask = nil
+        lock.unlock()
+
+        operationTask?.cancel()
+        timeoutTask?.cancel()
+        continuation?.resume(with: result)
+    }
 }
 
 actor MediaAttachmentDownloadLimiter {
@@ -16,30 +124,62 @@ actor MediaAttachmentDownloadLimiter {
         maxConcurrent: MediaAttachmentDownloadConcurrency.maxConcurrentDownloads
     )
 
+    private struct QueuedWaiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
     private let maxConcurrent: Int
     private var inFlight = 0
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [QueuedWaiter] = []
 
     init(maxConcurrent: Int) {
         self.maxConcurrent = max(1, maxConcurrent)
     }
 
-    func acquire() async {
+    func acquire() async throws {
+        try Task.checkCancellation()
         if inFlight < maxConcurrent {
             inFlight += 1
             return
         }
-        await withCheckedContinuation { continuation in
-            waiters.append(continuation)
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    waiters.append(QueuedWaiter(id: waiterID, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelQueuedWaiter(id: waiterID) }
+        }
+        if Task.isCancelled {
+            release()
+            throw CancellationError()
         }
     }
 
     func release() {
         if let waiter = waiters.first {
             waiters.removeFirst()
-            waiter.resume()
+            waiter.continuation.resume()
         } else {
             inFlight -= 1
         }
+    }
+
+    #if DEBUG
+        func queuedWaiterCount() -> Int {
+            waiters.count
+        }
+    #endif
+
+    private func cancelQueuedWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
     }
 }

--- a/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
+++ b/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// Bounds concurrent attachment downloads so opening a media-heavy chat cannot spawn
 /// unbounded FFI `downloadMedia` calls.
-enum MediaAttachmentDownloadConcurrency {
+nonisolated enum MediaAttachmentDownloadConcurrency {
     static let maxConcurrentDownloads = 4
 
     /// Wall-clock ceiling for one attachment's resolve+download FFI while holding a limiter slot.
@@ -22,13 +22,13 @@ enum MediaAttachmentDownloadConcurrency {
     #endif
 }
 
-struct MediaAttachmentDownloadTimeoutError: LocalizedError {
+nonisolated struct MediaAttachmentDownloadTimeoutError: LocalizedError {
     var errorDescription: String? {
         L10n.string("Attachment download timed out")
     }
 }
 
-func withMediaAttachmentDownloadTimeout<T>(
+nonisolated func withMediaAttachmentDownloadTimeout<T>(
     nanoseconds: UInt64 = MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds,
     operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
@@ -40,7 +40,7 @@ func withMediaAttachmentDownloadTimeout<T>(
     return try await race.value()
 }
 
-private final class MediaAttachmentDownloadTimeoutRace<T>: @unchecked Sendable {
+private nonisolated final class MediaAttachmentDownloadTimeoutRace<T>: @unchecked Sendable {
     private let nanoseconds: UInt64
     private let operation: @Sendable () async throws -> T
     private let lock = NSLock()
@@ -146,7 +146,7 @@ actor MediaAttachmentDownloadLimiter {
 
         let waiterID = UUID()
         try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 if Task.isCancelled {
                     continuation.resume(throwing: CancellationError())
                 } else {

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -245,7 +245,7 @@ extension WorkspaceState {
 
         do {
             let download = try await withMediaAttachmentDownloadTimeout {
-                let reference = try await resolvedMediaReference(
+                let reference = try await self.resolvedMediaReference(
                     attachment.reference,
                     accountId: accountId,
                     accountRef: accountRef,

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -206,7 +206,25 @@ extension WorkspaceState {
             return
         }
 
-        await MediaAttachmentDownloadLimiter.shared.acquire()
+        do {
+            try await MediaAttachmentDownloadLimiter.shared.acquire()
+        } catch is CancellationError {
+            guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
+                stateStore.update(.idle)
+                return
+            }
+            if case .loading = stateStore.state {
+                stateStore.update(.idle)
+            }
+            return
+        } catch {
+            guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
+                stateStore.update(.idle)
+                return
+            }
+            stateStore.update(.failed(error.localizedDescription))
+            return
+        }
         defer {
             Task { await MediaAttachmentDownloadLimiter.shared.release() }
         }
@@ -226,29 +244,20 @@ extension WorkspaceState {
         }
 
         do {
-            let reference = try await resolvedMediaReference(
-                attachment.reference,
-                accountId: accountId,
-                accountRef: accountRef,
-                groupIdHex: groupIdHex,
-                client: client
-            )
-            guard
-                canPublishMediaDownloadState(
-                    forKey: key,
-                    stateStore: stateStore,
+            let download = try await withMediaAttachmentDownloadTimeout {
+                let reference = try await resolvedMediaReference(
+                    attachment.reference,
                     accountId: accountId,
-                    groupIdHex: groupIdHex
+                    accountRef: accountRef,
+                    groupIdHex: groupIdHex,
+                    client: client
                 )
-            else {
-                stateStore.update(.idle)
-                return
+                return try await client.downloadMedia(
+                    accountRef: accountRef,
+                    groupIdHex: groupIdHex,
+                    reference: reference
+                )
             }
-            let download = try await client.downloadMedia(
-                accountRef: accountRef,
-                groupIdHex: groupIdHex,
-                reference: reference
-            )
             guard
                 canPublishMediaDownloadState(
                     forKey: key,
@@ -276,6 +285,14 @@ extension WorkspaceState {
                 accountId: accountId,
                 storeGuard: storeGuard
             )
+        } catch is CancellationError {
+            guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
+                stateStore.update(.idle)
+                return
+            }
+            if case .loading = stateStore.state {
+                stateStore.update(.idle)
+            }
         } catch {
             guard
                 canPublishMediaDownloadState(

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -244,15 +244,26 @@ extension WorkspaceState {
         }
 
         do {
-            let download = try await withMediaAttachmentDownloadTimeout {
-                let reference = try await self.resolvedMediaReference(
-                    attachment.reference,
+            let reference = try await resolvedMediaReference(
+                attachment.reference,
+                accountId: accountId,
+                accountRef: accountRef,
+                groupIdHex: groupIdHex,
+                client: client
+            )
+            guard
+                canPublishMediaDownloadState(
+                    forKey: key,
+                    stateStore: stateStore,
                     accountId: accountId,
-                    accountRef: accountRef,
-                    groupIdHex: groupIdHex,
-                    client: client
+                    groupIdHex: groupIdHex
                 )
-                return try await client.downloadMedia(
+            else {
+                stateStore.update(.idle)
+                return
+            }
+            let download = try await withMediaAttachmentDownloadTimeout {
+                try await client.downloadMedia(
                     accountRef: accountRef,
                     groupIdHex: groupIdHex,
                     reference: reference

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -669,8 +669,8 @@ struct IdentityKeysSettingsView: View {
                                 .font(.headline)
                                 .lineLimit(1)
                             Text(accountSigningDescription(for: account))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5729,7 +5729,7 @@ struct whitenoise_macTests {
         await withTaskGroup(of: Void.self) { group in
             for _ in 0..<8 {
                 group.addTask {
-                    await limiter.acquire()
+                    try? await limiter.acquire()
                     let current = inFlight.increment()
                     maxInFlight.record(current)
                     try? await Task.sleep(nanoseconds: 5_000_000)
@@ -5741,6 +5741,229 @@ struct whitenoise_macTests {
 
         #expect(maxInFlight.value <= 2)
         #expect(inFlight.value == 0)
+    }
+
+    @Test func mediaAttachmentDownloadLimiterDropsCancelledQueuedWaiter() async {
+        let limiter = MediaAttachmentDownloadLimiter(maxConcurrent: 1)
+        try? await limiter.acquire()
+
+        let cancelled = AtomicCounter()
+        let waitingTask = Task {
+            do {
+                try await limiter.acquire()
+                Issue.record("Cancelled queued waiter should not acquire a slot")
+            } catch is CancellationError {
+                cancelled.increment()
+            } catch {
+                Issue.record("Expected CancellationError, got \(error)")
+            }
+        }
+
+        for _ in 0..<100 {
+            if await limiter.queuedWaiterCount() == 1 {
+                break
+            }
+            await Task.yield()
+        }
+        #expect(await limiter.queuedWaiterCount() == 1)
+
+        waitingTask.cancel()
+        _ = await waitingTask.result
+        #expect(cancelled.value == 1)
+        #expect(await limiter.queuedWaiterCount() == 0)
+
+        let acquired = AtomicCounter()
+        let nextTask = Task {
+            try? await limiter.acquire()
+            acquired.increment()
+        }
+        for _ in 0..<50 where acquired.value == 0 {
+            await Task.yield()
+        }
+        #expect(acquired.value == 0)
+
+        await limiter.release()
+        for _ in 0..<50 where acquired.value == 0 {
+            await Task.yield()
+        }
+        #expect(acquired.value == 1)
+
+        await limiter.release()
+        _ = await nextTask.result
+    }
+
+    @MainActor
+    @Test func mediaAttachmentDownloadTimesOutAndReleasesLimiterSlot() async throws {
+        let previousTimeout = MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds
+        defer { MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds = previousTimeout }
+        MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds = 50_000_000
+
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: false
+        )
+        let stalledPlaintext = Data([0x01, 0x02, 0x03])
+        let stalledReference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "image/png",
+            fileName: "stalled.png",
+            plaintextSha256: hexSHA256(stalledPlaintext)
+        )
+        let followUpPlaintext = Data([0x04, 0x05, 0x06])
+        let followUpReference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "image/png",
+            fileName: "follow-up.png",
+            plaintextSha256: hexSHA256(followUpPlaintext)
+        )
+        let stalledDownload = MediaDownloadResultFfi(
+            plaintext: stalledPlaintext,
+            fileName: "stalled.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(stalledPlaintext.count)
+        )
+        let followUpDownload = MediaDownloadResultFfi(
+            plaintext: followUpPlaintext,
+            fileName: "follow-up.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(followUpPlaintext.count)
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "stalled-media-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: stalledReference,
+                caption: nil,
+                recordedAt: 1_700_000_000,
+                receivedAt: 1_700_000_000
+            ),
+            download: stalledDownload
+        )
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "follow-up-media-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: followUpReference,
+                caption: nil,
+                recordedAt: 1_700_000_001,
+                receivedAt: 1_700_000_001
+            ),
+            download: followUpDownload
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let stalledMessage = MessageItem(
+            id: "stalled-media-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "stalled-media-message#0#\(stalledReference.plaintextSha256)",
+                    reference: stalledReference
+                )
+            ]
+        )
+        let followUpMessage = MessageItem(
+            id: "follow-up-media-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_001),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "follow-up-media-message#0#\(followUpReference.plaintextSha256)",
+                    reference: followUpReference
+                )
+            ]
+        )
+        let stalledAttachment = try #require(stalledMessage.mediaAttachments.first)
+        let followUpAttachment = try #require(followUpMessage.mediaAttachments.first)
+        let stalledStore = state.mediaDownloadStateStore(for: stalledMessage, attachment: stalledAttachment)
+        let heldSlotCount = MediaAttachmentDownloadConcurrency.maxConcurrentDownloads - 1
+        for _ in 0..<heldSlotCount {
+            try await MediaAttachmentDownloadLimiter.shared.acquire()
+        }
+        defer {
+            Task {
+                for _ in 0..<heldSlotCount {
+                    await MediaAttachmentDownloadLimiter.shared.release()
+                }
+            }
+        }
+
+        runtime.mediaDownloadGateEnabled = true
+        let stalledLoad = Task { await state.loadMediaAttachment(stalledAttachment, for: stalledMessage) }
+        for _ in 0..<100 {
+            if runtime.didReachMediaDownloadGate {
+                break
+            }
+            await Task.yield()
+        }
+        guard runtime.didReachMediaDownloadGate else {
+            stalledLoad.cancel()
+            runtime.releaseMediaDownloadGate()
+            Issue.record("Expected stalled attachment download to reach the fake download gate")
+            return
+        }
+        for _ in 0..<40 {
+            if case .failed = stalledStore.state {
+                break
+            }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+
+        guard case .failed(let stalledFailure) = stalledStore.state else {
+            stalledLoad.cancel()
+            runtime.releaseMediaDownloadGate()
+            Issue.record("Expected stalled attachment download to fail after timeout")
+            return
+        }
+        _ = await stalledLoad.result
+        #expect(stalledFailure == MediaAttachmentDownloadTimeoutError().localizedDescription)
+
+        runtime.releaseMediaDownloadGate()
+        runtime.mediaDownloadGateEnabled = false
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        do {
+            try await withMediaAttachmentDownloadTimeout(nanoseconds: 500_000_000) {
+                await state.loadMediaAttachment(followUpAttachment, for: followUpMessage)
+            }
+        } catch {
+            Issue.record("Expected follow-up attachment download to acquire the released limiter slot, got \(error)")
+            return
+        }
+        guard
+            case .loaded(let loaded) = state.mediaDownloadState(
+                for: followUpMessage,
+                attachment: followUpAttachment
+            )
+        else {
+            Issue.record("Expected follow-up attachment download to succeed after timeout released the limiter slot")
+            return
+        }
+        #expect(loaded.data == followUpPlaintext)
     }
 
     @Test func messageAudioMetadataCacheHitPerformanceGuard() async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1204,6 +1204,7 @@ struct whitenoise_macTests {
             label: "Backup Account",
             accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: true
         )
@@ -1246,6 +1247,7 @@ struct whitenoise_macTests {
             label: "Backup Account",
             accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: true
         )
@@ -5806,6 +5808,7 @@ struct whitenoise_macTests {
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: false
         )


### PR DESCRIPTION
Fixes #395

## Summary
- Makes `MediaAttachmentDownloadLimiter.acquire()` cancellation-aware so cancelled queued waiters are removed and resumed instead of remaining in the shared queue.
- Adds a 60s app-side timeout around the combined media-reference resolution and `downloadMedia` FFI work while a limiter slot is held.
- On timeout/cancellation, the attachment state is reset or failed and the limiter slot is released; tests cover cancelled waiters and a stalled media download with the other limiter slots occupied.

## Verification
- `git diff --check` — passed
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed
- `xcodebuild` / `xcrun swift-format` / Swift unit tests — not run locally; this Linux host has no Xcode, `xcrun`, or `swift` toolchain. CI must run these on macOS.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->