### PR TITLE
fix: attribute media-only chat previews

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -105,18 +105,21 @@ extension ChatItem {
             presentation.isChatBubble
             && sourceTextIsEmpty
             && text == L10n.string("Unsupported message")
-        guard !text.isEmpty, !isMediaOnlyChat else {
-            return presentation.isChatBubble ? L10n.string("Attachment") : L10n.string("Unsupported message")
+        let body: String
+        if !text.isEmpty, !isMediaOnlyChat {
+            body = text
+        } else {
+            body = presentation.isChatBubble ? L10n.string("Attachment") : L10n.string("Unsupported message")
         }
         guard presentation.isChatBubble,
             preview.sender != activeAccountIdHex,
             let senderName = preview.senderDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
             !senderName.isEmpty
         else {
-            return text
+            return body
         }
 
-        return "\(senderName): \(text)"
+        return "\(senderName): \(body)"
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4047,7 +4047,7 @@ struct whitenoise_macTests {
         )
 
         let directChat = ChatItem(row: directRow, activeAccountIdHex: "self")
-        #expect(directChat.preview == "Attachment")
+        #expect(directChat.preview == "Alice: Attachment")
 
         let groupRow = ChatListRowFfi(
             groupIdHex: "group",
@@ -4079,7 +4079,9 @@ struct whitenoise_macTests {
         )
 
         let groupChat = ChatItem(row: groupRow, activeAccountIdHex: "self")
-        #expect(groupChat.preview == "Attachment")
+        // Regression for whitenoise-mac#471: media-only incoming previews must pass
+        // through the same sender-attribution path as incoming text previews.
+        #expect(groupChat.preview == "Alice: Attachment")
     }
 
     @MainActor


### PR DESCRIPTION
Fixes #471

## Summary
- Compute the media-only `Attachment` fallback before sender attribution instead of returning early.
- Apply the existing incoming-message sender prefix to attachment previews.
- Update regression coverage so incoming media-only previews with a display name render as `Alice: Attachment`.

## Verification
- `git diff --check` — passed.
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed.
- `scripts/ci/macos-sanity-checks.sh` — expected local failure on Linux: `xcodebuild: command not found`.
- CI-exact `xcrun swift-format`, Xcode unit tests, release build, and static analysis require macOS and will run in GitHub Actions.

## Sensitive paths
none

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->