### PR TITLE
fix: reject markdown links with embedded userinfo

### DIFF
--- a/whitenoise-mac/Core/MarkdownLinkPolicy.swift
+++ b/whitenoise-mac/Core/MarkdownLinkPolicy.swift
@@ -41,6 +41,10 @@ nonisolated enum MarkdownLinkPolicy {
         guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
             return false
         }
+        // Reject embedded userinfo before host-based checks. A peer-controlled
+        // link like `https://relay.damus.io@evil.example` connects to
+        // `evil.example` but reads as the trusted relay host to a human.
+        guard url.user == nil, url.password == nil else { return false }
         guard let host = url.host, !host.isEmpty else { return false }
         // Peer-controlled links must not point at literal private/loopback/link-local
         // destinations. Reuse the SSRF host check already implemented for avatar image URLs so

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1013,6 +1013,24 @@ struct PureValueTests {
         }
     }
 
+    @Test func markdownLinkPolicyRejectsEmbeddedUserinfoHostConfusion() async throws {
+        // Peer Markdown links are user-visible strings. Embedded userinfo can make
+        // the URL read like a trusted host while URL parsing sends the browser to
+        // the attacker-controlled host, so match RelayURLValidator's policy and
+        // reject any user/password component before exposing the link.
+        for raw in [
+            "https://relay.damus.io@evil.example/phish",
+            "http://trusted.example@evil.example/path",
+            "https://user:pass@evil.example/path",
+            "https://:pass@evil.example/path",
+            "https://user@evil.example/path",
+        ] {
+            let url = try #require(URL(string: raw))
+            #expect(!MarkdownLinkPolicy.isAllowedExternalURL(url), "expected rejection for \(raw)")
+            #expect(MarkdownLinkPolicy.sanitizedURL(from: raw) == nil, "expected nil for \(raw)")
+        }
+    }
+
     @Test func marmotProfileLinkAcceptsStrictProfileFormOnly() async throws {
         // Accepted: strict marmot://profile/<npub|nprofile>, query ignored, case-insensitive
         // scheme/host. These flow in from OS deep links and kit-emitted message autolinks.
@@ -1138,6 +1156,17 @@ struct PureValueTests {
             ], remainingDepth: 32)
         #expect(String(unsafeAutolink.characters) == "smb://attacker/share")
         #expect(links(in: unsafeAutolink).isEmpty)
+
+        let hostConfusion = MarkdownDisplayInlineBuilder.attributedString(
+            from: [
+                .link(
+                    dest: "https://relay.damus.io@evil.example/phish",
+                    title: nil,
+                    children: [.text(content: "spoof")]
+                )
+            ], remainingDepth: 32)
+        #expect(String(hostConfusion.characters) == "spoof")
+        #expect(links(in: hostConfusion).isEmpty)
     }
 
     @Test func markdownInlineBuilderKeepsNostrEntitiesInternal() async throws {


### PR DESCRIPTION
## Summary
- reject http/https Markdown links that include URL userinfo before host-based safety checks
- add PureValueTests coverage for trusted-host-as-userinfo links and Markdown inline link dropping

## Test Plan
- `git diff --check`
- `git grep -n '^<<<<<<<\|^=======\|^>>>>>>>' -- HEAD -- whitenoise-mac/Core/MarkdownLinkPolicy.swift whitenoise-macTests/PureValueTests.swift` (no matches)
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` (not run: `xcodebuild` is not installed on this Linux worker)

Fixes #424


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/436">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->