### PR TITLE
fix: guard voice recording start reentry

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -354,8 +354,11 @@ extension WorkspaceState {
     }
 
     func startVoiceRecording() async {
-        guard !isRecordingVoiceMessage else { return }
+        guard !isRecordingVoiceMessage, !isPreparingVoiceRecording else { return }
         guard canBeginMediaAttachmentSelection() else { return }
+
+        isPreparingVoiceRecording = true
+        defer { isPreparingVoiceRecording = false }
 
         let hasPermission = await requestMicrophoneAccess()
         guard hasPermission else {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -565,6 +565,9 @@ final class WorkspaceState {
     var isRefreshing = false
     var isSending = false
     var isRecordingVoiceMessage = false
+    /// Synchronous guard for the mic-permission await in `startVoiceRecording()` so a second
+    /// tap cannot interleave and orphan a hot recorder (#391).
+    var isPreparingVoiceRecording = false
     var voiceRecordingSamples: [CGFloat] = []
     var voiceRecordingDurationSeconds: Double = 0
     /// Per-target reentrancy guards for message actions. `react`/`deleteMessage`

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11867,6 +11867,20 @@ struct whitenoise_macTests {
         #expect(state.draftText == "half-written message")
     }
 
+    @MainActor
+    @Test func startVoiceRecordingIgnoresConcurrentInvocationWhilePreparing() async {
+        // #391: a second mic tap during the permission await must not start another recorder.
+        let state = WorkspaceState.preview()
+        state.isPreparingVoiceRecording = true
+
+        await state.startVoiceRecording()
+
+        #expect(state.isPreparingVoiceRecording)
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecorder == nil)
+        #expect(state.voiceRecordingURL == nil)
+    }
+
     /// Puts `state` into an in-progress voice-recording state (mic "hot", metering task running,
     /// plaintext temp file on disk) without needing real mic hardware, mirroring what
     /// `startVoiceRecording()` sets up. Returns the temp file URL so tests can assert the


### PR DESCRIPTION
Fixes #391

## Summary
- Add `isPreparingVoiceRecording` as a synchronous in-flight guard before `requestMicrophoneAccess()` suspends.
- Keep `isRecordingVoiceMessage` unchanged until an `AVAudioRecorder` is actually running, preserving existing recording UI semantics.
- Add a regression test covering a second `startVoiceRecording()` call while the prepare sentinel is already held.

## Verification
- `scripts/ci/macos-sanity-checks.sh` — failed locally: `xcodebuild: command not found` (Linux host, no Xcode)
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — failed locally: `xcrun: command not found` (Linux host, no Xcode tools)
- `git diff --check` — passed
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- whitenoise-mac/Core/WorkspaceState.swift whitenoise-mac/Core/WorkspaceState+Media.swift whitenoise-macTests/whitenoise_macTests.swift` — no matches

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+Media.swift` — microphone permission / `AVAudioRecorder` lifecycle / plaintext temp voice-recording file handling
- `whitenoise-mac/Core/WorkspaceState.swift` — voice recording state


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/440">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->