### PR TITLE
refactor: simplify archived chat metadata preservation

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -274,7 +274,7 @@ extension WorkspaceState {
         guard activeAccountId == account.id else { return }
 
         if row.archived {
-            moveChatToArchived(row: row, account: account, shouldEnrich: shouldEnrich)
+            moveChatToArchived(row: row, account: account)
             if shouldEnrich {
                 startChatListEnrichment(rows: [row], account: account, replacingCurrent: false)
             }
@@ -315,11 +315,7 @@ extension WorkspaceState {
         }
     }
 
-    func moveChatToArchived(
-        row: ChatListRowFfi,
-        account: AccountItem,
-        shouldEnrich: Bool = true
-    ) {
+    func moveChatToArchived(row: ChatListRowFfi, account: AccountItem) {
         guard activeAccountId == account.id else { return }
 
         let groupIdHex = row.groupIdHex
@@ -327,9 +323,7 @@ extension WorkspaceState {
         removeChatFromList(chatId: groupIdHex, forAccountId: account.id)
 
         var chat = baseChatItem(from: row, account: account)
-        if !shouldEnrich, let currentActive {
-            chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: currentActive)
-        } else if let currentActive {
+        if let currentActive {
             chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: currentActive)
         }
 


### PR DESCRIPTION
## Summary
- collapse identical moveChatToArchived branches into one unconditional metadata-preservation path
- remove the now-unused shouldEnrich helper parameter
- preserve existing behavior: archived rows retain resolved metadata before optional enrichment

## Verification
- git diff --check
- source regression assertions for the simplified call/signature/branch
- macOS xcodebuild and swift-format unavailable on this Linux worker; GitHub Mac CI will run the native checks

Fixes #472

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat archiving to preserve resolved chat details when moving an active chat to the archive.
  * Ensured archived chat rows consistently retain their available metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->