### PR TITLE
fix: guard group member mutation completions

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -142,12 +142,12 @@ extension WorkspaceState {
         guard let client, let activeAccount, let snapshot = groupDetailsSnapshot, !isInvitingGroupMember else { return }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex
-        let generation = groupDetailsLoadGeneration
         let query = groupInviteMemberQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard looksLikeMemberRef(query) else {
             lastError = L10n.string("Enter a valid npub, profile link, or hex public key.")
             return
         }
+        let generation = beginGroupDetailsMutation()
 
         lastError = nil
         isInvitingGroupMember = true
@@ -236,7 +236,7 @@ extension WorkspaceState {
         lastError = nil
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex
-        let generation = groupDetailsLoadGeneration
+        let generation = beginGroupDetailsMutation()
         let selfMemberId = snapshot.members.first(where: \.isSelf)?.id ?? activeAccount.accountIdHex
         mutatingGroupMemberId = selfMemberId
         defer { mutatingGroupMemberId = nil }
@@ -558,7 +558,7 @@ extension WorkspaceState {
         else { return }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex
-        let generation = groupDetailsLoadGeneration
+        let generation = beginGroupDetailsMutation()
         lastError = nil
         mutatingGroupMemberId = member.id
         defer { mutatingGroupMemberId = nil }
@@ -614,9 +614,9 @@ extension WorkspaceState {
     }
 
     /// True if a group-member mutation that captured these values on entry may still commit its
-    /// returned details. Mutations capture the current group-details generation without bumping it:
-    /// closing details or starting a newer load invalidates the token, but the mutation does not
-    /// steal ownership of `isLoadingGroupDetails` from an in-flight details load.
+    /// returned details. Mutations own a fresh group-details generation so they supersede any
+    /// already in-flight load; closing details, switching accounts, or starting a newer load
+    /// invalidates the token before stale details can be applied.
     func isCurrentGroupDetailsMutation(
         generation: UInt64,
         accountId: String,
@@ -660,6 +660,15 @@ extension WorkspaceState {
 
     func beginGroupDetailsLoad() -> UInt64 {
         groupDetailsLoadGeneration &+= 1
+        return groupDetailsLoadGeneration
+    }
+
+    /// Start a group-member mutation's guarded apply window. The mutation returns a fresh
+    /// `GroupDetailsFfi`, so it must invalidate any older `loadGroupDetails` already awaiting FFI;
+    /// otherwise that load can complete last and overwrite the mutation result with stale members.
+    /// Clear the shared load spinner here because the superseded load intentionally no longer owns it.
+    func beginGroupDetailsMutation() -> UInt64 {
+        invalidateGroupDetailsLoad()
         return groupDetailsLoadGeneration
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -112,7 +112,12 @@ extension WorkspaceState {
     }
 
     func saveGroupProfile() async {
-        guard let client, let activeAccount, let snapshot = groupDetailsSnapshot, !isSavingGroupProfile else { return }
+        guard let client,
+            let activeAccount,
+            let snapshot = groupDetailsSnapshot,
+            !isSavingGroupProfile,
+            !hasInFlightGroupDetailsMutation
+        else { return }
         let trimmedName = groupProfileDraftName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedDescription = groupProfileDraftDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else {

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -140,6 +140,9 @@ extension WorkspaceState {
 
     func inviteMemberToSelectedGroup() async {
         guard let client, let activeAccount, let snapshot = groupDetailsSnapshot, !isInvitingGroupMember else { return }
+        let accountId = activeAccount.id
+        let groupIdHex = snapshot.groupIdHex
+        let generation = groupDetailsLoadGeneration
         let query = groupInviteMemberQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard looksLikeMemberRef(query) else {
             lastError = L10n.string("Enter a valid npub, profile link, or hex public key.")
@@ -154,15 +157,36 @@ extension WorkspaceState {
             let normalized = try await runOffMain {
                 try client.normalizeMemberRef(memberRef: query)
             }
+            guard
+                isCurrentGroupDetailsMutation(
+                    generation: generation,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else { return }
             let result = try await client.inviteMembersDetailed(
                 accountRef: activeAccount.accountRef,
-                groupIdHex: snapshot.groupIdHex,
+                groupIdHex: groupIdHex,
                 memberRefs: [normalized.npub]
             )
+            guard
+                isCurrentGroupDetailsMutation(
+                    generation: generation,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else { return }
             groupInviteMemberQuery = ""
             applyGroupMutationResult(result)
             await reloadChats(forceFreshSnapshot: true)
         } catch {
+            guard
+                isCurrentGroupDetailsMutation(
+                    generation: generation,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else { return }
             lastError = error.localizedDescription
         }
     }
@@ -210,6 +234,9 @@ extension WorkspaceState {
         }
 
         lastError = nil
+        let accountId = activeAccount.id
+        let groupIdHex = snapshot.groupIdHex
+        let generation = groupDetailsLoadGeneration
         let selfMemberId = snapshot.members.first(where: \.isSelf)?.id ?? activeAccount.accountIdHex
         mutatingGroupMemberId = selfMemberId
         defer { mutatingGroupMemberId = nil }
@@ -217,11 +244,25 @@ extension WorkspaceState {
         do {
             let result = try await client.selfDemoteAdminDetailed(
                 accountRef: activeAccount.accountRef,
-                groupIdHex: snapshot.groupIdHex
+                groupIdHex: groupIdHex
             )
+            guard
+                isCurrentGroupDetailsMutation(
+                    generation: generation,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else { return }
             applyGroupMutationResult(result)
             await reloadChats(forceFreshSnapshot: true)
         } catch {
+            guard
+                isCurrentGroupDetailsMutation(
+                    generation: generation,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else { return }
             lastError = error.localizedDescription
         }
     }
@@ -515,6 +556,9 @@ extension WorkspaceState {
             let snapshot = groupDetailsSnapshot,
             mutatingGroupMemberId == nil
         else { return }
+        let accountId = activeAccount.id
+        let groupIdHex = snapshot.groupIdHex
+        let generation = groupDetailsLoadGeneration
         lastError = nil
         mutatingGroupMemberId = member.id
         defer { mutatingGroupMemberId = nil }
@@ -525,34 +569,62 @@ extension WorkspaceState {
             case .promote:
                 result = try await client.promoteAdminDetailed(
                     accountRef: activeAccount.accountRef,
-                    groupIdHex: snapshot.groupIdHex,
+                    groupIdHex: groupIdHex,
                     memberRef: member.npub
                 )
             case .demote:
                 if member.isSelf {
                     result = try await client.selfDemoteAdminDetailed(
                         accountRef: activeAccount.accountRef,
-                        groupIdHex: snapshot.groupIdHex
+                        groupIdHex: groupIdHex
                     )
                 } else {
                     result = try await client.demoteAdminDetailed(
                         accountRef: activeAccount.accountRef,
-                        groupIdHex: snapshot.groupIdHex,
+                        groupIdHex: groupIdHex,
                         memberRef: member.npub
                     )
                 }
             case .remove:
                 result = try await client.removeMembersDetailed(
                     accountRef: activeAccount.accountRef,
-                    groupIdHex: snapshot.groupIdHex,
+                    groupIdHex: groupIdHex,
                     memberRefs: [member.npub]
                 )
             }
+            guard
+                isCurrentGroupDetailsMutation(
+                    generation: generation,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else { return }
             applyGroupMutationResult(result)
             await reloadChats(forceFreshSnapshot: true)
         } catch {
+            guard
+                isCurrentGroupDetailsMutation(
+                    generation: generation,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else { return }
             lastError = error.localizedDescription
         }
+    }
+
+    /// True if a group-member mutation that captured these values on entry may still commit its
+    /// returned details. Mutations capture the current group-details generation without bumping it:
+    /// closing details or starting a newer load invalidates the token, but the mutation does not
+    /// steal ownership of `isLoadingGroupDetails` from an in-flight details load.
+    func isCurrentGroupDetailsMutation(
+        generation: UInt64,
+        accountId: String,
+        groupIdHex: String
+    ) -> Bool {
+        ownsGroupDetailsLoad(generation: generation)
+            && activeAccountId == accountId
+            && selectedChat?.id == groupIdHex
     }
 
     func applyGroupMutationResult(_ result: GroupMutationResultFfi) {

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -139,7 +139,11 @@ extension WorkspaceState {
     }
 
     func inviteMemberToSelectedGroup() async {
-        guard let client, let activeAccount, let snapshot = groupDetailsSnapshot, !isInvitingGroupMember else { return }
+        guard let client,
+            let activeAccount,
+            let snapshot = groupDetailsSnapshot,
+            !hasInFlightGroupDetailsMutation
+        else { return }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex
         let query = groupInviteMemberQuery.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -226,7 +230,7 @@ extension WorkspaceState {
         guard let client,
             let activeAccount,
             let snapshot = groupDetailsSnapshot,
-            mutatingGroupMemberId == nil
+            !hasInFlightGroupDetailsMutation
         else { return }
         guard snapshot.isSelfAdmin, !snapshot.isLastAdmin else {
             lastError = L10n.string("Make another member an admin before stepping down.")
@@ -550,11 +554,15 @@ extension WorkspaceState {
         }
     }
 
+    var hasInFlightGroupDetailsMutation: Bool {
+        isInvitingGroupMember || mutatingGroupMemberId != nil
+    }
+
     func mutateGroupMember(_ member: GroupMemberItem, action: GroupMemberMutationAction) async {
         guard let client,
             let activeAccount,
             let snapshot = groupDetailsSnapshot,
-            mutatingGroupMemberId == nil
+            !hasInFlightGroupDetailsMutation
         else { return }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex

--- a/whitenoise-mac/Core/WorkspaceState+Navigation.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Navigation.swift
@@ -65,8 +65,6 @@ extension WorkspaceState {
     }
 
     func toggleChatList() {
-        withAnimation(.smooth(duration: 0.18)) {
-            isChatListVisible.toggle()
-        }
+        isChatListVisible.toggle()
     }
 }

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -231,7 +231,7 @@ struct GroupDetailsSheet: View {
                                         systemImage: "person.badge.plus")
                                 }
                                 .disabled(
-                                    workspace.isInvitingGroupMember
+                                    workspace.hasInFlightGroupDetailsMutation
                                         || workspace.groupInviteMemberQuery.trimmingCharacters(
                                             in: .whitespacesAndNewlines
                                         ).isEmpty
@@ -258,7 +258,7 @@ struct GroupDetailsSheet: View {
                                 } label: {
                                     Label("Step Down as Admin", systemImage: "star.slash")
                                 }
-                                .disabled(workspace.mutatingGroupMemberId != nil || snapshot.isLastAdmin)
+                                .disabled(workspace.hasInFlightGroupDetailsMutation || snapshot.isLastAdmin)
                             }
 
                             Button(role: .destructive) {
@@ -393,6 +393,7 @@ struct GroupDetailsSheet: View {
             Button("Step Down", role: .destructive) {
                 Task { await workspace.selfDemoteSelectedGroupAdmin() }
             }
+            .disabled(workspace.hasInFlightGroupDetailsMutation)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("You'll stay in the group, but another admin will need to restore your admin status.")
@@ -553,7 +554,7 @@ struct GroupMemberRow: View {
                         .frame(width: 28, height: 28)
                 }
                 .menuStyle(.borderlessButton)
-                .disabled(workspace.mutatingGroupMemberId != nil)
+                .disabled(workspace.hasInFlightGroupDetailsMutation)
             }
         }
         .confirmationDialog(
@@ -564,6 +565,7 @@ struct GroupMemberRow: View {
             Button("Remove Member", role: .destructive) {
                 Task { await workspace.removeGroupMember(member) }
             }
+            .disabled(workspace.hasInFlightGroupDetailsMutation)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This removes \(member.displayName) from the group.")

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -158,7 +158,11 @@ struct GroupDetailsSheet: View {
                                     systemImage: "checkmark.circle")
                             }
                             .nativeGlassProminentButtonStyle()
-                            .disabled(!hasProfileChanges || workspace.isSavingGroupProfile)
+                            .disabled(
+                                !hasProfileChanges
+                                    || workspace.isSavingGroupProfile
+                                    || workspace.hasInFlightGroupDetailsMutation
+                            )
                         }
                     }
                     // Profile edits publish a group commit, which the core rejects for a

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -20,14 +20,21 @@ struct MessengerShellView: View {
                     AccountRailView()
                     GlassSeparator()
 
-                    if workspace.isChatListVisible {
-                        ChatListDrawerView()
-                            .frame(width: 300, alignment: .leading)
-                            .transition(.move(edge: .leading).combined(with: .opacity))
+                    Group {
+                        if workspace.isChatListVisible {
+                            ChatListDrawerView()
+                                .frame(width: 300, alignment: .leading)
+                                .transition(.move(edge: .leading).combined(with: .opacity))
 
-                        GlassSeparator()
-                            .transition(.opacity)
+                            GlassSeparator()
+                                .transition(.opacity)
+                        }
                     }
+                    // Scope the sidebar transition to the drawer. The detail pane
+                    // width should jump once, not animate through every intermediate
+                    // width and force the non-lazy transcript to re-wrap each frame.
+                    .animation(.smooth(duration: 0.18), value: workspace.isChatListVisible)
+
                     DetailPaneView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
@@ -47,7 +54,6 @@ struct MessengerShellView: View {
             MessagesWindowBackground()
         }
         .ignoresSafeArea(.container, edges: ignoredEdges)
-        .animation(.smooth(duration: 0.18), value: workspace.isChatListVisible)
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -9702,6 +9702,80 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func closingGroupDetailsInvalidatesInFlightGroupMemberMutationApply() async throws {
+        // Issue #392: group-member mutations return a fresh group-details snapshot. If the details
+        // panel is closed while the mutation is in flight, that completion must not repopulate the
+        // closed panel's backing snapshot.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let member = try #require(state.groupDetailsSnapshot?.members.first { !$0.isSelf })
+
+        runtime.groupMutationGateEnabled = true
+        async let promotion: Void = state.promoteGroupMember(member)
+        while !(state.mutatingGroupMemberId == member.id && runtime.didReachGroupMutationGate) {
+            await Task.yield()
+        }
+
+        state.closeGroupDetails()
+        #expect(state.groupDetailsSnapshot == nil)
+        #expect(!state.isGroupDetailsPresented)
+
+        runtime.releaseGroupMutationGate()
+        await promotion
+
+        #expect(state.groupDetailsSnapshot == nil)
+        #expect(!state.isGroupDetailsPresented)
+        #expect(state.mutatingGroupMemberId == nil)
+    }
+
+    @MainActor
+    @Test func accountSwitchInvalidatesInFlightGroupMemberMutationCacheApply() async throws {
+        // Issue #392: an account switch clears the member cache. A mutation started by the previous
+        // account must not re-seed that cache after the switch completes.
+        let primary = desktopAccount()
+        let backup = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, backup])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: primary.accountIdHex))
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let primaryAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+        state.prepareForActiveAccountSwitch(to: primaryAccount, preservingMessageCacheFor: nil)
+        await state.reloadChats(forceFreshSnapshot: true)
+        let groupChat = try #require(state.activeChats.first { $0.id == "group" })
+        state.selection = .chat(groupChat.id)
+        await state.showGroupDetails(for: groupChat)
+        let member = try #require(state.groupDetailsSnapshot?.members.first { !$0.isSelf })
+        #expect(state.groupMemberDetailsCache["group"] != nil)
+
+        runtime.groupMutationGateEnabled = true
+        async let promotion: Void = state.promoteGroupMember(member)
+        while !(state.mutatingGroupMemberId == member.id && runtime.didReachGroupMutationGate) {
+            await Task.yield()
+        }
+
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
+        #expect(state.activeAccountId == "Backup Account")
+        #expect(state.groupMemberDetailsCache.isEmpty)
+
+        runtime.releaseGroupMutationGate()
+        await promotion
+
+        #expect(state.activeAccountId == "Backup Account")
+        #expect(state.groupMemberDetailsCache.isEmpty)
+        #expect(state.mutatingGroupMemberId == nil)
+    }
+
+    @MainActor
     @Test func groupDetailsProfileSaveAndInviteUseBindings() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10063,6 +10063,60 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func inviteMemberDropsWhileMemberMutationIsInFlight() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        runtime.installNormalizedMemberRef(
+            query: "npub1newmember",
+            accountIdHex: "new1234567890new1234567890new1234567890new1234567890new1",
+            npub: "npub1newmember"
+        )
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let member = try #require(state.groupDetailsSnapshot?.members.first(where: { !$0.isSelf }))
+
+        runtime.groupMutationGateEnabled = true
+        async let firstPromote: Void = state.promoteGroupMember(member)
+        while !(state.mutatingGroupMemberId == member.id && runtime.didReachGroupMutationGate) {
+            await Task.yield()
+        }
+
+        state.groupInviteMemberQuery = "npub1newmember"
+        await state.inviteMemberToSelectedGroup()
+        #expect(runtime.inviteMembersDetailedCallCount == 0)
+
+        runtime.releaseGroupMutationGate()
+        await firstPromote
+    }
+
+    @MainActor
+    @Test func mutateGroupMemberDropsWhileInviteIsInFlight() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        runtime.installNormalizedMemberRef(
+            query: "npub1newmember",
+            accountIdHex: "new1234567890new1234567890new1234567890new1234567890new1",
+            npub: "npub1newmember"
+        )
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let member = try #require(state.groupDetailsSnapshot?.members.first(where: { !$0.isSelf }))
+
+        state.groupInviteMemberQuery = "npub1newmember"
+        runtime.groupMutationGateEnabled = true
+        async let firstInvite: Void = state.inviteMemberToSelectedGroup()
+        while !(state.isInvitingGroupMember && runtime.didReachGroupMutationGate) {
+            await Task.yield()
+        }
+
+        await state.promoteGroupMember(member)
+        #expect(runtime.promoteAdminDetailedCallCount == 0)
+
+        runtime.releaseGroupMutationGate()
+        await firstInvite
+    }
+
+    @MainActor
     @Test func selfDemoteAdminDropsOverlappingDuplicateInvocation() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -9776,6 +9776,36 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func groupMemberMutationInvalidatesOlderInFlightGroupDetailsLoad() async throws {
+        // Issue #392 follow-up: a mutation applies a fresh details/member snapshot. An older
+        // loadGroupDetails call that was already waiting in FFI must not complete afterward and
+        // overwrite the mutation result with its pre-mutation snapshot.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let member = try #require(state.groupDetailsSnapshot?.members.first { !$0.isSelf })
+        #expect(member.isAdmin == false)
+
+        runtime.groupDetailsGateEnabled = true
+        async let staleLoad: Void = state.reloadSelectedGroupDetails()
+        while !(state.isLoadingGroupDetails && runtime.didReachGroupDetailsGate) {
+            await Task.yield()
+        }
+
+        await state.promoteGroupMember(member)
+        #expect(state.groupDetailsSnapshot?.members.first(where: { $0.id == member.id })?.isAdmin == true)
+        #expect(state.isLoadingGroupDetails == false)
+
+        runtime.releaseGroupDetailsGate()
+        await staleLoad
+
+        #expect(state.groupDetailsSnapshot?.members.first(where: { $0.id == member.id })?.isAdmin == true)
+        #expect(state.isLoadingGroupDetails == false)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
     @Test func groupDetailsProfileSaveAndInviteUseBindings() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10033,6 +10033,35 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func saveGroupProfileDropsWhileMemberMutationIsInFlight() async throws {
+        // PR #418 review: a profile save triggers loadGroupDetails(), which must not start a
+        // newer details generation while a member mutation owns the apply window for its result.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let member = try #require(state.groupDetailsSnapshot?.members.first(where: { !$0.isSelf }))
+
+        runtime.groupMutationGateEnabled = true
+        async let firstPromote: Void = state.promoteGroupMember(member)
+        while !(state.mutatingGroupMemberId == member.id && runtime.didReachGroupMutationGate) {
+            await Task.yield()
+        }
+
+        state.groupProfileDraftName = "Renamed While Mutating"
+        state.groupProfileDraftDescription = "Should be ignored until mutation finishes"
+        await state.saveGroupProfile()
+        #expect(runtime.updateGroupProfileCallCount == 0)
+        #expect(state.isSavingGroupProfile == false)
+
+        runtime.releaseGroupMutationGate()
+        await firstPromote
+
+        #expect(runtime.promoteAdminDetailedCallCount == 1)
+        #expect(state.groupDetailsSnapshot?.members.first(where: { $0.id == member.id })?.isAdmin == true)
+    }
+
+    @MainActor
     @Test func inviteMemberDropsOverlappingDuplicateInvocation() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])


### PR DESCRIPTION
## Summary
- Adds post-await generation, selection, and active-account guards before group-member mutation completions apply returned group details.
- Skips stale invite/profile mutation UI writes and chat reloads after the details panel is closed, selection changes, or the account switches.
- Adds regression coverage for closed-panel snapshot resurrection and account-switch member-cache re-seeding.

## Test Plan
- `git diff --check`
- conflict marker sweep with `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':!*.xcstrings'`
- source-shape regression check for the new guards/tests
- Not run: `xcodebuild` (unavailable on this Linux host)

Fixes #392


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/418">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of group member actions when switching accounts, changing chats, or closing group details.
  * Prevented outdated responses from reopening closed details, repopulating stale data, or leaving loading indicators in the wrong state.
  * Reduced race-condition issues so newer group updates are not overwritten by older in-flight requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->