### PR TITLE
fix: trim saturated timeline indexes incrementally

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -347,8 +347,7 @@ final class MessageTimelineStore {
 
         var didTrimOlderMessages = false
         if messages.count > windowLimit {
-            messages.removeFirst(messages.count - windowLimit)
-            rebuildIndexes()
+            trimOldestMessages(count: messages.count - windowLimit)
             didTrimOlderMessages = true
             didChange = true
         }
@@ -371,6 +370,18 @@ final class MessageTimelineStore {
             messages.enumerated().map { ($0.element.id, $0.offset) },
             uniquingKeysWith: { _, new in new }
         )
+    }
+
+    private func trimOldestMessages(count trimCount: Int) {
+        guard trimCount > 0 else { return }
+        let trimmedIDs = messages.prefix(trimCount).map(\.id)
+        messages.removeFirst(trimCount)
+        messageIDs.removeFirst(trimCount)
+        for id in trimmedIDs {
+            lookup[id] = nil
+            indexById[id] = nil
+        }
+        reindexMessages(startingAt: 0)
     }
 
     private func insertMessage(_ item: MessageItem, at index: Int) {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -285,6 +285,54 @@ struct PureValueTests {
     }
 
     @MainActor
+    @Test func messageTimelineStoreTrimsSaturatedWindowWithoutStaleIndexes() async throws {
+        // Regression for whitenoise-mac#422: once the live window is saturated, appending one
+        // newer message should trim only the oldest row and keep the lookup/index structures
+        // aligned without a full dedup/index rebuild on every message.
+        func message(id: String, timelineAt: UInt64, body: String? = nil) -> MessageItem {
+            MessageItem(
+                id: id,
+                senderName: "sender",
+                body: body ?? id,
+                sentAt: Date(timeIntervalSince1970: TimeInterval(timelineAt)),
+                timelineAt: timelineAt,
+                isOutgoing: false
+            )
+        }
+
+        let store = MessageTimelineStore.loaded(with: [
+            message(id: "m0", timelineAt: 0),
+            message(id: "m1", timelineAt: 1),
+            message(id: "m2", timelineAt: 2),
+        ])
+
+        let result = store.applyProjection(
+            upserts: [message(id: "m3", timelineAt: 3)],
+            removals: [],
+            anchoredToNewest: true,
+            windowLimit: 3
+        )
+
+        #expect(result.didTrimOlderMessages)
+        #expect(store.messages.map(\.id) == ["m1", "m2", "m3"])
+        #expect(store.messageIDs == ["m1", "m2", "m3"])
+        #expect(!store.containsMessage(id: "m0"))
+        #expect(store.lookup["m0"] == nil)
+        #expect(store.lookup["m1"]?.body == "m1")
+
+        _ = store.applyProjection(
+            upserts: [message(id: "m1", timelineAt: 1, body: "updated")],
+            removals: [],
+            anchoredToNewest: true,
+            windowLimit: 3
+        )
+
+        #expect(store.messages.map(\.body) == ["updated", "m2", "m3"])
+        #expect(store.messageIDs == ["m1", "m2", "m3"])
+        #expect(store.lookup["m1"]?.body == "updated")
+    }
+
+    @MainActor
     @Test func replacingTimelineWindowEvictsMediaDownloadsOutsideWindow() async throws {
         // Regression for whitenoise-mac#394: decrypted attachment payloads for messages that
         // leave the selected timeline window must be released instead of staying resident until


### PR DESCRIPTION
## Summary
- replace the saturated timeline trim path with an incremental prefix trim
- remove only the evicted ids from lookup/index state, then reindex the retained window
- add coverage that appending past the live window keeps messageIDs, lookup, and retained-row updates aligned

## Test Plan
- git diff --check
- xcodebuild/swift tests not run: Linux host has no xcodebuild or swift toolchain

Fixes #422


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message timeline trimming so only the oldest items are removed when the window limit is reached.
  * Kept message lists, IDs, and lookup indexes in sync after trimming, preventing stale or mismatched entries.
  * Preserved correct updates when an existing message is updated after the window has been trimmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->