### PR TITLE
fix: keep media reference resolution outside download limiter

### DIFF
--- a/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
+++ b/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
@@ -10,7 +10,7 @@ import Foundation
 nonisolated enum MediaAttachmentDownloadConcurrency {
     static let maxConcurrentDownloads = 4
 
-    /// Wall-clock ceiling for one attachment's resolve+download FFI while holding a limiter slot.
+    /// Wall-clock ceiling for one attachment's download FFI while holding a limiter slot.
     /// Matches `RemoteImageURLPolicy.downloadResourceTimeout` so stalled relay fetches cannot
     /// occupy all download slots indefinitely.
     static let defaultFfiDownloadTimeoutNanoseconds: UInt64 = 60 * 1_000_000_000

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -206,28 +206,6 @@ extension WorkspaceState {
             return
         }
 
-        do {
-            try await MediaAttachmentDownloadLimiter.shared.acquire()
-        } catch is CancellationError {
-            guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
-                stateStore.update(.idle)
-                return
-            }
-            if case .loading = stateStore.state {
-                stateStore.update(.idle)
-            }
-            return
-        } catch {
-            guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
-                stateStore.update(.idle)
-                return
-            }
-            stateStore.update(.failed(error.localizedDescription))
-            return
-        }
-        defer {
-            Task { await MediaAttachmentDownloadLimiter.shared.release() }
-        }
         if case .loaded = stateStore.state {
             return
         }
