### PR TITLE
fix: ignore stale timeline pagination windows

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -204,7 +204,11 @@ extension WorkspaceState {
             let page = try await TimelineSignpost.pagination.asyncInterval("paginateBackwards") {
                 try await subscription.paginateBackwards(count: Self.timelinePageLimit)
             }
-            guard activeAccountId == activeAccount.id, selectedChat?.id == groupIdHex else { return }
+            guard activeAccountId == activeAccount.id,
+                selectedChat?.id == groupIdHex,
+                activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === subscription
+            else { return }
             await applyTimelineWindow(page, groupIdHex: groupIdHex, account: activeAccount, client: client)
         } catch {
             lastError = error.localizedDescription
@@ -233,7 +237,11 @@ extension WorkspaceState {
             let page = try await TimelineSignpost.pagination.asyncInterval("paginateForwards") {
                 try await subscription.paginateForwards(count: Self.timelinePageLimit)
             }
-            guard activeAccountId == activeAccount.id, selectedChat?.id == groupIdHex else { return }
+            guard activeAccountId == activeAccount.id,
+                selectedChat?.id == groupIdHex,
+                activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === subscription
+            else { return }
             await applyTimelineWindow(page, groupIdHex: groupIdHex, account: activeAccount, client: client)
         } catch {
             lastError = error.localizedDescription

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -209,8 +209,19 @@ extension WorkspaceState {
                 activeTimelineGroupId == groupIdHex,
                 activeTimelineSubscription === subscription
             else { return }
-            await applyTimelineWindow(page, groupIdHex: groupIdHex, account: activeAccount, client: client)
+            await applyTimelineWindow(
+                page,
+                groupIdHex: groupIdHex,
+                account: activeAccount,
+                client: client,
+                expectedTimelineSubscription: subscription
+            )
         } catch {
+            guard activeAccountId == activeAccount.id,
+                selectedChat?.id == groupIdHex,
+                activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === subscription
+            else { return }
             lastError = error.localizedDescription
         }
     }
@@ -242,8 +253,19 @@ extension WorkspaceState {
                 activeTimelineGroupId == groupIdHex,
                 activeTimelineSubscription === subscription
             else { return }
-            await applyTimelineWindow(page, groupIdHex: groupIdHex, account: activeAccount, client: client)
+            await applyTimelineWindow(
+                page,
+                groupIdHex: groupIdHex,
+                account: activeAccount,
+                client: client,
+                expectedTimelineSubscription: subscription
+            )
         } catch {
+            guard activeAccountId == activeAccount.id,
+                selectedChat?.id == groupIdHex,
+                activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === subscription
+            else { return }
             lastError = error.localizedDescription
         }
     }
@@ -255,9 +277,14 @@ extension WorkspaceState {
         _ page: TimelinePageFfi,
         groupIdHex: String,
         account: AccountItem,
-        client: any MarmotRuntime
+        client: any MarmotRuntime,
+        expectedTimelineSubscription: TimelineMessagesSubscription? = nil
     ) async {
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard canApplyTimelineWindow(
+            groupIdHex: groupIdHex,
+            accountId: account.id,
+            expectedTimelineSubscription: expectedTimelineSubscription
+        ) else { return }
         let senderProfiles = await TimelineSignpost.mapping.asyncInterval(
             "resolveSenders.window", count: page.messages.count
         ) {
@@ -268,7 +295,20 @@ extension WorkspaceState {
                 client: client
             )
         }
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard canApplyTimelineWindow(
+            groupIdHex: groupIdHex,
+            accountId: account.id,
+            expectedTimelineSubscription: expectedTimelineSubscription
+        ) else { return }
+
+        #if DEBUG
+            await passTimelineApplyMapGateIfArmed()
+            guard canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                expectedTimelineSubscription: expectedTimelineSubscription
+            ) else { return }
+        #endif
 
         // Maps every record in the window and builds each bubble's Markdown display model
         // (attributed strings + block ids) eagerly — historically the dominant scroll-back
