### PR TITLE
fix: preserve group mutation guards on close

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -39,15 +39,11 @@ extension WorkspaceState {
         // Invalidate any in-flight load so a stale completion cannot repopulate closed details or
         // resurrect the spinner; this also clears `isLoadingGroupDetails`. See issue #135.
         invalidateGroupDetailsLoad()
-        isSavingGroupProfile = false
-        isInvitingGroupMember = false
         isAcceptingGroupInvite = false
         isDecliningGroupInvite = false
         isArchivingGroup = false
-        isLeavingGroup = false
         isExportingGroupTranscript = false
         groupTranscriptExportStatus = nil
-        mutatingGroupMemberId = nil
     }
 
     func startCopySelectedGroupTranscriptJSON() {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11495,6 +11495,29 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func closingGroupDetailsPreservesOperationOwnedFlags() {
+        // Issue #522: these flags are mutexes owned by the async operations that set them. Closing
+        // the panel while FFI is suspended must leave them set until each operation's defer runs.
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+        state.isSavingGroupProfile = true
+        state.isInvitingGroupMember = true
+        state.isLeavingGroup = true
+        state.isSavingGroupImage = true
+        state.isUpdatingDisappearingMessages = true
+        state.mutatingGroupMemberId = "member-in-flight"
+
+        state.closeGroupDetails()
+
+        #expect(state.isSavingGroupProfile)
+        #expect(state.isInvitingGroupMember)
+        #expect(state.isLeavingGroup)
+        #expect(state.isSavingGroupImage)
+        #expect(state.isUpdatingDisappearingMessages)
+        #expect(state.mutatingGroupMemberId == "member-in-flight")
+        #expect(state.hasInFlightGroupDetailsMutation)
+    }
+
+    @MainActor
     @Test func closingGroupDetailsInvalidatesInFlightGroupMemberMutationApply() async throws {
         // Issue #392: group-member mutations return a fresh group-details snapshot. If the details
         // panel is closed while the mutation is in flight, that completion must not repopulate the

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11526,6 +11526,7 @@ struct whitenoise_macTests {
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
         let state = try await openInstalledGroupDetails(runtime: runtime)
+        let groupChat = try #require(state.activeChats.first { $0.id == "group" })
         let member = try #require(state.groupDetailsSnapshot?.members.first { !$0.isSelf })
 
         runtime.groupMutationGateEnabled = true
@@ -11541,10 +11542,8 @@ struct whitenoise_macTests {
 
         // Issue #522: reopening the same group while the first MLS commit is still suspended must
         // not permit a second member mutation through the shared in-flight guard.
-        let groupChat = try #require(state.activeChats.first { $0.id == "group" })
         await state.showGroupDetails(for: groupChat)
-        let reopenedMember = try #require(state.groupDetailsSnapshot?.members.first { $0.id == member.id })
-        await state.promoteGroupMember(reopenedMember)
+        await state.promoteGroupMember(member)
         #expect(runtime.promoteAdminDetailedCallCount == 1)
         state.closeGroupDetails()
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11543,6 +11543,7 @@ struct whitenoise_macTests {
         // Issue #522: reopening the same group while the first MLS commit is still suspended must
         // not permit a second member mutation through the shared in-flight guard.
         await state.showGroupDetails(for: groupChat)
+        #expect(state.groupDetailsSnapshot?.members.contains(where: { $0.id == member.id }) == true)
         await state.promoteGroupMember(member)
         #expect(runtime.promoteAdminDetailedCallCount == 1)
         state.closeGroupDetails()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11537,6 +11537,16 @@ struct whitenoise_macTests {
         state.closeGroupDetails()
         #expect(state.groupDetailsSnapshot == nil)
         #expect(!state.isGroupDetailsPresented)
+        #expect(state.mutatingGroupMemberId == member.id)
+
+        // Issue #522: reopening the same group while the first MLS commit is still suspended must
+        // not permit a second member mutation through the shared in-flight guard.
+        let groupChat = try #require(state.activeChats.first { $0.id == "group" })
+        await state.showGroupDetails(for: groupChat)
+        let reopenedMember = try #require(state.groupDetailsSnapshot?.members.first { $0.id == member.id })
+        await state.promoteGroupMember(reopenedMember)
+        #expect(runtime.promoteAdminDetailedCallCount == 1)
+        state.closeGroupDetails()
 
         runtime.releaseGroupMutationGate()
         await promotion


### PR DESCRIPTION
## Summary
- keep group-details async operation flags set when the details panel closes
- preserve the invite/member-mutation overlap mutex until the owning FFI call completes
- add regression coverage for all operation-owned flags named in issue #522

## Verification
- PASS: source-contract check confirms closeGroupDetails no longer resets operation-owned flags
- PASS: git diff --check
- PASS: independent pre-commit logic/security review
- Not run locally: xcodebuild/Swift are unavailable on this Linux worker; Mac CI will run formatting, unit tests, release build, and static analysis

Fixes #522

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/551">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group details closing behavior so active group operations continue without losing their progress state.
  * Preserved ongoing actions such as saving, inviting, leaving, archiving, and transcript export when group details are closed.

* **Tests**
  * Added coverage to verify that in-progress group operations remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->