### PR TITLE
fix: refresh selected archived chat metadata

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1524,6 +1524,9 @@ final class WorkspaceState {
 
     private func bumpArchivedChatListGeneration(forAccountId accountId: String) {
         archivedChatListGenerationByAccount[accountId, default: 0] += 1
+        if activeAccountId == accountId {
+            selectedChatRevision += 1
+        }
         if filteredArchivedChatsCache?.accountId == accountId {
             filteredArchivedChatsCache = nil
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10234,6 +10234,75 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func selectedChatObservationInvalidatesOnSelectedArchivedChatMetadataDelta() async throws {
+        // Regression for #449: archived chats resolve through ignored O(1) indexes too, so live
+        // archived-list deltas must bump the same observed token as active-list updates.
+        let account = AccountItem.samples[0]
+        let selected = ChatItem(
+            id: "selected-archived-chat",
+            title: "Original archived group",
+            subtitle: "Group message",
+            preview: "before",
+            updatedAt: Date(timeIntervalSince1970: 100),
+            avatarSeed: "selected-archived-chat",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let background = ChatItem(
+            id: "background-archived-chat",
+            title: "Background archived group",
+            subtitle: "Group message",
+            preview: "background",
+            updatedAt: Date(timeIntervalSince1970: 90),
+            avatarSeed: "background-archived-chat",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [:],
+            clientFactory: { FakeMarmotRuntime(accounts: []) }
+        )
+        state.activeAccountId = account.id
+        state.setArchivedChats([selected, background], forAccountId: account.id)
+        state.selection = .chat(selected.id)
+
+        #expect(state.selectedChat?.title == "Original archived group")
+        #expect(state.selectedChat?.isNoLongerMember == false)
+
+        let invalidated = ObservationInvalidationFlag()
+        withObservationTracking {
+            _ = state.selectedChat?.title
+            _ = state.selectedChat?.isNoLongerMember
+        } onChange: {
+            invalidated.markInvalidated()
+        }
+
+        state.upsertArchivedChat(
+            ChatItem(
+                id: selected.id,
+                title: "Renamed archived group",
+                subtitle: selected.subtitle,
+                preview: "after",
+                updatedAt: selected.updatedAt,
+                avatarSeed: "renamed-archived-avatar",
+                pictureURL: selected.pictureURL,
+                unreadCount: selected.unreadCount,
+                unreadMentionCount: selected.unreadMentionCount,
+                isDirect: selected.isDirect,
+                pendingConfirmation: selected.pendingConfirmation,
+                selfMembership: .removed
+            ),
+            forAccountId: account.id
+        )
+
+        #expect(invalidated.value)
+        #expect(state.selectedChat?.title == "Renamed archived group")
+        #expect(state.selectedChat?.avatarSeed == "renamed-archived-avatar")
+        #expect(state.selectedChat?.isNoLongerMember == true)
+    }
+
+    @MainActor
     @Test func filteredChatsObservationInvalidatesOnChatListDeltaAfterCacheHit() async throws {
         // Regression for #390: `filteredChats` is memoized through ignored cache state, but each
         // body pass still has to read the observed chat list. Otherwise a cache-hit pass drops the


### PR DESCRIPTION
Fixes #449

## Summary
- Invalidate `selectedChat` observation when the active account archived-chat index changes.
- Add a regression test proving an open archived chat refreshes title, avatar, and membership state after an archived metadata upsert.

## Verification
- `git diff --check` — passed
- `bash scripts/ci/macos-sanity-checks.sh` — unavailable on this Linux worker (`xcodebuild: command not found`)
- macOS Xcode build and unit tests deferred to CI

## Sensitive paths
None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->