@@ -286,7 +326,11 @@ extension WorkspaceState {
                 senderProfiles: senderProfiles
             )
         }
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard canApplyTimelineWindow(
+            groupIdHex: groupIdHex,
+            accountId: account.id,
+            expectedTimelineSubscription: expectedTimelineSubscription
+        ) else { return }
 
         let editMutations = MessageEditOverlay.mutations(from: page.messages)
         let currentPaging = timelinePagingByChat[groupIdHex]
@@ -304,6 +348,20 @@ extension WorkspaceState {
             )
         }
         await markLatestVisibleMessageRead(groupIdHex: groupIdHex, account: account, client: client)
+    }
+
+    private func canApplyTimelineWindow(
+        groupIdHex: String,
+        accountId: String,
+        expectedTimelineSubscription: TimelineMessagesSubscription?
+    ) -> Bool {
+        guard activeAccountId == accountId, selectedChat?.id == groupIdHex else { return false }
+        if let expectedTimelineSubscription {
+            guard activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === expectedTimelineSubscription
+            else { return false }
+        }
+        return true
     }
 
     /// Route a live timeline subscription update to the right apply path.

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -280,11 +280,13 @@ extension WorkspaceState {
         client: any MarmotRuntime,
         expectedTimelineSubscription: TimelineMessagesSubscription? = nil
     ) async {
-        guard canApplyTimelineWindow(
-            groupIdHex: groupIdHex,
-            accountId: account.id,
-            expectedTimelineSubscription: expectedTimelineSubscription
-        ) else { return }
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                expectedTimelineSubscription: expectedTimelineSubscription
+            )
+        else { return }
         let senderProfiles = await TimelineSignpost.mapping.asyncInterval(
             "resolveSenders.window", count: page.messages.count
         ) {
@@ -295,19 +297,23 @@ extension WorkspaceState {
                 client: client
             )
         }
-        guard canApplyTimelineWindow(
-            groupIdHex: groupIdHex,
-            accountId: account.id,
-            expectedTimelineSubscription: expectedTimelineSubscription
-        ) else { return }
-
-        #if DEBUG
-            await passTimelineApplyMapGateIfArmed()
-            guard canApplyTimelineWindow(
+        guard
+            canApplyTimelineWindow(
                 groupIdHex: groupIdHex,
                 accountId: account.id,
                 expectedTimelineSubscription: expectedTimelineSubscription
-            ) else { return }
+            )
+        else { return }
+
+        #if DEBUG
+            await passTimelineApplyMapGateIfArmed()
+            guard
+                canApplyTimelineWindow(
+                    groupIdHex: groupIdHex,
+                    accountId: account.id,
+                    expectedTimelineSubscription: expectedTimelineSubscription
+                )
+            else { return }
         #endif
 
         // Maps every record in the window and builds each bubble's Markdown display model
@@ -326,11 +332,13 @@ extension WorkspaceState {
                 senderProfiles: senderProfiles
             )
         }
-        guard canApplyTimelineWindow(
-            groupIdHex: groupIdHex,
-            accountId: account.id,
-            expectedTimelineSubscription: expectedTimelineSubscription
-        ) else { return }
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                expectedTimelineSubscription: expectedTimelineSubscription
+            )
+        else { return }
 
         let editMutations = MessageEditOverlay.mutations(from: page.messages)
         let currentPaging = timelinePagingByChat[groupIdHex]

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1059,6 +1059,28 @@ final class WorkspaceState {
                 ownsGroupDetailsLoad(generation: generation)
             )
         }
+
+        /// Issue #529 regression support: when armed, the first `applyTimelineWindow` map pass
+        /// suspends until `releaseTimelineApplyMapGate()` is invoked.
+        var timelineApplyMapGateEnabled = false
+        private(set) var didReachTimelineApplyMapGate = false
+        private var timelineApplyMapGateContinuation: CheckedContinuation<Void, Never>?
+
+        func releaseTimelineApplyMapGate() {
+            timelineApplyMapGateContinuation?.resume()
+            timelineApplyMapGateContinuation = nil
+        }
+
+        func passTimelineApplyMapGateIfArmed() async {
+            guard timelineApplyMapGateEnabled,
+                timelineApplyMapGateContinuation == nil,
+                !didReachTimelineApplyMapGate
+            else { return }
+            didReachTimelineApplyMapGate = true
+            await withCheckedContinuation { continuation in
+                timelineApplyMapGateContinuation = continuation
+            }
+        }
     #endif
 
     /// How long a *complete* peer-profile lookup is trusted before it is re-resolved

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -8530,6 +8530,180 @@ struct whitenoise_macTests {
         #expect(state.messagesByChat["direct-group"]?.first?.id != scrolledBackFirst)
     }
 
