### PR TITLE
fix: serialize account mutations

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -239,7 +239,7 @@ extension WorkspaceState {
     /// in-memory message/profile caches are cleared and a remaining account is reselected
     /// (or the app returns to onboarding when none remain).
     func removeAccount(_ account: AccountItem) async {
-        guard let client, !isRemovingAccount else { return }
+        guard let client, !isAccountMutationInProgress else { return }
 
         lastError = nil
         isRemovingAccount = true
@@ -370,7 +370,7 @@ extension WorkspaceState {
     /// it (and cleans up its relay key packages). If it was the active account, the
     /// UI switches to another signed-in account, or onboarding when none remain.
     func signOutAccount(_ account: AccountItem) async {
-        guard let client, !isSigningOutAccount else { return }
+        guard let client, !isAccountMutationInProgress else { return }
         lastError = nil
         isSigningOutAccount = true
         defer { isSigningOutAccount = false }
@@ -422,7 +422,7 @@ extension WorkspaceState {
 
     /// Re-activate a previously signed-out account and make it the active one.
     func signInAccount(_ account: AccountItem) async {
-        guard let client, !isSigningOutAccount else { return }
+        guard let client, !isAccountMutationInProgress else { return }
         lastError = nil
         isSigningOutAccount = true
         defer { isSigningOutAccount = false }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -816,6 +816,8 @@ final class WorkspaceState {
     var isSavingProfile = false
     var isRemovingAccount = false
     var isSigningOutAccount = false
+    /// True while any account remove, sign-out, or sign-in mutation is in flight.
+    var isAccountMutationInProgress: Bool { isRemovingAccount || isSigningOutAccount }
     /// Per-account unread totals keyed by `accountIdHex`, for switcher avatar badges.
     var accountUnreadByIdHex: [String: Int] = [:]
     var isSavingRelays = false

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -170,6 +170,7 @@ private func removeAccountConfirmationTitle(for account: AccountItem?) -> String
 private struct RemoveAccountConfirmationModifier: ViewModifier {
     let account: AccountItem?
     @Binding var isPresented: Bool
+    let isRemoveDisabled: Bool
     let onRemove: () -> Void
 
     func body(content: Content) -> some View {
@@ -181,6 +182,7 @@ private struct RemoveAccountConfirmationModifier: ViewModifier {
             Button("Remove Account", role: .destructive) {
                 onRemove()
             }
+            .disabled(isRemoveDisabled)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(removeAccountConfirmationMessage)
@@ -192,12 +194,14 @@ private extension View {
     func removeAccountConfirmation(
         account: AccountItem?,
         isPresented: Binding<Bool>,
+        isRemoveDisabled: Bool,
         onRemove: @escaping () -> Void
     ) -> some View {
         modifier(
             RemoveAccountConfirmationModifier(
                 account: account,
                 isPresented: isPresented,
+                isRemoveDisabled: isRemoveDisabled,
                 onRemove: onRemove
             )
         )
@@ -222,7 +226,7 @@ struct AccountsSettingsView: View {
                         account: account,
                         isActive: account.id == workspace.activeAccountId,
                         isRemoving: workspace.isRemovingAccount,
-                        isSigningOut: workspace.isSigningOutAccount,
+                        isAccountMutationInProgress: workspace.isAccountMutationInProgress,
                         onSelect: {
                             workspace.selectAccountFromSettings(account)
                         },
@@ -288,7 +292,11 @@ struct AccountsSettingsView: View {
             }
 
         }
-        .removeAccountConfirmation(account: accountPendingRemoval, isPresented: removeConfirmationBinding) {
+        .removeAccountConfirmation(
+            account: accountPendingRemoval,
+            isPresented: removeConfirmationBinding,
+            isRemoveDisabled: workspace.isAccountMutationInProgress
+        ) {
             guard let account = accountPendingRemoval else { return }
             accountPendingRemoval = nil
             Task { await workspace.removeAccount(account) }
@@ -309,7 +317,7 @@ struct AccountSettingsRow: View {
     let account: AccountItem
     let isActive: Bool
     let isRemoving: Bool
-    let isSigningOut: Bool
+    let isAccountMutationInProgress: Bool
     let onSelect: () -> Void
     let onRemove: () -> Void
     let onSignOut: () -> Void
@@ -353,7 +361,7 @@ struct AccountSettingsRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .disabled(isRemoving)
+            .disabled(isRemoving || (account.signedOut && isAccountMutationInProgress))
 
             PublicIdentityQRCodeButton(
                 accountIdHex: account.accountIdHex,
@@ -366,14 +374,14 @@ struct AccountSettingsRow: View {
                     Image(systemName: "person.crop.circle.badge.checkmark")
                 }
                 .buttonStyle(.borderless)
-                .disabled(isSigningOut)
+                .disabled(isAccountMutationInProgress)
                 .help(L10n.string("Sign in to this account"))
             } else {
                 Button(action: onSignOut) {
                     Image(systemName: "rectangle.portrait.and.arrow.right")
                 }
                 .buttonStyle(.borderless)
-                .disabled(isSigningOut)
+                .disabled(isAccountMutationInProgress)
                 .help(L10n.string("Sign out of this account on this Mac"))
             }
 
@@ -382,7 +390,7 @@ struct AccountSettingsRow: View {
             }
             .buttonStyle(.borderless)
             .foregroundStyle(.red)
-            .disabled(isRemoving)
+            .disabled(isAccountMutationInProgress)
             .help(L10n.string("Remove this account from this Mac"))
             .accessibilityLabel(Text(String(format: L10n.string("Remove %@"), account.displayName)))
         }
@@ -737,7 +745,7 @@ struct IdentityKeysSettingsView: View {
                             workspace.isRemovingAccount ? L10n.string("Removing...") : L10n.string("Remove Account"),
                             systemImage: "person.crop.circle.badge.minus")
                     }
-                    .disabled(workspace.isRemovingAccount)
+                    .disabled(workspace.isAccountMutationInProgress)
                 }
             } else {
                 Section {
@@ -749,7 +757,8 @@ struct IdentityKeysSettingsView: View {
         }
         .removeAccountConfirmation(
             account: workspace.activeAccount,
-            isPresented: $showRemoveAccountConfirmation
+            isPresented: $showRemoveAccountConfirmation,
+            isRemoveDisabled: workspace.isAccountMutationInProgress
         ) {
             Task { await workspace.removeActiveAccount() }
         }

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -104,6 +104,7 @@ private struct AccountRailAvatar: View {
             }
         }
         .buttonStyle(.plain)
+        .disabled(account.signedOut && workspace.isAccountMutationInProgress)
         .help(account.signedOut ? "\(account.displayName) — \(L10n.string("Signed out"))" : account.displayName)
         .contextMenu {
             if account.signedOut {
@@ -112,14 +113,14 @@ private struct AccountRailAvatar: View {
                 } label: {
                     Label("Sign In", systemImage: "person.crop.circle.badge.checkmark")
                 }
-                .disabled(workspace.isSigningOutAccount)
+                .disabled(workspace.isAccountMutationInProgress)
             } else {
                 Button {
                     Task { await workspace.signOutAccount(account) }
                 } label: {
                     Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
                 }
-                .disabled(workspace.isSigningOutAccount)
+                .disabled(workspace.isAccountMutationInProgress)
             }
         }
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -998,6 +998,167 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func removingAccountBlocksSignOutMidFlight() async throws {
+        // Regression for whitenoise-mac#531: remove and sign-out must be mutually exclusive.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        let desktopAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+
+        runtime.onRemoveAccountMidFlight = { _ in
+            await state.signOutAccount(desktopAccount)
+        }
+
+        await state.removeAccount(backupAccount)
+
+        #expect(runtime.removedAccountRefs == ["Backup Account"])
+        #expect(runtime.signOutCallCount == 0)
+        #expect(runtime.signedOutAccountRefs.isEmpty)
+    }
+
+    @MainActor
+    @Test func removingAccountBlocksSignInMidFlight() async throws {
+        // Regression for whitenoise-mac#531: remove and sign-in must be mutually exclusive.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let other = AccountSummaryFfi(
+            label: "Other Account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let signedOut = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, other, signedOut])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let otherAccount = try #require(state.accounts.first { $0.id == "Other Account" })
+        let signedOutAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+
+        runtime.onRemoveAccountMidFlight = { _ in
+            await state.signInAccount(signedOutAccount)
+        }
+
+        await state.removeAccount(otherAccount)
+
+        #expect(runtime.removedAccountRefs == ["Other Account"])
+        #expect(runtime.signInAccountCallCount == 0)
+        #expect(state.accounts.first { $0.id == "Backup Account" }?.signedOut == true)
+    }
+
+    @MainActor
+    @Test func signingOutAccountBlocksRemoveMidFlight() async throws {
+        // Regression for whitenoise-mac#531: sign-out and remove must be mutually exclusive.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        let desktopAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+
+        runtime.onSignOutAccountMidFlight = { _ in
+            await state.removeAccount(backupAccount)
+        }
+
+        await state.signOutAccount(desktopAccount)
+
+        #expect(runtime.signedOutAccountRefs == ["Desktop Account"])
+        #expect(runtime.removedAccountRefs.isEmpty)
+        #expect(state.accounts.map(\.id) == ["Desktop Account", "Backup Account"])
+    }
+
+    @MainActor
+    @Test func signingInAccountBlocksRemoveMidFlight() async throws {
+        // Regression for whitenoise-mac#531: sign-in and remove must be mutually exclusive.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let signedOut = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, signedOut])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let signedOutAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        let desktopAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+
+        runtime.onSignInAccountMidFlight = { _ in
+            await state.removeAccount(desktopAccount)
+        }
+
+        await state.signInAccount(signedOutAccount)
+
+        #expect(runtime.signInAccountCallCount == 1)
+        #expect(runtime.removedAccountRefs.isEmpty)
+        #expect(state.accounts.map(\.id) == ["Desktop Account", "Backup Account"])
+        #expect(state.accounts.first { $0.id == "Backup Account" }?.signedOut == false)
+    }
+
+    @MainActor
     @Test func deleteAllDataResetsToNewInstallState() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
Replacement for #540, retired because a known intermittent test made that PR ever-red. This PR contains the same adversarially reviewed commit; CI must pass cleanly here.

Fixes #531

## Summary
- derive one shared account-mutation predicate from the existing remove and sign-status flags
- reject overlapping remove/sign-out/sign-in operations in `WorkspaceState`
- cross-disable mutation controls and open removal confirmations without blocking selection of already signed-in accounts
- add four mid-flight regression tests covering remove versus sign-out/sign-in in both directions

## Verification
- `git diff --check` — passed
- Python `plistlib` validation for app, entitlements, and MarmotKit xcframework plists — passed
- static reference audit for all remove/sign-in/sign-out UI entry points — passed
- independent fail-closed pre-commit review — passed after two UI edge cases were corrected
- macOS `xcodebuild` / `xcrun swift-format` — not available on this Linux worker; GitHub macOS CI must run these checks

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+Account.swift`: account removal and sign-in/sign-out lifecycle guards
- `whitenoise-mac/Core/WorkspaceState.swift`: shared account-mutation state projection
- account-management UI entry points in Settings and Sidebar

No MarmotKit, MLS, CGKA, cryptographic primitive, or generated binding changes.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/540">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->