### PR TITLE
fix: preserve new chat draft for profile links

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Links.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Links.swift
@@ -41,11 +41,40 @@ extension WorkspaceState {
     }
 
     /// Shared destination for every profile reference the app consumes in-app (nostr autolinks,
-    /// marmot profile autolinks, and OS-level marmot:// deep links): open the New Chat composer
-    /// against the referenced profile via the FFI `normalizeMemberRef` path.
+    /// marmot profile autolinks, and OS-level marmot:// deep links): open or augment the New Chat
+    /// composer against the referenced profile via the FFI `normalizeMemberRef` path.
     func openProfileReference(_ reference: String) async {
-        showNewChat()
-        newChatQuery = "nostr:\(reference)"
-        _ = await resolveNewChatQuery()
+        let query = "nostr:\(reference)"
+        if isNewChatComposerVisible {
+            leaveActiveConversation()
+            lastError = nil
+            if hasInProgressNewChatComposition {
+                await appendProfileReferenceToCurrentNewChat(query: query)
+            } else {
+                invalidateNewChatLookup()
+                newChatRecipient = nil
+                newChatQuery = query
+                _ = await resolveNewChatQuery()
+            }
+        } else {
+            showNewChat()
+            newChatQuery = query
+            _ = await resolveNewChatQuery()
+        }
+    }
+
+    private func appendProfileReferenceToCurrentNewChat(query: String) async {
+        let previousQuery = newChatQuery
+        let previousRecipient = newChatRecipient
+
+        invalidateNewChatLookup()
+        newChatRecipient = nil
+        newChatQuery = query
+        if let recipient = await resolveNewChatQuery() {
+            _ = appendNewChatRecipient(recipient)
+        }
+        invalidateNewChatLookup()
+        newChatQuery = previousQuery
+        newChatRecipient = previousRecipient
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState+Links.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Links.swift
@@ -64,17 +64,12 @@ extension WorkspaceState {
     }
 
     private func appendProfileReferenceToCurrentNewChat(query: String) async {
-        let previousQuery = newChatQuery
-        let previousRecipient = newChatRecipient
-
-        invalidateNewChatLookup()
-        newChatRecipient = nil
-        newChatQuery = query
-        if let recipient = await resolveNewChatQuery() {
-            _ = appendNewChatRecipient(recipient)
+        do {
+            if let recipient = try await resolveNewChatRecipient(for: query) {
+                _ = appendNewChatRecipient(recipient)
+            }
+        } catch {
+            lastError = L10n.string("Enter a valid npub, profile link, or hex public key.")
         }
-        invalidateNewChatLookup()
-        newChatQuery = previousQuery
-        newChatRecipient = previousRecipient
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -19,7 +19,7 @@ extension WorkspaceState {
     @discardableResult
     func resolveNewChatQuery() async -> NewChatRecipient? {
         let query = newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let client else { return nil }
+        guard client != nil else { return nil }
         guard !query.isEmpty else {
             invalidateNewChatLookup()
             newChatRecipient = nil
@@ -44,34 +44,7 @@ extension WorkspaceState {
         }
 
         do {
-            let memberRef = try await memberRefCandidate(for: query)
-            let member = try await runOffMain {
-                try client.normalizeMemberRef(memberRef: memberRef)
-            }
-            try? await client.refreshProfile(accountIdHex: member.accountIdHex, relays: MarmotClient.seedRelays)
-            peerProfileFFICache[member.accountIdHex] = nil
-            let resolved = try? await runOffMain { () -> ResolvedPeerFFI in
-                let profile = try? client.userProfile(accountIdHex: member.accountIdHex)
-                return ResolvedPeerFFI(
-                    profileDisplayName: profile?.displayName,
-                    profileName: profile?.name,
-                    profilePicture: profile?.picture,
-                    directoryDisplayName: client.displayName(accountIdHex: member.accountIdHex)
-                )
-            }
-            let displayName = firstNonBlank([
-                resolved?.profileDisplayName,
-                resolved?.profileName,
-                resolved?.directoryDisplayName,
-            ])
-            let recipient = NewChatRecipient(
-                sourceQuery: query,
-                memberRef: member.memberRef,
-                accountIdHex: member.accountIdHex,
-                npub: member.npub,
-                displayName: displayName,
-                pictureURL: resolved?.profilePicture
-            )
+            guard let recipient = try await resolveNewChatRecipient(for: query) else { return nil }
             guard isCurrentNewChatLookup(generation: lookupGeneration, query: query) else {
                 return nil
             }
@@ -85,6 +58,40 @@ extension WorkspaceState {
             lastError = L10n.string("Enter a valid NIP-05, npub, profile link, or hex public key.")
             return nil
         }
+    }
+
+    /// Resolve a profile/member reference without reading from or writing to the live New Chat
+    /// input fields. Callers that own the composer state can apply their own freshness checks.
+    func resolveNewChatRecipient(for query: String) async throws -> NewChatRecipient? {
+        guard let client else { return nil }
+        let memberRef = try await memberRefCandidate(for: query)
+        let member = try await runOffMain {
+            try client.normalizeMemberRef(memberRef: memberRef)
+        }
+        try? await client.refreshProfile(accountIdHex: member.accountIdHex, relays: MarmotClient.seedRelays)
+        peerProfileFFICache[member.accountIdHex] = nil
+        let resolved = try? await runOffMain { () -> ResolvedPeerFFI in
+            let profile = try? client.userProfile(accountIdHex: member.accountIdHex)
+            return ResolvedPeerFFI(
+                profileDisplayName: profile?.displayName,
+                profileName: profile?.name,
+                profilePicture: profile?.picture,
+                directoryDisplayName: client.displayName(accountIdHex: member.accountIdHex)
+            )
+        }
+        let displayName = firstNonBlank([
+            resolved?.profileDisplayName,
+            resolved?.profileName,
+            resolved?.directoryDisplayName,
+        ])
+        return NewChatRecipient(
+            sourceQuery: query,
+            memberRef: member.memberRef,
+            accountIdHex: member.accountIdHex,
+            npub: member.npub,
+            displayName: displayName,
+            pictureURL: resolved?.profilePicture
+        )
     }
 
     func resolveNewChatQueryIfReady() async {

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -210,6 +210,13 @@ extension WorkspaceState {
         }
     }
 
+    var hasInProgressNewChatComposition: Bool {
+        !newChatRecipients.isEmpty
+            || !newChatName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !newChatDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     func resetNewChatComposer() {
         invalidateNewChatLookup()
         newChatQuery = ""

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -669,8 +669,8 @@ struct IdentityKeysSettingsView: View {
                                 .font(.headline)
                                 .lineLimit(1)
                             Text(accountSigningDescription(for: account))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -12982,6 +12982,51 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func profileLinkAppendDoesNotOverwriteMidLookupComposerEdits() async throws {
+        // Regression for the #421 review finding: appending a profile link into an existing
+        // draft must not borrow `newChatQuery` as scratch state and later restore stale input
+        // over user edits made while the link lookup was in flight.
+        let account = desktopAccount()
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
+        let carolId = "carol1234567890carol1234567890carol1234567890carol1234567890"
+        let daveId = "dave1234567890dave1234567890dave1234567890dave1234567890"
+        let bobReference = "nprofile1bob"
+        let bobQuery = "nostr:\(bobReference)"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installNormalizedMemberRef(query: bobQuery, accountIdHex: bobId, npub: "npub1bob")
+        runtime.installNormalizedMemberRef(query: "npub1carol", accountIdHex: carolId, npub: "npub1carol")
+        runtime.installNormalizedMemberRef(query: "npub1dave", accountIdHex: daveId, npub: "npub1dave")
+        runtime.profileRefreshDelaysByAccountId[bobId] = 200_000_000
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatName = "Project Room"
+        state.newChatQuery = "npub1carol"
+        await state.resolveNewChatQuery()
+        #expect(state.resolvedNewChatRecipient?.accountIdHex == carolId)
+
+        async let appendProfileLink: Void = state.openProfileReference(bobReference)
+        let bobLookupStarted = await waitFor {
+            runtime.refreshedProfileIds.contains(bobId)
+        }
+        #expect(bobLookupStarted)
+
+        state.newChatQuery = "npub1dave"
+        state.newChatRecipient = nil
+        await state.resolveNewChatQuery()
+        #expect(state.resolvedNewChatRecipient?.accountIdHex == daveId)
+
+        _ = await appendProfileLink
+
+        #expect(state.isNewChatComposerVisible)
+        #expect(state.newChatRecipients.map(\.accountIdHex) == [bobId])
+        #expect(state.newChatName == "Project Room")
+        #expect(state.newChatQuery == "npub1dave")
+        #expect(state.resolvedNewChatRecipient?.accountIdHex == daveId)
+    }
+
+    @MainActor
     @Test func marmotDeepLinkPreservesInProgressNewChatComposition() async throws {
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -12931,6 +12931,87 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func openingProfileLinkPreservesInProgressNewChatComposition() async throws {
+        // Issue #421: profile autolinks/deep links must not wipe an in-progress New Chat
+        // draft (recipients, group name, description) when the composer is already visible.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
+        let carolId = "carol1234567890carol1234567890carol1234567890carol1234567890"
+        let nprofile = "nprofile1bob"
+        let query = "nostr:\(nprofile)"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installNormalizedMemberRef(query: "npub1alice", accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: query, accountIdHex: bobId, npub: "npub1bob")
+        runtime.installNormalizedMemberRef(query: "npub1carol", accountIdHex: carolId, npub: "npub1carol")
+        runtime.installProfile(
+            accountIdHex: bobId,
+            profile: UserProfileMetadataFfi(
+                name: "bob",
+                displayName: "Bob Link",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatQuery = "npub1alice"
+        _ = await state.addCurrentNewChatRecipient()
+        state.newChatName = "Project Room"
+        state.newChatDescription = "planning space"
+        state.newChatQuery = "npub1carol"
+        await state.resolveNewChatQuery()
+        #expect(state.resolvedNewChatRecipient?.accountIdHex == carolId)
+
+        _ = state.handleMessageLinkOpen(URL(string: query)!)
+        let added = await waitFor {
+            state.newChatRecipients.contains { $0.accountIdHex == bobId }
+        }
+
+        #expect(added)
+        #expect(state.isNewChatComposerVisible)
+        #expect(state.newChatRecipients.map(\.accountIdHex) == [aliceId, bobId])
+        #expect(state.newChatName == "Project Room")
+        #expect(state.newChatDescription == "planning space")
+        #expect(state.newChatQuery == "npub1carol")
+        #expect(state.resolvedNewChatRecipient?.accountIdHex == carolId)
+    }
+
+    @MainActor
+    @Test func marmotDeepLinkPreservesInProgressNewChatComposition() async throws {
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
+        let routedQuery = "nostr:npub1bob"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installNormalizedMemberRef(query: "npub1alice", accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: bobId, npub: "npub1bob")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatQuery = "npub1alice"
+        _ = await state.addCurrentNewChatRecipient()
+        state.newChatName = "Project Room"
+        state.newChatDescription = "planning space"
+
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1bob?from=qr")!)
+        let added = await waitFor {
+            state.newChatRecipients.contains { $0.accountIdHex == bobId }
+        }
+
+        #expect(added)
+        #expect(state.isNewChatComposerVisible)
+        #expect(state.newChatRecipients.map(\.accountIdHex) == [aliceId, bobId])
+        #expect(state.newChatName == "Project Room")
+        #expect(state.newChatDescription == "planning space")
+    }
+
+    @MainActor
     @Test func openingMarmotProfileAutolinkShowsNewChatComposerAndResolvesRecipient() async throws {
         // Kit-emitted marmot://profile/... autolinks in message text route through the same
         // in-app profile flow as nostr: links (mdk#725 / #340); the FFI receives the

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1204,6 +1204,7 @@ struct whitenoise_macTests {
             label: "Backup Account",
             accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: true
         )
@@ -1246,6 +1247,7 @@ struct whitenoise_macTests {
             label: "Backup Account",
             accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
             localSigning: true,
+            externalSigning: false,
             signedOut: false,
             running: true
         )


### PR DESCRIPTION
Fixes #421

## Summary
- Preserve an existing New Chat draft when a Nostr/marmot profile link is opened while the composer is already visible.
- Resolve the linked profile into the existing composer as an added recipient instead of routing through `showNewChat()` and wiping recipients, group name, description, or a pending recipient query.
- Add regression coverage for message autolinks and OS-level `marmot://profile/...` deep links preserving the draft.

## Verification
- `git diff --check` — passed
- `git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . ':!*.xcresult'` — no conflict markers
- GitHub `PR Checks` — passed
- GitHub `Static Analysis` — passed
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — not runnable on this Linux host (`xcrun: command not found`, exit 127)
- `scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host (`xcodebuild: command not found`, exit 127)
- `xcodebuild -version` — not runnable on this Linux host (`xcodebuild: command not found`, exit 127)

## Review bot status
- CodeRabbit posted a rate-limit notice and no inline findings.

## Sensitive paths
none
