### PR TITLE
fix: guard notification update settings snapshot

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -19,6 +19,11 @@ extension WorkspaceState {
     func handleNotificationUpdate(_ update: NotificationUpdateFfi) async {
         guard !update.isFromSelf else { return }
         guard !deliveredNotificationKeys.contains(update.notificationKey) else { return }
+        let activeNotificationAccountId =
+            activeAccount?.accountIdHex == update.accountIdHex ? activeAccount?.id : nil
+        // A same-account settings toggle/load that commits while the FFI read is
+        // in flight owns the newer published snapshot; do not clobber it on resume.
+        let notificationSettingsGenerationAtStart = notificationSettingsGeneration
 
         // Read the account's notification settings exactly once over the FFI
         // boundary, then reuse the snapshot for both responsibilities below:
@@ -29,7 +34,12 @@ extension WorkspaceState {
         // snapshot untouched, matching the prior early-return-on-error behavior.
         guard let settings = await fetchNotificationSettings(for: update) else { return }
 
-        if activeAccount?.accountIdHex == update.accountIdHex {
+        if let activeNotificationAccountId,
+            ownsNotificationSettingsOperation(
+                accountId: activeNotificationAccountId,
+                generation: notificationSettingsGenerationAtStart
+            )
+        {
             notificationSettings = NotificationSettingsSnapshot(settings: settings)
         }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13610,6 +13610,7 @@ struct whitenoise_macTests {
         _ = await staleUpdate
 
         #expect(state.notificationSettings.localNotificationsEnabled)
+        #expect(notificationCenter.postedRequests.isEmpty)
         #expect(state.lastError == nil)
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13564,6 +13564,56 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func staleIncomingNotificationSettingsReadDoesNotClobberCommittedToggle() async throws {
+        // Issue #428: a notification update reuses one settings read for both the
+        // published snapshot and delivery gate. If that read was already in flight
+        // when a same-account toggle committed, its stale snapshot must not
+        // overwrite the newer toggle state.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: false)
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(!state.notificationSettings.localNotificationsEnabled)
+
+        runtime.notificationSettingsGateEnabled = true
+        async let staleUpdate: Void = state.handleNotificationUpdate(
+            notificationUpdate(
+                account: account,
+                notificationKey: "notice-1",
+                groupIdHex: "direct-group",
+                senderName: "Alice",
+                previewText: "See you there."
+            ))
+        while !runtime.didReachNotificationSettingsGate {
+            await Task.yield()
+        }
+
+        await state.setLocalNotificationsEnabled(true)
+        #expect(runtime.localNotificationsEnabledSet == true)
+        #expect(state.notificationSettings.localNotificationsEnabled)
+
+        runtime.releaseNotificationSettingsGate()
+        _ = await staleUpdate
+
+        #expect(state.notificationSettings.localNotificationsEnabled)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
     @Test func senderOnlyPreviewModeOmitsDecryptedMessageBody() async throws {
         // Issue #30: notification body must never leak decrypted plaintext when
         // the user opts into sender-only previews. DM => body is generic, group


### PR DESCRIPTION
## Summary
- Guard the notification listener's active-account snapshot write with the existing notification settings generation token.
- Add a regression test for a stale in-flight notification settings read racing a just-committed local notification toggle.

## Test Plan
- `git diff --check HEAD^`
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' HEAD -- . ':!Vendored'`
- Not run: `xcodebuild` unit tests (xcodebuild/swift are unavailable on this Linux worker).

Fixes #428


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->