### PR TITLE
fix: keep media cache footprint in sync on read deletes

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -204,7 +204,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private var purgeSequence = 0
     private var purgeTasks: [Int: ActivePurge] = [:]
     private var didSweepStagingDirectories = false
-    // Updated under `fileMutationLock` on commit and eviction; reset or invalidated on purge.
+    // Updated under `fileMutationLock` on commit, read-path deletion, and eviction; reset or invalidated on purge.
     // Seeded with one full scan when nil so stores under the cap avoid re-walking the tree every time (#377).
     private var trackedFootprint: CacheFootprint?
 
@@ -259,8 +259,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             return nil
         }
 
-        let result = await Task.detached(priority: .utility) {
-            Self.readDownload(for: key, root: root, symmetricKey: symmetricKey)
+        let result = await Task.detached(priority: .utility) { [self] in
+            readDownload(for: key, root: root, symmetricKey: symmetricKey, start: start)
         }.value
 
         guard isCurrent(start) else { return nil }
@@ -540,7 +540,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
     }
 
-    private struct AccessHandle {
+    private struct AccessHandle: Sendable {
         let accountDigest: String
         let globalGeneration: Int
         let accountGeneration: Int
@@ -578,12 +578,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         case unavailable
     }
 
-    private static func readDownload(
+    private func readDownload(
         for key: MessageMediaDiskCacheKey,
         root: URL,
-        symmetricKey: SymmetricKey
+        symmetricKey: SymmetricKey,
+        start: AccessHandle
     ) -> MessageMediaDownload? {
-        let entryDirectory = entryDirectory(for: key, root: root)
+        let entryDirectory = Self.entryDirectory(for: key, root: root)
         let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
         let payloadURL = entryDirectory.appendingPathComponent(payloadFileName)
 
@@ -598,14 +599,14 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
         let metadata: Metadata
         do {
-            let metadataPlaintext = try open(
+            let metadataPlaintext = try Self.open(
                 metadataData,
                 using: symmetricKey,
-                authenticatedBy: metadataAAD(for: key.cacheID)
+                authenticatedBy: Self.metadataAAD(for: key.cacheID)
             )
             metadata = try JSONDecoder().decode(Metadata.self, from: metadataPlaintext)
         } catch {
-            try? FileManager.default.removeItem(at: entryDirectory)
+            removeEntryAfterFailedRead(entryDirectory: entryDirectory, root: root, start: start)
             return nil
         }
         guard metadata.version == 1,
@@ -613,7 +614,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             metadata.ciphertextSha256 == key.ciphertextSha256,
             metadata.plaintextSha256 == key.plaintextSha256
         else {
-            try? FileManager.default.removeItem(at: entryDirectory)
+            removeEntryAfterFailedRead(entryDirectory: entryDirectory, root: root, start: start)
             return nil
         }
 
@@ -627,10 +628,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
 
         do {
-            let plaintext = try open(
+            let plaintext = try Self.open(
                 payloadData,
                 using: symmetricKey,
-                authenticatedBy: payloadAAD(for: key.cacheID)
+                authenticatedBy: Self.payloadAAD(for: key.cacheID)
             )
             // AES-GCM `open` above already authenticates the payload against its key and
             // AAD, and the store path verifies the plaintext SHA-256 before writing, so the
@@ -646,8 +647,29 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 sizeBytes: metadata.sizeBytes
             )
         } catch {
-            try? FileManager.default.removeItem(at: entryDirectory)
+            removeEntryAfterFailedRead(entryDirectory: entryDirectory, root: root, start: start)
             return nil
+        }
+    }
+
+    private func removeEntryAfterFailedRead(entryDirectory: URL, root: URL, start: AccessHandle) {
+        fileMutationLock.lock()
+        defer { fileMutationLock.unlock() }
+
+        guard isCurrent(start), FileManager.default.fileExists(atPath: entryDirectory.path) else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: entryDirectory)
+            // The read path can delete entries whose on-disk bytes may already have diverged
+            // from the tracked accountant (corruption, cache-buster metadata mismatch). Match
+            // account purges by invalidating and letting the next store re-seed from disk.
+            trackedFootprint = nil
+            Self.removeEmptyDirectory(entryDirectory.deletingLastPathComponent())
+            Self.removeEmptyDirectory(root)
+        } catch {
+            return
         }
     }
 

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -204,7 +204,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private var purgeSequence = 0
     private var purgeTasks: [Int: ActivePurge] = [:]
     private var didSweepStagingDirectories = false
-    // Updated under `fileMutationLock` on commit, read-path deletion, and eviction; reset or invalidated on purge.
+    // Updated under `fileMutationLock` on commit and eviction.
+    // Invalidated when read-path deletions or account purges remove an unknown subset.
     // Seeded with one full scan when nil so stores under the cap avoid re-walking the tree every time (#377).
     private var trackedFootprint: CacheFootprint?
 
@@ -585,8 +586,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         start: AccessHandle
     ) -> MessageMediaDownload? {
         let entryDirectory = Self.entryDirectory(for: key, root: root)
-        let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
-        let payloadURL = entryDirectory.appendingPathComponent(payloadFileName)
+        let metadataURL = entryDirectory.appendingPathComponent(Self.metadataFileName)
+        let payloadURL = entryDirectory.appendingPathComponent(Self.payloadFileName)
 
         let metadataData: Data
         do {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1871,13 +1871,21 @@ struct whitenoise_macTests {
         )
         let corruptReference = mediaDiskCacheReference(plaintext: corruptPlaintext, ciphertextByte: 0xa2)
         let replacementReference = mediaDiskCacheReference(plaintext: replacementPlaintext, ciphertextByte: 0xa3)
-        let staleKey = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: staleReference)
+        let staleKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: staleReference
+        )
         let invalidatingKey = MessageMediaDiskCacheKey(
             accountId: "account-a",
             groupIdHex: "group-a",
             reference: invalidatingReference
         )
