### PR TITLE
fix: preserve chat state across archive transitions

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -203,18 +203,15 @@ extension WorkspaceState {
         let activeItems = activeRows.map { baseChatItem(from: $0, account: account) }
         let archivedItems = archivedRows.map { baseChatItem(from: $0, account: account) }
 
-        let previousActiveChatIds = Set((chatsByAccount[account.id] ?? []).map(\.id))
-        let nextActiveChatIds = Set(activeItems.map(\.id))
-        let removedActiveChatIds = previousActiveChatIds.subtracting(nextActiveChatIds)
+        let previousChatIds = Set((chatsByAccount[account.id] ?? []).map(\.id))
+            .union((archivedChatsByAccount[account.id] ?? []).map(\.id))
+        let nextChatIds = Set(activeItems.map(\.id)).union(archivedItems.map(\.id))
+        let removedChatIds = previousChatIds.subtracting(nextChatIds)
 
-        let previousArchivedChatIds = Set((archivedChatsByAccount[account.id] ?? []).map(\.id))
-        let nextArchivedChatIds = Set(archivedItems.map(\.id))
-        let removedArchivedChatIds = previousArchivedChatIds.subtracting(nextArchivedChatIds)
-
-        for groupId in removedActiveChatIds.union(removedArchivedChatIds) {
+        for groupId in removedChatIds {
             invalidateGroupMembers(for: groupId)
         }
-        clearComposerDrafts(for: Array(removedActiveChatIds.union(removedArchivedChatIds)), accountId: account.id)
+        clearComposerDrafts(for: Array(removedChatIds), accountId: account.id)
         setChats(sortedChatItems(activeItems), forAccountId: account.id)
         setArchivedChats(sortedChatItems(archivedItems), forAccountId: account.id)
         dismissGroupImagePickerIfSelectedChatUnavailable()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13128,6 +13128,46 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func bulkChatRowsPreserveConversationStateAcrossArchiveTransitions() async throws {
+        let state = WorkspaceState.preview()
+        let account = AccountItem.samples[0]
+        let chat = try #require(state.selectedChat)
+        let draftKey = try #require(state.selectedComposerDraftKey)
+        state.draftTextByConversation[draftKey] = "see you at 6"
+        state.storeGroupMembers([], for: chat.id)
+
+        func row(archived: Bool) -> ChatListRowFfi {
+            chatListRow(
+                groupIdHex: chat.id,
+                title: chat.title,
+                preview: chat.preview,
+                sender: "alice",
+                timelineAt: 1_700_000_000,
+                archived: archived
+            )
+        }
+
+        await state.applyChatRows([row(archived: true)], account: account)
+
+        #expect(state.activeChats.isEmpty)
+        #expect(state.archivedChats.map(\.id) == [chat.id])
+        #expect(state.draftTextByConversation[draftKey] == "see you at 6")
+        #expect(state.groupMemberDetailsCache[chat.id] != nil)
+
+        await state.applyChatRows([row(archived: false)], account: account)
+
+        #expect(state.activeChats.map(\.id) == [chat.id])
+        #expect(state.archivedChats.isEmpty)
+        #expect(state.draftTextByConversation[draftKey] == "see you at 6")
+        #expect(state.groupMemberDetailsCache[chat.id] != nil)
+
+        await state.applyChatRows([], account: account)
+
+        #expect(state.draftTextByConversation[draftKey] == nil)
+        #expect(state.groupMemberDetailsCache[chat.id] == nil)
+    }
+
+    @MainActor
     @Test func startingNewChatCreatesAndSelectsConversation() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -18336,12 +18376,13 @@ private func chatListRow(
     preview: String,
     sender: String,
     timelineAt: UInt64,
+    archived: Bool = false,
     kind: UInt64 = 9,
     selfMembership: SelfMembershipFfi = .member
 ) -> ChatListRowFfi {
     ChatListRowFfi(
         groupIdHex: groupIdHex,
-        archived: false,
+        archived: archived,
         pendingConfirmation: false,
         title: title,
         groupName: "",


### PR DESCRIPTION
## Summary
- compute removed chats across the combined active and archived snapshots
- preserve composer drafts and group-member cache entries when chats move between lists
- add regression coverage for archive, unarchive, and true removal snapshots

## Verification
- git diff --check
- bash -n scripts/ci/macos-sanity-checks.sh
- source regression assertions: 8/8 passed
- xcodebuild unavailable on this Linux worker; GitHub macOS CI runs the Swift suite

Fixes #466

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/482">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->