### PR TITLE
fix: isolate media cache entries by plaintext hash

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -17,7 +17,7 @@ nonisolated struct MessageMediaDiskCacheKey: Hashable, Sendable {
     }
 
     var cacheID: String {
-        Self.hexDigest("media-cache-v1", accountId, groupIdHex, ciphertextSha256)
+        Self.hexDigest("media-cache-v1", accountId, groupIdHex, ciphertextSha256, plaintextSha256)
     }
 
     var accountDigest: String {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1870,6 +1870,56 @@ struct whitenoise_macTests {
         #expect(fileManager.fileExists(atPath: entryDirectory.path))
     }
 
+    @Test func messageMediaDiskCachePlaintextHashMismatchDoesNotEvictValidEntry() async throws {
+        // #389: cacheID must include plaintextSha256 so a peer-crafted reference reusing a
+        // real ciphertext hash cannot share an entry directory and delete the valid cache on read.
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(root: root)
+        let plaintext = Data("legitimate cached media bytes".utf8)
+        let sharedCiphertextSha256 = String(repeating: "cc", count: 32)
+        let validReference = mediaDiskCacheReference(
+            plaintext: plaintext,
+            ciphertextSha256: sharedCiphertextSha256
+        )
+        let bogusReference = mediaDiskCacheReference(
+            plaintext: Data("bogus plaintext claim".utf8),
+            ciphertextSha256: sharedCiphertextSha256
+        )
+        let validKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: validReference
+        )
+        let bogusKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: bogusReference
+        )
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "photo.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(plaintext.count),
+            payloadId: "network-download"
+        )
+
+        #expect(validKey.cacheID != bogusKey.cacheID)
+
+        await cache.store(download, for: validKey)
+        let validEntryDirectory = try #require(cache.entryDirectory(for: validKey))
+
+        #expect(await cache.cachedDownload(for: bogusKey) == nil)
+        #expect(fileManager.fileExists(atPath: validEntryDirectory.path))
+
+        let restored = try #require(await cache.cachedDownload(for: validKey))
+        #expect(restored.data == plaintext)
+        #expect(fileManager.fileExists(atPath: validEntryDirectory.path))
+    }
+
     @Test func messageMediaDiskCacheEvictsCorruptEntries() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
@@ -17861,11 +17911,13 @@ private func messageMediaDiskCache(
 
 private func mediaDiskCacheReference(
     plaintext: Data,
-    ciphertextByte: UInt8 = 0xcc
+    ciphertextByte: UInt8 = 0xcc,
+    ciphertextSha256: String? = nil
 ) -> MediaAttachmentReferenceFfi {
     MediaAttachmentReferenceFfi(
         locators: [],
-        ciphertextSha256: String(repeating: String(format: "%02x", ciphertextByte), count: 32),
+        ciphertextSha256: ciphertextSha256
+            ?? String(repeating: String(format: "%02x", ciphertextByte), count: 32),
         plaintextSha256: hexSHA256(plaintext),
         nonceHex: String(repeating: "00", count: 12),
         fileName: "cached.bin",


### PR DESCRIPTION
Fixes #389

## Summary
- Includes `plaintextSha256` in `MessageMediaDiskCacheKey.cacheID`, so peer-crafted references that reuse a ciphertext hash but claim a different plaintext hash no longer share an on-disk cache entry.
- Adds a regression test that stores a valid entry, reads a same-ciphertext/different-plaintext bogus key as a miss, and verifies the valid entry remains readable.

## Verification
- `git diff --check` — passed
- conflict-marker sweep with `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .` — passed
- `xcodebuild` — not available on this Linux host
- `swift --version` — not available on this Linux host

Inspection-only for Xcode build/test on this host. Expected macOS checks:

```sh
xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO
xcodebuild test-without-building -scheme whitenoise-mac -configuration Debug \
  -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO
```

## Sensitive paths
- `whitenoise-mac/Core/MessageMediaDiskCache.swift` — cache CryptoKit/AES-GCM sealed-record path; no MLS/CGKA/auth/trust-anchor changes.

## Notes
Changing `cacheID` changes the directory/AAD identity for existing cached media entries. Existing entries may be cold-missed once after upgrade and later evicted/cleaned up.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/444">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->