### PR TITLE
fix: invalidate selected chat on metadata deltas

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -468,7 +468,9 @@ final class WorkspaceState {
     /// Observed invalidation token for `selectedChat`, whose actual lookup stays in the
     /// ignored O(1) indexes below. Live chat-list deltas mutate those indexes, so the selected
     /// conversation needs this tracked scalar to re-read fresh metadata without subscribing to
-    /// the whole chat dictionary.
+    /// the whole chat dictionary. It is intentionally coarse: any active-account chat-list
+    /// mutation invalidates the selected conversation chrome, while transcript reads remain
+    /// scoped through per-chat timeline stores.
     var selectedChatRevision = 0
     @ObservationIgnored var chatLookupByAccount: [String: [String: ChatItem]] = [:]
     @ObservationIgnored var chatIndexByAccount: [String: [String: Int]] = [:]
@@ -1283,6 +1285,9 @@ final class WorkspaceState {
     }
 
     func resetChats() {
+        // Currently used only by `resetToNewInstallState`, which clears `activeAccountId` and
+        // `selection` in the same synchronous reset path. A future caller that keeps a selected
+        // chat alive while clearing these ignored indexes must also bump `selectedChatRevision`.
         chatsByAccount = [:]
         chatLookupByAccount = [:]
         chatIndexByAccount = [:]

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -465,6 +465,11 @@ final class WorkspaceState {
     var phase: Phase = .bootstrapping
     var accounts: [AccountItem]
     var chatsByAccount: [String: [ChatItem]]
+    /// Observed invalidation token for `selectedChat`, whose actual lookup stays in the
+    /// ignored O(1) indexes below. Live chat-list deltas mutate those indexes, so the selected
+    /// conversation needs this tracked scalar to re-read fresh metadata without subscribing to
+    /// the whole chat dictionary.
+    var selectedChatRevision = 0
     @ObservationIgnored var chatLookupByAccount: [String: [String: ChatItem]] = [:]
     @ObservationIgnored var chatIndexByAccount: [String: [String: Int]] = [:]
     @ObservationIgnored var chatListGenerationByAccount: [String: Int] = [:]
@@ -1208,6 +1213,7 @@ final class WorkspaceState {
 
     var selectedChat: ChatItem? {
         guard case .chat(let chatId) = selection else { return nil }
+        _ = selectedChatRevision
         return activeAccountId.flatMap { chatLookupByAccount[$0]?[chatId] }
     }
 
@@ -1333,6 +1339,9 @@ final class WorkspaceState {
 
     private func bumpChatListGeneration(forAccountId accountId: String) {
         chatListGenerationByAccount[accountId, default: 0] += 1
+        if activeAccountId == accountId {
+            selectedChatRevision += 1
+        }
         if filteredChatsCache?.accountId == accountId {
             filteredChatsCache = nil
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -9086,6 +9086,75 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func selectedChatObservationInvalidatesOnSelectedChatMetadataDelta() async throws {
+        // Regression for #388: `selectedChat` resolves through ignored O(1) indexes, so it must
+        // still read an observed token that live chat-list deltas bump. Otherwise the open
+        // conversation keeps rendering a frozen ChatItem after renames/membership-ended flips.
+        let account = AccountItem.samples[0]
+        let selected = ChatItem(
+            id: "selected-chat",
+            title: "Original group",
+            subtitle: "Group message",
+            preview: "before",
+            updatedAt: Date(timeIntervalSince1970: 100),
+            avatarSeed: "selected-chat",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let background = ChatItem(
+            id: "background-chat",
+            title: "Background group",
+            subtitle: "Group message",
+            preview: "background",
+            updatedAt: Date(timeIntervalSince1970: 90),
+            avatarSeed: "background-chat",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [selected, background]],
+            clientFactory: { FakeMarmotRuntime(accounts: []) }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(selected.id)
+
+        #expect(state.selectedChat?.title == "Original group")
+        #expect(state.selectedChat?.isNoLongerMember == false)
+
+        let invalidated = ObservationInvalidationFlag()
+        withObservationTracking {
+            _ = state.selectedChat?.title
+            _ = state.selectedChat?.isNoLongerMember
+        } onChange: {
+            invalidated.markInvalidated()
+        }
+
+        state.upsertChat(
+            ChatItem(
+                id: selected.id,
+                title: "Renamed group",
+                subtitle: selected.subtitle,
+                preview: "after",
+                updatedAt: selected.updatedAt,
+                avatarSeed: "renamed-avatar",
+                pictureURL: selected.pictureURL,
+                unreadCount: selected.unreadCount,
+                unreadMentionCount: selected.unreadMentionCount,
+                isDirect: selected.isDirect,
+                pendingConfirmation: selected.pendingConfirmation,
+                selfMembership: .removed
+            ),
+            forAccountId: account.id
+        )
+
+        #expect(invalidated.value)
+        #expect(state.selectedChat?.title == "Renamed group")
+        #expect(state.selectedChat?.avatarSeed == "renamed-avatar")
+        #expect(state.selectedChat?.isNoLongerMember == true)
+    }
+
+    @MainActor
     @Test func workspaceChatIndexesAndFilterCachePerformanceGuard() async throws {
         let account = AccountItem.samples[0]
         let chats = performanceChatItems(count: 5_000)


### PR DESCRIPTION
## Summary
- add an observed selected-chat revision token while keeping selectedChat on the ignored O(1) lookup index
- bump that token when the active account chat list changes so the open conversation re-reads fresh rename/avatar/invite/membership-ended metadata
- add a Swift Observation regression test for a selected-chat metadata delta

Fixes #388

## Test plan
- `git diff --check`
- `git grep -n '^<<<<<<<\\|^=======\\|^>>>>>>>' -- . ':!Vendored/MarmotKit/MarmotKit.xcframework'`
- Not run on this Linux host: `xcrun swift-format ...` (`xcrun` missing), `xcodebuild test ...` (`xcodebuild` missing)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->