-        let corruptKey = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: corruptReference)
+        let corruptKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: corruptReference
+        )
         let replacementKey = MessageMediaDiskCacheKey(
             accountId: "account-a",
             groupIdHex: "group-a",
@@ -1909,6 +1917,8 @@ struct whitenoise_macTests {
         )
         let staleEntryDirectory = try #require(cache.entryDirectory(for: staleKey))
         let corruptEntryDirectory = try #require(cache.entryDirectory(for: corruptKey))
+        // The corrupt unread entry is a sentinel for an unintended full cacheScan: a stale,
+        // inflated trackedFootprint would force a scan on the next store and remove it early.
         try Data("not sealed metadata".utf8).write(to: corruptEntryDirectory.appendingPathComponent("metadata.bin"))
 
         #expect(await cache.cachedDownload(for: invalidatingKey) == nil)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1849,6 +1849,86 @@ struct whitenoise_macTests {
         #expect(!fileManager.fileExists(atPath: entryDirectory.path))
     }
 
+    @Test func messageMediaDiskCacheReadDeletionMaintainsTrackedFootprint() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cachedAtCounter = AtomicCounter()
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 2, maxTotalBytes: UInt64.max),
+            timestampProvider: { TimeInterval(cachedAtCounter.increment()) }
+        )
+        let stalePlaintext = Data("stale media for replaced reference".utf8)
+        let corruptPlaintext = Data("corrupt metadata entry that should not be swept early".utf8)
+        let replacementPlaintext = Data("replacement media after read-path deletion".utf8)
+        let staleReference = mediaDiskCacheReference(plaintext: stalePlaintext, ciphertextByte: 0xa1)
+        let invalidatingReference = mediaDiskCacheReference(
+            plaintext: Data("different plaintext digest for the same ciphertext".utf8),
+            ciphertextByte: 0xa1
+        )
+        let corruptReference = mediaDiskCacheReference(plaintext: corruptPlaintext, ciphertextByte: 0xa2)
+        let replacementReference = mediaDiskCacheReference(plaintext: replacementPlaintext, ciphertextByte: 0xa3)
+        let staleKey = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: staleReference)
+        let invalidatingKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: invalidatingReference
+        )
+        let corruptKey = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: corruptReference)
+        let replacementKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: replacementReference
+        )
+
+        #expect(staleKey.cacheID == invalidatingKey.cacheID)
+        #expect(staleKey.plaintextSha256 != invalidatingKey.plaintextSha256)
+
+        await cache.store(
+            MessageMediaDownload(
+                data: stalePlaintext,
+                fileName: "stale.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(stalePlaintext.count),
+                payloadId: "stale"
+            ),
+            for: staleKey
+        )
+        await cache.store(
+            MessageMediaDownload(
+                data: corruptPlaintext,
+                fileName: "corrupt.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(corruptPlaintext.count),
+                payloadId: "corrupt"
+            ),
+            for: corruptKey
+        )
+        let staleEntryDirectory = try #require(cache.entryDirectory(for: staleKey))
+        let corruptEntryDirectory = try #require(cache.entryDirectory(for: corruptKey))
+        try Data("not sealed metadata".utf8).write(to: corruptEntryDirectory.appendingPathComponent("metadata.bin"))
+
+        #expect(await cache.cachedDownload(for: invalidatingKey) == nil)
+        #expect(!fileManager.fileExists(atPath: staleEntryDirectory.path))
+
+        await cache.store(
+            MessageMediaDownload(
+                data: replacementPlaintext,
+                fileName: "replacement.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(replacementPlaintext.count),
+                payloadId: "replacement"
+            ),
+            for: replacementKey
+        )
+
+        #expect(fileManager.fileExists(atPath: corruptEntryDirectory.path))
+        #expect(try #require(await cache.cachedDownload(for: replacementKey)).data == replacementPlaintext)
+    }
+
     @Test func messageMediaDiskCachePreservesEntryWhenMetadataCannotBeRead() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
## Summary
- route `readDownload` entry deletions through the cache instance
- invalidate `trackedFootprint` after read-path removals so the next store re-seeds from disk instead of carrying an inflated counter
- add a regression covering metadata-mismatch read deletion followed by an under-cap store

## Test Plan
- `git diff --check`
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .` (no conflict markers)
- `xcodebuild` not run: unavailable on this Linux host

Fixes #426


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/433">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->