### PR TITLE
fix: preserve media after failed data deletion

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -494,15 +494,16 @@ extension WorkspaceState {
             stopChatListListener()
             stopTimelineListener()
 
-            // Marmot only owns its storage root; plaintext media scratch directories and
-            // the encrypted media cache live outside it, so purge them before the
-            // potentially throwing Marmot deletion call when wiping local data.
+            // Marmot only owns its storage root. Purge plaintext media scratch directories before
+            // the potentially throwing deletion so a wipe attempt removes exposed media immediately.
+            // Keep the encrypted cache and its key intact until Marmot deletion succeeds; otherwise
+            // failure recovery would restore messages whose cached attachments can no longer decrypt.
             try? await runOffMain {
                 MediaPlaybackTempStore.purge()
                 OutgoingMediaMetadataTempStore.purge()
             }
-            await mediaDiskCache.purgeAll(removeEncryptionKey: true)
             try await client.deleteAllLocalData()
+            await mediaDiskCache.purgeAll(removeEncryptionKey: true)
             self.client = nil
             observabilityRuntimeConfiguration = nil
             resetToNewInstallState(storageRootPath: client.storageRootPath)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1009,7 +1009,15 @@ struct whitenoise_macTests {
         )
         let runtime = FakeMarmotRuntime(accounts: [primary])
         UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
-        let state = WorkspaceState(clientFactory: { runtime })
+        let fileManager = FileManager.default
+        let mediaCacheRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-successful-delete-media-cache-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: mediaCacheRoot) }
+        let didDeleteMediaEncryptionKey = MutableFlag(false)
+        let mediaDiskCache = messageMediaDiskCache(root: mediaCacheRoot) {
+            didDeleteMediaEncryptionKey.value = true
+        }
+        let state = WorkspaceState(mediaDiskCache: mediaDiskCache, clientFactory: { runtime })
 
         await state.bootstrap()
         state.showSettings(.privacySecurity)
@@ -1027,6 +1035,7 @@ struct whitenoise_macTests {
         await state.deleteAllData()
 
         #expect(runtime.didDeleteAllLocalData)
+        #expect(didDeleteMediaEncryptionKey.value)
         let accounts = try runtime.listAccounts()
         #expect(accounts.isEmpty)
         #expect(state.phase == .onboarding)
@@ -1055,7 +1064,32 @@ struct whitenoise_macTests {
         )
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroup(messageGroup())
-        let state = WorkspaceState(clientFactory: { runtime })
+
+        let fileManager = FileManager.default
+        let mediaCacheRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-failed-delete-media-cache-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: mediaCacheRoot) }
+        let didDeleteMediaEncryptionKey = MutableFlag(false)
+        let mediaDiskCache = messageMediaDiskCache(root: mediaCacheRoot) {
+            didDeleteMediaEncryptionKey.value = true
+        }
+        let cachedMediaPlaintext = Data("media that must survive a failed wipe".utf8)
+        let cachedMediaKey = MessageMediaDiskCacheKey(
+            accountId: account.label,
+            groupIdHex: "group",
+            reference: mediaDiskCacheReference(plaintext: cachedMediaPlaintext)
+        )
+        await mediaDiskCache.store(
+            MessageMediaDownload(
+                data: cachedMediaPlaintext,
+                fileName: "surviving-photo.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(cachedMediaPlaintext.count),
+                payloadId: "failed-wipe-media"
+            ),
+            for: cachedMediaKey
+        )
+        let state = WorkspaceState(mediaDiskCache: mediaDiskCache, clientFactory: { runtime })
 
         await state.bootstrap()
         let didStartNotifications = await waitFor {
@@ -1087,6 +1121,8 @@ struct whitenoise_macTests {
         #expect(runtime.chatListSubscriptionCount >= chatListSubscriptionBaseline + 1)
         #expect(runtime.timelineSubscriptionCount >= timelineSubscriptionBaseline + 1)
         #expect(state.lastError == "Unused fake runtime error.")
+        #expect(!didDeleteMediaEncryptionKey.value)
+        #expect(try #require(await mediaDiskCache.cachedDownload(for: cachedMediaKey)).data == cachedMediaPlaintext)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Defer encrypted media cache and key deletion until Marmot local-data deletion succeeds.
- Preserve the pre-delete plaintext scratch purge while keeping recoverable encrypted attachments intact on failure.
- Extend delete-all-data regressions to cover key deletion on success and cache/key preservation on failure.

## Verification
- [x] `git diff --check`
- [x] Source ordering contract: Marmot deletion precedes media cache/key purge
- [x] Independent pre-commit review: no blocking findings
- [ ] macOS Swift format, unit tests, static analysis, and release build (CI; xcodebuild unavailable on Linux)

Fixes #524

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/546">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->