### PR TITLE
fix: restore transcript hit testing on chat switch

### DIFF
--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -390,6 +390,7 @@ private struct ConversationView: View {
                         pendingPrependAnchorId = nil
                         pendingAppendAnchorId = nil
                         isPinnedToBottom = true
+                        isActivelyScrolling = false
                         hoverSelectionCoordinator.reset()
                     }
                     .onChange(of: messageIDs.last) { _, newMessageId in


### PR DESCRIPTION
## Summary
- Reset `isActivelyScrolling` when `chat.id` changes.
- Prevent a newly opened transcript from inheriting the previous chat’s disabled hit-testing state.

## Test plan
- [x] `git diff --check`
- [ ] macOS CI (Swift format, unit tests, release build, static analysis)

Fixes #452

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/454">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->