### PR TITLE
fix: preserve raced account selection on sign-in

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -427,13 +427,27 @@ extension WorkspaceState {
         isSigningOutAccount = true
         defer { isSigningOutAccount = false }
 
+        let preAwaitActiveAccountId = activeAccountId
         do {
             _ = try await client.signInAccount(accountRef: account.accountRef)
             accounts = try await accountItemsFromRuntime(client: client)
             if let refreshed = accounts.first(where: { $0.id == account.id }) {
-                switchActiveAccount(refreshed, finalSelection: .settings(.accounts))
-                try await configureObservabilityRuntime()
-                await loadSettingsData()
+                let currentActiveAccount = activeAccountId.flatMap { id in
+                    accounts.first { $0.id == id && !$0.signedOut }
+                }
+                // `activeAccountId` may have changed during the awaits above — e.g. the user
+                // selected another account while this sign-in was in flight (account switching
+                // is not gated by `isSigningOutAccount`). Only activate the just-signed-in
+                // account when no other valid signed-in account was raced to mid-flight.
+                let userRacedToDifferentAccount =
+                    currentActiveAccount != nil
+                    && activeAccountId != preAwaitActiveAccountId
+                    && currentActiveAccount?.id != account.id
+                if !userRacedToDifferentAccount {
+                    switchActiveAccount(refreshed, finalSelection: .settings(.accounts))
+                    try await configureObservabilityRuntime()
+                    await loadSettingsData()
+                }
             }
             await refreshAccountUnreadSummary()
         } catch {

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -669,8 +669,8 @@ struct IdentityKeysSettingsView: View {
                                 .font(.headline)
                                 .lineLimit(1)
                             Text(accountSigningDescription(for: account))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -950,6 +950,7 @@ struct whitenoise_macTests {
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: true
         )
@@ -959,6 +960,7 @@ struct whitenoise_macTests {
             label: "Other Account",
             accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: true
         )
@@ -966,6 +968,7 @@ struct whitenoise_macTests {
             label: "Backup Account",
             accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
             localSigning: true,
+            externalSigning: false,
             signedOut: true,
             running: false
         )
@@ -1260,6 +1263,7 @@ struct whitenoise_macTests {
             label: "Backup Account",
             accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: true
         )
@@ -1302,6 +1306,7 @@ struct whitenoise_macTests {
             label: "Backup Account",
             accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: true
         )

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -939,6 +939,62 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func signingInAccountSelectedMidFlightKeepsRacedSelection() async throws {
+        // Regression for the sign-in/account-switch race (whitenoise-mac#393): if the user
+        // selects another account while a signed-out account's sign-in is in flight,
+        // `activeAccountId` now points at the newly-selected account. Naive code would still
+        // unconditionally `switchActiveAccount` to the just-signed-in account, tearing down the
+        // raced-to session. Sign-in must recompute against post-await state and leave a valid
+        // raced selection untouched.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        // Naive code would unconditionally activate the just-signed-in "Backup Account",
+        // discarding the user's explicit mid-flight selection of "Other Account".
+        let other = AccountSummaryFfi(
+            label: "Other Account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let signedOut = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, other, signedOut])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let signedOutAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        let otherAccount = try #require(state.accounts.first { $0.id == "Other Account" })
+
+        // Simulate the racing UI selection from the account rail, mid-await.
+        runtime.onSignInAccountMidFlight = { _ in
+            await MainActor.run {
+                state.selectAccount(otherAccount)
+            }
+        }
+
+        await state.signInAccount(signedOutAccount)
+
+        #expect(runtime.signInAccountCallCount == 1)
+        #expect(state.accounts.first { $0.id == "Backup Account" }?.signedOut == false)
+        // The user's explicit mid-flight selection must survive: sign-in must not activate
+        // the just-signed-in "Backup Account" over the raced-to "Other Account".
+        #expect(state.activeAccountId == "Other Account")
+        #expect(UserDefaults.standard.string(forKey: "whitenoise.mac.activeAccountId") == "Other Account")
+    }
+
+    @MainActor
     @Test func deleteAllDataResetsToNewInstallState() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",
@@ -15952,6 +16008,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// marked signed out, but before the call returns, used to simulate a racing UI action (e.g.
     /// the user selecting another account while sign-out is in flight) mid-await.
     var onSignOutAccountMidFlight: (@Sendable (String) async -> Void)?
+    /// Optional hook fired inside `signInAccount` after the stored account is marked signed in,
+    /// but before the call returns, used to simulate a racing UI action (e.g. the user selecting
+    /// another account while sign-in is in flight) mid-await.
+    var onSignInAccountMidFlight: (@Sendable (String) async -> Void)?
     /// Optional hook fired inside `userProfile`, on the off-main FFI batch thread. A test can
     /// use it to advance an injected clock and model a slow batch (whitenoise-mac#181).
     var onUserProfileLookup: (@Sendable (String) -> Void)?
@@ -17133,14 +17193,23 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func signInAccount(accountRef: String) async throws -> AccountSummaryFfi {
         signInAccountCallCount += 1
-        return AccountSummaryFfi(
-            label: accountRef,
-            accountIdHex: accountRef,
-            localSigning: true,
-            externalSigning: false,
-            signedOut: false,
-            running: true
-        )
+        if let index = storedAccounts.firstIndex(where: { $0.label == accountRef }) {
+            storedAccounts[index].signedOut = false
+            storedAccounts[index].running = true
+        }
+        if let onSignInAccountMidFlight {
+            await onSignInAccountMidFlight(accountRef)
+        }
+        let summary = storedAccounts.first(where: { $0.label == accountRef })
+        return summary
+            ?? AccountSummaryFfi(
+                label: accountRef,
+                accountIdHex: accountRef,
+                localSigning: true,
+                externalSigning: false,
+                signedOut: false,
+                running: true
+            )
     }
 
     func revealNsec(accountRef: String) throws -> String {


### PR DESCRIPTION
Fixes #393

## Summary
- Guard `signInAccount` against the same mid-await account-switch race already handled in `signOutAccount`.
- After the FFI/sign-in awaits, preserve a different valid signed-in account selected by the user instead of unconditionally switching back to the just-signed-in account.
- Add a regression test that simulates the mid-flight account-rail selection and extends the fake runtime with a sign-in hook/state update.

## Verification
- `git diff --check` — passed
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .` — passed (no conflict markers)
- GitHub Mac CI / `PR Checks` — passed on commit `6a9c00e4d7d44ace179dc2e0eb08296f19847d17`
- GitHub Mac CI / `Static Analysis` — passed on commit `6a9c00e4d7d44ace179dc2e0eb08296f19847d17`
- CodeRabbit — passed, no actionable comments
- `scripts/ci/macos-sanity-checks.sh` — not runnable locally on Linux: `xcodebuild: command not found` (exit 127)
- Full local macOS commands (`xcrun swift-format`, `xcodebuild test/build/analyze`) — not runnable locally because Xcode tooling is unavailable on Linux

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+Account.swift` — account sign-in / active-account selection flow

## Note
The first CI run failed `swift-format`; formatting was fixed and the rerun is green. Per Pip policy, the merge gate should treat this PR as having had red CI historically even though the current head is green.
