### PR TITLE
fix: preserve message edits across timeline windows

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -120,6 +120,62 @@ extension ChatItem {
     }
 }
 
+nonisolated enum MessageEditMutation: Equatable, Sendable {
+    case upsert(MessageEditOverlay)
+    case retract(editMessageIdHex: String)
+}
+
+nonisolated struct MessageEditOverlay: Equatable, Sendable {
+    let targetMessageIdHex: String
+    let editMessageIdHex: String
+    let sender: String
+    let plaintext: String
+    let timelineAt: UInt64
+
+    static func mutations(from records: [TimelineMessageRecordFfi]) -> [MessageEditMutation] {
+        records.compactMap { record in
+            guard record.kind == MarmotTimelineKind.messageEdit else { return nil }
+            if record.deleted || record.invalidationStatus != nil {
+                return .retract(editMessageIdHex: record.messageIdHex)
+            }
+            guard let targetId = editTargetMessageId(in: record.tags) else {
+                return .retract(editMessageIdHex: record.messageIdHex)
+            }
+            return .upsert(
+                MessageEditOverlay(
+                    targetMessageIdHex: targetId,
+                    editMessageIdHex: record.messageIdHex,
+                    sender: record.sender,
+                    plaintext: record.plaintext,
+                    timelineAt: record.timelineAt
+                )
+            )
+        }
+    }
+
+    static func shouldPrefer(_ candidate: MessageEditOverlay, over existing: MessageEditOverlay?) -> Bool {
+        guard let existing else { return true }
+        if candidate.timelineAt != existing.timelineAt {
+            return candidate.timelineAt > existing.timelineAt
+        }
+        return candidate.editMessageIdHex > existing.editMessageIdHex
+    }
+
+    fileprivate static func editTargetMessageId(in tags: [MessageTagFfi]) -> String? {
+        var target: String?
+        for tag in tags where tag.values.first == "e" {
+            guard tag.values.count == 2,
+                let candidate = tag.values.dropFirst().first?.nilIfBlank,
+                target == nil
+            else {
+                return nil
+            }
+            target = candidate
+        }
+        return target
+    }
+}
+
 // The whole timeline record → view-model transformation is pure (it only reads the
 // `Sendable` FFI record and the resolved sender-profile map) and is deliberately run
 // off the main actor while mapping a window/projection so the attributed-string /
