### PR TITLE
fix: stop recording on last account sign-out

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -310,9 +310,10 @@ extension WorkspaceState {
         }
     }
 
-    /// Clears all active-account-scoped in-memory UI state (timelines, caches,
-    /// drafts, settings snapshots). Shared by account removal and sign-out.
+    /// Clears all active-account-scoped in-memory UI state (conversation resources,
+    /// timelines, caches, drafts, settings snapshots). Shared by account removal and sign-out.
     func resetActiveAccountUIState() {
+        leaveActiveConversation()
         stopTimelineListener()
         cancelTimelineLoad()
         cancelChatListReload()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -776,6 +776,38 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func signOutLastActiveAccountStopsInProgressVoiceRecording() async throws {
+        // #386: the account-rail sign-out path can send the last signed-in account
+        // straight to onboarding, removing the composer that owns the Stop control.
+        // It must still run active-conversation teardown so the mic is not left hot
+        // and the plaintext scratch recording does not survive sign-out.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+
+        let primary = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [primary])
+        UserDefaults.standard.set(primary.label, forKey: WorkspaceState.activeAccountKey)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let url = try armInProgressVoiceRecording(on: state)
+        let desktopAccount = try #require(state.accounts.first { $0.id == primary.label })
+
+        await state.signOutAccount(desktopAccount)
+
+        #expect(runtime.signedOutAccountRefs == [primary.label])
+        #expect(state.phase == .onboarding)
+        #expect(state.activeAccountId == nil)
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecorder == nil)
+        #expect(state.voiceRecordingURL == nil)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(state.voiceRecordingSamples.isEmpty)
+        #expect(state.voiceRecordingDurationSeconds == 0)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
     @Test func removingBackgroundAccountSelectedMidFlightRecoversActiveAccount() async throws {
         // Regression for the account-switch/remove race: if the user selects the
         // background account that is currently being removed while removal is in flight,


### PR DESCRIPTION
## Summary
- Route active-account UI reset through `leaveActiveConversation()` so sign-out/removal teardown cancels recorder-owned conversation resources before the composer disappears.
- Add regression coverage for signing out the only active account while a voice recording is in progress; onboarding now clears recorder state and deletes the plaintext `.m4a` scratch file.

## Test Plan
- `git diff --check`
- `git grep -nE '^<<<<<<<|^=======|^>>>>>>>' -- .` (no conflict markers)
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` not run: `xcodebuild` is unavailable on this Linux worker
- `swift-format` / `swift` not run: unavailable on this Linux worker

Fixes #386


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/439">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->