### PR TITLE
fix: format collection counts as 64-bit values

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -6,8 +6,16 @@ import MarmotKit
 import UniformTypeIdentifiers
 
 nonisolated enum CollectionCountFormat {
-    static func localizedLabel(template: String, count: Int) -> String {
-        String(format: L10n.string(template), CUnsignedLongLong(UInt64(count)))
+    static func memberLabel(count: Int) -> String {
+        localizedLabel(template: "%lld members", count: count)
+    }
+
+    static func attachmentLabel(count: Int) -> String {
+        localizedLabel(template: "%lld attachments", count: count)
+    }
+
+    private static func localizedLabel(template: String, count: Int) -> String {
+        String(format: L10n.string(template), CLongLong(count))
     }
 }
 
@@ -240,7 +248,7 @@ struct GroupDetailsSnapshot: Hashable {
     let disappearingMessageSecs: UInt64
 
     var memberCountLabel: String {
-        CollectionCountFormat.localizedLabel(template: "%llu members", count: members.count)
+        CollectionCountFormat.memberLabel(count: members.count)
     }
 
     var disappearingMessagesEnabled: Bool { disappearingMessageSecs > 0 }
@@ -340,7 +348,7 @@ nonisolated struct MessageMediaAttachment: Identifiable, Hashable {
         if attachments.count == 1 {
             return first.previewLabel
         }
-        return CollectionCountFormat.localizedLabel(template: "%llu attachments", count: attachments.count)
+        return CollectionCountFormat.attachmentLabel(count: attachments.count)
     }
 }
 

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -5,6 +5,12 @@ import ImageIO
 import MarmotKit
 import UniformTypeIdentifiers
 
+nonisolated enum CollectionCountFormat {
+    static func localizedLabel(template: String, count: Int) -> String {
+        String(format: L10n.string(template), CUnsignedLongLong(UInt64(count)))
+    }
+}
+
 struct AccountItem: Identifiable, Hashable {
     let id: String
     let accountRef: String
@@ -234,7 +240,7 @@ struct GroupDetailsSnapshot: Hashable {
     let disappearingMessageSecs: UInt64
 
     var memberCountLabel: String {
-        String(format: L10n.string("%d members"), members.count)
+        CollectionCountFormat.localizedLabel(template: "%llu members", count: members.count)
     }
 
     var disappearingMessagesEnabled: Bool { disappearingMessageSecs > 0 }
@@ -334,7 +340,7 @@ nonisolated struct MessageMediaAttachment: Identifiable, Hashable {
         if attachments.count == 1 {
             return first.previewLabel
         }
-        return String(format: L10n.string("%d attachments"), attachments.count)
+        return CollectionCountFormat.localizedLabel(template: "%llu attachments", count: attachments.count)
     }
 }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -33,6 +33,23 @@ struct PureValueTests {
         #expect(DisappearingMessageOption.custom(oversizedSeconds).label == "9223372036854775808 seconds")
     }
 
+    @Test func collectionCountLabelFormatsLargeIntCountsWithoutTruncation() async throws {
+        // Regression for whitenoise-mac#533: Swift `Int` collection counts are
+        // 64-bit on macOS, but `%d` consumes a 32-bit CInt and can misprint large
+        // values. The shared formatter must use `%llu` with an explicit-width arg.
+        let above32Bit = Int(Int32.max) + 1
+
+        #expect(
+            CollectionCountFormat.localizedLabel(template: "%llu members", count: above32Bit)
+                == "2147483648 members"
+        )
+        #expect(
+            CollectionCountFormat.localizedLabel(template: "%llu attachments", count: above32Bit)
+                == "2147483648 attachments"
+        )
+        #expect(CollectionCountFormat.localizedLabel(template: "%llu members", count: 3) == "3 members")
+    }
+
     @Test func composerAudioWaveformUsesPrecomputedFallbackBars() async throws {
         // Regression for whitenoise-mac#292: fallback waveform samples/bars are used
         // while metadata loads, including during playback-progress repaint ticks. Keep

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -36,18 +36,12 @@ struct PureValueTests {
     @Test func collectionCountLabelFormatsLargeIntCountsWithoutTruncation() async throws {
         // Regression for whitenoise-mac#533: Swift `Int` collection counts are
         // 64-bit on macOS, but `%d` consumes a 32-bit CInt and can misprint large
-        // values. The shared formatter must use `%llu` with an explicit-width arg.
+        // values. The production formatters must use `%lld` with an explicit-width arg.
         let above32Bit = Int(Int32.max) + 1
 
-        #expect(
-            CollectionCountFormat.localizedLabel(template: "%llu members", count: above32Bit)
-                == "2147483648 members"
-        )
-        #expect(
-            CollectionCountFormat.localizedLabel(template: "%llu attachments", count: above32Bit)
-                == "2147483648 attachments"
-        )
-        #expect(CollectionCountFormat.localizedLabel(template: "%llu members", count: 3) == "3 members")
+        #expect(CollectionCountFormat.memberLabel(count: above32Bit) == "2147483648 members")
+        #expect(CollectionCountFormat.attachmentLabel(count: above32Bit) == "2147483648 attachments")
+        #expect(CollectionCountFormat.memberLabel(count: 3) == "3 members")
     }
 
     @Test func composerAudioWaveformUsesPrecomputedFallbackBars() async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3049,6 +3049,16 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func localizedMemberCountUsesSelectedAppLanguage() async throws {
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
+
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
+        #expect(CollectionCountFormat.memberLabel(count: 3) == "Miembros de 3")
+    }
+
+    @MainActor
     @Test func localizedStringBundleCacheInvalidatesOnLanguageChange() async throws {
         // Regression for the residual half of #28 (#117): `L10n.string` caches the
         // resolved `.lproj` bundle to avoid a per-call filesystem stat + `Bundle`


### PR DESCRIPTION
Fixes #533

## Summary
- format member and attachment collection counts through fixed semantic APIs using `%lld` and an explicit `CLongLong` argument
- preserve the existing translated `%lld members` catalog key instead of introducing an untranslated key
- cover values above `Int32.max` through the production formatter APIs and assert the selected Spanish localization path

## Verification
- `git diff --check`
- targeted source/catalog assertions confirm the unsafe `%d`/`%llu` call sites are gone, both production paths use the semantic 64-bit formatters, and the existing nine member-count translations remain intact
- `Localizable.xcstrings` parses as valid JSON
- Xcode/Swift checks not run locally: this worker is on Linux without `xcodebuild`, `swift`, or `swift-format`; Mac CI runs the repository gates

## Sensitive paths
None.