### PR TITLE
fix: avoid redundant reaction summary work

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -1246,25 +1246,22 @@ private extension String {
 
 private nonisolated extension MessageReaction {
     static func summarize(_ summary: TimelineReactionSummaryFfi, activeAccountIdHex: String?) -> [MessageReaction] {
-        summary.byEmoji
-            .map { reaction in
-                let ownReactionMessageId = activeAccountIdHex.flatMap { accountIdHex in
-                    summary.userReactions.first { userReaction in
-                        userReaction.emoji == reaction.emoji && userReaction.sender == accountIdHex
-                    }?.reactionMessageIdHex
-                }
-                let isOwn = activeAccountIdHex.map { reaction.senders.contains($0) } ?? false
+        let ownReactionIdsByEmoji = activeAccountIdHex.map { accountIdHex in
+            Dictionary(
+                summary.userReactions.lazy
+                    .filter { $0.sender == accountIdHex }
+                    .map { ($0.emoji, $0.reactionMessageIdHex) },
+                uniquingKeysWith: { first, _ in first }
+            )
+        } ?? [:]
 
-                return MessageReaction(
-                    emoji: reaction.emoji,
-                    count: reaction.senders.count,
-                    isOwn: isOwn,
-                    ownReactionMessageId: ownReactionMessageId
-                )
-            }
-            .sorted { lhs, rhs in
-                if lhs.count != rhs.count { return lhs.count > rhs.count }
-                return lhs.emoji < rhs.emoji
-            }
+        return summary.byEmoji.map { reaction in
+            MessageReaction(
+                emoji: reaction.emoji,
+                count: reaction.senders.count,
+                isOwn: activeAccountIdHex.map { reaction.senders.contains($0) } ?? false,
+                ownReactionMessageId: ownReactionIdsByEmoji[reaction.emoji]
+            )
+        }
     }
 }

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -1246,14 +1246,15 @@ private extension String {
 
 private nonisolated extension MessageReaction {
     static func summarize(_ summary: TimelineReactionSummaryFfi, activeAccountIdHex: String?) -> [MessageReaction] {
-        let ownReactionIdsByEmoji = activeAccountIdHex.map { accountIdHex in
-            Dictionary(
-                summary.userReactions.lazy
-                    .filter { $0.sender == accountIdHex }
-                    .map { ($0.emoji, $0.reactionMessageIdHex) },
-                uniquingKeysWith: { first, _ in first }
-            )
-        } ?? [:]
+        let ownReactionIdsByEmoji =
+            activeAccountIdHex.map { accountIdHex in
+                Dictionary(
+                    summary.userReactions.lazy
+                        .filter { $0.sender == accountIdHex }
+                        .map { ($0.emoji, $0.reactionMessageIdHex) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            } ?? [:]
 
         return summary.byEmoji.map { reaction in
             MessageReaction(


### PR DESCRIPTION
Fixes #423

## Summary
- Precompute the active account's reaction IDs by emoji in one pass over `userReactions`.
- Map the FFI-provided `byEmoji` tallies directly with O(1) own-reaction lookups.
- Remove the redundant client-side sort because `TimelineReactionSummaryFfi.byEmoji` is already sorted by the MarmotKit contract.

## Verification
- `git diff --check` — passed.
- `xcodebuild` — not run: unavailable on this Linux host.
- `swift --version` — not available on this Linux host.

## Sensitive paths
none


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->