### PR TITLE
fix: report Swift-side markdown truncation

### DIFF
--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -20,17 +20,33 @@ nonisolated struct MarkdownDisplayDocument {
     fileprivate static let maxDepth = 32
 
     init(document: MarkdownDocumentFfi) {
-        self.blocks = Self.makeBlocks(from: document.blocks, remainingDepth: Self.maxDepth)
-        self.truncated = document.truncated
+        var swiftTruncated = false
+        self.blocks = Self.makeBlocks(
+            from: document.blocks,
+            remainingDepth: Self.maxDepth,
+            truncated: &swiftTruncated
+        )
+        self.truncated = document.truncated || swiftTruncated
     }
 
     fileprivate static func makeBlocks(
         from blocks: [MarkdownBlockFfi],
-        remainingDepth: Int
+        remainingDepth: Int,
+        truncated: inout Bool
     ) -> [MarkdownDisplayBlockNode] {
-        guard remainingDepth > 0 else { return [] }
+        guard remainingDepth > 0 else {
+            truncated = truncated || !blocks.isEmpty
+            return []
+        }
         return blocks.enumerated().map { index, block in
-            MarkdownDisplayBlockNode(id: index, block: MarkdownDisplayBlock(block, remainingDepth: remainingDepth))
+            MarkdownDisplayBlockNode(
+                id: index,
+                block: MarkdownDisplayBlock(
+                    block,
+                    remainingDepth: remainingDepth,
+                    truncated: &truncated
+                )
+            )
         }
     }
 }
