### PR TITLE
fix: validate NIP-05 redirect targets

### DIFF
--- a/whitenoise-mac/Core/NIP05Resolver.swift
+++ b/whitenoise-mac/Core/NIP05Resolver.swift
@@ -45,7 +45,8 @@ struct NIP05Resolver: NIP05Resolving {
         var request = URLRequest(url: url)
         request.setValue("WhiteNoiseMac/1.0", forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await session.data(for: request)
+        let redirectDelegate = NIP05RedirectDelegate()
+        let (data, response) = try await session.data(for: request, delegate: redirectDelegate)
         guard let http = response as? HTTPURLResponse else {
             throw NIP05ResolutionError.invalidResponse
         }
@@ -69,6 +70,37 @@ struct NIP05Resolver: NIP05Resolving {
         configuration.timeoutIntervalForRequest = 10
         configuration.timeoutIntervalForResource = 15
         return configuration
+    }
+}
+
+/// Re-validates every NIP-05 redirect target so an allowed public endpoint cannot bounce the
+/// resolver into a private, loopback, link-local, or cleartext destination.
+nonisolated final class NIP05RedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    static let maxRedirectHops = 5
+
+    private let lock = NSLock()
+    private var redirectHopCount = 0
+
+    func validatedRedirectRequest(_ request: URLRequest) -> URLRequest? {
+        guard let url = request.url, RemoteImageURLPolicy.isAllowed(url) else {
+            return nil
+        }
+
+        let hopCount = lock.withLock {
+            redirectHopCount += 1
+            return redirectHopCount
+        }
+        return hopCount <= Self.maxRedirectHops ? request : nil
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(validatedRedirectRequest(request))
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -12174,6 +12174,38 @@ struct whitenoise_macTests {
         #expect(state.streamingDebugEnabled)
     }
 
+    @Test func nip05RedirectPolicyRejectsDisallowedTargets() throws {
+        let delegate = NIP05RedirectDelegate()
+        let publicRequest = URLRequest(
+            url: try #require(URL(string: "https://cdn.example.org/.well-known/nostr.json"))
+        )
+        let privateRequest = URLRequest(
+            url: try #require(URL(string: "https://127.0.0.1:8080/internal"))
+        )
+        let cleartextRequest = URLRequest(
+            url: try #require(URL(string: "http://example.org/.well-known/nostr.json"))
+        )
+
+        #expect(delegate.validatedRedirectRequest(publicRequest) != nil)
+        #expect(delegate.validatedRedirectRequest(privateRequest) == nil)
+        #expect(delegate.validatedRedirectRequest(cleartextRequest) == nil)
+    }
+
+    @Test func nip05RedirectPolicyCapsHopsPerRequest() throws {
+        let delegate = NIP05RedirectDelegate()
+        let request = URLRequest(
+            url: try #require(URL(string: "https://cdn.example.org/.well-known/nostr.json"))
+        )
+
+        for _ in 0..<NIP05RedirectDelegate.maxRedirectHops {
+            #expect(delegate.validatedRedirectRequest(request) != nil)
+        }
+        #expect(delegate.validatedRedirectRequest(request) == nil)
+
+        // Each lookup creates a delegate and therefore receives an independent redirect budget.
+        #expect(NIP05RedirectDelegate().validatedRedirectRequest(request) != nil)
+    }
+
     @Test func remoteImagePolicyAllowsOnlyHttpsWithHost() async throws {
         // Allowed: https with a real host.
         #expect(RemoteImageURLPolicy.isAllowed(URL(string: "https://example.com/avatar.png")!))


### PR DESCRIPTION
## Summary
- attach a task-specific redirect delegate to each NIP-05 lookup
- re-validate every redirect target with `RemoteImageURLPolicy`
- stop after five redirects with independent per-request state

## Test plan
- added unit coverage for public, private, loopback, and cleartext redirect targets
- added unit coverage for the five-hop cap and independent request budgets
- `git diff --check`
- macOS build/tests: deferred to CI because this worker runs on Linux without Xcode

Fixes #448


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->