### PR TITLE
fix: reconcile cache footprint after failed purge

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -147,6 +147,7 @@ nonisolated enum MessageMediaDiskCacheKeychain {
 
 nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     typealias DirectoryResolver = @Sendable () throws -> URL
+    typealias RootRemover = @Sendable (URL) throws -> Void
     typealias KeyProvider = @Sendable () throws -> SymmetricKey
     typealias KeyDeleter = @Sendable () -> Void
     typealias TimestampProvider = @Sendable () -> TimeInterval
@@ -178,6 +179,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private static let payloadFileName = "payload.bin"
 
     private let directoryResolver: DirectoryResolver
+    private let rootRemover: RootRemover
     private let keyProvider: KeyProvider
     private let keyDeleter: KeyDeleter
     private let timestampProvider: TimestampProvider
@@ -211,6 +213,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
     init(
         directoryResolver: @escaping DirectoryResolver = MessageMediaDiskCache.defaultDirectoryURL,
+        rootRemover: @escaping RootRemover = { try FileManager.default.removeItem(at: $0) },
         keyProvider: @escaping KeyProvider = MessageMediaDiskCacheKeychain.symmetricKey,
         keyDeleter: @escaping KeyDeleter = MessageMediaDiskCacheKeychain.deleteKey,
         timestampProvider: @escaping TimestampProvider = { Date().timeIntervalSince1970 },
@@ -218,6 +221,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         sessionStartedAtUnixSeconds: TimeInterval = Date().timeIntervalSince1970
     ) {
         self.directoryResolver = directoryResolver
+        self.rootRemover = rootRemover
         self.keyProvider = keyProvider
         self.keyDeleter = keyDeleter
         self.timestampProvider = timestampProvider
@@ -315,16 +319,28 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     }
 
     func purgeAll(removeEncryptionKey: Bool = false) async {
-        let root = try? directoryResolver()
+        let root: URL?
+        do {
+            root = try directoryResolver()
+        } catch {
+            root = nil
+        }
+        let removeRoot = rootRemover
         let deleteKey = keyDeleter
         let task = beginPurge(scope: .all) { [self] in
             if let root {
-                try? FileManager.default.removeItem(at: root)
+                do {
+                    try removeRoot(root)
+                    trackedFootprint = CacheFootprint(entryCount: 0, byteCount: 0)
+                } catch {
+                    trackedFootprint = nil
+                }
+            } else {
+                trackedFootprint = nil
             }
             if removeEncryptionKey {
                 deleteKey()
             }
-            trackedFootprint = CacheFootprint(entryCount: 0, byteCount: 0)
         }
         await task.task.value
         finishPurge(task)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2858,6 +2858,76 @@ struct whitenoise_macTests {
         #expect(!fileManager.fileExists(atPath: root.path))
     }
 
+    @Test func messageMediaDiskCachePurgeAllReSeedsFootprintWhenRootRemovalFails() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-purge-fail-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cachedAtCounter = AtomicCounter()
+        let didAttemptRootRemoval = MutableFlag(false)
+        let didDeleteKey = MutableFlag(false)
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 1, maxTotalBytes: UInt64.max),
+            timestampProvider: { TimeInterval(cachedAtCounter.increment()) },
+            rootRemover: { _ in
+                didAttemptRootRemoval.value = true
+                throw NSError(domain: "MessageMediaDiskCacheTests", code: 1)
+            },
+            keyDeleter: { didDeleteKey.value = true }
+        )
+        let firstPlaintext = Data("surviving cache entry after failed purge".utf8)
+        let secondPlaintext = Data("replacement entry after failed purge".utf8)
+        let firstKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: firstPlaintext, ciphertextByte: 0xc1)
+        )
+        let secondKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: secondPlaintext, ciphertextByte: 0xc2)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: firstPlaintext,
+                fileName: "first.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(firstPlaintext.count),
+                payloadId: "first"
+            ),
+            for: firstKey
+        )
+        let firstEntryDirectory = try #require(cache.entryDirectory(for: firstKey))
+        #expect(fileManager.fileExists(atPath: firstEntryDirectory.path))
+
+        await cache.purgeAll(removeEncryptionKey: true)
+
+        #expect(didAttemptRootRemoval.value)
+        #expect(didDeleteKey.value)
+        #expect(fileManager.fileExists(atPath: root.path))
+        #expect(fileManager.fileExists(atPath: firstEntryDirectory.path))
+        #expect(try #require(await cache.cachedDownload(for: firstKey)).data == firstPlaintext)
+
+        await cache.store(
+            MessageMediaDownload(
+                data: secondPlaintext,
+                fileName: "second.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(secondPlaintext.count),
+                payloadId: "second"
+            ),
+            for: secondKey
+        )
+
+        #expect(await cache.cachedDownload(for: firstKey) == nil)
+        #expect(try #require(await cache.cachedDownload(for: secondKey)).data == secondPlaintext)
+        let cacheFiles = try fileManager.subpathsOfDirectory(atPath: root.path)
+        #expect(cacheFiles.filter { $0.hasSuffix("payload.bin") }.count == 1)
+    }
+
     @Test func messageMediaDiskCachePurgesByAccountAndFullWipeDeletesKey() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
@@ -19047,10 +19117,12 @@ private func messageMediaDiskCache(
     evictionPolicy: MessageMediaDiskCache.EvictionPolicy = .standard,
     timestampProvider: @escaping MessageMediaDiskCache.TimestampProvider = { Date().timeIntervalSince1970 },
     sessionStartedAtUnixSeconds: TimeInterval = Date().timeIntervalSince1970,
+    rootRemover: @escaping MessageMediaDiskCache.RootRemover = { try FileManager.default.removeItem(at: $0) },
     keyDeleter: @escaping @Sendable () -> Void = {}
 ) -> MessageMediaDiskCache {
     MessageMediaDiskCache(
         directoryResolver: { root },
+        rootRemover: rootRemover,
         keyProvider: { SymmetricKey(data: keyData) },
         keyDeleter: keyDeleter,
         timestampProvider: timestampProvider,


### PR DESCRIPTION
Fixes #453

## Summary
- invalidate `trackedFootprint` when cache-root resolution or removal fails
- preserve an empty footprint only after confirmed root removal
- inject deterministic root-removal failure in tests and verify the next store re-scans survivors before enforcing the entry cap
- preserve encryption-key deletion even when filesystem removal fails

## Verification
- `git diff --check` (pass)
- independent pre-commit review after one fix cycle (pass; no blocking findings)
- macOS Swift format, build, analyze, and unit tests unavailable on this Linux host; GitHub Actions will run the repository's macOS CI

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->