@@ -244,6 +222,8 @@ extension WorkspaceState {
         }
 
         do {
+            // Resolve first: the synchronous `listMedia` FFI may stall and must not consume one
+            // of the scarce slots reserved for attachment downloads.
             let reference = try await resolvedMediaReference(
                 attachment.reference,
                 accountId: accountId,
@@ -262,6 +242,26 @@ extension WorkspaceState {
                 stateStore.update(.idle)
                 return
             }
+
+            try await MediaAttachmentDownloadLimiter.shared.acquire()
+            defer {
+                Task { await MediaAttachmentDownloadLimiter.shared.release() }
+            }
+            if case .loaded = stateStore.state {
+                return
+            }
+            guard
+                canPublishMediaDownloadState(
+                    forKey: key,
+                    stateStore: stateStore,
+                    accountId: accountId,
+                    groupIdHex: groupIdHex
+                )
+            else {
+                stateStore.update(.idle)
+                return
+            }
+
             let download = try await withMediaAttachmentDownloadTimeout {
                 try await client.downloadMedia(
                     accountRef: accountRef,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6741,6 +6741,101 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func mediaReferenceResolutionDoesNotConsumeDownloadLimiterSlot() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: false
+        )
+        let plaintext = Data([0x01, 0x02, 0x03])
+        let timelineReference = mediaAttachmentReference(
+            sourceEpoch: 0,
+            mediaType: "image/png",
+            fileName: "resolve-before-slot.png",
+            plaintextSha256: hexSHA256(plaintext)
+        )
+        let resolvedReference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "image/png",
+            fileName: "resolve-before-slot.png",
+            plaintextSha256: timelineReference.plaintextSha256
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "resolve-before-slot-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: resolvedReference,
+                caption: nil,
+                recordedAt: 1_700_000_000,
+                receivedAt: 1_700_000_000
+            ),
+            download: MediaDownloadResultFfi(
+                plaintext: plaintext,
+                fileName: "resolve-before-slot.png",
+                mediaType: "image/png",
+                sizeBytes: UInt64(plaintext.count)
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let message = MessageItem(
+            id: "resolve-before-slot-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "resolve-before-slot-message#0#\(timelineReference.plaintextSha256)",
+                    reference: timelineReference
+                )
+            ]
+        )
+        let attachment = try #require(message.mediaAttachments.first)
+
+        for _ in 0..<MediaAttachmentDownloadConcurrency.maxConcurrentDownloads {
+            try await MediaAttachmentDownloadLimiter.shared.acquire()
+        }
+        runtime.listMediaGateEnabled = true
+        let load = Task { await state.loadMediaAttachment(attachment, for: message) }
+        for _ in 0..<100 {
+            if runtime.didReachListMediaGate {
+                break
+            }
+            await Task.yield()
+        }
+
+        #expect(runtime.didReachListMediaGate)
+
+        runtime.releaseListMediaGate()
+        for _ in 0..<MediaAttachmentDownloadConcurrency.maxConcurrentDownloads {
+            await MediaAttachmentDownloadLimiter.shared.release()
+        }
+        await load.value
+
+        guard case .loaded(let download) = state.mediaDownloadState(for: message, attachment: attachment) else {
+            Issue.record("Expected attachment download to complete after reference resolution")
+            return
+        }
+        #expect(download.data == plaintext)
+        #expect(runtime.listMediaCallCount == 1)
+        #expect(runtime.downloadMediaCallCount == 1)
+    }
+
+    @MainActor
     @Test func mediaAttachmentDownloadTimesOutAndReleasesLimiterSlot() async throws {
         let previousTimeout = MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds
         defer { MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds = previousTimeout }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6826,6 +6826,16 @@ struct whitenoise_macTests {
         }
         await load.value
 
+        // `loadMediaAttachment` releases its actor-isolated slot from a deferred task. Reacquiring
+        // every slot waits for that deferred release before this serialized test yields the shared
+        // limiter to the next test.
+        for _ in 0..<MediaAttachmentDownloadConcurrency.maxConcurrentDownloads {
+            try await MediaAttachmentDownloadLimiter.shared.acquire()
+        }
+        for _ in 0..<MediaAttachmentDownloadConcurrency.maxConcurrentDownloads {
+            await MediaAttachmentDownloadLimiter.shared.release()
+        }
+
         guard case .loaded(let download) = state.mediaDownloadState(for: message, attachment: attachment) else {
             Issue.record("Expected attachment download to complete after reference resolution")
             return

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6754,7 +6754,7 @@ struct whitenoise_macTests {
             signedOut: false,
             running: false
         )
-        let plaintext = Data([0x01, 0x02, 0x03])
+        let plaintext = Data([0x51, 0x52, 0x53])
         let timelineReference = mediaAttachmentReference(
             sourceEpoch: 0,
             mediaType: "image/png",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6815,7 +6815,7 @@ struct whitenoise_macTests {
             if runtime.didReachListMediaGate {
                 break
             }
-            await Task.yield()
+            try await Task.sleep(nanoseconds: 10_000_000)
         }
 
         #expect(runtime.didReachListMediaGate)
@@ -6960,7 +6960,7 @@ struct whitenoise_macTests {
             if runtime.didReachMediaDownloadGate {
                 break
             }
-            await Task.yield()
+            try await Task.sleep(nanoseconds: 10_000_000)
         }
         guard runtime.didReachMediaDownloadGate else {
             stalledLoad.cancel()


### PR DESCRIPTION
## Summary
- resolve source-epoch-zero media references before acquiring an attachment download slot
- keep stalled synchronous `listMedia` FFI work from saturating all four download slots
- add a regression that exhausts the limiter and proves reference resolution still starts
- synchronize the fake runtime observations exercised by concurrent downloads

## Verification
- Mac CI PR Checks green at `58096f6`: strict swift-format, project sanity, 442 unit tests, release build
- Static Analysis green
- `git diff --check`

## CI history
Earlier runs exposed and then corrected a concurrent fake-runtime append race plus a test-fixture disk-cache collision. The current head is green; the PR has ever-red CI history for merge-gate policy.

Fixes #526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media attachment download handling so reference resolution does not consume a download slot.
  * Ensured download slots are released reliably, including during cancellation and concurrent operations.
  * Preserved correct download behavior when concurrency limits are reached.

* **Tests**
  * Added coverage for media reference resolution and limiter behavior under maximum concurrency.
  * Improved reliability of asynchronous media download tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->