@@ -50,32 +66,61 @@ nonisolated enum MarkdownDisplayBlock {
     case table(header: [MarkdownDisplayTableCell], rows: [MarkdownDisplayTableRow])
     case mathBlock(String)
 
-    init(_ block: MarkdownBlockFfi, remainingDepth: Int) {
+    init(_ block: MarkdownBlockFfi, remainingDepth: Int, truncated: inout Bool) {
         switch block {
         case .paragraph(let inlines):
             self = .paragraph(
-                MarkdownDisplayInlineBuilder.attributedString(from: inlines, remainingDepth: remainingDepth)
+                MarkdownDisplayInlineBuilder.attributedString(
+                    from: inlines,
+                    remainingDepth: remainingDepth,
+                    truncated: &truncated
+                )
             )
         case .heading(let level, let inlines):
             self = .heading(
                 level: level,
-                text: MarkdownDisplayInlineBuilder.attributedString(from: inlines, remainingDepth: remainingDepth)
+                text: MarkdownDisplayInlineBuilder.attributedString(
+                    from: inlines,
+                    remainingDepth: remainingDepth,
+                    truncated: &truncated
+                )
             )
         case .thematicBreak:
             self = .thematicBreak
         case .codeBlock(_, _, let content):
             self = .codeBlock(content)
         case .blockQuote(let blocks):
-            self = .blockQuote(MarkdownDisplayDocument.makeBlocks(from: blocks, remainingDepth: remainingDepth - 1))
+            self = .blockQuote(
+                MarkdownDisplayDocument.makeBlocks(
+                    from: blocks,
+                    remainingDepth: remainingDepth - 1,
+                    truncated: &truncated
+                )
+            )
         case .listBlock(let kind, _, let items):
-            self = .list(items: Self.listItems(kind: kind, items: items, remainingDepth: remainingDepth))
+            self = .list(
+                items: Self.listItems(
+                    kind: kind,
+                    items: items,
+                    remainingDepth: remainingDepth,
+                    truncated: &truncated
+                )
+            )
         case .table(_, let header, let rows):
             self = .table(
-                header: Self.tableCells(from: header, remainingDepth: remainingDepth),
+                header: Self.tableCells(
+                    from: header,
+                    remainingDepth: remainingDepth,
+                    truncated: &truncated
+                ),
                 rows: rows.enumerated().map { rowIndex, row in
                     MarkdownDisplayTableRow(
                         id: rowIndex,
-                        cells: Self.tableCells(from: row, remainingDepth: remainingDepth)
+                        cells: Self.tableCells(
+                            from: row,
+                            remainingDepth: remainingDepth,
+                            truncated: &truncated
+                        )
                     )
                 }
             )
@@ -89,13 +134,18 @@ nonisolated enum MarkdownDisplayBlock {
     private static func listItems(
         kind: MarkdownListKindFfi,
         items: [MarkdownListItemFfi],
-        remainingDepth: Int
+        remainingDepth: Int,
+        truncated: inout Bool
     ) -> [MarkdownDisplayListItem] {
         items.enumerated().map { index, item in
             MarkdownDisplayListItem(
                 id: index,
                 marker: listMarker(kind: kind, item: item, index: index),
-                blocks: MarkdownDisplayDocument.makeBlocks(from: item.blocks, remainingDepth: remainingDepth - 1)
+                blocks: MarkdownDisplayDocument.makeBlocks(
+                    from: item.blocks,
+                    remainingDepth: remainingDepth - 1,
+                    truncated: &truncated
+                )
             )
         }
     }
@@ -120,12 +170,17 @@ nonisolated enum MarkdownDisplayBlock {
 
     private static func tableCells(
         from cells: [MarkdownTableCellFfi],
-        remainingDepth: Int
+        remainingDepth: Int,
+        truncated: inout Bool
     ) -> [MarkdownDisplayTableCell] {
         cells.enumerated().map { index, cell in
             MarkdownDisplayTableCell(
                 id: index,
-                text: MarkdownDisplayInlineBuilder.attributedString(from: cell.inlines, remainingDepth: remainingDepth)
+                text: MarkdownDisplayInlineBuilder.attributedString(
+                    from: cell.inlines,
+                    remainingDepth: remainingDepth,
+                    truncated: &truncated
+                )
             )
         }
     }
@@ -154,10 +209,30 @@ nonisolated struct MarkdownDisplayTableRow: Identifiable {
 
 nonisolated enum MarkdownDisplayInlineBuilder {
     static func attributedString(from inlines: [MarkdownInlineFfi], remainingDepth: Int) -> AttributedString {
-        guard remainingDepth > 0 else { return AttributedString() }
+        var truncated = false
+        return attributedString(from: inlines, remainingDepth: remainingDepth, truncated: &truncated)
+    }
+
+    fileprivate static func attributedString(
+        from inlines: [MarkdownInlineFfi],
+        remainingDepth: Int,
+        truncated: inout Bool
+    ) -> AttributedString {
+        guard remainingDepth > 0 else {
+            truncated = truncated || !inlines.isEmpty
+            return AttributedString()
+        }
         var result = AttributedString()
         for inline in inlines {
-            result.append(render(inline, intent: [], link: nil, remainingDepth: remainingDepth))
+            result.append(
+                render(
+                    inline,
+                    intent: [],
+                    link: nil,
+                    remainingDepth: remainingDepth,
+                    truncated: &truncated
+                )
+            )
         }
         return result
     }
@@ -166,7 +241,8 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         _ inline: MarkdownInlineFfi,
         intent: InlinePresentationIntent,
         link: URL?,
-        remainingDepth: Int
+        remainingDepth: Int,
+        truncated: inout Bool
     ) -> AttributedString {
         switch inline {
         case .text(let content):
@@ -178,28 +254,44 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         case .code(let content):
             return styled(content, intent: intent.union(.code), link: link)
         case .emph(let children):
-            return concat(children, intent: intent.union(.emphasized), link: link, remainingDepth: remainingDepth - 1)
+            return concat(
+                children,
+                intent: intent.union(.emphasized),
+                link: link,
+                remainingDepth: remainingDepth - 1,
+                truncated: &truncated
+            )
         case .strong(let children):
             return concat(
                 children,
                 intent: intent.union(.stronglyEmphasized),
                 link: link,
-                remainingDepth: remainingDepth - 1
+                remainingDepth: remainingDepth - 1,
+                truncated: &truncated
             )
         case .strikethrough(let children):
             return concat(
                 children,
                 intent: intent.union(.strikethrough),
                 link: link,
-                remainingDepth: remainingDepth - 1
+                remainingDepth: remainingDepth - 1,
+                truncated: &truncated
             )
         case .link(let dest, _, let children):
             return concat(
                 children, intent: intent, link: MarkdownLinkPolicy.sanitizedURL(from: dest),
-                remainingDepth: remainingDepth - 1)
+                remainingDepth: remainingDepth - 1,
+                truncated: &truncated
+            )
         case .image(_, let title, let alt):
             if !alt.isEmpty {
-                return concat(alt, intent: intent, link: link, remainingDepth: remainingDepth - 1)
+                return concat(
+                    alt,
+                    intent: intent,
+                    link: link,
+                    remainingDepth: remainingDepth - 1,
+                    truncated: &truncated
+                )
             }
             return styled(title ?? "", intent: intent, link: link)
         case .autolink(let url, _):
@@ -217,12 +309,24 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         _ inlines: [MarkdownInlineFfi],
         intent: InlinePresentationIntent,
         link: URL?,
-        remainingDepth: Int
+        remainingDepth: Int,
+        truncated: inout Bool
     ) -> AttributedString {
-        guard remainingDepth > 0 else { return AttributedString() }
+        guard remainingDepth > 0 else {
+            truncated = truncated || !inlines.isEmpty
+            return AttributedString()
+        }
         var result = AttributedString()
         for inline in inlines {
-            result.append(render(inline, intent: intent, link: link, remainingDepth: remainingDepth))
+            result.append(
+                render(
+                    inline,
+                    intent: intent,
+                    link: link,
+                    remainingDepth: remainingDepth,
+                    truncated: &truncated
+                )
+            )
         }
         return result
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3701,6 +3701,67 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func deeplyNestedMarkdownListItemsMarkDocumentTruncated() async throws {
+        let document = MarkdownDocumentFfi(
+            blocks: [
+                .listBlock(
+                    kind: .bullet(marker: "-"),
+                    tight: true,
+                    items: [
+                        MarkdownListItemFfi(
+                            blocks: [
+                                nestedBlockQuote(
+                                    depth: 256,
+                                    leaf: .paragraph(inlines: [.text(content: "deep")])
+                                )
+                            ],
+                            checked: nil
+                        )
+                    ]
+                )
+            ],
+            truncated: false
+        )
+
+        let display = MarkdownDisplayDocument(document: document)
+
+        guard case .list(let items) = display.blocks.first?.block else {
+            Issue.record("expected a list block")
+            return
+        }
+        #expect(items.count == 1)
+        #expect(display.truncated)
+    }
+
+    @MainActor
+    @Test func deeplyNestedMarkdownTableCellsMarkDocumentTruncated() async throws {
+        let document = MarkdownDocumentFfi(
+            blocks: [
+                .table(
+                    alignments: [.left],
+                    header: [
+                        MarkdownTableCellFfi(
+                            inlines: [nestedStrong(depth: 256, leaf: .text(content: "deep"))]
+                        )
+                    ],
+                    rows: []
+                )
+            ],
+            truncated: false
+        )
+
+        let display = MarkdownDisplayDocument(document: document)
+
+        guard case .table(let header, _) = display.blocks.first?.block else {
+            Issue.record("expected a table block")
+            return
+        }
+        let headerCell = try #require(header.first)
+        #expect(String(headerCell.text.characters).isEmpty)
+        #expect(display.truncated)
+    }
+
+    @MainActor
     @Test func boundedNestedMarkdownStillStylesAndLinks() async throws {
         // Normal Markdown nesting (well within the bound) must keep its styles and links:
         // the depth guard only collapses the over-depth remainder.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3675,6 +3675,7 @@ struct whitenoise_macTests {
         let preservedDepth = blockQuoteNestingDepth(display.blocks)
         #expect(preservedDepth <= 32)
         #expect(preservedDepth >= 1)
+        #expect(display.truncated)
     }
 
     @MainActor
@@ -3696,6 +3697,7 @@ struct whitenoise_macTests {
         // The leaf text sits below the bound, so it is dropped entirely rather than the
         // renderer recursing through every wrapper to reach it.
         #expect(String(text.characters).isEmpty)
+        #expect(display.truncated)
     }
 
     @MainActor
@@ -3730,6 +3732,16 @@ struct whitenoise_macTests {
         let run = paragraph.runs.first
         #expect(run?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
         #expect(run?.link == URL(string: "https://example.com"))
+        #expect(!display.truncated)
+    }
+
+    @MainActor
+    @Test func markdownDisplayPreservesCoreTruncationFlag() async throws {
+        let display = MarkdownDisplayDocument(
+            document: MarkdownDocumentFfi(blocks: [], truncated: true)
+        )
+
+        #expect(display.truncated)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- propagate Swift block/inline depth-limit truncation into `MarkdownDisplayDocument.truncated`
- preserve the MarmotKit-provided truncation flag
- cover block, inline, bounded, and core-provided truncation cases

## Verification
- `swiftc -parse` with Swift 6.2 Docker image
- `swift-format lint --strict` with the repository configuration
- full macOS tests deferred to CI because this worker runs on Linux

Fixes #528

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/543">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->