### PR TITLE
fix: reject stale timeline pagination windows

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -204,9 +204,24 @@ extension WorkspaceState {
             let page = try await TimelineSignpost.pagination.asyncInterval("paginateBackwards") {
                 try await subscription.paginateBackwards(count: Self.timelinePageLimit)
             }
-            guard activeAccountId == activeAccount.id, selectedChat?.id == groupIdHex else { return }
-            await applyTimelineWindow(page, groupIdHex: groupIdHex, account: activeAccount, client: client)
+            guard activeAccountId == activeAccount.id,
+                selectedChat?.id == groupIdHex,
+                activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === subscription
+            else { return }
+            await applyTimelineWindow(
+                page,
+                groupIdHex: groupIdHex,
+                account: activeAccount,
+                client: client,
+                expectedTimelineSubscription: subscription
+            )
         } catch {
+            guard activeAccountId == activeAccount.id,
+                selectedChat?.id == groupIdHex,
+                activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === subscription
+            else { return }
             lastError = error.localizedDescription
         }
     }
@@ -233,9 +248,24 @@ extension WorkspaceState {
             let page = try await TimelineSignpost.pagination.asyncInterval("paginateForwards") {
                 try await subscription.paginateForwards(count: Self.timelinePageLimit)
             }
-            guard activeAccountId == activeAccount.id, selectedChat?.id == groupIdHex else { return }
-            await applyTimelineWindow(page, groupIdHex: groupIdHex, account: activeAccount, client: client)
+            guard activeAccountId == activeAccount.id,
+                selectedChat?.id == groupIdHex,
+                activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === subscription
+            else { return }
+            await applyTimelineWindow(
+                page,
+                groupIdHex: groupIdHex,
+                account: activeAccount,
+                client: client,
+                expectedTimelineSubscription: subscription
+            )
         } catch {
+            guard activeAccountId == activeAccount.id,
+                selectedChat?.id == groupIdHex,
+                activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === subscription
+            else { return }
             lastError = error.localizedDescription
         }
     }
@@ -247,9 +277,16 @@ extension WorkspaceState {
         _ page: TimelinePageFfi,
         groupIdHex: String,
         account: AccountItem,
-        client: any MarmotRuntime
+        client: any MarmotRuntime,
+        expectedTimelineSubscription: TimelineMessagesSubscription? = nil
     ) async {
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                expectedTimelineSubscription: expectedTimelineSubscription
+            )
+        else { return }
         let senderProfiles = await TimelineSignpost.mapping.asyncInterval(
             "resolveSenders.window", count: page.messages.count
         ) {
@@ -260,7 +297,24 @@ extension WorkspaceState {
                 client: client
             )
         }
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                expectedTimelineSubscription: expectedTimelineSubscription
+            )
+        else { return }
+
+        #if DEBUG
+            await passTimelineApplyMapGateIfArmed()
+            guard
+                canApplyTimelineWindow(
+                    groupIdHex: groupIdHex,
+                    accountId: account.id,
+                    expectedTimelineSubscription: expectedTimelineSubscription
+                )
+            else { return }
+        #endif
 
         // Maps every record in the window and builds each bubble's Markdown display model
         // (attributed strings + block ids) eagerly — historically the dominant scroll-back
@@ -278,7 +332,13 @@ extension WorkspaceState {
                 senderProfiles: senderProfiles
             )
         }
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                expectedTimelineSubscription: expectedTimelineSubscription
+            )
+        else { return }
 
         let editMutations = MessageEditOverlay.mutations(from: page.messages)
         let currentPaging = timelinePagingByChat[groupIdHex]
@@ -296,6 +356,20 @@ extension WorkspaceState {
             )
         }
         await markLatestVisibleMessageRead(groupIdHex: groupIdHex, account: account, client: client)
+    }
+
+    private func canApplyTimelineWindow(
+        groupIdHex: String,
+        accountId: String,
+        expectedTimelineSubscription: TimelineMessagesSubscription?
+    ) -> Bool {
+        guard activeAccountId == accountId, selectedChat?.id == groupIdHex else { return false }
+        if let expectedTimelineSubscription {
+            guard activeTimelineGroupId == groupIdHex,
+                activeTimelineSubscription === expectedTimelineSubscription
+            else { return false }
+        }
+        return true
     }
 
     /// Route a live timeline subscription update to the right apply path.

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1059,6 +1059,28 @@ final class WorkspaceState {
                 ownsGroupDetailsLoad(generation: generation)
             )
         }
