### PR TITLE
fix: cancel offscreen media downloads

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -341,6 +341,7 @@ private struct AutomaticMediaDownloadModifier: ViewModifier {
     let message: MessageItem
     let requiresScrollVisibility: Bool
     @State private var isVisibleInScrollView = false
+    @State private var automaticDownloadTask: Task<Void, Never>?
 
     func body(content: Content) -> some View {
         Group {
@@ -352,6 +353,8 @@ private struct AutomaticMediaDownloadModifier: ViewModifier {
                         isVisibleInScrollView = isVisible
                         if isVisible {
                             startAutomaticDownloadIfNeeded()
+                        } else {
+                            cancelAutomaticDownload()
                         }
                     }
             } else {
@@ -362,6 +365,7 @@ private struct AutomaticMediaDownloadModifier: ViewModifier {
             }
         }
         .onChange(of: attachment.id) { _, _ in
+            cancelAutomaticDownload()
             if shouldStartForCurrentVisibility {
                 startAutomaticDownloadIfNeeded()
             }
@@ -371,6 +375,9 @@ private struct AutomaticMediaDownloadModifier: ViewModifier {
                 startAutomaticDownloadIfNeeded()
             }
         }
+        .onDisappear {
+            cancelAutomaticDownload()
+        }
     }
 
     private var shouldStartForCurrentVisibility: Bool {
@@ -379,7 +386,15 @@ private struct AutomaticMediaDownloadModifier: ViewModifier {
 
     private func startAutomaticDownloadIfNeeded() {
         guard downloadState.shouldStartAutomaticDownload else { return }
-        Task { await workspace.loadMediaAttachment(attachment, for: message) }
+        automaticDownloadTask?.cancel()
+        automaticDownloadTask = Task {
+            await workspace.loadMediaAttachment(attachment, for: message)
+        }
+    }
+
+    private func cancelAutomaticDownload() {
+        automaticDownloadTask?.cancel()
+        automaticDownloadTask = nil
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5846,6 +5846,39 @@ struct whitenoise_macTests {
         #expect(tileSource.contains("Task { await workspace.loadMediaAttachment(attachment, for: message) }"))
     }
 
+    @Test func automaticMediaDownloadCancelsWhenTileLeavesViewport() throws {
+        // AutomaticMediaDownloadModifier is SwiftUI lifecycle wiring, so exercise its source
+        // contract directly: the task must be retained and cancelled both on scroll-out and
+        // when SwiftUI removes the tile entirely.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+        let modifierStart = try #require(
+            source.range(of: "private struct AutomaticMediaDownloadModifier: ViewModifier {")
+        )
+        let rest = source[modifierStart.upperBound...]
+        let modifierEnd = try #require(rest.range(of: "\n/// The chat-bubble shape:")?.lowerBound)
+        let modifierSource = String(source[modifierStart.lowerBound..<modifierEnd])
+
+        #expect(modifierSource.contains("@State private var automaticDownloadTask: Task<Void, Never>?"))
+        #expect(
+            modifierSource.contains(
+                "} else {\n                            cancelAutomaticDownload()"
+            )
+        )
+        #expect(
+            modifierSource.contains(
+                ".onDisappear {\n            cancelAutomaticDownload()\n        }"
+            )
+        )
+        #expect(modifierSource.contains("automaticDownloadTask?.cancel()"))
+    }
+
     @MainActor
     @Test func loadMediaAttachmentRetriesFromFailedState() async throws {
         let account = AccountSummaryFfi(


### PR DESCRIPTION
## Summary
- retain each tile's automatic media download task
- cancel queued or in-flight work when the tile scrolls out, disappears, or changes attachment
- add a regression check for the SwiftUI cancellation wiring

## Test plan
- source contract regression check passes
- git diff --check
- macOS build/tests deferred to GitHub CI (Xcode unavailable on Linux)

Fixes #468

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/476">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->