### PR TITLE
fix: invalidate stale voice recording starts

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -438,16 +438,25 @@ extension WorkspaceState {
 
     func startVoiceRecording() async {
         guard !isRecordingVoiceMessage, !isPreparingVoiceRecording else { return }
+        guard let draftKey = selectedComposerDraftKey else { return }
         guard canBeginMediaAttachmentSelection() else { return }
 
         isPreparingVoiceRecording = true
         defer { isPreparingVoiceRecording = false }
 
+        let preparationGeneration = voiceRecordingPreparationGeneration
+
         let hasPermission = await requestMicrophoneAccess()
         guard hasPermission else {
-            lastError = L10n.string("Microphone access is needed to record voice messages.")
+            if voiceRecordingPreparationGeneration == preparationGeneration,
+                canResumeVoiceRecording(for: draftKey)
+            {
+                lastError = L10n.string("Microphone access is needed to record voice messages.")
+            }
             return
         }
+        guard voiceRecordingPreparationGeneration == preparationGeneration else { return }
+        guard canResumeVoiceRecording(for: draftKey) else { return }
 
         do {
             let directory = try MediaPlaybackTempStore.voiceRecordingsDirectoryURL()
@@ -513,6 +522,7 @@ extension WorkspaceState {
     }
 
     func cancelVoiceRecording() {
+        voiceRecordingPreparationGeneration &+= 1
         resetVoiceRecording(deleteFile: true)
     }
 
@@ -521,11 +531,26 @@ extension WorkspaceState {
         // importers, paste, and recording shortcuts can still fire while the visible
         // composer is replaced, and collected media would otherwise accumulate
         // invisibly (the pending-media strip is hidden) and never be sent.
-        guard client != nil, selectedChat?.canUseComposer == true else { return false }
+        guard let draftKey = selectedComposerDraftKey else { return false }
+        guard composerSupportsMediaAttachmentSelection(for: draftKey) else { return false }
         guard remainingMediaAttachmentSlots > 0 else {
             presentMaxMediaAttachmentWarning()
             return false
         }
+        return true
+    }
+
+    /// Revalidates the composer draft captured before the mic-permission await. Unlike
+    /// `canBeginMediaAttachmentSelection()`, this never surfaces max-attachment warnings for a
+    /// stale captured context (#441).
+    private func canResumeVoiceRecording(for draftKey: ComposerDraftKey) -> Bool {
+        guard composerSupportsMediaAttachmentSelection(for: draftKey) else { return false }
+        return remainingMediaAttachmentSlots > 0
+    }
+
+    private func composerSupportsMediaAttachmentSelection(for draftKey: ComposerDraftKey) -> Bool {
+        guard selectedComposerDraftKey == draftKey else { return false }
+        guard client != nil, selectedChat?.canUseComposer == true else { return false }
         return true
     }
 
@@ -570,7 +595,7 @@ extension WorkspaceState {
         )
     }
 
-    func requestMicrophoneAccess() async -> Bool {
+    static func requestSystemMicrophoneAccess() async -> Bool {
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .authorized:
             return true
@@ -585,6 +610,10 @@ extension WorkspaceState {
         @unknown default:
             return false
         }
+    }
+
+    func requestMicrophoneAccess() async -> Bool {
+        await microphoneAccessProvider()
     }
 
     func startVoiceRecordingMetering() {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -579,6 +579,9 @@ final class WorkspaceState {
     /// Synchronous guard for the mic-permission await in `startVoiceRecording()` so a second
     /// tap cannot interleave and orphan a hot recorder (#391).
     var isPreparingVoiceRecording = false
+    /// Bumped by `cancelVoiceRecording()` so an in-flight mic-permission await cannot resume
+    /// and create a recorder after navigation tears down the composer (#441).
+    var voiceRecordingPreparationGeneration: UInt64 = 0
     var voiceRecordingSamples: [CGFloat] = []
     var voiceRecordingDurationSeconds: Double = 0
     /// Per-target reentrancy guards for message actions. `react`/`deleteMessage`
@@ -733,6 +736,7 @@ final class WorkspaceState {
     /// Injectable clock for peer-profile cache TTL decisions, so tests can drive cache
     /// expiry deterministically (whitenoise-mac#8). Defaults to the system clock.
     let nowProvider: @MainActor () -> Date
+    let microphoneAccessProvider: @MainActor () async -> Bool
     var client: (any MarmotRuntime)?
     var observabilityRuntimeConfiguration: ObservabilityRuntimeConfiguration?
     var notificationTask: Task<Void, Never>?
@@ -1137,6 +1141,9 @@ final class WorkspaceState {
         groupImageSearchClient: (any GroupImageSearchClient)? = nil,
         nip05Resolver: (any NIP05Resolving)? = nil,
         nowProvider: @escaping @MainActor () -> Date = { Date() },
+        microphoneAccessProvider: @escaping @MainActor () async -> Bool = {
+            await WorkspaceState.requestSystemMicrophoneAccess()
+        },
         mediaDiskCache: MessageMediaDiskCache = .shared,
         clientFactory: @escaping @MainActor () throws -> any MarmotRuntime = { try MarmotClient() }
     ) {
@@ -1153,6 +1160,7 @@ final class WorkspaceState {
         self.groupImageSearchClient = groupImageSearchClient ?? OpenverseGroupImageSearchClient()
         self.nip05Resolver = nip05Resolver ?? NIP05Resolver()
         self.nowProvider = nowProvider
+        self.microphoneAccessProvider = microphoneAccessProvider
         self.mediaDiskCache = mediaDiskCache
         self.clientFactory = clientFactory
         self.developerMode = UserDefaults.standard.bool(forKey: Self.developerModeKey)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -37,6 +37,43 @@ private final class MutableFlag: @unchecked Sendable {
     }
 }
 
+private final class SuspendingMicrophoneAccessGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var permissionContinuation: CheckedContinuation<Bool, Never>?
+    private let requested = DispatchSemaphore(value: 0)
+
+    @MainActor
+    func provider() async -> Bool {
+        await withCheckedContinuation { continuation in
+            lock.withLock {
+                permissionContinuation = continuation
+            }
+            requested.signal()
+        }
+    }
+
+    func waitUntilRequested(timeout: DispatchTime = .now() + 2) async -> Bool {
+        await waitForSemaphore(requested, timeout: timeout) == .success
+    }
+
+    func grantAccess() {
+        resumePermissionRequest(granted: true)
+    }
+
+    func denyAccess() {
+        resumePermissionRequest(granted: false)
+    }
+
+    private func resumePermissionRequest(granted: Bool) {
+        let continuation = lock.withLock { () -> CheckedContinuation<Bool, Never>? in
+            let continuation = permissionContinuation
+            permissionContinuation = nil
+            return continuation
+        }
+        continuation?.resume(returning: granted)
+    }
+}
+
 private func waitForSemaphore(
     _ semaphore: DispatchSemaphore,
     timeout: DispatchTime
@@ -12905,6 +12942,57 @@ struct whitenoise_macTests {
         #expect(!state.isRecordingVoiceMessage)
         #expect(state.voiceRecorder == nil)
         #expect(state.voiceRecordingURL == nil)
+    }
+
+    @MainActor
+    @Test func startVoiceRecordingDoesNotResumeAfterNavigationDuringPermissionAwait() async throws {
+        // #441: a suspended mic-permission await must not resume after navigation tears down the
+        // composer, including when the user returns to the same chat before granting access.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup()])
+        let microphoneGate = SuspendingMicrophoneAccessGate()
+        let state = WorkspaceState(
+            microphoneAccessProvider: { await microphoneGate.provider() },
+            clientFactory: { runtime }
+        )
+        await state.bootstrap()
+
+        guard let chat = state.activeChats.first(where: { $0.id == "group" }) else {
+            Issue.record("Expected group chat")
+            return
+        }
+        state.selectChat(chat)
+
+        let recordingTask = Task { await state.startVoiceRecording() }
+        #expect(await microphoneGate.waitUntilRequested())
+        #expect(state.isPreparingVoiceRecording)
+
+        state.showSettings(.profile)
+        state.selectChat(chat)
+
+        microphoneGate.grantAccess()
+        await recordingTask.value
+
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecorder == nil)
+        #expect(state.voiceRecordingURL == nil)
+        #expect(state.voiceRecordingMeterTask == nil)
+
+        state.lastError = nil
+        let deniedTask = Task { await state.startVoiceRecording() }
+        #expect(await microphoneGate.waitUntilRequested())
+        state.showSettings(.profile)
+        microphoneGate.denyAccess()
+        await deniedTask.value
+        #expect(state.lastError == nil)
     }
 
     /// Puts `state` into an in-progress voice-recording state (mic "hot", metering task running,


### PR DESCRIPTION
Fixes #441

## Summary
- capture the active composer and a preparation generation before awaiting microphone permission
- invalidate suspended starts through existing voice-recording teardown paths
- revalidate the current composer after permission returns, before creating a plaintext file or recorder
- add a suspended-permission regression test covering navigation away and return to the same chat, plus stale denial errors

## Verification
- `git diff --check` — passed
- `scripts/ci/macos-sanity-checks.sh` — unavailable on this Linux host (`xcodebuild: command not found`); macOS CI will run Swift formatting, unit tests, release build, and static analysis

## Sensitive paths
None. No crypto, MLS/CGKA, key handling, trust anchors, authentication, or protocol core paths changed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/455">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->