### PR TITLE
fix: close IPv6 SSRF embedding gaps

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -119,8 +119,8 @@ nonisolated enum RemoteImageURLPolicy {
     }
 
     /// Rejects IPv6 literals in non-public ranges: unspecified `::`, loopback `::1`,
-    /// ULA `fc00::/7`, link-local `fe80::/10`, and IPv4-mapped `::ffff:0:0/96` /
-    /// IPv4-compatible addresses whose embedded IPv4 is itself private.
+    /// ULA `fc00::/7`, link-local `fe80::/10`, multicast `ff00::/8`, and well-known
+    /// IPv4-embedding prefixes whose embedded IPv4 is itself private.
     private static func isPrivateIPv6(_ groups: [UInt16]) -> Bool {
         guard groups.count == 8 else { return true }  // be conservative on anything unparseable
 
@@ -134,13 +134,19 @@ nonisolated enum RemoteImageURLPolicy {
         if (first & 0xFE00) == 0xFC00 { return true }
         // Link-local fe80::/10 — top 10 bits == 1111111010.
         if (first & 0xFFC0) == 0xFE80 { return true }
+        // Multicast ff00::/8.
+        if (first & 0xFF00) == 0xFF00 { return true }
 
-        // IPv4-mapped `::ffff:a.b.c.d` (and IPv4-compatible `::a.b.c.d`): re-check the
-        // embedded IPv4 against the private ranges so `[::ffff:192.168.0.1]` is rejected too.
-        if groups[0...4].allSatisfy({ $0 == 0 }), groups[5] == 0xFFFF {
-            return isPrivateIPv4(embeddedIPv4(groups))
-        }
-        if groups[0...5].allSatisfy({ $0 == 0 }), groups[6] != 0 || groups[7] != 0 {
+        let isIPv4Mapped = groups[0...4].allSatisfy({ $0 == 0 }) && groups[5] == 0xFFFF
+        let isIPv4Compatible = groups[0...5].allSatisfy({ $0 == 0 })
+        let isIPv4Translated =
+            groups[0...3].allSatisfy({ $0 == 0 }) && groups[4] == 0xFFFF && groups[5] == 0
+        let isWellKnownNAT64 =
+            groups[0] == 0x0064 && groups[1] == 0xFF9B && groups[2...5].allSatisfy({ $0 == 0 })
+
+        // Re-check the low 32 bits for standardized IPv4 embeddings. Public embedded addresses
+        // remain allowed, while private/loopback/link-local/reserved IPv4 destinations are blocked.
+        if isIPv4Mapped || isIPv4Compatible || isIPv4Translated || isWellKnownNAT64 {
             return isPrivateIPv4(embeddedIPv4(groups))
         }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -12483,15 +12483,19 @@ struct whitenoise_macTests {
             #expect(!RemoteImageURLPolicy.isAllowed(URL(string: s)!), "expected SSRF rejection for \(s)")
         }
 
-        // IPv6 loopback / unspecified / ULA / link-local / IPv4-mapped private.
+        // IPv6 loopback / unspecified / ULA / link-local / multicast / embedded-private IPv4.
         let blockedV6 = [
             "https://[::1]/x.png",
             "https://[::]/x.png",
             "https://[fc00::1]/x.png",
             "https://[fd12:3456::1]/x.png",
             "https://[fe80::1]/x.png",
-            "https://[::ffff:192.168.0.1]/x.png",
+            "https://[ff00::1]/x.png",  // multicast ff00::/8 (low edge)
+            "https://[ffff::1]/x.png",  // multicast ff00::/8 (high edge)
+            "https://[::ffff:192.168.0.1]/x.png",  // IPv4-mapped
             "https://[::ffff:127.0.0.1]/x.png",
+            "https://[::ffff:0:192.168.0.1]/x.png",  // IPv4-translated ::ffff:0:0:0/96
+            "https://[64:ff9b::192.168.0.1]/x.png",  // NAT64 well-known prefix
         ]
         for s in blockedV6 {
             #expect(!RemoteImageURLPolicy.isAllowed(URL(string: s)!), "expected SSRF rejection for \(s)")
@@ -12517,6 +12521,8 @@ struct whitenoise_macTests {
             "https://223.255.255.255/x.png",  // just below multicast 224.0.0.0/4
             "https://[2606:4700:4700::1111]/x.png",  // public IPv6 (Cloudflare)
             "https://[::ffff:8.8.8.8]/x.png",  // IPv4-mapped public address
+            "https://[::ffff:0:8.8.8.8]/x.png",  // IPv4-translated public address
+            "https://[64:ff9b::8.8.8.8]/x.png",  // NAT64 embedding of public address
         ]
         for s in allowed {
             #expect(RemoteImageURLPolicy.isAllowed(URL(string: s)!), "expected allow for \(s)")


### PR DESCRIPTION
## Summary
- reject IPv6 multicast literals in `ff00::/8`
- re-check private IPv4 destinations embedded through IPv4-translated and well-known NAT64 prefixes
- preserve public embedded IPv4 destinations and add regression coverage for both outcomes

## Test plan
- [x] `git diff --check`
- [x] exact behavioral model reproduces all 4 old-policy bypasses and passes 10/10 updated expectations
- [x] macOS PR CI (green on retry; first attempt hit an unrelated flaky media-cache test)

Fixes #530

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
