### PR TITLE
fix: tear down group details during account switch

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -87,6 +87,7 @@ extension WorkspaceState {
         cancelTimelineLoad()
         cancelChatListReload()
         stopChatListListener()
+        closeGroupDetails()
         clearEnteredLoginIdentity()
         activeAccountId = account.id
         invalidateNotificationSettingsOperations()

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -74,9 +74,11 @@ extension WorkspaceState {
         defer { isExportingGroupTranscript = false }
 
         do {
+            let accountId = activeAccount.id
             let accountRef = activeAccount.accountRef
             let groupIdHex = snapshot.groupIdHex
             let groupName = snapshot.name
+            let detailsGeneration = groupDetailsLoadGeneration
             // Paginates the whole transcript via blocking FFI and JSON-encodes it; keep it
             // off the main thread so a large export does not freeze the UI.
             let export = try await runOffMainCancellable { checkCancellation -> (json: String, eventCount: Int) in
@@ -93,6 +95,12 @@ extension WorkspaceState {
                 )
                 return (try ConversationTranscriptExport.encodeJSONString(document), document.eventCount)
             }
+            guard !Task.isCancelled,
+                activeAccountId == accountId,
+                groupDetailsLoadGeneration == detailsGeneration,
+                isGroupDetailsPresented,
+                groupDetailsSnapshot == snapshot
+            else { return }
             copyText(export.json)
             groupTranscriptExportStatus = String(
                 format: L10n.string("Copied transcript JSON for %d events."),

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1164,6 +1164,115 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func prepareForActiveAccountSwitchClosesGroupDetails() async throws {
+        let primary = desktopAccount()
+        let backup = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, backup])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: primary.accountIdHex))
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let primaryAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+        state.prepareForActiveAccountSwitch(to: primaryAccount, preservingMessageCacheFor: nil)
+        await state.reloadChats(forceFreshSnapshot: true)
+        let groupChat = try #require(state.activeChats.first { $0.id == "group" })
+        await state.showGroupDetails(for: groupChat)
+        #expect(state.isGroupDetailsPresented)
+        #expect(state.groupDetailsSnapshot?.members.count == 3)
+
+        state.groupProfileDraftName = "Private group name"
+        state.groupProfileDraftDescription = "Private group description"
+        state.groupInviteMemberQuery = "npub1privateinvite"
+        state.groupTranscriptExportStatus = "Copied transcript JSON for 1 events."
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+
+        state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
+
+        // Live switches are account-boundary teardown: account A's details/transcript-export UI
+        // must not stay visible under account B. See #420.
+        #expect(state.activeAccountId == backupAccount.id)
+        #expect(!state.isGroupDetailsPresented)
+        #expect(state.groupDetailsSnapshot == nil)
+        #expect(state.groupProfileDraftName.isEmpty)
+        #expect(state.groupProfileDraftDescription.isEmpty)
+        #expect(state.groupInviteMemberQuery.isEmpty)
+        #expect(state.groupTranscriptExportStatus == nil)
+    }
+
+    @MainActor
+    @Test func groupTranscriptExportDoesNotCopyAfterAccountSwitch() async throws {
+        let primary = desktopAccount()
+        let backup = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, backup])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: primary.accountIdHex))
+
+        let exportEntered = DispatchSemaphore(value: 0)
+        let releaseExport = DispatchSemaphore(value: 0)
+        let messageId = String(repeating: "1", count: 64)
+        runtime.timelineMessagesHandler = { query in
+            if query.before == nil {
+                exportEntered.signal()
+                _ = releaseExport.wait(timeout: .now() + 5)
+                return TimelinePageFfi(
+                    messages: [
+                        timelineMessage(
+                            id: messageId,
+                            groupIdHex: "group",
+                            sender: primary.accountIdHex,
+                            plaintext: "account A decrypted transcript",
+                            recordedAt: 1_700_000_000
+                        )
+                    ],
+                    hasMoreBefore: false,
+                    hasMoreAfter: false
+                )
+            }
+            return TimelinePageFfi(messages: [], hasMoreBefore: false, hasMoreAfter: false)
+        }
+
+        var copiedText: String?
+        let state = WorkspaceState(
+            copyTextHandler: { text, _ in copiedText = text },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        let primaryAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+        state.prepareForActiveAccountSwitch(to: primaryAccount, preservingMessageCacheFor: nil)
+        await state.reloadChats(forceFreshSnapshot: true)
+        let groupChat = try #require(state.activeChats.first { $0.id == "group" })
+        await state.showGroupDetails(for: groupChat)
+
+        // Call the async helper directly (rather than startCopySelectedGroupTranscriptJSON)
+        // so this test isolates the post-await stale-account guard from task cancellation.
+        async let export: Void = state.copySelectedGroupTranscriptJSON()
+        #expect(await waitForSemaphore(exportEntered, timeout: .now() + 2) == .success)
+
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
+        releaseExport.signal()
+        await export
+
+        // Even if the off-main export survives cancellation long enough to return, its completion
+        // must not write account A's decrypted transcript or status after switching to account B.
+        #expect(state.activeAccountId == backupAccount.id)
+        #expect(copiedText == nil)
+        #expect(state.groupTranscriptExportStatus == nil)
+    }
+
+    @MainActor
     @Test func resetActiveAccountUIStateClearsGroupAndNewChatPII() async throws {
         let primary = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [primary])


### PR DESCRIPTION
## Summary
- close group details during live account switches before committing the new active account
- guard transcript export completion against stale account/details-generation state before writing to pasteboard/status
- add regression coverage for account-switch details teardown and stale transcript export completion

## Test Plan
- `git diff --check`
- static privacy guard assertions via Python
- conflict marker sweep via `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .`
- Not run: `xcodebuild test -scheme whitenoise-mac -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO` (`xcodebuild` unavailable on this Linux host)

Fixes #420


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/445">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->