### PR TITLE
Low-severity fixes: scroll gate, media cache footprint, preview attribution, dead branch

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -105,18 +105,23 @@ extension ChatItem {
             presentation.isChatBubble
             && sourceTextIsEmpty
             && text == L10n.string("Unsupported message")
-        guard !text.isEmpty, !isMediaOnlyChat else {
-            return presentation.isChatBubble ? L10n.string("Attachment") : L10n.string("Unsupported message")
+        // Resolve the body first so the sender prefix applies to media-only previews too, not
+        // just text — otherwise a group attachment shows up unattributed.
+        let body: String
+        if text.isEmpty || isMediaOnlyChat {
+            body = presentation.isChatBubble ? L10n.string("Attachment") : L10n.string("Unsupported message")
+        } else {
+            body = text
         }
         guard presentation.isChatBubble,
             preview.sender != activeAccountIdHex,
             let senderName = preview.senderDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
             !senderName.isEmpty
         else {
-            return text
+            return body
         }
 
-        return "\(senderName): \(text)"
+        return "\(senderName): \(body)"
     }
 }
 

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -318,13 +318,20 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         let root = try? directoryResolver()
         let deleteKey = keyDeleter
         let task = beginPurge(scope: .all) { [self] in
-            if let root {
-                try? FileManager.default.removeItem(at: root)
+            var removalSucceeded = true
+            if let root, FileManager.default.fileExists(atPath: root.path) {
+                do {
+                    try FileManager.default.removeItem(at: root)
+                } catch {
+                    removalSucceeded = false
+                }
             }
             if removeEncryptionKey {
                 deleteKey()
             }
-            trackedFootprint = CacheFootprint(entryCount: 0, byteCount: 0)
+            // On a failed removal, entries survive on disk — a zero footprint would be a false
+            // zero the incremental accountant never reconciles, so nil it to force a re-seed.
+            trackedFootprint = removalSucceeded ? CacheFootprint(entryCount: 0, byteCount: 0) : nil
         }
         await task.task.value
         finishPurge(task)

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -318,7 +318,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         let root = try? directoryResolver()
         let deleteKey = keyDeleter
         let task = beginPurge(scope: .all) { [self] in
-            var removalSucceeded = true
+            var removalSucceeded = root != nil
             if let root, FileManager.default.fileExists(atPath: root.path) {
                 do {
                     try FileManager.default.removeItem(at: root)
@@ -329,8 +329,9 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             if removeEncryptionKey {
                 deleteKey()
             }
-            // On a failed removal, entries survive on disk — a zero footprint would be a false
-            // zero the incremental accountant never reconciles, so nil it to force a re-seed.
+            // An unresolved root or a failed removal can leave entries on disk — a zero footprint
+            // would be a false zero the incremental accountant never reconciles, so nil it instead
+            // to force a re-seed.
             trackedFootprint = removalSucceeded ? CacheFootprint(entryCount: 0, byteCount: 0) : nil
         }
         await task.task.value

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -327,9 +327,9 @@ extension WorkspaceState {
         removeChatFromList(chatId: groupIdHex, forAccountId: account.id)
 
         var chat = baseChatItem(from: row, account: account)
-        if !shouldEnrich, let currentActive {
-            chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: currentActive)
-        } else if let currentActive {
+        // Preserve enrichment-resolved metadata across the archive move regardless of
+        // shouldEnrich — when enrichment does run, startChatListEnrichment corrects it.
+        if let currentActive {
             chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: currentActive)
         }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -390,6 +390,9 @@ private struct ConversationView: View {
                         pendingPrependAnchorId = nil
                         pendingAppendAnchorId = nil
                         isPinnedToBottom = true
+                        // The fresh ScrollView starts idle without emitting a phase transition, so
+                        // clear the gate here or the new transcript stays non-interactive until a scroll.
+                        isActivelyScrolling = false
                         hoverSelectionCoordinator.reset()
                     }
                     .onChange(of: messageIDs.last) { _, newMessageId in

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2179,6 +2179,12 @@ struct whitenoise_macTests {
     }
 
     @Test func messageMediaDiskCacheReadDeletionMaintainsTrackedFootprint() async throws {
+        // Since #444 isolates entries by (ciphertext, plaintext) hash, the read path no longer
+        // deletes a colliding stale entry — but it still deletes an entry whose sealed metadata
+        // cannot be opened, and must invalidate the tracked footprint when it does. Otherwise
+        // the next store sees an inflated count, runs a full eviction scan, and that scan sweeps
+        // an untouched corrupt sentinel early. The sentinel surviving proves the read deletion
+        // kept the footprint honest (no spurious scan).
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
@@ -2190,68 +2196,54 @@ struct whitenoise_macTests {
             evictionPolicy: .init(maxEntryCount: 2, maxTotalBytes: UInt64.max),
             timestampProvider: { TimeInterval(cachedAtCounter.increment()) }
         )
-        let stalePlaintext = Data("stale media for replaced reference".utf8)
-        let corruptPlaintext = Data("corrupt metadata entry that should not be swept early".utf8)
-        let replacementPlaintext = Data("replacement media after read-path deletion".utf8)
-        let staleReference = mediaDiskCacheReference(plaintext: stalePlaintext, ciphertextByte: 0xa1)
-        let invalidatingReference = mediaDiskCacheReference(
-            plaintext: Data("different plaintext digest for the same ciphertext".utf8),
-            ciphertextByte: 0xa1
-        )
-        let corruptReference = mediaDiskCacheReference(plaintext: corruptPlaintext, ciphertextByte: 0xa2)
-        let replacementReference = mediaDiskCacheReference(plaintext: replacementPlaintext, ciphertextByte: 0xa3)
-        let staleKey = MessageMediaDiskCacheKey(
+        let victimPlaintext = Data("entry whose metadata is corrupted before read".utf8)
+        let sentinelPlaintext = Data("corrupt sentinel that only a full scan would sweep".utf8)
+        let replacementPlaintext = Data("replacement media stored after the read deletion".utf8)
+        let victimKey = MessageMediaDiskCacheKey(
             accountId: "account-a",
             groupIdHex: "group-a",
-            reference: staleReference
+            reference: mediaDiskCacheReference(plaintext: victimPlaintext, ciphertextByte: 0xa1)
         )
-        let invalidatingKey = MessageMediaDiskCacheKey(
+        let sentinelKey = MessageMediaDiskCacheKey(
             accountId: "account-a",
             groupIdHex: "group-a",
-            reference: invalidatingReference
-        )
-        let corruptKey = MessageMediaDiskCacheKey(
-            accountId: "account-a",
-            groupIdHex: "group-a",
-            reference: corruptReference
+            reference: mediaDiskCacheReference(plaintext: sentinelPlaintext, ciphertextByte: 0xa2)
         )
         let replacementKey = MessageMediaDiskCacheKey(
             accountId: "account-a",
             groupIdHex: "group-a",
-            reference: replacementReference
+            reference: mediaDiskCacheReference(plaintext: replacementPlaintext, ciphertextByte: 0xa3)
         )
-
-        #expect(staleKey.cacheID == invalidatingKey.cacheID)
-        #expect(staleKey.plaintextSha256 != invalidatingKey.plaintextSha256)
 
         await cache.store(
             MessageMediaDownload(
-                data: stalePlaintext,
-                fileName: "stale.jpg",
+                data: victimPlaintext,
+                fileName: "victim.jpg",
                 mediaType: "image/jpeg",
-                sizeBytes: UInt64(stalePlaintext.count),
-                payloadId: "stale"
+                sizeBytes: UInt64(victimPlaintext.count),
+                payloadId: "victim"
             ),
-            for: staleKey
+            for: victimKey
         )
         await cache.store(
             MessageMediaDownload(
-                data: corruptPlaintext,
-                fileName: "corrupt.jpg",
+                data: sentinelPlaintext,
+                fileName: "sentinel.jpg",
                 mediaType: "image/jpeg",
-                sizeBytes: UInt64(corruptPlaintext.count),
-                payloadId: "corrupt"
+                sizeBytes: UInt64(sentinelPlaintext.count),
+                payloadId: "sentinel"
             ),
-            for: corruptKey
+            for: sentinelKey
         )
-        let staleEntryDirectory = try #require(cache.entryDirectory(for: staleKey))
-        let corruptEntryDirectory = try #require(cache.entryDirectory(for: corruptKey))
-        // The corrupt unread entry is a sentinel for an unintended full cacheScan: a stale,
-        // inflated trackedFootprint would force a scan on the next store and remove it early.
-        try Data("not sealed metadata".utf8).write(to: corruptEntryDirectory.appendingPathComponent("metadata.bin"))
+        let victimEntryDirectory = try #require(cache.entryDirectory(for: victimKey))
+        let sentinelEntryDirectory = try #require(cache.entryDirectory(for: sentinelKey))
+        // Corrupt both sealed metadata blobs: reading the victim must delete it (exercising the
+        // read-path deletion), while the sentinel is only ever removed by a full eviction scan.
+        try Data("not sealed metadata".utf8).write(to: victimEntryDirectory.appendingPathComponent("metadata.bin"))
+        try Data("not sealed metadata".utf8).write(to: sentinelEntryDirectory.appendingPathComponent("metadata.bin"))
 
-        #expect(await cache.cachedDownload(for: invalidatingKey) == nil)
-        #expect(!fileManager.fileExists(atPath: staleEntryDirectory.path))
+        #expect(await cache.cachedDownload(for: victimKey) == nil)
+        #expect(!fileManager.fileExists(atPath: victimEntryDirectory.path))
 
         await cache.store(
             MessageMediaDownload(
@@ -2264,7 +2256,7 @@ struct whitenoise_macTests {
             for: replacementKey
         )
 
-        #expect(fileManager.fileExists(atPath: corruptEntryDirectory.path))
+        #expect(fileManager.fileExists(atPath: sentinelEntryDirectory.path))
         #expect(try #require(await cache.cachedDownload(for: replacementKey)).data == replacementPlaintext)
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4017,6 +4017,8 @@ struct whitenoise_macTests {
         // Regression for whitenoise-mac#175: `ChatListMessagePreviewFfi` carries no media
         // payload, so a media-only chat message arrives with empty plaintext. The chat-list
         // preview must fall back to "Attachment" rather than "Unsupported message".
+        // An incoming chat-bubble preview from another member is attributed with the sender
+        // name, so the media fallback reads "Alice: Attachment" — consistent with text previews.
         let directRow = ChatListRowFfi(
             groupIdHex: "direct-group",
             archived: false,
@@ -4047,7 +4049,7 @@ struct whitenoise_macTests {
         )
 
         let directChat = ChatItem(row: directRow, activeAccountIdHex: "self")
-        #expect(directChat.preview == "Attachment")
+        #expect(directChat.preview == "Alice: Attachment")
 
         let groupRow = ChatListRowFfi(
             groupIdHex: "group",
@@ -4079,7 +4081,7 @@ struct whitenoise_macTests {
         )
 
         let groupChat = ChatItem(row: groupRow, activeAccountIdHex: "self")
-        #expect(groupChat.preview == "Attachment")
+        #expect(groupChat.preview == "Alice: Attachment")
     }
 
     @MainActor


### PR DESCRIPTION
Four self-contained low-severity fixes, each in its own commit. All app-side Swift; no engine/binding changes.

- **Transcript non-interactive after a mid-fling chat switch.** `isActivelyScrolling` gates `.allowsHitTesting` on the transcript but was never reset on a chat switch. The fresh inner `ScrollView` starts idle without emitting a phase transition, so a flag left `true` from the previous chat's fling left the new transcript's first tap silently ignored until the next scroll. Reset it in the existing `onChange(of: chat.id)` block alongside its siblings.
- **Media cache footprint under-count on failed purge.** `purgeAll` swallowed a removal failure and then zeroed `trackedFootprint` unconditionally. If entries survived on disk, that false zero was never reconciled (only a `nil` footprint re-seeds from an authoritative scan), so the eviction cap under-enforced indefinitely. Now the footprint is zeroed only when removal actually succeeds and nil'd on failure, matching `purgeAccount`.
- **Media-only group previews were unattributed.** The chat-list preview returned the "Attachment" fallback before the sender-prefix block, so a media-only message from a peer in a group showed a bare "Attachment" with no sender name while a text message from the same peer was attributed. Resolve the body first, then apply the incoming-group sender prefix uniformly to both.
- **Dead branch in `moveChatToArchived`.** The two arms gated on `shouldEnrich` ran byte-identical code. Collapsed to the single unconditional form; behavior-preserving.

Closes #452
Closes #453
Closes #471
Closes #472


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat previews now consistently include the sender’s name, even for attachment-only and unsupported/empty messages.
  * Switching chats no longer leaves scrolling disabled for the newly opened conversation.
  * Moving chats to Archived now preserves enrichment-resolved metadata consistently.
  * Media cache purge now updates tracking correctly based on actual filesystem removal results.
* **Tests**
  * Reworked media-disk-cache deletion regression coverage, including cases where sealed metadata cannot be opened.
  * Updated media fallback chat-list preview assertions to include sender attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->