### PR TITLE
fix: tear down offscreen video playback

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1094,9 +1094,7 @@ struct MessageVideoAttachmentPlayer: View {
         .contentShape(Rectangle())
         .onTapGesture {
             if isPreparingPlayback {
-                playbackTask?.cancel()
-                playbackTask = nil
-                stopPlayback()
+                tearDownPlayback()
             } else {
                 playbackTask?.cancel()
                 playbackTask = Task { await togglePlayback() }
@@ -1107,14 +1105,10 @@ struct MessageVideoAttachmentPlayer: View {
         // its decrypted playback scratch file as soon as the tile is no longer visible.
         .onScrollVisibilityChange(threshold: 0.01) { isVisible in
             guard !isVisible else { return }
-            playbackTask?.cancel()
-            playbackTask = nil
-            stopPlayback()
+            tearDownPlayback()
         }
         .onDisappear {
-            playbackTask?.cancel()
-            playbackTask = nil
-            stopPlayback()
+            tearDownPlayback()
         }
         // If this view's identity outlives a change of the attachment it renders (e.g. a
         // media grid slot flips to a different attachment, or the download's decrypted
@@ -1129,11 +1123,15 @@ struct MessageVideoAttachmentPlayer: View {
         .accessibilityLabel("Video attachment")
     }
 
-    private func resetForAttachmentChange() {
+    private func tearDownPlayback() {
         playbackTask?.cancel()
         playbackTask = nil
-        didFail = false
         stopPlayback()
+    }
+
+    private func resetForAttachmentChange() {
+        didFail = false
+        tearDownPlayback()
     }
 
     @MainActor

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1102,6 +1102,15 @@ struct MessageVideoAttachmentPlayer: View {
                 playbackTask = Task { await togglePlayback() }
             }
         }
+        // Transcript rows are intentionally eager, so scrolling this tile out of the viewport
+        // does not trigger onDisappear. Tear down here as well to release the player and delete
+        // its decrypted playback scratch file as soon as the tile is no longer visible.
+        .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+            guard !isVisible else { return }
+            playbackTask?.cancel()
+            playbackTask = nil
+            stopPlayback()
+        }
         .onDisappear {
             playbackTask?.cancel()
             playbackTask = nil

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6090,6 +6090,36 @@ struct whitenoise_macTests {
         #expect(modifierSource.contains("automaticDownloadTask?.cancel()"))
     }
 
+    @Test func videoPlayerReclaimsScratchFileWhenTileLeavesViewport() throws {
+        // MessageVideoAttachmentPlayer lives inside the deliberately eager transcript VStack,
+        // where scrolling a row away does not trigger onDisappear. Its scroll-visibility hook
+        // must cancel any in-flight materialization and run the same teardown that removes the
+        // decrypted playback scratch file.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+        let playerStart = try #require(source.range(of: "struct MessageVideoAttachmentPlayer: View {"))
+        let rest = source[playerStart.upperBound...]
+        let playerEnd = try #require(rest.range(of: "\nenum MessageMediaPlaybackFileStore {")?.lowerBound)
+        let playerSource = String(source[playerStart.lowerBound..<playerEnd])
+
+        let offscreenTeardown = [
+            "guard !isVisible else { return }",
+            "            playbackTask?.cancel()",
+            "            playbackTask = nil",
+            "            stopPlayback()",
+        ].joined(separator: "\n")
+
+        #expect(playerSource.contains(".onScrollVisibilityChange(threshold: 0.01) { isVisible in"))
+        #expect(playerSource.contains(offscreenTeardown))
+        #expect(playerSource.contains("MessageMediaPlaybackFileStore.remove(at: url)"))
+    }
+
     @MainActor
     @Test func loadMediaAttachmentRetriesFromFailedState() async throws {
         let account = AccountSummaryFfi(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6108,16 +6108,19 @@ struct whitenoise_macTests {
         let playerEnd = try #require(rest.range(of: "\nenum MessageMediaPlaybackFileStore {")?.lowerBound)
         let playerSource = String(source[playerStart.lowerBound..<playerEnd])
 
-        let offscreenTeardown = [
-            "guard !isVisible else { return }",
-            "            playbackTask?.cancel()",
-            "            playbackTask = nil",
-            "            stopPlayback()",
-        ].joined(separator: "\n")
+        let normalizedSource = playerSource.components(separatedBy: .whitespacesAndNewlines).joined()
 
-        #expect(playerSource.contains(".onScrollVisibilityChange(threshold: 0.01) { isVisible in"))
-        #expect(playerSource.contains(offscreenTeardown))
-        #expect(playerSource.contains("MessageMediaPlaybackFileStore.remove(at: url)"))
+        #expect(
+            normalizedSource.contains(
+                ".onScrollVisibilityChange(threshold:0.01){isVisibleinguard!isVisibleelse{return}tearDownPlayback()}"
+            )
+        )
+        #expect(
+            normalizedSource.contains(
+                "privatefunctearDownPlayback(){playbackTask?.cancel()playbackTask=nilstopPlayback()}"
+            )
+        )
+        #expect(normalizedSource.contains("MessageMediaPlaybackFileStore.remove(at:url)"))
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- tear down video playback as soon as its eager transcript tile leaves the scroll viewport
- cancel in-flight scratch-file preparation and delete any materialized decrypted plaintext
- add a regression contract for visibility-driven playback teardown

## Test plan
- [x] Regression contract mirrored against source (red before fix, green after fix)
- [x] git diff --check
- [ ] macOS unit/build CI (xcodebuild unavailable on this Linux worker)

Fixes #532

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/536">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video attachment cleanup when media tiles leave the visible area.
  * Playback now stops promptly, cancels pending loading, and removes temporary decrypted files, helping reduce resource usage.

* **Tests**
  * Added coverage to verify that offscreen video tiles release playback resources and temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->