### PR TITLE
fix: retry failed visual media downloads

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -427,6 +427,22 @@ struct MessageImageGalleryPresentation: Identifiable, Equatable {
     }
 }
 
+enum MessageVisualMediaTileTapAction: Equatable {
+    case retryDownload
+    case openImageGallery
+    case none
+}
+
+enum MessageVisualMediaTileInteraction {
+    static func tapAction(
+        downloadState: MediaDownloadState,
+        attachmentKind: MessageMediaKind
+    ) -> MessageVisualMediaTileTapAction {
+        if case .failed = downloadState { return .retryDownload }
+        return attachmentKind == .image ? .openImageGallery : .none
+    }
+}
+
 struct MessageVisualMediaGrid: View {
     @Environment(WorkspaceState.self) private var workspace
     let message: MessageItem
@@ -539,14 +555,21 @@ struct MessageVisualMediaTile: View {
             message: message
         )
         .onTapGesture {
-            if case .failed = downloadState.state {
+            switch MessageVisualMediaTileInteraction.tapAction(
+                downloadState: downloadState.state,
+                attachmentKind: attachment.kind
+            ) {
+            case .retryDownload:
                 Task { await workspace.loadMediaAttachment(attachment, for: message) }
-                return
-            }
-            if attachment.kind == .image,
-                let gallery = MessageImageGalleryPresentation(message: message, initialAttachment: attachment)
-            {
-                onOpenImageGallery(gallery)
+            case .openImageGallery:
+                if let gallery = MessageImageGalleryPresentation(
+                    message: message,
+                    initialAttachment: attachment
+                ) {
+                    onOpenImageGallery(gallery)
+                }
+            case .none:
+                break
             }
         }
         .accessibilityIdentifier("message.media.visualTile.\(attachment.id)")

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -509,6 +509,7 @@ struct MessageVisualMediaGrid: View {
 }
 
 struct MessageVisualMediaTile: View {
+    @Environment(WorkspaceState.self) private var workspace
     @Environment(\.displayScale) private var displayScale
     let downloadState: MediaDownloadStateStore
     let message: MessageItem
@@ -538,6 +539,10 @@ struct MessageVisualMediaTile: View {
             message: message
         )
         .onTapGesture {
+            if case .failed = downloadState.state {
+                Task { await workspace.loadMediaAttachment(attachment, for: message) }
+                return
+            }
             if attachment.kind == .image,
                 let gallery = MessageImageGalleryPresentation(message: message, initialAttachment: attachment)
             {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5284,6 +5284,57 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func visualMediaTileTapActionRetriesFailedVideoBeforeGallery() {
+        #expect(
+            MessageVisualMediaTileInteraction.tapAction(
+                downloadState: .failed("network"),
+                attachmentKind: .video
+            ) == .retryDownload
+        )
+        #expect(
+            MessageVisualMediaTileInteraction.tapAction(
+                downloadState: .failed("network"),
+                attachmentKind: .image
+            ) == .retryDownload
+        )
+        #expect(
+            MessageVisualMediaTileInteraction.tapAction(
+                downloadState: .idle,
+                attachmentKind: .image
+            ) == .openImageGallery
+        )
+        #expect(
+            MessageVisualMediaTileInteraction.tapAction(
+                downloadState: .idle,
+                attachmentKind: .video
+            ) == .none
+        )
+    }
+
+    @Test func visualMediaTileTapGestureRoutesRetryActionToDownload() throws {
+        // MessageVisualMediaTile is a SwiftUI gesture surface that the unit tests cannot
+        // tap directly here. Guard the wiring shape so a failed-tile retry action remains
+        // connected to the explicit download entry point, while the pure decision helper
+        // above guards that failed video tiles choose that action.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+        let tileStart = try #require(source.range(of: "struct MessageVisualMediaTile: View {"))
+        let rest = source[tileStart.upperBound...]
+        let tileEnd = try #require(rest.range(of: "\nstruct MessageMediaAttachmentView: View {")?.lowerBound)
+        let tileSource = String(source[tileStart.lowerBound..<tileEnd])
+
+        #expect(tileSource.contains("MessageVisualMediaTileInteraction.tapAction"))
+        #expect(tileSource.contains("case .retryDownload:"))
+        #expect(tileSource.contains("Task { await workspace.loadMediaAttachment(attachment, for: message) }"))
+    }
+
+    @MainActor
     @Test func loadMediaAttachmentRetriesFromFailedState() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5283,6 +5283,81 @@ struct whitenoise_macTests {
         #expect(store.shouldStartAutomaticDownload)
     }
 
+    @MainActor
+    @Test func loadMediaAttachmentRetriesFromFailedState() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: false
+        )
+        let plaintext = Data([0x00, 0x0F, 0xF0, 0xFF])
+        let reference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "video/mp4",
+            fileName: "clip.mp4",
+            plaintextSha256: hexSHA256(plaintext)
+        )
+        let download = MediaDownloadResultFfi(
+            plaintext: plaintext,
+            fileName: "clip.mp4",
+            mediaType: "video/mp4",
+            sizeBytes: UInt64(plaintext.count)
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        state.selection = .chat("group")
+        let message = MessageItem(
+            id: "failed-video-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "failed-video-message#0#\(reference.plaintextSha256)",
+                    reference: reference
+                )
+            ]
+        )
+        let attachment = try #require(message.mediaAttachments.first)
+        state.replaceMessages([message], groupIdHex: "group")
+
+        await state.loadMediaAttachment(attachment, for: message)
+        guard case .failed = state.mediaDownloadState(for: message, attachment: attachment) else {
+            Issue.record("Expected initial video download to fail")
+            return
+        }
+        #expect(runtime.downloadMediaCallCount == 1)
+
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "failed-video-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: reference,
+                caption: nil,
+                recordedAt: 1_700_000_000,
+                receivedAt: 1_700_000_000
+            ),
+            download: download
+        )
+        await state.loadMediaAttachment(attachment, for: message)
+
+        guard case .loaded(let loaded) = state.mediaDownloadState(for: message, attachment: attachment) else {
+            Issue.record("Expected failed video download to retry successfully")
+            return
+        }
+        #expect(loaded.data == plaintext)
+        #expect(runtime.downloadMediaCallCount == 2)
+    }
+
     @Test func mediaAttachmentDownloadLimiterCapsConcurrentAcquires() async {
         let limiter = MediaAttachmentDownloadLimiter(maxConcurrent: 2)
         let inFlight = AtomicCounter()


### PR DESCRIPTION
Fixes #425

## Summary
- Makes failed visual media grid tiles actionable by retrying `workspace.loadMediaAttachment(...)` when tapped.
- Keeps the existing image-gallery tap path for non-failed image tiles.
- Extracts the visual-tile tap decision into a small testable helper so failed video tiles choose the retry path before image-gallery handling.
- Adds regression coverage for both the failed-video tap decision/wiring and the underlying `loadMediaAttachment` retry from `.failed` to `.loaded`.

## Verification
Local (vault Linux):
- `git diff --check` — passed.
- Source-shape assertions for `MessageVisualMediaTile` retry wiring — passed via `python3`.
- `bash scripts/ci/macos-sanity-checks.sh` — could not run locally because `xcodebuild` is not installed (`exit 127`).
- `xcodebuild`, `xcrun`, `swift`, `swift-format` — unavailable locally.

GitHub CI on PR #434 at `a3cbf7fdc930dfbbf20c35b60ac1e9a3135a86de`:
- CodeRabbit — passed.
- PR Checks — passed.
- Static Analysis — passed.

## Sensitive paths
none
