### PR TITLE
fix: prevent deep links from interrupting active work

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+DeepLinks.swift
+++ b/whitenoise-mac/Core/WorkspaceState+DeepLinks.swift
@@ -32,7 +32,7 @@ extension WorkspaceState {
         }
 
         appActivationHandler(false)
-        Task { await openProfileReference(reference) }
+        Task { await openProfileReferenceFromDeepLink(reference) }
     }
 
     func flushPendingDeepLinkIfReady() {
@@ -42,6 +42,25 @@ extension WorkspaceState {
         pendingDeepLinkProfileReference = nil
         // Queued links came from an earlier untrusted URL event. Handle them once ready,
         // but do not foreground the app later as a delayed side effect.
-        Task { await openProfileReference(reference) }
+        Task { await openProfileReferenceFromDeepLink(reference) }
+    }
+
+    /// OS-level links are unsolicited. Do not let them interrupt a recording flow or alter a
+    /// New Chat draft; profile links explicitly tapped inside the app still use the normal
+    /// `openProfileReference` behavior.
+    private func openProfileReferenceFromDeepLink(_ reference: String) async {
+        guard !isRecordingVoiceMessage, !isPreparingVoiceRecording else {
+            backgroundStatus = L10n.string("Finish the current voice recording before opening this link.")
+            return
+        }
+
+        guard !(isNewChatComposerVisible && hasInProgressNewChatComposition) else {
+            backgroundStatus = L10n.string(
+                "Finish or discard the current New Chat draft before opening this link."
+            )
+            return
+        }
+
+        await openProfileReference(reference)
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -14728,7 +14728,9 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func marmotDeepLinkPreservesInProgressNewChatComposition() async throws {
+    @Test func marmotDeepLinkDoesNotMutateInProgressNewChatComposition() async throws {
+        // Issue #510: OS-delivered marmot:// links are untrusted and must not silently append
+        // an attacker-chosen recipient to a draft that the user is already composing.
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
         let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
@@ -14736,7 +14738,11 @@ struct whitenoise_macTests {
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installNormalizedMemberRef(query: "npub1alyce", accountIdHex: aliceId, npub: "npub1alyce")
         runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: bobId, npub: "npub1p0p")
-        let state = WorkspaceState(clientFactory: { runtime })
+        let activationRecorder = AppActivationRecorder()
+        let state = WorkspaceState(
+            appActivationHandler: activationRecorder.record,
+            clientFactory: { runtime }
+        )
 
         await state.bootstrap()
         state.showNewChat()
@@ -14746,15 +14752,76 @@ struct whitenoise_macTests {
         state.newChatDescription = "planning space"
 
         state.handleDeepLinkURL(URL(string: "marmot://profile/npub1p0p?from=qr")!)
-        let added = await waitFor {
-            state.newChatRecipients.contains { $0.accountIdHex == bobId }
+        let blocked = await waitFor {
+            state.backgroundStatus == "Finish or discard the current New Chat draft before opening this link."
         }
 
-        #expect(added)
+        #expect(blocked)
         #expect(state.isNewChatComposerVisible)
-        #expect(state.newChatRecipients.map(\.accountIdHex) == [aliceId, bobId])
+        #expect(state.newChatRecipients.map(\.accountIdHex) == [aliceId])
         #expect(state.newChatName == "Project Room")
         #expect(state.newChatDescription == "planning space")
+        #expect(!runtime.refreshedProfileIds.contains(bobId))
+        #expect(activationRecorder.requests == [false])
+    }
+
+    @MainActor
+    @Test func marmotDeepLinkDoesNotCancelInProgressVoiceRecording() async throws {
+        // Issue #510: an unsolicited external link must not discard plaintext audio that the
+        // user is still recording or hide the recording controls by opening New Chat.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let activationRecorder = AppActivationRecorder()
+        let state = WorkspaceState(
+            appActivationHandler: activationRecorder.record,
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        let recordingURL = try armInProgressVoiceRecording(on: state)
+        defer { state.cancelVoiceRecording() }
+
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1p0p")!)
+        let blocked = await waitFor {
+            state.backgroundStatus == "Finish the current voice recording before opening this link."
+        }
+
+        #expect(blocked)
+        #expect(state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingURL == recordingURL)
+        #expect(state.voiceRecordingMeterTask != nil)
+        #expect(FileManager.default.fileExists(atPath: recordingURL.path))
+        #expect(!state.isNewChatComposerVisible)
+        #expect(state.resolvedNewChatRecipient == nil)
+        #expect(activationRecorder.requests == [false])
+    }
+
+    @MainActor
+    @Test func marmotDeepLinkDoesNotInterruptVoiceRecordingPreparation() async throws {
+        // The microphone-permission await is part of the recording flow too. Navigating during
+        // it could let recording begin after the New Chat composer has hidden the stop controls.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let activationRecorder = AppActivationRecorder()
+        let state = WorkspaceState(
+            appActivationHandler: activationRecorder.record,
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        state.isPreparingVoiceRecording = true
+        defer { state.isPreparingVoiceRecording = false }
+
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1p0p")!)
+        let blocked = await waitFor {
+            state.backgroundStatus == "Finish the current voice recording before opening this link."
+        }
+
+        #expect(blocked)
+        #expect(state.isPreparingVoiceRecording)
+        #expect(!state.isNewChatComposerVisible)
+        #expect(state.resolvedNewChatRecipient == nil)
+        #expect(activationRecorder.requests == [false])
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- blocks unsolicited OS profile deep links while New Chat contains an in-progress draft
- preserves active and permission-pending voice recordings instead of navigating away
- keeps explicitly tapped in-app profile links on the existing append/open path

## Test plan
- [x] Added regression coverage for recipient injection, active-recording cancellation, and permission-pending interruption
- [x] git diff --check
- [ ] macOS unit tests and swift-format (CI; Xcode toolchain unavailable on Linux worker)

Fixes #510

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/554">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->