### PR TITLE
fix: keep selected archived chat on live delta

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -274,7 +274,7 @@ extension WorkspaceState {
         guard activeAccountId == account.id else { return }
 
         if row.archived {
-            moveChatToArchived(row: row, account: account, shouldEnrich: shouldEnrich)
+            moveChatToArchived(row: row, account: account)
             if shouldEnrich {
                 startChatListEnrichment(rows: [row], account: account, replacingCurrent: false)
             }
@@ -315,29 +315,25 @@ extension WorkspaceState {
         }
     }
 
-    func moveChatToArchived(
-        row: ChatListRowFfi,
-        account: AccountItem,
-        shouldEnrich: Bool = true
-    ) {
+    func moveChatToArchived(row: ChatListRowFfi, account: AccountItem) {
         guard activeAccountId == account.id else { return }
 
         let groupIdHex = row.groupIdHex
-        let currentActive = chatItem(accountId: account.id, chatId: groupIdHex)
+        let current = chatItem(accountId: account.id, chatId: groupIdHex)
+        let wasActive = chatLookupByAccount[account.id]?[groupIdHex] != nil
         removeChatFromList(chatId: groupIdHex, forAccountId: account.id)
 
         var chat = baseChatItem(from: row, account: account)
-        if !shouldEnrich, let currentActive {
-            chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: currentActive)
-        } else if let currentActive {
-            chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: currentActive)
+        if let current {
+            chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: current)
         }
 
         upsertArchivedChat(chat, forAccountId: account.id)
         cancelVoiceRecordingIfSelectedMembershipEnded()
         ensureSelectedMessageTimelineStore()
 
-        guard case .chat(let selectedGroupId) = selection,
+        guard wasActive,
+            case .chat(let selectedGroupId) = selection,
             selectedGroupId == groupIdHex
         else { return }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11577,6 +11577,54 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func archivedChatDeltaKeepsAlreadyArchivedSelection() async throws {
+        // Regression for #450: ordinary deltas for a chat that was already archived must update
+        // that row in place, not repeat the active-to-archived transition's auto-reselection.
+        let state = WorkspaceState.preview()
+        let account = AccountItem.samples[0]
+        let archivedChatId = try #require(state.selectedChat?.id)
+        let sender = "alice1234567890alice1234567890alice1234567890alice1234567890"
+
+        await state.applyChatRow(
+            chatListRow(
+                groupIdHex: archivedChatId,
+                title: "Marmot Design",
+                preview: "Archived",
+                sender: sender,
+                timelineAt: 1_700_000_000,
+                archived: true
+            ),
+            account: account,
+            shouldEnrich: false
+        )
+
+        // The genuine active-to-archived transition still leaves the removed conversation.
+        #expect(state.selection != .chat(archivedChatId))
+        #expect(!state.activeChats.contains { $0.id == archivedChatId })
+        #expect(state.archivedChats.first { $0.id == archivedChatId }?.preview == "Archived")
+
+        // Archived rows are selectable from the sidebar. A live preview delta for the selected
+        // archived chat must preserve that selection while applying the row update.
+        state.selection = .chat(archivedChatId)
+        await state.applyChatRow(
+            chatListRow(
+                groupIdHex: archivedChatId,
+                title: "Marmot Design",
+                preview: "New message",
+                sender: sender,
+                timelineAt: 1_700_000_100,
+                archived: true
+            ),
+            account: account,
+            shouldEnrich: false
+        )
+
+        #expect(state.selection == .chat(archivedChatId))
+        #expect(state.selectedChat?.preview == "New message")
+        #expect(state.archivedChats.first { $0.id == archivedChatId }?.preview == "New message")
+    }
+
+    @MainActor
     @Test func archivedChatSearchFiltersArchivedSection() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
@@ -18337,11 +18385,12 @@ private func chatListRow(
     sender: String,
     timelineAt: UInt64,
     kind: UInt64 = 9,
-    selfMembership: SelfMembershipFfi = .member
+    selfMembership: SelfMembershipFfi = .member,
+    archived: Bool = false
 ) -> ChatListRowFfi {
     ChatListRowFfi(
         groupIdHex: groupIdHex,
-        archived: false,
+        archived: archived,
         pendingConfirmation: false,
         title: title,
         groupName: "",


### PR DESCRIPTION
## Summary
- distinguish genuine active-to-archived transitions from steady-state archived-row deltas
- keep an already-archived conversation selected while refreshing its preview/read-state fields
- preserve existing auto-reselection when the selected chat actually leaves the active list

## Test plan
- added a regression test covering both the initial archive transition and a later live delta while the archived chat is selected
- `git diff --check`
- macOS unit/build checks deferred to GitHub Actions (`xcodebuild` is unavailable on this Linux worker)

Fixes #450

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->