### PR TITLE
fix: defer composer height measurements

### DIFF
--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -108,7 +108,9 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         configureHandlers(for: textView, coordinator: context.coordinator)
 
         scrollView.documentView = textView
-        context.coordinator.updateMeasuredHeight(for: textView)
+        DispatchQueue.main.async {
+            context.coordinator.updateMeasuredHeight(for: textView)
+        }
         return scrollView
     }
 
@@ -124,7 +126,6 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         if textView.string != text {
             textView.string = text
         }
-        context.coordinator.updateMeasuredHeight(for: textView)
         DispatchQueue.main.async {
             context.coordinator.updateMeasuredHeight(for: textView)
         }


### PR DESCRIPTION
Fixes #469

## Summary
- defer the initial composer height measurement until after `makeNSView` returns
- remove the duplicate synchronous measurement from `updateNSView` and retain its deferred measurement
- keep direct measurement in `textDidChange`, which runs from the AppKit delegate event rather than SwiftUI's representable update transaction

## Verification
- `git diff --check` — passed
- static lifecycle inspection — both `makeNSView` and `updateNSView` contain exactly one deferred measurement and no synchronous binding write
- `scripts/ci/macos-sanity-checks.sh` — unavailable on this Linux host (`xcodebuild: command not found`)
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — unavailable on this Linux host (`xcrun: command not found`)
- Xcode unit test command — unavailable on this Linux host (`xcodebuild: command not found`)

No regression test was added: this bug is specifically SwiftUI/AppKit lifecycle scheduling, and a meaningful behavior test requires macOS execution. A source-scrape test or test-only visibility hook would be more brittle and complex than the two-call fix. CI will run the native checks.

## Sensitive paths
None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/474">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->