### PR TITLE
fix: keep filtered chats observed on cache hits

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1204,6 +1204,9 @@ final class WorkspaceState {
 
     var filteredChats: [ChatItem] {
         guard let activeAccountId else { return [] }
+        // Read the observed list before a cache-hit return so SwiftUI keeps invalidating the
+        // sidebar on incoming chat updates even when filtering work is memoized.
+        let chats = chatsByAccount[activeAccountId] ?? []
         let generation = chatListGenerationByAccount[activeAccountId] ?? 0
         let query = searchText
         if let cache = filteredChatsCache,
@@ -1214,7 +1217,7 @@ final class WorkspaceState {
             return cache.result
         }
 
-        let result = ChatFilter.filtered(chatsByAccount[activeAccountId] ?? [], query: query)
+        let result = ChatFilter.filtered(chats, query: query)
         filteredChatsCache = FilteredChatsCache(
             accountId: activeAccountId,
             generation: generation,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -9384,6 +9384,69 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func filteredChatsObservationInvalidatesOnChatListDeltaAfterCacheHit() async throws {
+        // Regression for #390: `filteredChats` is memoized through ignored cache state, but each
+        // body pass still has to read the observed chat list. Otherwise a cache-hit pass drops the
+        // sidebar's `chatsByAccount` subscription and background-chat updates do not repaint it.
+        let account = AccountItem.samples[0]
+        let selected = ChatItem(
+            id: "selected-chat",
+            title: "Selected group",
+            subtitle: "Group message",
+            preview: "selected preview",
+            updatedAt: Date(timeIntervalSince1970: 100),
+            avatarSeed: "selected-chat",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let background = ChatItem(
+            id: "background-chat",
+            title: "Background group",
+            subtitle: "Group message",
+            preview: "old background",
+            updatedAt: Date(timeIntervalSince1970: 90),
+            avatarSeed: "background-chat",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [selected, background]],
+            clientFactory: { FakeMarmotRuntime(accounts: []) }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(selected.id)
+
+        #expect(state.filteredChats.map(\.id) == [selected.id, background.id])
+
+        let invalidated = ObservationInvalidationFlag()
+        withObservationTracking {
+            _ = state.filteredChats.map(\.id)
+        } onChange: {
+            invalidated.markInvalidated()
+        }
+
+        state.upsertChat(
+            ChatItem(
+                id: background.id,
+                title: background.title,
+                subtitle: background.subtitle,
+                preview: "new background",
+                updatedAt: Date(timeIntervalSince1970: 200),
+                avatarSeed: background.avatarSeed,
+                pictureURL: background.pictureURL,
+                unreadCount: 3
+            ),
+            forAccountId: account.id
+        )
+
+        #expect(invalidated.value)
+        #expect(state.filteredChats.map(\.id) == [background.id, selected.id])
+        #expect(state.filteredChats.first?.preview == "new background")
+        #expect(state.filteredChats.first?.unreadCount == 3)
+    }
+
+    @MainActor
     @Test func workspaceChatIndexesAndFilterCachePerformanceGuard() async throws {
         let account = AccountItem.samples[0]
         let chats = performanceChatItems(count: 5_000)


### PR DESCRIPTION
## Summary
- keep `filteredChats` subscribed to the observed active-account chat list before cache-hit returns
- add a Swift Observation regression test for cache-hit filtered chat reads followed by background chat updates

## Test Plan
- `git diff --check`
- Not run: `xcodebuild` / Swift tests (Linux worker has no `xcodebuild` or `swift` toolchain)

Fixes #390


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->