### PR TITLE
Fix NIP-05 redirect SSRF and archive-transition draft loss

### DIFF
--- a/whitenoise-mac/Core/NIP05Resolver.swift
+++ b/whitenoise-mac/Core/NIP05Resolver.swift
@@ -23,7 +23,13 @@ enum NIP05ResolutionError: Error {
 struct NIP05Resolver: NIP05Resolving {
     private let session: URLSession
 
-    init(session: URLSession = URLSession(configuration: Self.makeSessionConfiguration())) {
+    init(
+        session: URLSession = URLSession(
+            configuration: Self.makeSessionConfiguration(),
+            delegate: NIP05RedirectPolicy(),
+            delegateQueue: nil
+        )
+    ) {
         self.session = session
     }
 
@@ -69,6 +75,27 @@ struct NIP05Resolver: NIP05Resolving {
         configuration.timeoutIntervalForRequest = 10
         configuration.timeoutIntervalForResource = 15
         return configuration
+    }
+}
+
+/// Re-validates each redirect target against the SSRF host policy — URLSession auto-follows
+/// redirects, so without this a public well-known host could 3xx the lookup to a private/
+/// loopback/link-local address the up-front guard blocks. Mirrors the avatar path's
+/// CappedImageDownloadDelegate.
+final class NIP05RedirectPolicy: NSObject, URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard let url = request.url, RemoteImageURLPolicy.isAllowed(url) else {
+            completionHandler(nil)
+            task.cancel()
+            return
+        }
+        completionHandler(request)
     }
 }
 

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -205,16 +205,19 @@ extension WorkspaceState {
 
         let previousActiveChatIds = Set((chatsByAccount[account.id] ?? []).map(\.id))
         let nextActiveChatIds = Set(activeItems.map(\.id))
-        let removedActiveChatIds = previousActiveChatIds.subtracting(nextActiveChatIds)
-
         let previousArchivedChatIds = Set((archivedChatsByAccount[account.id] ?? []).map(\.id))
         let nextArchivedChatIds = Set(archivedItems.map(\.id))
-        let removedArchivedChatIds = previousArchivedChatIds.subtracting(nextArchivedChatIds)
 
-        for groupId in removedActiveChatIds.union(removedArchivedChatIds) {
+        // A chat that merely moves active↔archived is missing from one "next" list but present in
+        // the other, so per-list subtraction would wrongly flag it as removed. Only chats gone from
+        // both lists are truly removed — clearing drafts for a moved chat drops its composer draft.
+        let removedChatIds = previousActiveChatIds.union(previousArchivedChatIds)
+            .subtracting(nextActiveChatIds.union(nextArchivedChatIds))
+
+        for groupId in removedChatIds {
             invalidateGroupMembers(for: groupId)
         }
-        clearComposerDrafts(for: Array(removedActiveChatIds.union(removedArchivedChatIds)), accountId: account.id)
+        clearComposerDrafts(for: Array(removedChatIds), accountId: account.id)
         setChats(sortedChatItems(activeItems), forAccountId: account.id)
         setArchivedChats(sortedChatItems(archivedItems), forAccountId: account.id)
         dismissGroupImagePickerIfSelectedChatUnavailable()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13128,6 +13128,64 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func archivingChatPreservesComposerDraftAcrossSnapshotReload() async throws {
+        // #466: a chat moved active→archived through the full-snapshot reload (`applyChatRows`)
+        // must not be treated as removed — its per-conversation composer draft has to survive.
+        let state = WorkspaceState.preview()
+        let account = AccountItem.samples[0]
+        let chatId = "draft-survives-archive"
+        let sender = "alice1234567890alice1234567890alice1234567890alice1234567890"
+
+        await state.applyChatRows(
+            [chatListRow(groupIdHex: chatId, title: "Planning", preview: "hi", sender: sender, timelineAt: 1)],
+            account: account
+        )
+        let activeChat = try #require(state.chatsByAccount[account.id]?.first { $0.id == chatId })
+        state.selectChat(activeChat)
+        state.draftText = "see you at 6"
+        let draftKey = WorkspaceState.ComposerDraftKey(accountId: account.id, chatId: chatId)
+        #expect(state.draftTextByConversation[draftKey] == "see you at 6")
+
+        // Same chat, now archived, via a fresh snapshot.
+        await state.applyChatRows(
+            [
+                ChatListRowFfi(
+                    groupIdHex: chatId,
+                    archived: true,
+                    pendingConfirmation: false,
+                    title: "Planning",
+                    groupName: "",
+                    avatarUrl: nil,
+                    avatar: nil,
+                    lastMessage: ChatListMessagePreviewFfi(
+                        messageIdHex: "preview",
+                        sender: sender,
+                        senderDisplayName: nil,
+                        plaintext: "hi",
+                        contentTokens: emptyMarkdownDocument(),
+                        kind: 9,
+                        timelineAt: 1,
+                        deleted: false
+                    ),
+                    unreadCount: 0,
+                    hasUnread: false,
+                    unreadMentionCount: 0,
+                    unreadMention: false,
+                    firstUnreadMessageIdHex: nil,
+                    lastReadMessageIdHex: nil,
+                    lastReadTimelineAt: nil,
+                    updatedAt: 1,
+                    selfMembership: .member
+                )
+            ],
+            account: account
+        )
+
+        #expect(state.archivedChatsByAccount[account.id]?.contains { $0.id == chatId } == true)
+        #expect(state.draftTextByConversation[draftKey] == "see you at 6")
+    }
+
+    @MainActor
     @Test func startingNewChatCreatesAndSelectsConversation() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13265,6 +13265,39 @@ struct whitenoise_macTests {
         #expect(state.resolvedNewChatRecipient?.pictureURL == "https://example.com/avatar.png")
     }
 
+    @Test func nip05RedirectPolicyRevalidatesRedirectTargets() throws {
+        // #448: the resolver's session must re-check every redirect hop against the SSRF host
+        // policy, so a public well-known host cannot 3xx the lookup to a private/loopback/
+        // non-https target.
+        let policy = NIP05RedirectPolicy()
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        let task = session.dataTask(with: URL(string: "https://example.com/.well-known/nostr.json")!)
+        let redirectResponse = HTTPURLResponse(
+            url: URL(string: "https://example.com")!, statusCode: 302, httpVersion: nil, headerFields: nil
+        )!
+
+        func followedRequest(to target: String) -> URLRequest? {
+            var decided: URLRequest?
+            policy.urlSession(
+                session,
+                task: task,
+                willPerformHTTPRedirection: redirectResponse,
+                newRequest: URLRequest(url: URL(string: target)!)
+            ) { decided = $0 }
+            return decided
+        }
+
+        // Blocked: loopback, link-local, private, IPv6 loopback, and scheme downgrade.
+        #expect(followedRequest(to: "https://127.0.0.1:8080/x") == nil)
+        #expect(followedRequest(to: "https://169.254.169.254/x") == nil)
+        #expect(followedRequest(to: "https://10.0.0.5/x") == nil)
+        #expect(followedRequest(to: "https://[::1]/x") == nil)
+        #expect(followedRequest(to: "http://example.com/x") == nil)
+        // Allowed: a public https target is followed unchanged.
+        #expect(followedRequest(to: "https://relay.example.com/x")?.url?.absoluteString == "https://relay.example.com/x")
+    }
+
     @MainActor
     @Test func resolvingNewChatRecipientUsesNIP05() async throws {
         let account = desktopAccount()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13353,7 +13353,8 @@ struct whitenoise_macTests {
         #expect(followedRequest(to: "https://[::1]/x") == nil)
         #expect(followedRequest(to: "http://example.com/x") == nil)
         // Allowed: a public https target is followed unchanged.
-        #expect(followedRequest(to: "https://relay.example.com/x")?.url?.absoluteString == "https://relay.example.com/x")
+        let allowed = followedRequest(to: "https://relay.example.com/x")
+        #expect(allowed?.url?.absoluteString == "https://relay.example.com/x")
     }
 
     @MainActor


### PR DESCRIPTION
Two self-contained fixes, each with a unit test — no on-device verification needed.

- **NIP-05 resolver redirect SSRF (#448).** `NIP05Resolver` validated only the initial `.well-known/nostr.json` URL against the SSRF host policy; its `URLSession` had no redirect delegate, so a `3xx` from the well-known host was auto-followed to any host — including loopback/private/link-local addresses the up-front guard blocks — turning a contact lookup into a blind internal probe. Added `NIP05RedirectPolicy` (a `URLSessionTaskDelegate`) that re-runs `RemoteImageURLPolicy.isAllowed` on every redirect target and cancels the task on a disallowed one, mirroring the avatar path's `CappedImageDownloadDelegate`. Test drives the delegate directly: loopback, link-local, private, IPv6-loopback, and scheme-downgrade targets are blocked; a public `https` target is followed unchanged.
- **Archive transition drops composer drafts (#466).** `applyChatRows` computed "removed" chats as the union of per-list removals, so a chat that merely moved active↔archived (absent from one "next" list, present in the other) was wrongly treated as removed and had its composer draft cleared and group-member cache invalidated. Now the removed set is `(previousActive ∪ previousArchived) − (nextActive ∪ nextArchived)`, so only truly-gone chats are cleared. Test archives a chat holding a draft through the snapshot reload and asserts the draft survives.

Closes #448
Closes #466

---
CI note: this branch is cut from `master`, which is currently red on two pre-existing tests unrelated to this change — `messageMediaDiskCacheReadDeletionMaintainsTrackedFootprint` (an obsolete assertion from the #444 plaintext-hash isolation change, fixed separately) and the flaky `workspaceCoalescesAndCachesSourceEpochZeroMediaReferenceResolution`. Both fail on `master` itself; the two new tests here pass and this change adds no new failures.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when following redirects during NIP-05 lookups by blocking unsafe destinations and insecure scheme downgrades.
  * Preserved conversation drafts when chats move between active and archived views.
  * Prevented chats from being incorrectly treated as removed during active/archive transitions.

* **Tests**
  * Added coverage for secure redirect handling and draft preservation across chat state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->