### PR TITLE
fix: clear read markers on account switch

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -100,6 +100,11 @@ extension WorkspaceState {
         // account does not inherit stale cross-account entries (whitenoise-mac#8/#9).
         peerProfileFFICache.removeAll()
         clearGroupMemberCache()
+        // Read markers are keyed by groupIdHex only; stale entries from the
+        // previous account suppress the first legitimate advance for a shared
+        // group id under the new identity. See #429.
+        lastMarkedReadMarkers.removeAll()
+        lastConfirmedReadMarkers.removeAll()
         refreshObservabilityRuntime()
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1091,6 +1091,47 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func prepareForActiveAccountSwitchClearsReadMarkers() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let backup = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let primaryAccount = AccountItem(summary: primary)
+        let backupAccount = AccountItem(summary: backup)
+        let runtime = FakeMarmotRuntime(accounts: [primary, backup])
+        let state = WorkspaceState(
+            accounts: [primaryAccount, backupAccount],
+            clientFactory: { runtime }
+        )
+        state.activeAccountId = primaryAccount.id
+
+        let marker = ReadMarker(
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            messageId: "m10"
+        )
+        state.lastMarkedReadMarkers["shared-group"] = marker
+        state.lastConfirmedReadMarkers["shared-group"] = marker
+
+        state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
+
+        // Live account switches must not inherit groupIdHex-keyed read markers from
+        // the previous identity. See #429.
+        #expect(state.lastMarkedReadMarkers.isEmpty)
+        #expect(state.lastConfirmedReadMarkers.isEmpty)
+        #expect(state.activeAccountId == backupAccount.id)
+    }
+
+    @MainActor
     @Test func resetActiveAccountUIStateClearsGroupAndNewChatPII() async throws {
         let primary = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [primary])


### PR DESCRIPTION
Fixes #429

## Summary
- Clear `lastMarkedReadMarkers` and `lastConfirmedReadMarkers` during the live active-account switch path so groupIdHex-keyed read-marker state cannot leak from the previous local identity.
- Add a regression test covering `prepareForActiveAccountSwitch` with stale read markers before switching to another account.

## Verification
- `git diff --check` — pass
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- whitenoise-mac/Core/WorkspaceState+Account.swift whitenoise-macTests/whitenoise_macTests.swift` — no conflict markers
- `command -v xcodebuild xcrun swift` — `xcodebuild`, `xcrun`, and `swift` are missing on this Linux host; macOS/Xcode CI commands were not run locally

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+Account.swift` — active-account switch/read-marker state; no crypto, key handling, or generated FFI touched


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->