### PR TITLE
fix: drop global draft thumbnail cache

### DIFF
--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -52,7 +52,7 @@ struct PendingMediaDraftTile: View {
     let tileSize: CGSize
 
     @State private var decodedImagePreview: NSImage?
-    @State private var decodedImageCacheKey: String?
+    @State private var decodedImageTaskID: String?
 
     var body: some View {
         Group {
@@ -93,7 +93,7 @@ struct PendingMediaDraftTile: View {
     }
 
     private var imagePreviewTaskID: String {
-        Self.cacheKey(for: attachment, maxPixelSize: imagePreviewMaxPixelSize)
+        Self.previewTaskID(for: attachment, maxPixelSize: imagePreviewMaxPixelSize)
     }
 
     private var imagePreviewMaxPixelSize: CGFloat {
@@ -102,12 +102,12 @@ struct PendingMediaDraftTile: View {
 
     @MainActor
     private func loadImagePreview() async {
-        let cacheKey = imagePreviewTaskID
-        if decodedImageCacheKey == cacheKey {
+        let taskID = imagePreviewTaskID
+        if decodedImageTaskID == taskID {
             return
         }
 
-        decodedImageCacheKey = cacheKey
+        decodedImageTaskID = taskID
         decodedImagePreview = nil
 
         let data = attachment.data
@@ -116,11 +116,11 @@ struct PendingMediaDraftTile: View {
             PendingMediaDraftThumbnailDecoder.image(from: data, maxPixelSize: maxPixelSize)
         }.value
 
-        guard decodedImageCacheKey == cacheKey else { return }
+        guard decodedImageTaskID == taskID else { return }
         decodedImagePreview = decoded
     }
 
-    private static func cacheKey(for attachment: PendingMediaAttachment, maxPixelSize: CGFloat) -> String {
+    private static func previewTaskID(for attachment: PendingMediaAttachment, maxPixelSize: CGFloat) -> String {
         "\(attachment.id.uuidString)|\(attachment.data.count)|\(Int(maxPixelSize))"
     }
 
@@ -170,8 +170,6 @@ struct PendingMediaDraftTile: View {
 }
 
 nonisolated enum PendingMediaDraftThumbnailDecoder {
-    static let defaultDecodedCacheTotalCostLimit = 8 * 1024 * 1024
-
     static func image(from data: Data, maxPixelSize: CGFloat) -> NSImage? {
         let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
         guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
@@ -188,16 +186,6 @@ nonisolated enum PendingMediaDraftThumbnailDecoder {
             return nil
         }
         return DownsampledImageSizing.image(fromDownsampled: cgImage)
-    }
-
-    static func decodedCost(for image: NSImage) -> Int {
-        let representation = image.representations.first
-        let width = max(1, representation?.pixelsWide ?? Int(ceil(image.size.width)))
-        let height = max(1, representation?.pixelsHigh ?? Int(ceil(image.size.height)))
-        guard width <= Int.max / max(height, 1) / 4 else {
-            return defaultDecodedCacheTotalCostLimit
-        }
-        return width * height * 4
     }
 }
 

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -54,26 +54,6 @@ struct PendingMediaDraftTile: View {
     @State private var decodedImagePreview: NSImage?
     @State private var decodedImageCacheKey: String?
 
-    // The composer only shows a handful of draft tiles. Keep thumbnails bounded while allowing
-    // enough headroom for several ~148px previews and matching failed-decode entries.
-    private static let imagePreviewCacheCountLimit = 64
-    private static let failedImagePreviewCacheCountLimit = imagePreviewCacheCountLimit
-    private static let imagePreviewCacheTotalCostLimit =
-        PendingMediaDraftThumbnailDecoder.defaultDecodedCacheTotalCostLimit
-
-    private static let imagePreviewCache: NSCache<NSString, NSImage> = {
-        let cache = NSCache<NSString, NSImage>()
-        cache.countLimit = imagePreviewCacheCountLimit
-        cache.totalCostLimit = imagePreviewCacheTotalCostLimit
-        return cache
-    }()
-
-    private static let failedImagePreviewCache: NSCache<NSString, NSNumber> = {
-        let cache = NSCache<NSString, NSNumber>()
-        cache.countLimit = failedImagePreviewCacheCountLimit
-        return cache
-    }()
-
     var body: some View {
         Group {
             switch attachment.kind {
@@ -123,18 +103,7 @@ struct PendingMediaDraftTile: View {
     @MainActor
     private func loadImagePreview() async {
         let cacheKey = imagePreviewTaskID
-        let nsCacheKey = cacheKey as NSString
         if decodedImageCacheKey == cacheKey {
-            return
-        }
-        if let cached = Self.imagePreviewCache.object(forKey: nsCacheKey) {
-            decodedImageCacheKey = cacheKey
-            decodedImagePreview = cached
-            return
-        }
-        if Self.failedImagePreviewCache.object(forKey: nsCacheKey) != nil {
-            decodedImageCacheKey = cacheKey
-            decodedImagePreview = nil
             return
         }
 
@@ -148,16 +117,6 @@ struct PendingMediaDraftTile: View {
         }.value
 
         guard decodedImageCacheKey == cacheKey else { return }
-        if let decoded {
-            Self.failedImagePreviewCache.removeObject(forKey: nsCacheKey)
-            Self.imagePreviewCache.setObject(
-                decoded,
-                forKey: nsCacheKey,
-                cost: PendingMediaDraftThumbnailDecoder.decodedCost(for: decoded)
-            )
-        } else {
-            Self.failedImagePreviewCache.setObject(NSNumber(value: true), forKey: nsCacheKey)
-        }
         decodedImagePreview = decoded
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10777,10 +10777,6 @@ struct whitenoise_macTests {
         let representation = try #require(image.representations.first)
 
         #expect(max(representation.pixelsWide, representation.pixelsHigh) <= productionTileMaxPixelSize)
-        #expect(
-            PendingMediaDraftThumbnailDecoder.decodedCost(for: image)
-                <= productionTileMaxPixelSize * productionTileMaxPixelSize * 4
-        )
     }
 
     @Test func pendingMediaDraftThumbnailDecoderRejectsInvalidImageData() async throws {


### PR DESCRIPTION
Fixes #427

## Summary
- Removed the process-global `PendingMediaDraftTile` decoded-thumbnail `NSCache` and failed-decode cache.
- Draft image previews now rely on the existing per-tile `@State`, so decoded thumbnails are released with the tile instead of surviving attachment removal, account switch, or sign-out.
- Kept the change limited to the composer tile path; no account/workspace teardown hooks needed.

## Verification
- `git diff --check` — passed
- `git grep -n 'imagePreviewCache\|failedImagePreviewCache' -- . || true` — no matches
- `git grep -n 'NSCache<NSString, NSImage>' -- whitenoise-mac/Views/ComposerViews.swift || true` — no matches
- `scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host (`xcodebuild: command not found`)
- `xcodebuild` / Swift format / unit tests — not runnable on this Linux host (`xcodebuild`, `xcrun`, `swift-format`, and `swift` not installed)

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image preview loading for draft media tiles so previews are less likely to show stale or outdated images.
  * Updated thumbnail handling for large images to keep preview dimensions within the expected display size, helping ensure more consistent image quality and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->