+    @MainActor
+    @Test func staleTimelinePaginationApplyDoesNotClobberReplacementSubscriptionWindow() async throws {
+        // Issue #529 follow-up: the subscription identity guard must survive `applyTimelineWindow`
+        // suspension during sender resolution and off-main mapping, not only the paginate await.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "message-005")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+
+        state.timelineApplyMapGateEnabled = true
+        async let staleBack: Void = state.loadOlderMessages(groupIdHex: "direct-group")
+        let didSuspendApply = await waitFor {
+            state.selectedTimelinePaging.isLoadingBefore && state.didReachTimelineApplyMapGate
+        }
+        guard didSuspendApply else {
+            state.timelineApplyMapGateEnabled = false
+            state.releaseTimelineApplyMapGate()
+            _ = await staleBack
+            Issue.record("Expected backwards pagination apply to reach the map gate")
+            return
+        }
+
+        let replacementMessages = (0..<105).map { index in
+            timelineMessage(
+                id: String(format: "fresh-apply-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh apply \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacement = FakeTimelineMessagesSubscription(
+            messages: replacementMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacement
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacement.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-apply-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-apply-104")
+
+        state.releaseTimelineApplyMapGate()
+        _ = await staleBack
+
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-apply-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-apply-104")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+    }
+
+    @MainActor
+    @Test func staleTimelinePaginationErrorDoesNotSurfaceAfterSubscriptionReplacement() async throws {
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        let staleSubscription = try #require(state.activeTimelineSubscription as? FakeTimelineMessagesSubscription)
+        state.lastError = nil
+
+        staleSubscription.paginationGateEnabled = true
+        staleSubscription.throwsAfterPaginationGate = true
+        async let staleBack: Void = state.loadOlderMessages(groupIdHex: "direct-group")
+        let didSuspendBack = await waitFor {
+            state.selectedTimelinePaging.isLoadingBefore && staleSubscription.didReachPaginationGate
+        }
+        guard didSuspendBack else {
+            staleSubscription.paginationGateEnabled = false
+            staleSubscription.throwsAfterPaginationGate = false
+            staleSubscription.releasePaginationGate()
+            _ = await staleBack
+            Issue.record("Expected backwards pagination to reach the test gate")
+            return
+        }
+
+        let replacement = FakeTimelineMessagesSubscription(
+            messages: [
+                timelineMessage(
+                    id: "fresh-error-000",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Fresh error",
+                    recordedAt: baseTime
+                ),
+            ],
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacement
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacement.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+
+        staleSubscription.releasePaginationGate()
+        _ = await staleBack
+
+        #expect(state.lastError == nil)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-error-000")
+    }
+
     @Test func newerTimelinePagingRestoresAnchorInsteadOfScrollingToBottom() {
         let historicalPaging = TimelinePagingState(
             hasMoreBefore: true,
@@ -18443,6 +18617,10 @@ private final class FakeChatListSubscription: ChatListSubscription {
 // `paginateBackwards`/`paginateForwards` and mutated by live `next()` updates. Mirrors the
 // marmot-app windowing contract closely enough for client-level tests; the exact math is
 // unit-tested in Rust.
+private enum FakeTimelinePaginationError: Error {
+    case staleSubscription
+}
+
 private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscription {
     private var fullSet: TimelinePageFfi
     private let limit: Int
@@ -18460,6 +18638,8 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
     var paginationGateEnabled = false
     private(set) var didReachPaginationGate = false
     private var paginationGateContinuation: CheckedContinuation<Void, Never>?
+    /// When set with `paginationGateEnabled`, the paginate call throws after the gate releases.
+    var throwsAfterPaginationGate = false
 
     required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.fullSet = emptyTimelinePage()
@@ -18516,6 +18696,9 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
     override func paginateBackwards(count: UInt32) async throws -> TimelinePageFfi {
         paginateBackwardsCount += 1
         await passPaginationGateIfArmed()
+        if throwsAfterPaginationGate {
+            throw FakeTimelinePaginationError.staleSubscription
+        }
         lo = max(0, lo - Int(count))
         if hi - lo > windowCap { hi = lo + windowCap }
         return windowPage()
@@ -18524,6 +18707,9 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
     override func paginateForwards(count: UInt32) async throws -> TimelinePageFfi {
         paginateForwardsCount += 1
         await passPaginationGateIfArmed()
+        if throwsAfterPaginationGate {
+            throw FakeTimelinePaginationError.staleSubscription
+        }
         hi = min(fullSet.messages.count, hi + Int(count))
         if hi - lo > windowCap { lo = hi - windowCap }
         return windowPage()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -8355,6 +8355,181 @@ struct whitenoise_macTests {
         #expect(runtime.lastTimelineSubscription?.paginateForwardsCount == 1)
     }
 
+    @MainActor
+    @Test func staleTimelinePaginationDoesNotClobberReplacementSubscriptionWindow() async throws {
+        // Issue #529: `loadOlderMessages` / `loadNewerMessages` capture the active subscription,
+        // await pagination, then must re-check subscription identity. A mid-paginate listener
+        // reconnect for the same account/group replaces `activeTimelineSubscription` without
+        // changing selection; the stale page must not overwrite the replacement window.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        let staleSubscription = try #require(state.activeTimelineSubscription as? FakeTimelineMessagesSubscription)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "message-005")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+
+        staleSubscription.paginationGateEnabled = true
+        async let staleBack: Void = state.loadOlderMessages(groupIdHex: "direct-group")
+        let didSuspendBack = await waitFor {
+            state.selectedTimelinePaging.isLoadingBefore && staleSubscription.didReachPaginationGate
+        }
+        guard didSuspendBack else {
+            staleSubscription.paginationGateEnabled = false
+            staleSubscription.releasePaginationGate()
+            _ = await staleBack
+            Issue.record("Expected backwards pagination to reach the test gate")
+            return
+        }
+
+        let replacementBackMessages = (0..<105).map { index in
+            timelineMessage(
+                id: String(format: "fresh-back-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh back \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacementBack = FakeTimelineMessagesSubscription(
+            messages: replacementBackMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacementBack
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacementBack.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-back-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-back-104")
+
+        staleSubscription.releasePaginationGate()
+        _ = await staleBack
+
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-back-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-back-104")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+
+        let replacementFwdMessages = (0..<450).map { index in
+            timelineMessage(
+                id: String(format: "fresh-fwd-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh fwd \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacementFwd = FakeTimelineMessagesSubscription(
+            messages: replacementFwdMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        _ = try await replacementFwd.paginateBackwards(count: 100)
+        _ = try await replacementFwd.paginateBackwards(count: 100)
+        _ = try await replacementFwd.paginateBackwards(count: 100)
+        let scrolledBackWindow = try #require(replacementFwd.snapshot())
+        #expect(scrolledBackWindow.hasMoreAfter)
+
+        state.activeTimelineSubscription = replacementFwd
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            scrolledBackWindow,
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        let scrolledBackFirst = try #require(state.messagesByChat["direct-group"]?.first?.id)
+        #expect(state.selectedTimelinePaging.hasMoreAfter)
+
+        replacementFwd.paginationGateEnabled = true
+        async let staleForward: Void = state.loadNewerMessages(groupIdHex: "direct-group")
+        let didSuspendForward = await waitFor {
+            state.selectedTimelinePaging.isLoadingAfter && replacementFwd.didReachPaginationGate
+        }
+        guard didSuspendForward else {
+            replacementFwd.paginationGateEnabled = false
+            replacementFwd.releasePaginationGate()
+            _ = await staleForward
+            Issue.record("Expected forwards pagination to reach the test gate")
+            return
+        }
+
+        let replacementForwardMessages = (0..<450).map { index in
+            timelineMessage(
+                id: String(format: "fresh-forward-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh forward \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacementForward = FakeTimelineMessagesSubscription(
+            messages: replacementForwardMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        _ = try? await replacementForward.paginateBackwards(count: 100)
+        _ = try? await replacementForward.paginateBackwards(count: 100)
+        let replacementForwardWindow = replacementForward.snapshot() ?? emptyTimelinePage()
+
+        state.activeTimelineSubscription = replacementForward
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacementForwardWindow,
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        let replacementForwardFirst = state.messagesByChat["direct-group"]?.first?.id
+        let replacementForwardLast = state.messagesByChat["direct-group"]?.last?.id
+        #expect(replacementForwardFirst != nil)
+        #expect(replacementForwardLast != nil)
+        #expect(replacementForwardFirst != scrolledBackFirst)
+
+        replacementFwd.releasePaginationGate()
+        _ = await staleForward
+
+        #expect(state.messagesByChat["direct-group"]?.first?.id == replacementForwardFirst)
+        #expect(state.messagesByChat["direct-group"]?.last?.id == replacementForwardLast)
+        #expect(state.messagesByChat["direct-group"]?.first?.id != scrolledBackFirst)
+    }
+
     @Test func newerTimelinePagingRestoresAnchorInsteadOfScrollingToBottom() {
         let historicalPaging = TimelinePagingState(
             hasMoreBefore: true,
@@ -18280,6 +18455,11 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
     private let recordSnapshot: () -> Void
     private(set) var paginateBackwardsCount = 0
     private(set) var paginateForwardsCount = 0
+    /// Issue #529 regression support: when armed, the first `paginateBackwards` or
+    /// `paginateForwards` call suspends until `releasePaginationGate()` is invoked.
+    var paginationGateEnabled = false
+    private(set) var didReachPaginationGate = false
+    private var paginationGateContinuation: CheckedContinuation<Void, Never>?
 
     required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.fullSet = emptyTimelinePage()
@@ -18335,6 +18515,7 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
 
     override func paginateBackwards(count: UInt32) async throws -> TimelinePageFfi {
         paginateBackwardsCount += 1
+        await passPaginationGateIfArmed()
         lo = max(0, lo - Int(count))
         if hi - lo > windowCap { hi = lo + windowCap }
         return windowPage()
@@ -18342,9 +18523,23 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
 
     override func paginateForwards(count: UInt32) async throws -> TimelinePageFfi {
         paginateForwardsCount += 1
+        await passPaginationGateIfArmed()
         hi = min(fullSet.messages.count, hi + Int(count))
         if hi - lo > windowCap { lo = hi - windowCap }
         return windowPage()
+    }
+
+    private func passPaginationGateIfArmed() async {
+        guard paginationGateEnabled, paginationGateContinuation == nil, !didReachPaginationGate else { return }
+        didReachPaginationGate = true
+        await withCheckedContinuation { continuation in
+            paginationGateContinuation = continuation
+        }
+    }
+
+    func releasePaginationGate() {
+        paginationGateContinuation?.resume()
+        paginationGateContinuation = nil
     }
 
     /// Dequeue the next queued signal, mutate the fake's server-side `fullSet` and

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -8683,7 +8683,7 @@ struct whitenoise_macTests {
                     sender: aliceId,
                     plaintext: "Fresh error",
                     recordedAt: baseTime
-                ),
+                )
             ],
             limit: 100,
             windowCap: 200


### PR DESCRIPTION
Fixes #529

## Summary
- re-check the captured timeline subscription's object identity and active group after backwards/forwards pagination awaits
- discard a stale subscription's page when a same-chat listener reconnect has installed a replacement subscription
- add deterministic regression coverage for both pagination directions using a continuation-backed fake subscription gate

## Verification
- `git diff --check`
- `bash -n scripts/ci/macos-sanity-checks.sh`
- macOS compilation, Swift format, and the Swift Testing suite require Xcode; this Linux worker has no `xcodebuild`, `xcrun`, `swift`, or `swift-format`. GitHub's macOS CI runs the repository's exact format, sanity, unit-test, release-build, and static-analysis gates.

## Sensitive paths
None. This changes client timeline window coordination and its test fake; no crypto, MLS/CGKA, key handling, trust anchors, authentication, or protocol semantics.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/539">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->