@@ -206,99 +262,22 @@ nonisolated extension MessageItem {
         // MarmotKit returns an authoritative timeline window. Keep that order
         // intact: `timelineAt` is second-granular, and re-sorting in the client
         // can reshuffle records that the runtime/database already tie-broke.
-        return displayRecords(from: page.messages).map { displayRecord in
-            MessageItem(
-                record: displayRecord.record,
+        return page.messages.compactMap { record in
+            guard record.kind != MarmotTimelineKind.messageEdit else { return nil }
+            return MessageItem(
+                record: record,
                 activeAccountIdHex: activeAccountIdHex,
                 senderProfiles: senderProfiles,
-                editedPlaintext: displayRecord.editedPlaintext,
-                isEdited: displayRecord.isEdited,
                 reactions: MessageReaction.summarize(
-                    displayRecord.record.reactions,
+                    record.reactions,
                     activeAccountIdHex: activeAccountIdHex
                 ),
                 replyContext: MessageItem.replyContext(
-                    for: displayRecord.record.replyPreview,
+                    for: record.replyPreview,
                     senderProfiles: senderProfiles
                 )
             )
         }
-    }
-
-    private struct TimelineDisplayRecord {
-        let record: TimelineMessageRecordFfi
-        let editedPlaintext: String?
-
-        var isEdited: Bool { editedPlaintext != nil }
-    }
-
-    private struct MessageEditOverlay {
-        let plaintext: String
-        let timelineAt: UInt64
-        let messageIdHex: String
-    }
-
-    private static func displayRecords(from records: [TimelineMessageRecordFfi]) -> [TimelineDisplayRecord] {
-        guard records.contains(where: { $0.kind == MarmotTimelineKind.messageEdit }) else {
-            return records.map { TimelineDisplayRecord(record: $0, editedPlaintext: nil) }
-        }
-
-        let recordsById = records.reduce(into: [String: TimelineMessageRecordFfi]()) { result, record in
-            result[record.messageIdHex] = record
-        }
-        var editsByTarget = [String: MessageEditOverlay]()
-
-        for record in records where record.kind == MarmotTimelineKind.messageEdit {
-            guard record.invalidationStatus == nil,
-                let targetId = editTargetMessageId(in: record.tags),
-                let target = recordsById[targetId],
-                target.kind == MarmotTimelineKind.chat,
-                target.sender == record.sender,
-                !target.deleted,
-                target.invalidationStatus == nil
-            else {
-                continue
-            }
-
-            let overlay = MessageEditOverlay(
-                plaintext: record.plaintext,
-                timelineAt: record.timelineAt,
-                messageIdHex: record.messageIdHex
-            )
-            if shouldUseEdit(overlay, over: editsByTarget[targetId]) {
-                editsByTarget[targetId] = overlay
-            }
-        }
-
-        return records.compactMap { record in
-            guard record.kind != MarmotTimelineKind.messageEdit else { return nil }
-            return TimelineDisplayRecord(
-                record: record,
-                editedPlaintext: editsByTarget[record.messageIdHex]?.plaintext
-            )
-        }
-    }
-
-    private static func shouldUseEdit(_ candidate: MessageEditOverlay, over existing: MessageEditOverlay?) -> Bool {
-        guard let existing else { return true }
-        if candidate.timelineAt != existing.timelineAt {
-            return candidate.timelineAt > existing.timelineAt
-        }
-        return candidate.messageIdHex > existing.messageIdHex
-    }
-
-    private static func editTargetMessageId(in tags: [MessageTagFfi]) -> String? {
-        var target: String?
-        for tag in tags where tag.values.first == "e" {
-            guard tag.values.count == 2,
-                let candidate = tag.values.dropFirst().first?.nilIfBlank,
-                target == nil
-            else {
-                return nil
-            }
-            target = candidate
-        }
-        return target
     }
 
     fileprivate static func presentation(for kind: UInt64) -> MessagePresentation {
@@ -771,7 +750,7 @@ nonisolated extension MessageItem {
         return parsedText == displayedBody
     }
 
-    fileprivate static func displayText(
+    static func displayText(
         presentation: MessagePresentation,
         plaintext: String,
         tags: [MessageTagFfi],

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -280,6 +280,7 @@ extension WorkspaceState {
         }
         guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
 
+        let editMutations = MessageEditOverlay.mutations(from: page.messages)
         let currentPaging = timelinePagingByChat[groupIdHex]
         TimelineSignpost.store.interval("replaceMessages", count: mappedMessages.count) {
             replaceMessages(
@@ -290,7 +291,8 @@ extension WorkspaceState {
                     hasMoreAfter: page.hasMoreAfter,
                     isLoadingBefore: currentPaging?.isLoadingBefore ?? false,
                     isLoadingAfter: currentPaging?.isLoadingAfter ?? false
-                )
+                ),
+                editMutations: editMutations
             )
         }
         await markLatestVisibleMessageRead(groupIdHex: groupIdHex, account: account, client: client)
@@ -354,7 +356,8 @@ extension WorkspaceState {
                 }
             }
         }
-        guard !upsertRecords.isEmpty || !removalIds.isEmpty else { return }
+        let editMutations = MessageEditOverlay.mutations(from: upsertRecords)
+        guard !upsertRecords.isEmpty || !removalIds.isEmpty || !editMutations.isEmpty else { return }
 
         // Resolve senders for just the changed records (the common case is an all-cached
         // lookup) and map only those records — not the entire window.
@@ -419,6 +422,7 @@ extension WorkspaceState {
             timelineStore.applyProjection(
                 upserts: mappedUpserts,
                 removals: removalIds,
+                editMutations: editMutations,
                 anchoredToNewest: anchored,
                 windowLimit: Self.timelineWindowLimit
             )
@@ -764,7 +768,8 @@ extension WorkspaceState {
     func replaceMessages(
         _ messages: [MessageItem],
         groupIdHex: String,
-        paging: TimelinePagingState? = nil
+        paging: TimelinePagingState? = nil,
+        editMutations: [MessageEditMutation] = []
     ) {
         // The window is already ordered, deduped, and capped by the runtime subscription,
         // so render it as-is. The per-chat id/lookup caches live on the store
@@ -779,7 +784,11 @@ extension WorkspaceState {
 
         cachedMessageChatIds = [groupIdHex]
         messageTimelineStores = [groupIdHex: timelineStore]
-        timelineStore.replace(with: messages)
+        timelineStore.replace(
+            with: messages,
+            editMutations: editMutations,
+            windowLimit: Self.timelineWindowLimit
+        )
         if timelinePagingByChat.count == 1, timelinePagingByChat[groupIdHex] != nil {
             timelinePagingByChat[groupIdHex] = nextPaging
         } else {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -260,6 +260,12 @@ final class MessageTimelineStore {
     /// (and `messageIDs`) so callers don't maintain parallel per-chat dictionaries.
     @ObservationIgnored private(set) var lookup: [String: MessageItem]
     @ObservationIgnored private var indexById: [String: Int]
+    /// Unedited chat targets keyed by message id. Rendered rows in `messages`/`lookup` are derived
+    /// from these bases plus the newest valid kind-1009 candidate per materialized target.
+    @ObservationIgnored private var baseMessagesById: [String: MessageItem] = [:]
+    /// Active kind-1009 edit candidates keyed by edit-event id. Retained across trim and
+    /// authoritative window replaces that omit edit records; bounded by `windowLimit`.
+    @ObservationIgnored private var editCandidatesById: [String: MessageEditOverlay] = [:]
     private(set) var isLoaded: Bool
 
     init(messages: [MessageItem] = [], isLoaded: Bool = false) {
@@ -271,6 +277,7 @@ final class MessageTimelineStore {
             messages.enumerated().map { ($0.element.id, $0.offset) },
             uniquingKeysWith: { _, new in new }
         )
+        self.baseMessagesById = Dictionary(messages.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
         self.isLoaded = isLoaded
     }
 
@@ -282,9 +289,15 @@ final class MessageTimelineStore {
         MessageTimelineStore(messages: messages, isLoaded: true)
     }
 
-    func replace(with messages: [MessageItem]) {
-        self.messages = messages
+    func replace(with messages: [MessageItem], editMutations: [MessageEditMutation] = [], windowLimit: Int? = nil) {
+        let bases = Self.deduplicatedMessages(messages)
+        self.messages = bases
+        baseMessagesById = Dictionary(bases.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
         rebuildIndexes()
+        applyEditMutations(editMutations)
+        pruneInvalidSenderCandidatesForMaterializedTargets()
+        pruneEditCandidates(windowLimit: windowLimit ?? max(bases.count, 1))
+        _ = recomputeAllRenderedMessages()
         self.isLoaded = true
     }
 
@@ -293,6 +306,8 @@ final class MessageTimelineStore {
         messageIDs = []
         lookup = [:]
         indexById = [:]
+        baseMessagesById = [:]
+        editCandidatesById = [:]
         isLoaded = false
     }
 
@@ -303,6 +318,7 @@ final class MessageTimelineStore {
     func applyProjection(
         upserts: [MessageItem],
         removals removalIds: Set<String>,
+        editMutations: [MessageEditMutation] = [],
         anchoredToNewest: Bool,
         windowLimit: Int
     ) -> ProjectionApplyResult {
@@ -311,10 +327,15 @@ final class MessageTimelineStore {
 
         if !removalIds.isEmpty {
             let originalCount = messages.count
+            let removedMessageIds = Set(messages.filter { removalIds.contains($0.id) }.map(\.id))
             messages.removeAll { removalIds.contains($0.id) }
             didRemoveMessages = messages.count != originalCount
-            didChange = didRemoveMessages
+            for removedId in removedMessageIds {
+                baseMessagesById.removeValue(forKey: removedId)
+            }
+            purgeEditCandidates(forRemovalIds: removalIds)
             if didRemoveMessages {
+                didChange = true
                 rebuildIndexes()
             }
         }
@@ -326,6 +347,7 @@ final class MessageTimelineStore {
 
         for item in upserts {
             if let existingIndex = indexById[item.id] {
+                baseMessagesById[item.id] = item
                 guard messages[existingIndex] != item else { continue }
                 if TimelineSortKey(messages[existingIndex]) == TimelineSortKey(item) {
                     messages[existingIndex] = item
@@ -341,14 +363,23 @@ final class MessageTimelineStore {
 
             let isInsideDetachedWindow = newestKey.map { TimelineSortKey(item) <= $0 } ?? false
             guard anchoredToNewest || isInsideDetachedWindow else { continue }
+            baseMessagesById[item.id] = item
             insertMessage(item, at: insertionIndex(for: item))
             didChange = true
         }
+
+        applyEditMutations(editMutations)
 
         var didTrimOlderMessages = false
         if messages.count > windowLimit {
             trimOldestMessages(count: messages.count - windowLimit)
             didTrimOlderMessages = true
+            didChange = true
+        }
+
+        pruneInvalidSenderCandidatesForMaterializedTargets()
+        pruneEditCandidates(windowLimit: windowLimit)
+        if recomputeAllRenderedMessages() {
             didChange = true
         }
 
@@ -360,6 +391,141 @@ final class MessageTimelineStore {
             didRemoveMessages: didRemoveMessages,
             didTrimOlderMessages: didTrimOlderMessages
         )
+    }
+
+    private func applyEditMutations(_ mutations: [MessageEditMutation]) {
+        for mutation in mutations {
+            switch mutation {
+            case .upsert(let overlay):
+                editCandidatesById[overlay.editMessageIdHex] = overlay
+            case .retract(let editMessageIdHex):
+                editCandidatesById.removeValue(forKey: editMessageIdHex)
+            }
+        }
+    }
+
+    @discardableResult
+    private func recomputeAllRenderedMessages() -> Bool {
+        var didChange = false
+        for index in messages.indices {
+            let messageId = messages[index].id
+            guard let base = baseMessagesById[messageId] else { continue }
+            let rendered = renderedMessage(from: base)
+            guard messages[index] != rendered else { continue }
+            messages[index] = rendered
+            lookup[messageId] = rendered
+            didChange = true
+        }
+        return didChange
+    }
+
+    private func renderedMessage(from base: MessageItem) -> MessageItem {
+        guard let edit = effectiveEdit(for: base.id, base: base) else { return base }
+        return base.applyingEdit(plaintext: edit.plaintext)
+    }
+
+    private func effectiveEdit(for targetId: String, base: MessageItem) -> MessageEditOverlay? {
+        guard isValidEditTarget(base, editSender: base.senderAccountIdHex) else { return nil }
+        return editCandidatesById.values
+            .filter { $0.targetMessageIdHex == targetId && $0.sender == base.senderAccountIdHex }
+            .max(by: { lhs, rhs in
+                MessageEditOverlay.shouldPrefer(rhs, over: lhs)
+            })
+    }
+
+    private func purgeEditCandidates(forRemovalIds removalIds: Set<String>) {
+        guard !removalIds.isEmpty, !editCandidatesById.isEmpty else { return }
+        editCandidatesById = editCandidatesById.filter { _, candidate in
+            !removalIds.contains(candidate.editMessageIdHex)
+                && !removalIds.contains(candidate.targetMessageIdHex)
+        }
+    }
+
+    private func pruneInvalidSenderCandidatesForMaterializedTargets() {
+        guard !editCandidatesById.isEmpty else { return }
+        editCandidatesById = editCandidatesById.filter { _, candidate in
+            guard let base = baseMessagesById[candidate.targetMessageIdHex] else { return true }
+            return candidate.sender == base.senderAccountIdHex
+        }
+    }
+
+    private func pruneEditCandidates(windowLimit limit: Int) {
+        guard limit > 0, editCandidatesById.count > limit else { return }
+
+        typealias CandidateEntry = (key: String, value: MessageEditOverlay)
+
+        func sortNewestFirst(_ lhs: CandidateEntry, _ rhs: CandidateEntry) -> Bool {
+            if lhs.value.timelineAt != rhs.value.timelineAt {
+                return lhs.value.timelineAt > rhs.value.timelineAt
+            }
+            return lhs.value.editMessageIdHex > rhs.value.editMessageIdHex
+        }
+
+        // Preserve the current winner for each visible target. For unresolved targets,
+        // also preserve one representative per target/sender pair before using spare
+        // capacity for history. Repeated forged edits from one peer therefore cannot
+        // evict a pending candidate from the target's actual author.
+        var materializedWinnerIds = Set<String>()
+        for (targetId, base) in baseMessagesById {
+            if let winner = effectiveEdit(for: targetId, base: base) {
+                materializedWinnerIds.insert(winner.editMessageIdHex)
+            }
+        }
+
+        var pendingRepresentativesByTarget = [String: [String: MessageEditOverlay]]()
+        for candidate in editCandidatesById.values where baseMessagesById[candidate.targetMessageIdHex] == nil {
+            let existing = pendingRepresentativesByTarget[candidate.targetMessageIdHex]?[candidate.sender]
+            if MessageEditOverlay.shouldPrefer(candidate, over: existing) {
+                pendingRepresentativesByTarget[candidate.targetMessageIdHex, default: [:]][candidate.sender] = candidate
+            }
+        }
+        let pendingRepresentativeIds = Set(
+            pendingRepresentativesByTarget.values
+                .flatMap(\.values)
+                .map(\.editMessageIdHex)
+        )
+
+        let materializedWinners =
+            editCandidatesById
+            .filter { materializedWinnerIds.contains($0.key) }
+            .sorted(by: sortNewestFirst)
+            .prefix(limit)
+        var kept = Dictionary(
+            uniqueKeysWithValues: materializedWinners.map { ($0.key, $0.value) }
+        )
+
+        let pendingSlots = limit - kept.count
+        if pendingSlots > 0 {
+            let pendingRepresentatives =
+                editCandidatesById
+                .filter { pendingRepresentativeIds.contains($0.key) }
+                .sorted(by: sortNewestFirst)
+                .prefix(pendingSlots)
+            for candidate in pendingRepresentatives {
+                kept[candidate.key] = candidate.value
+            }
+        }
+
+        let remainingSlots = limit - kept.count
+        if remainingSlots > 0 {
+            let remaining =
+                editCandidatesById
+                .filter { kept[$0.key] == nil }
+                .sorted(by: sortNewestFirst)
+                .prefix(remainingSlots)
+            for candidate in remaining {
+                kept[candidate.key] = candidate.value
+            }
+        }
+        editCandidatesById = kept
+    }
+
+    private func isValidEditTarget(_ message: MessageItem, editSender: String) -> Bool {
+        message.timelineKind == 9
+            && message.presentation == .chat
+            && message.senderAccountIdHex == editSender
+            && !message.isDeleted
+            && message.invalidationStatus == nil
     }
 
     private func rebuildIndexes() {
@@ -380,6 +546,7 @@ final class MessageTimelineStore {
         for id in trimmedIDs {
             lookup[id] = nil
             indexById[id] = nil
+            baseMessagesById.removeValue(forKey: id)
         }
         reindexMessages(startingAt: 0)
     }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1665,6 +1665,39 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         self.metadataLabel = metadataParts.joined(separator: "  ")
     }
 
+    func applyingEdit(plaintext editedPlaintext: String) -> MessageItem {
+        let body = MessageItem.displayText(
+            presentation: presentation,
+            plaintext: editedPlaintext,
+            tags: [],
+            deleted: isDeleted,
+            invalidationStatus: invalidationStatus,
+            hasMediaAttachments: !mediaAttachments.isEmpty
+        )
+        return MessageItem(
+            id: id,
+            groupIdHex: groupIdHex,
+            sourceMessageIdHex: sourceMessageIdHex,
+            replyTargetIdHex: replyTargetIdHex,
+            senderAccountIdHex: senderAccountIdHex,
+            senderName: senderName,
+            senderPictureURL: senderPictureURL,
+            body: body,
+            contentMarkdown: nil,
+            sentAt: sentAt,
+            timelineAt: timelineAt,
+            timelineKind: timelineKind,
+            isDeleted: isDeleted,
+            invalidationStatus: invalidationStatus,
+            isEdited: true,
+            isOutgoing: isOutgoing,
+            reactions: reactions,
+            replyContext: replyContext,
+            mediaAttachments: mediaAttachments,
+            presentation: presentation
+        )
+    }
+
     nonisolated private static func partitionMediaAttachments(_ attachments: [MessageMediaAttachment]) -> (
         visual: [MessageMediaAttachment], nonvisual: [MessageMediaAttachment]
     ) {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -456,6 +456,410 @@ struct PureValueTests {
     }
 
     @MainActor
+    @Test func messageTimelineStoreAppliesEditOverlaysToTargets() async throws {
+        // Regression for whitenoise-mac#419: standalone edit overlays patch materialized targets,
+        // reject forged senders, and stay pending until the target is inserted or replaced.
+        let overlay = makeEditOverlay(
+            editId: "edit-new",
+            plaintext: "Edited body",
+            timelineAt: 1_800_000_060
+        )
+
+        let materialized = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)
+        ])
+        let applied = materialized.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [editUpsert(overlay)],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(applied.didChange)
+        let patched = try #require(materialized.lookup["target"])
+        #expect(patched.body == "Edited body")
+        #expect(patched.isEdited)
+        #expect(patched.metadataLabel.contains("Edited"))
+
+        let forged = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)
+        ])
+        let rejected = forged.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [
+                editUpsert(
+                    makeEditOverlay(
+                        editId: "mallory-edit",
+                        sender: "mallory",
+                        plaintext: "Forged",
+                        timelineAt: 1_800_000_030
+                    )
+                )
+            ],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(!rejected.didChange)
+        let untouched = try #require(forged.lookup["target"])
+        #expect(untouched.body == "Original")
+        #expect(!untouched.isEdited)
+
+        let pending = MessageTimelineStore()
+        let pendingOnly = pending.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [editUpsert(overlay)],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(!pendingOnly.didChange)
+        #expect(pending.messages.isEmpty)
+
+        let inserted = pending.applyProjection(
+            upserts: [chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)],
+            removals: [],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(inserted.didChange)
+        let deferred = try #require(pending.lookup["target"])
+        #expect(deferred.body == "Edited body")
+        #expect(deferred.isEdited)
+
+        let poisoned = MessageTimelineStore()
+        _ = poisoned.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [
+                editUpsert(
+                    makeEditOverlay(
+                        editId: "alice-edit",
+                        plaintext: "Legitimate",
+                        timelineAt: 1_800_000_030
+                    )
+                )
+            ],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        let forgedFlood = (0..<200).map { index in
+            editUpsert(
+                makeEditOverlay(
+                    editId: "mallory-edit-\(index)",
+                    sender: "mallory",
+                    plaintext: "Forged \(index)",
+                    timelineAt: 1_800_000_060 + UInt64(index)
+                )
+            )
+        }
+        _ = poisoned.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: forgedFlood,
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        _ = poisoned.applyProjection(
+            upserts: [chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)],
+            removals: [],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        let unpoisoned = try #require(poisoned.lookup["target"])
+        #expect(unpoisoned.body == "Legitimate")
+        #expect(unpoisoned.isEdited)
+
+        let replacedStore = MessageTimelineStore()
+        replacedStore.replace(
+            with: [chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)],
+            editMutations: [editUpsert(overlay)]
+        )
+        let replaced = try #require(replacedStore.lookup["target"])
+        #expect(replaced.body == "Edited body")
+        #expect(replaced.isEdited)
+    }
+
+    @MainActor
+    @Test func messageTimelineStoreReplaceReappliesStoredEditsAcrossWindowChanges() async throws {
+        // Regression for whitenoise-mac#419: replace() rebuilds indexes before validating targets,
+        // and stored overlays survive authoritative replaces that omit the edit record.
+        let overlay = makeEditOverlay(
+            editId: "edit-new",
+            plaintext: "Edited",
+            timelineAt: 300
+        )
+
+        let staleIndexStore = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", sender: "mallory", body: "Wrong row", timelineAt: 100),
+            chatMessage(id: "other", sender: "bob", body: "Other", timelineAt: 200),
+        ])
+        staleIndexStore.replace(
+            with: [
+                chatMessage(id: "a", sender: "alice", body: "A", timelineAt: 10),
+                chatMessage(id: "target", sender: "alice", body: "Original", timelineAt: 20),
+            ],
+            editMutations: [editUpsert(overlay)]
+        )
+        let reindexed = try #require(staleIndexStore.lookup["target"])
+        #expect(reindexed.body == "Edited")
+        #expect(reindexed.isEdited)
+
+        let crossWindowStore = MessageTimelineStore()
+        _ = crossWindowStore.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [
+                editUpsert(
+                    makeEditOverlay(editId: "edit-new", plaintext: "Edited later", timelineAt: 1_800_000_060)
+                )
+            ],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(crossWindowStore.messages.isEmpty)
+
+        crossWindowStore.replace(
+            with: [chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)],
+            editMutations: []
+        )
+        let reapplied = try #require(crossWindowStore.lookup["target"])
+        #expect(reapplied.body == "Edited later")
+        #expect(reapplied.isEdited)
+    }
+
+    @MainActor
+    @Test func messageTimelineStoreEditFallbackOnCandidateRetraction() async throws {
+        // Regression for whitenoise-mac#419: removing the newest edit event falls back to the
+        // next-newest valid candidate, then to the unedited base.
+        let store = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)
+        ])
+        _ = store.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [
+                editUpsert(
+                    makeEditOverlay(editId: "edit-old", plaintext: "Edited older", timelineAt: 1_800_000_030)
+                ),
+                editUpsert(
+                    makeEditOverlay(editId: "edit-new", plaintext: "Edited newer", timelineAt: 1_800_000_060)
+                ),
+            ],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(store.lookup["target"]?.body == "Edited newer")
+
+        let removedNewest = store.applyProjection(
+            upserts: [],
+            removals: ["edit-new"],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(removedNewest.didChange)
+        #expect(store.lookup["target"]?.body == "Edited older")
+        #expect(store.lookup["target"]?.isEdited == true)
+
+        let removedOlder = store.applyProjection(
+            upserts: [],
+            removals: ["edit-old"],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(removedOlder.didChange)
+        let restored = try #require(store.lookup["target"])
+        #expect(restored.body == "Original")
+        #expect(!restored.isEdited)
+
+        let reprojected = store.applyProjection(
+            upserts: [chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)],
+            removals: [],
+            editMutations: [
+                editUpsert(
+                    makeEditOverlay(editId: "edit-new", plaintext: "Edited newer", timelineAt: 1_800_000_060)
+                )
+            ],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(reprojected.didChange)
+        let afterReupsert = try #require(store.lookup["target"])
+        #expect(afterReupsert.body == "Edited newer")
+        #expect(afterReupsert.isEdited)
+    }
+
+    @MainActor
+    @Test func messageTimelineStoreEditOverlayLifecycleAndRetention() async throws {
+        let pendingEdit = makeEditOverlay(
+            editId: "edit-new",
+            plaintext: "Edited later",
+            timelineAt: 1_800_000_060
+        )
+
+        let cleared = MessageTimelineStore()
+        _ = cleared.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [editUpsert(pendingEdit)],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        cleared.clear()
+        _ = cleared.applyProjection(
+            upserts: [chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)],
+            removals: [],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        let afterClear = try #require(cleared.lookup["target"])
+        #expect(afterClear.body == "Original")
+        #expect(!afterClear.isEdited)
+
+        let removed = MessageTimelineStore()
+        _ = removed.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [editUpsert(pendingEdit)],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        _ = removed.applyProjection(
+            upserts: [],
+            removals: ["target"],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        _ = removed.applyProjection(
+            upserts: [chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)],
+            removals: [],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        let afterRemoval = try #require(removed.lookup["target"])
+        #expect(afterRemoval.body == "Original")
+        #expect(!afterRemoval.isEdited)
+
+        let invalidTarget = MessageTimelineStore()
+        _ = invalidTarget.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [editUpsert(pendingEdit)],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        _ = invalidTarget.applyProjection(
+            upserts: [chatMessage(id: "target", sender: "mallory", body: "Original", timelineAt: 1_800_000_000)],
+            removals: [],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        let mismatched = try #require(invalidTarget.lookup["target"])
+        #expect(mismatched.body == "Original")
+        #expect(!mismatched.isEdited)
+
+        let invalidated = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)
+        ])
+        _ = invalidated.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [editUpsert(pendingEdit)],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        let retractInvalid = invalidated.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [editRetract("edit-new")],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(retractInvalid.didChange)
+        let afterInvalidation = try #require(invalidated.lookup["target"])
+        #expect(afterInvalidation.body == "Original")
+        #expect(!afterInvalidation.isEdited)
+
+        let trimmed = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", body: "Original", timelineAt: 0),
+            chatMessage(id: "m1", timelineAt: 1),
+        ])
+        _ = trimmed.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [
+                editUpsert(makeEditOverlay(editId: "edit-new", plaintext: "Edited later", timelineAt: 2))
+            ],
+            anchoredToNewest: true,
+            windowLimit: 2
+        )
+        #expect(trimmed.lookup["target"]?.body == "Edited later")
+        _ = trimmed.applyProjection(
+            upserts: [chatMessage(id: "m2", timelineAt: 2)],
+            removals: [],
+            editMutations: [],
+            anchoredToNewest: true,
+            windowLimit: 2
+        )
+        #expect(!trimmed.containsMessage(id: "target"))
+        trimmed.replace(
+            with: [
+                chatMessage(id: "target", body: "Original", timelineAt: 0),
+                chatMessage(id: "m1", timelineAt: 1),
+            ],
+            editMutations: []
+        )
+        let afterTrim = try #require(trimmed.lookup["target"])
+        #expect(afterTrim.body == "Edited later")
+        #expect(afterTrim.isEdited)
+    }
+
+    @MainActor
+    @Test func messageTimelineStoreEditBodyNormalizationMatchesDisplayText() async throws {
+        let unsupported = L10n.string("Unsupported message")
+        let store = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)
+        ])
+        _ = store.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [
+                editUpsert(
+                    makeEditOverlay(editId: "edit-trim", plaintext: "  trimmed  ", timelineAt: 1_800_000_010)
+                )
+            ],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(store.lookup["target"]?.body == "trimmed")
+
+        let whitespaceOnly = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)
+        ])
+        _ = whitespaceOnly.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [
+                editUpsert(
+                    makeEditOverlay(editId: "edit-empty", plaintext: "   ", timelineAt: 1_800_000_010)
+                )
+            ],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(whitespaceOnly.lookup["target"]?.body == unsupported)
+        #expect(whitespaceOnly.lookup["target"]?.isEdited == true)
+    }
+
+    @MainActor
     @Test func workspaceChatSnapshotsDeduplicateDuplicateChatIds() async throws {
         // Regression for whitenoise-mac#309: full-list chat snapshots must not leave duplicate
         // ChatItem.id values in the observed arrays that feed SwiftUI ForEach and later
@@ -1243,6 +1647,48 @@ struct PureValueTests {
             #expect(String(attributed.characters) == testCase.displayText)
             #expect(links(in: attributed).map(\.absoluteString) == ["nostr:\(testCase.reference)"])
         }
+    }
+
+    @MainActor
+    private func chatMessage(
+        id: String,
+        sender: String = "alice",
+        body: String? = nil,
+        timelineAt: UInt64
+    ) -> MessageItem {
+        MessageItem(
+            id: id,
+            senderAccountIdHex: sender,
+            senderName: sender,
+            body: body ?? (id == "target" ? "Original" : id),
+            sentAt: Date(timeIntervalSince1970: TimeInterval(timelineAt)),
+            timelineAt: timelineAt,
+            isOutgoing: false
+        )
+    }
+
+    private func makeEditOverlay(
+        target: String = "target",
+        editId: String,
+        sender: String = "alice",
+        plaintext: String,
+        timelineAt: UInt64
+    ) -> MessageEditOverlay {
+        MessageEditOverlay(
+            targetMessageIdHex: target,
+            editMessageIdHex: editId,
+            sender: sender,
+            plaintext: plaintext,
+            timelineAt: timelineAt
+        )
+    }
+
+    private func editUpsert(_ overlay: MessageEditOverlay) -> MessageEditMutation {
+        .upsert(overlay)
+    }
+
+    private func editRetract(_ editMessageIdHex: String) -> MessageEditMutation {
+        .retract(editMessageIdHex: editMessageIdHex)
     }
 
     private func groupImageResult(imageURL: String, thumbnailURL: String?) -> GroupImageSearchResult {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3369,7 +3369,7 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func timelineMappingFoldsKind1009EditsIntoTargetChatRows() async throws {
+    @Test func timelineStoreFoldsKind1009EditsIntoTargetChatRows() async throws {
         let originalTokens = MarkdownDocumentFfi(
             blocks: [.paragraph(inlines: [.strong(children: [.text(content: "Original")])])],
             truncated: false
@@ -3408,9 +3408,18 @@ struct whitenoise_macTests {
         )
 
         let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
-
         #expect(messages.count == 1)
-        let message = try #require(messages.first)
+        #expect(messages[0].body == "**Original**")
+        #expect(!messages[0].isEdited)
+
+        let editMutations = MessageEditOverlay.mutations(from: page.messages)
+        #expect(editMutations.filter { if case .upsert = $0 { true } else { false } }.count == 2)
+
+        let store = MessageTimelineStore.loaded(with: messages)
+        store.replace(with: messages, editMutations: editMutations)
+
+        #expect(store.messages.count == 1)
+        let message = try #require(store.messages.first)
         #expect(message.id == "target")
         #expect(message.timelineKind == 9)
         #expect(message.body == "Edited twice")
@@ -3420,7 +3429,7 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func timelineMappingIgnoresKind1009EditsFromDifferentAuthors() async throws {
+    @Test func timelineStoreIgnoresKind1009EditsFromDifferentAuthors() async throws {
         let page = TimelinePageFfi(
             messages: [
                 timelineMessage(
@@ -3445,13 +3454,174 @@ struct whitenoise_macTests {
         )
 
         let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let editMutations = MessageEditOverlay.mutations(from: page.messages)
+        let store = MessageTimelineStore.loaded(with: messages)
+        store.replace(with: messages, editMutations: editMutations)
 
-        #expect(messages.count == 1)
-        let message = try #require(messages.first)
+        #expect(store.messages.count == 1)
+        let message = try #require(store.messages.first)
         #expect(message.id == "target")
         #expect(message.body == "Original")
         #expect(!message.isEdited)
         #expect(!message.metadataLabel.contains("Edited"))
+    }
+
+    @MainActor
+    @Test func messageEditRecordInvalidationAndDeletionRetractCandidates() async throws {
+        func editRecord(
+            id: String,
+            plaintext: String,
+            recordedAt: UInt64,
+            deleted: Bool = false,
+            invalidationStatus: String? = nil
+        ) -> TimelineMessageRecordFfi {
+            timelineMessage(
+                id: id,
+                groupIdHex: "group",
+                sender: "alice",
+                plaintext: plaintext,
+                kind: 1_009,
+                tags: [MessageTagFfi(values: ["e", "target"])],
+                recordedAt: recordedAt,
+                deleted: deleted,
+                invalidationStatus: invalidationStatus
+            )
+        }
+
+        let oldEdit = editRecord(id: "edit-old", plaintext: "Older", recordedAt: 1_800_000_030)
+        let newEdit = editRecord(id: "edit-new", plaintext: "Newer", recordedAt: 1_800_000_060)
+        let store = MessageTimelineStore.loaded(with: [
+            MessageItem(
+                id: "target",
+                groupIdHex: "group",
+                senderAccountIdHex: "alice",
+                senderName: "alice",
+                body: "Original",
+                sentAt: Date(timeIntervalSince1970: 1_800_000_000),
+                timelineAt: 1_800_000_000,
+                isOutgoing: false
+            )
+        ])
+
+        _ = store.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: MessageEditOverlay.mutations(from: [oldEdit, newEdit]),
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(store.lookup["target"]?.body == "Newer")
+
+        let invalidatedNew = editRecord(
+            id: "edit-new",
+            plaintext: "Newer",
+            recordedAt: 1_800_000_060,
+            invalidationStatus: "losing-branch"
+        )
+        _ = store.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: MessageEditOverlay.mutations(from: [invalidatedNew]),
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(store.lookup["target"]?.body == "Older")
+
+        let deletedOld = editRecord(
+            id: "edit-old",
+            plaintext: "Older",
+            recordedAt: 1_800_000_030,
+            deleted: true
+        )
+        _ = store.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: MessageEditOverlay.mutations(from: [deletedOld]),
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        let restored = try #require(store.lookup["target"])
+        #expect(restored.body == "Original")
+        #expect(!restored.isEdited)
+    }
+
+    @MainActor
+    @Test func timelineProjectionAppliesStandaloneEditOverlayToExistingTarget() async throws {
+        // Regression for whitenoise-mac#419: edit-only projection deltas must patch an existing
+        // materialized target instead of mapping to an empty upsert list.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let accountItem = AccountItem(summary: account)
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let chat = ChatItem(
+            id: "group",
+            title: "Test Group",
+            subtitle: "Group message",
+            preview: "Original",
+            updatedAt: nil,
+            avatarSeed: "group",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let state = WorkspaceState(
+            accounts: [accountItem],
+            chatsByAccount: [accountItem.id: [chat]],
+            messagesByChat: [
+                "group": [
+                    MessageItem(
+                        id: "target",
+                        groupIdHex: "group",
+                        senderAccountIdHex: "alice",
+                        senderName: "alice",
+                        body: "Original",
+                        sentAt: Date(timeIntervalSince1970: 1_800_000_000),
+                        timelineAt: 1_800_000_000,
+                        isOutgoing: false
+                    )
+                ]
+            ],
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
+        state.activeAccountId = accountItem.id
+        state.selection = .chat("group")
+
+        await state.applyTimelineProjection(
+            TimelineProjectionUpdateFfi(
+                groupIdHex: "group",
+                messages: [],
+                changes: [
+                    .upsert(
+                        trigger: .messageEditedOrReprojected,
+                        message: timelineMessage(
+                            id: "edit-new",
+                            groupIdHex: "group",
+                            sender: "alice",
+                            plaintext: "Edited via projection",
+                            kind: 1_009,
+                            tags: [MessageTagFfi(values: ["e", "target"])],
+                            recordedAt: 1_800_000_060
+                        ))
+                ],
+                chatListRow: nil,
+                chatListTrigger: .newLastMessage
+            ),
+            groupIdHex: "group",
+            account: accountItem,
+            client: runtime
+        )
+
+        let message = try #require(state.ensureMessageTimelineStore(for: "group").lookup["target"])
+        #expect(message.body == "Edited via projection")
+        #expect(message.isEdited)
+        #expect(state.ensureMessageTimelineStore(for: "group").messages.count == 1)
     }
 
     @MainActor


### PR DESCRIPTION
Fixes #419

## Summary
- Moves kind-1009 edit folding from batch-local mapping into `MessageTimelineStore`, so standalone edit deltas can update an existing row and pending edits survive timeline-window replacement/pagination.
- Keeps unedited base rows plus bounded edit candidates keyed by edit event, validates target kind/author before rendering, and restores the next valid edit or original body on removal/invalidation/deletion.
- Preserves normal chat-body normalization and Markdown fallback behavior for edited plaintext.

## Regression coverage
- standalone edit-only projection delta
- target and edit arriving in different windows
- newest edit ordering and fallback after retraction
- invalidated/deleted edit retraction
- forged-sender rejection, including a 200-edit pending flood
- trim, clear, target removal, replacement, and body normalization

## Verification
- `git diff --check` — pass
- added-line security/debug scan — pass
- conflict-marker scan — pass
- added Swift lines over 120 columns — none
- signed commit verified with `git verify-commit`
- `bash scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux host (`xcodebuild: command not found`); macOS CI is the authoritative compile/test run

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for message edits in timeline updates and live projections.
  * Edited messages now display updated text while preserving reactions, replies, and other message details.
  * Edit overlays are validated by author and can fall back to earlier edits or the original message.

* **Bug Fixes**
  * Fixed edit-only timeline updates not appearing immediately.
  * Correctly handles invalidated, deleted, retracted, and whitespace-only edits.

* **Tests**
  * Added comprehensive coverage for edit application, reversion, validation, and window changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->