+
+        /// Issue #529 regression support: when armed, the first `applyTimelineWindow` map pass
+        /// suspends until `releaseTimelineApplyMapGate()` is invoked.
+        var timelineApplyMapGateEnabled = false
+        private(set) var didReachTimelineApplyMapGate = false
+        private var timelineApplyMapGateContinuation: CheckedContinuation<Void, Never>?
+
+        func releaseTimelineApplyMapGate() {
+            timelineApplyMapGateContinuation?.resume()
+            timelineApplyMapGateContinuation = nil
+        }
+
+        func passTimelineApplyMapGateIfArmed() async {
+            guard timelineApplyMapGateEnabled,
+                timelineApplyMapGateContinuation == nil,
+                !didReachTimelineApplyMapGate
+            else { return }
+            didReachTimelineApplyMapGate = true
+            await withCheckedContinuation { continuation in
+                timelineApplyMapGateContinuation = continuation
+            }
+        }
     #endif
 
     /// How long a *complete* peer-profile lookup is trusted before it is re-resolved

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -8355,6 +8355,355 @@ struct whitenoise_macTests {
         #expect(runtime.lastTimelineSubscription?.paginateForwardsCount == 1)
     }
 
+    @MainActor
+    @Test func staleTimelinePaginationDoesNotClobberReplacementSubscriptionWindow() async throws {
+        // Issue #529: `loadOlderMessages` / `loadNewerMessages` capture the active subscription,
+        // await pagination, then must re-check subscription identity. A mid-paginate listener
+        // reconnect for the same account/group replaces `activeTimelineSubscription` without
+        // changing selection; the stale page must not overwrite the replacement window.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        let staleSubscription = try #require(state.activeTimelineSubscription as? FakeTimelineMessagesSubscription)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "message-005")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+
+        staleSubscription.paginationGateEnabled = true
+        async let staleBack: Void = state.loadOlderMessages(groupIdHex: "direct-group")
+        let didSuspendBack = await waitFor {
+            state.selectedTimelinePaging.isLoadingBefore && staleSubscription.didReachPaginationGate
+        }
+        guard didSuspendBack else {
+            staleSubscription.paginationGateEnabled = false
+            staleSubscription.releasePaginationGate()
+            _ = await staleBack
+            Issue.record("Expected backwards pagination to reach the test gate")
+            return
+        }
+
+        let replacementBackMessages = (0..<105).map { index in
+            timelineMessage(
+                id: String(format: "fresh-back-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh back \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacementBack = FakeTimelineMessagesSubscription(
+            messages: replacementBackMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacementBack
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacementBack.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-back-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-back-104")
+
+        staleSubscription.releasePaginationGate()
+        _ = await staleBack
+
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-back-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-back-104")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+
+        let replacementFwdMessages = (0..<450).map { index in
+            timelineMessage(
+                id: String(format: "fresh-fwd-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh fwd \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacementFwd = FakeTimelineMessagesSubscription(
+            messages: replacementFwdMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        _ = try await replacementFwd.paginateBackwards(count: 100)
+        _ = try await replacementFwd.paginateBackwards(count: 100)
+        _ = try await replacementFwd.paginateBackwards(count: 100)
+        let scrolledBackWindow = try #require(replacementFwd.snapshot())
+        #expect(scrolledBackWindow.hasMoreAfter)
+
+        state.activeTimelineSubscription = replacementFwd
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            scrolledBackWindow,
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        let scrolledBackFirst = try #require(state.messagesByChat["direct-group"]?.first?.id)
+        #expect(state.selectedTimelinePaging.hasMoreAfter)
+
+        replacementFwd.paginationGateEnabled = true
+        async let staleForward: Void = state.loadNewerMessages(groupIdHex: "direct-group")
+        let didSuspendForward = await waitFor {
+            state.selectedTimelinePaging.isLoadingAfter && replacementFwd.didReachPaginationGate
+        }
+        guard didSuspendForward else {
+            replacementFwd.paginationGateEnabled = false
+            replacementFwd.releasePaginationGate()
+            _ = await staleForward
+            Issue.record("Expected forwards pagination to reach the test gate")
+            return
+        }
+
+        let replacementForwardMessages = (0..<450).map { index in
+            timelineMessage(
+                id: String(format: "fresh-forward-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh forward \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacementForward = FakeTimelineMessagesSubscription(
+            messages: replacementForwardMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        _ = try? await replacementForward.paginateBackwards(count: 100)
+        _ = try? await replacementForward.paginateBackwards(count: 100)
+        let replacementForwardWindow = replacementForward.snapshot() ?? emptyTimelinePage()
+
+        state.activeTimelineSubscription = replacementForward
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacementForwardWindow,
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        let replacementForwardFirst = state.messagesByChat["direct-group"]?.first?.id
+        let replacementForwardLast = state.messagesByChat["direct-group"]?.last?.id
+        #expect(replacementForwardFirst != nil)
+        #expect(replacementForwardLast != nil)
+        #expect(replacementForwardFirst != scrolledBackFirst)
+
+        replacementFwd.releasePaginationGate()
+        _ = await staleForward
+
+        #expect(state.messagesByChat["direct-group"]?.first?.id == replacementForwardFirst)
+        #expect(state.messagesByChat["direct-group"]?.last?.id == replacementForwardLast)
+        #expect(state.messagesByChat["direct-group"]?.first?.id != scrolledBackFirst)
+    }
+
+    @MainActor
+    @Test func staleTimelinePaginationApplyDoesNotClobberReplacementSubscriptionWindow() async throws {
+        // Issue #529 follow-up: the subscription identity guard must survive `applyTimelineWindow`
+        // suspension during sender resolution and off-main mapping, not only the paginate await.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "message-005")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+
+        state.timelineApplyMapGateEnabled = true
+        async let staleBack: Void = state.loadOlderMessages(groupIdHex: "direct-group")
+        let didSuspendApply = await waitFor {
+            state.selectedTimelinePaging.isLoadingBefore && state.didReachTimelineApplyMapGate
+        }
+        guard didSuspendApply else {
+            state.timelineApplyMapGateEnabled = false
+            state.releaseTimelineApplyMapGate()
+            _ = await staleBack
+            Issue.record("Expected backwards pagination apply to reach the map gate")
+            return
+        }
+
+        let replacementMessages = (0..<105).map { index in
+            timelineMessage(
+                id: String(format: "fresh-apply-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh apply \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacement = FakeTimelineMessagesSubscription(
+            messages: replacementMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacement
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacement.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-apply-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-apply-104")
+
+        state.releaseTimelineApplyMapGate()
+        _ = await staleBack
+
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-apply-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-apply-104")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+    }
+
+    @MainActor
+    @Test func staleTimelinePaginationErrorDoesNotSurfaceAfterSubscriptionReplacement() async throws {
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        let staleSubscription = try #require(state.activeTimelineSubscription as? FakeTimelineMessagesSubscription)
+        state.lastError = nil
+
+        staleSubscription.paginationGateEnabled = true
+        staleSubscription.throwsAfterPaginationGate = true
+        async let staleBack: Void = state.loadOlderMessages(groupIdHex: "direct-group")
+        let didSuspendBack = await waitFor {
+            state.selectedTimelinePaging.isLoadingBefore && staleSubscription.didReachPaginationGate
+        }
+        guard didSuspendBack else {
+            staleSubscription.paginationGateEnabled = false
+            staleSubscription.throwsAfterPaginationGate = false
+            staleSubscription.releasePaginationGate()
+            _ = await staleBack
+            Issue.record("Expected backwards pagination to reach the test gate")
+            return
+        }
+
+        let replacement = FakeTimelineMessagesSubscription(
+            messages: [
+                timelineMessage(
+                    id: "fresh-error-000",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Fresh error",
+                    recordedAt: baseTime
+                )
+            ],
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacement
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacement.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+
+        staleSubscription.releasePaginationGate()
+        _ = await staleBack
+
+        #expect(state.lastError == nil)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-error-000")
+    }
+
     @Test func newerTimelinePagingRestoresAnchorInsteadOfScrollingToBottom() {
         let historicalPaging = TimelinePagingState(
             hasMoreBefore: true,
@@ -18268,6 +18617,10 @@ private final class FakeChatListSubscription: ChatListSubscription {
 // `paginateBackwards`/`paginateForwards` and mutated by live `next()` updates. Mirrors the
 // marmot-app windowing contract closely enough for client-level tests; the exact math is
 // unit-tested in Rust.
+private enum FakeTimelinePaginationError: Error {
+    case staleSubscription
+}
+
 private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscription {
     private var fullSet: TimelinePageFfi
     private let limit: Int
@@ -18280,6 +18633,13 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
     private let recordSnapshot: () -> Void
     private(set) var paginateBackwardsCount = 0
     private(set) var paginateForwardsCount = 0
+    /// Issue #529 regression support: when armed, the first `paginateBackwards` or
+    /// `paginateForwards` call suspends until `releasePaginationGate()` is invoked.
+    var paginationGateEnabled = false
+    private(set) var didReachPaginationGate = false
+    private var paginationGateContinuation: CheckedContinuation<Void, Never>?
+    /// When set with `paginationGateEnabled`, the paginate call throws after the gate releases.
+    var throwsAfterPaginationGate = false
 
     required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
         self.fullSet = emptyTimelinePage()
@@ -18335,6 +18695,10 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
 
     override func paginateBackwards(count: UInt32) async throws -> TimelinePageFfi {
         paginateBackwardsCount += 1
+        await passPaginationGateIfArmed()
+        if throwsAfterPaginationGate {
+            throw FakeTimelinePaginationError.staleSubscription
+        }
         lo = max(0, lo - Int(count))
         if hi - lo > windowCap { hi = lo + windowCap }
         return windowPage()
@@ -18342,9 +18706,26 @@ private final class FakeTimelineMessagesSubscription: TimelineMessagesSubscripti
 
     override func paginateForwards(count: UInt32) async throws -> TimelinePageFfi {
         paginateForwardsCount += 1
+        await passPaginationGateIfArmed()
+        if throwsAfterPaginationGate {
+            throw FakeTimelinePaginationError.staleSubscription
+        }
         hi = min(fullSet.messages.count, hi + Int(count))
         if hi - lo > windowCap { lo = hi - windowCap }
         return windowPage()
+    }
+
+    private func passPaginationGateIfArmed() async {
+        guard paginationGateEnabled, paginationGateContinuation == nil, !didReachPaginationGate else { return }
+        didReachPaginationGate = true
+        await withCheckedContinuation { continuation in
+            paginationGateContinuation = continuation
+        }
+    }
+
+    func releasePaginationGate() {
+        paginationGateContinuation?.resume()
+        paginationGateContinuation = nil
     }
 
     /// Dequeue the next queued signal, mutate the fake's server-side `fullSet` and


### PR DESCRIPTION
Fixes #529

Replaces retired setup PRs #539 and #549. This branch contains a fresh signed commit attributed to agent-p1p with the identical corrected tree.

## Summary
- preserve the captured subscription identity through pagination window application and re-check ownership after every suspension point before replacing messages
- suppress errors from pagination operations whose subscription has been replaced
- add deterministic regressions for backwards/forwards replacement, replacement during apply, and stale pagination errors

## Review feedback addressed
The blocking #539 review identified a TOCTOU gap inside `applyTimelineWindow`; ownership is now carried into that helper and validated after sender resolution and off-main mapping, immediately before `replaceMessages`. The stale-error suggestion is also implemented.

## Verification
- `git diff --check origin/master...HEAD`
- `bash -n scripts/ci/macos-sanity-checks.sh`
- identical corrected tree passed Mac CI run 29610195585: Swift format, project sanity, unit tests, arm64 release build, and static analysis
- this replacement PR must pass a fresh Mac CI run before handoff

## Sensitive paths
None. Client timeline coordination and test-only fakes/hooks only; no crypto, MLS/CGKA, key handling, trust anchors, authentication, or protocol semantics.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/550">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->