### PR TITLE
fix: enforce media cache cap across unavailable and staged entries

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -145,6 +145,12 @@ nonisolated enum MessageMediaDiskCacheKeychain {
     }
 }
 
+private actor MessageMediaDiskCacheStagingCoordinator {
+    func perform(_ operation: @Sendable () -> Void) {
+        operation()
+    }
+}
+
 nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     typealias DirectoryResolver = @Sendable () throws -> URL
     typealias KeyProvider = @Sendable () throws -> SymmetricKey
@@ -182,6 +188,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private let keyDeleter: KeyDeleter
     private let timestampProvider: TimestampProvider
     private let evictionPolicy: EvictionPolicy
+    // Preparation and commit share one actor-isolated synchronous operation so at most one full
+    // encrypted payload is present in `staging/` per cache instance. This bounds the temporary
+    // disk spike without putting encryption or file writes back on the read/purge bookkeeping lock.
+    private let stagingCoordinator = MessageMediaDiskCacheStagingCoordinator()
     // Staging directories older than this cache instance were left by a previous process and
     // are safe to discard; same-session staging may still be an in-flight store.
     private let sessionStartedAtUnixSeconds: TimeInterval
@@ -280,39 +290,43 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         guard !Task.isCancelled else { return }
 
         let root: URL
-        let symmetricKey: SymmetricKey
         do {
             root = try directoryResolver()
         } catch {
             return
         }
         sweepStaleStagingDirectoriesIfNeeded(root: root)
-        do {
-            symmetricKey = try keyProvider()
-        } catch {
-            return
-        }
         guard !Task.isCancelled, isCurrent(start) else { return }
 
         let plaintext = download.payload.data
-        let cachedAtUnixSeconds = timestampProvider()
-        let prepared = await Task.detached(priority: .utility) {
-            Self.prepareStagedEntry(
-                download: download,
-                plaintext: plaintext,
-                for: key,
-                root: root,
-                symmetricKey: symmetricKey,
-                cachedAtUnixSeconds: cachedAtUnixSeconds
-            )
-        }.value
+        await stagingCoordinator.perform { [self] in
+            guard !Task.isCancelled, isCurrent(start) else { return }
 
-        guard let prepared else { return }
-        guard !Task.isCancelled else {
-            Self.discardPreparedEntry(prepared)
-            return
+            let symmetricKey: SymmetricKey
+            do {
+                symmetricKey = try keyProvider()
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, isCurrent(start) else { return }
+
+            guard
+                let prepared = Self.prepareStagedEntry(
+                    download: download,
+                    plaintext: plaintext,
+                    for: key,
+                    root: root,
+                    symmetricKey: symmetricKey,
+                    cachedAtUnixSeconds: timestampProvider()
+                )
+            else { return }
+
+            guard !Task.isCancelled else {
+                Self.discardPreparedEntry(prepared)
+                return
+            }
+            commitPreparedEntry(prepared, start: start, symmetricKey: symmetricKey)
         }
-        commitPreparedEntry(prepared, start: start, symmetricKey: symmetricKey)
     }
 
     func purgeAll(removeEncryptionKey: Bool = false) async {

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -204,7 +204,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private var purgeSequence = 0
     private var purgeTasks: [Int: ActivePurge] = [:]
     private var didSweepStagingDirectories = false
-    // Updated under `fileMutationLock` on commit and eviction.
+    // Updated under `fileMutationLock` on commit and eviction. Tracks committed entries only;
+    // live staging bytes are sampled separately when enforcing the byte cap.
     // Invalidated when read-path deletions or account purges remove an unknown subset.
     // Seeded with one full scan when nil so stores under the cap avoid re-walking the tree every time (#377).
     private var trackedFootprint: CacheFootprint?
@@ -578,7 +579,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
     private struct CacheScan {
         let removableEntries: [CacheEntry]
-        let footprint: CacheFootprint
+        let committedFootprint: CacheFootprint
+        let stagingByteCount: UInt64
     }
 
     private enum MetadataStatus {
@@ -907,7 +909,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         root: URL
     ) {
         if trackedFootprint == nil {
-            trackedFootprint = Self.cacheFootprint(root: root)
+            trackedFootprint = Self.committedFootprint(root: root)
             return
         }
 
@@ -923,19 +925,24 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
     private func enforceEvictionPolicy(root: URL, symmetricKey: SymmetricKey) {
         guard let tracked = trackedFootprint else { return }
+        let trackedTotalBytes = Self.addingWithSaturation(
+            tracked.byteCount,
+            Self.stagingByteCount(root: root)
+        )
         guard
             tracked.entryCount > evictionPolicy.maxEntryCount
-                || tracked.byteCount > evictionPolicy.maxTotalBytes
+                || trackedTotalBytes > evictionPolicy.maxTotalBytes
         else { return }
 
         let scan = Self.cacheScan(root: root, symmetricKey: symmetricKey)
         var entries = scan.removableEntries
-        var totalBytes = scan.footprint.byteCount
-        var remainingCount = scan.footprint.entryCount
+        var committedBytes = scan.committedFootprint.byteCount
+        var totalBytes = Self.addingWithSaturation(committedBytes, scan.stagingByteCount)
+        var remainingCount = scan.committedFootprint.entryCount
 
         guard remainingCount > evictionPolicy.maxEntryCount || totalBytes > evictionPolicy.maxTotalBytes
         else {
-            trackedFootprint = CacheFootprint(entryCount: remainingCount, byteCount: totalBytes)
+            trackedFootprint = CacheFootprint(entryCount: remainingCount, byteCount: committedBytes)
             return
         }
 
@@ -955,6 +962,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             do {
                 try FileManager.default.removeItem(at: entry.directory)
                 remainingCount -= 1
+                committedBytes = committedBytes > entry.byteCount ? committedBytes - entry.byteCount : 0
                 totalBytes = totalBytes > entry.byteCount ? totalBytes - entry.byteCount : 0
                 Self.removeEmptyDirectory(entry.directory.deletingLastPathComponent())
             } catch {
@@ -962,10 +970,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             }
         }
         Self.removeEmptyDirectory(root)
-        trackedFootprint = CacheFootprint(entryCount: remainingCount, byteCount: totalBytes)
+        // Staging bytes are live, temporary disk usage rather than committed cache entries.
+        // Keep the incremental accountant committed-only so each staging directory is counted
+        // exactly once when a later commit moves it into place.
+        trackedFootprint = CacheFootprint(entryCount: remainingCount, byteCount: committedBytes)
     }
 
-    private static func cacheFootprint(root: URL) -> CacheFootprint {
+    private static func committedFootprint(root: URL) -> CacheFootprint {
         guard
             let shardDirectories = try? FileManager.default.contentsOfDirectory(
                 at: root,
@@ -994,6 +1005,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     }
 
     private static func cacheScan(root: URL, symmetricKey: SymmetricKey) -> CacheScan {
+        let stagedBytes = stagingByteCount(root: root)
         guard
             let shardDirectories = try? FileManager.default.contentsOfDirectory(
                 at: root,
@@ -1003,7 +1015,8 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         else {
             return CacheScan(
                 removableEntries: [],
-                footprint: CacheFootprint(entryCount: 0, byteCount: 0)
+                committedFootprint: CacheFootprint(entryCount: 0, byteCount: 0),
+                stagingByteCount: stagedBytes
             )
         }
 
@@ -1021,10 +1034,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
             for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
                 let entryByteCount = entryByteCount(at: entryDirectory)
-                let metadata: Metadata
+                let cachedAtUnixSeconds: TimeInterval
                 switch metadataStatus(in: entryDirectory, symmetricKey: symmetricKey) {
-                case .readable(let decodedMetadata):
-                    metadata = decodedMetadata
+                case .readable(let metadata):
+                    cachedAtUnixSeconds = metadata.cachedAtUnixSeconds
                     entryCount += 1
                     byteCount = addingWithSaturation(byteCount, entryByteCount)
                 case .corrupt:
@@ -1032,15 +1045,18 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                     removeEmptyDirectory(shardDirectory)
                     continue
                 case .unavailable:
+                    // Cache entries are disposable under pressure. If metadata is temporarily
+                    // unreadable or belongs to a newer format, reclaim it before evicting a
+                    // readable entry; otherwise its bytes can keep the cache over cap forever.
+                    cachedAtUnixSeconds = -Double.infinity
                     entryCount += 1
                     byteCount = addingWithSaturation(byteCount, entryByteCount)
-                    continue
                 }
 
                 entries.append(
                     CacheEntry(
                         directory: entryDirectory,
-                        cachedAtUnixSeconds: metadata.cachedAtUnixSeconds,
+                        cachedAtUnixSeconds: cachedAtUnixSeconds,
                         byteCount: entryByteCount
                     )
                 )
@@ -1048,8 +1064,25 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
         return CacheScan(
             removableEntries: entries,
-            footprint: CacheFootprint(entryCount: entryCount, byteCount: byteCount)
+            committedFootprint: CacheFootprint(entryCount: entryCount, byteCount: byteCount),
+            stagingByteCount: stagedBytes
         )
+    }
+
+    private static func stagingByteCount(root: URL) -> UInt64 {
+        let stagingRoot = root.appendingPathComponent("staging", isDirectory: true)
+        guard
+            let stagingDirectories = try? FileManager.default.contentsOfDirectory(
+                at: stagingRoot,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        else { return 0 }
+
+        return stagingDirectories.reduce(into: UInt64(0)) { byteCount, stagingDirectory in
+            guard isDirectory(stagingDirectory) else { return }
+            byteCount = addingWithSaturation(byteCount, entryByteCount(at: stagingDirectory))
+        }
     }
 
     private static func isDirectory(_ url: URL) -> Bool {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -87,8 +87,10 @@ private final class BlockingFfiGate: @unchecked Sendable {
 private final class OneShotKeyProviderGate: @unchecked Sendable {
     private let lock = NSLock()
     private let reached = DispatchSemaphore(value: 0)
+    private let secondCallReached = DispatchSemaphore(value: 0)
     private let release = DispatchSemaphore(value: 0)
     private let keyData: Data
+    private var callCount = 0
     private var shouldBlock = true
 
     init(keyData: Data = Data(repeating: 0x42, count: 32)) {
@@ -96,10 +98,14 @@ private final class OneShotKeyProviderGate: @unchecked Sendable {
     }
 
     func symmetricKey() throws -> SymmetricKey {
-        let shouldWait = lock.withLock {
-            let value = shouldBlock
+        let (shouldWait, isSecondCall) = lock.withLock {
+            callCount += 1
+            let shouldWait = shouldBlock
             shouldBlock = false
-            return value
+            return (shouldWait, callCount == 2)
+        }
+        if isSecondCall {
+            secondCallReached.signal()
         }
         if shouldWait {
             reached.signal()
@@ -110,6 +116,10 @@ private final class OneShotKeyProviderGate: @unchecked Sendable {
 
     func waitUntilReached() {
         reached.wait()
+    }
+
+    func waitForSecondCall(timeout: DispatchTime) async -> DispatchTimeoutResult {
+        await waitForSemaphore(secondCallReached, timeout: timeout)
     }
 
     func releaseGate() {
@@ -2634,7 +2644,8 @@ struct whitenoise_macTests {
         defer { try? fileManager.removeItem(at: root) }
 
         let stagedPayload = Data(repeating: 0xab, count: 128 * 1_024)
-        let stagingDirectory = root
+        let stagingDirectory =
+            root
             .appendingPathComponent("staging", isDirectory: true)
             .appendingPathComponent("active-store", isDirectory: true)
         let stagingPayloadURL = stagingDirectory.appendingPathComponent("payload.bin")
@@ -2666,6 +2677,73 @@ struct whitenoise_macTests {
 
         #expect(fileManager.fileExists(atPath: stagingPayloadURL.path))
         #expect(await cache.cachedDownload(for: key) == nil)
+    }
+
+    @Test func messageMediaDiskCacheSerializesConcurrentStorePreparation() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let keyProviderGate = OneShotKeyProviderGate()
+        let cache = MessageMediaDiskCache(
+            directoryResolver: { root },
+            keyProvider: keyProviderGate.symmetricKey,
+            keyDeleter: {}
+        )
+        let firstPlaintext = Data("first concurrently stored media".utf8)
+        let secondPlaintext = Data("second concurrently stored media".utf8)
+        let firstKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: firstPlaintext, ciphertextByte: 0xa1)
+        )
+        let secondKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: secondPlaintext, ciphertextByte: 0xa2)
+        )
+
+        let firstStore = Task {
+            await cache.store(
+                MessageMediaDownload(
+                    data: firstPlaintext,
+                    fileName: "first.jpg",
+                    mediaType: "image/jpeg",
+                    sizeBytes: UInt64(firstPlaintext.count),
+                    payloadId: "first"
+                ),
+                for: firstKey
+            )
+        }
+        await Task.detached {
+            keyProviderGate.waitUntilReached()
+        }.value
+
+        let secondStore = Task {
+            await cache.store(
+                MessageMediaDownload(
+                    data: secondPlaintext,
+                    fileName: "second.jpg",
+                    mediaType: "image/jpeg",
+                    sizeBytes: UInt64(secondPlaintext.count),
+                    payloadId: "second"
+                ),
+                for: secondKey
+            )
+        }
+
+        #expect(
+            await keyProviderGate.waitForSecondCall(timeout: .now() + .milliseconds(200)) == .timedOut
+        )
+        keyProviderGate.releaseGate()
+        await firstStore.value
+        await secondStore.value
+        #expect(
+            await keyProviderGate.waitForSecondCall(timeout: .now() + .seconds(1)) == .success
+        )
+        #expect(try #require(await cache.cachedDownload(for: firstKey)).data == firstPlaintext)
+        #expect(try #require(await cache.cachedDownload(for: secondKey)).data == secondPlaintext)
     }
 
     @Test func messageMediaDiskCacheAccountPurgeCleansUnreadableEntriesAfterAccountPass() async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2686,8 +2686,15 @@ struct whitenoise_macTests {
         defer { try? fileManager.removeItem(at: root) }
 
         let keyProviderGate = OneShotKeyProviderGate()
+        let directoryResolutionCount = AtomicCounter()
+        let secondStoreResolvedDirectory = DispatchSemaphore(value: 0)
         let cache = MessageMediaDiskCache(
-            directoryResolver: { root },
+            directoryResolver: {
+                if directoryResolutionCount.increment() == 2 {
+                    secondStoreResolvedDirectory.signal()
+                }
+                return root
+            },
             keyProvider: keyProviderGate.symmetricKey,
             keyDeleter: {}
         )
@@ -2733,6 +2740,12 @@ struct whitenoise_macTests {
             )
         }
 
+        #expect(
+            await waitForSemaphore(
+                secondStoreResolvedDirectory,
+                timeout: .now() + .seconds(1)
+            ) == .success
+        )
         #expect(
             await keyProviderGate.waitForSecondCall(timeout: .now() + .milliseconds(200)) == .timedOut
         )

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2574,6 +2574,100 @@ struct whitenoise_macTests {
         #expect(!cacheFiles.contains { $0.hasSuffix("payload.bin") })
     }
 
+    @Test func messageMediaDiskCacheEvictionReclaimsUnavailableEntriesBeforeReadableEntries() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 1, maxTotalBytes: UInt64.max)
+        )
+        let unavailablePlaintext = Data("temporarily unavailable cached media".utf8)
+        let readablePlaintext = Data("readable cached media".utf8)
+        let unavailableKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: unavailablePlaintext, ciphertextByte: 0xa1)
+        )
+        let readableKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: readablePlaintext, ciphertextByte: 0xa2)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: unavailablePlaintext,
+                fileName: "unavailable.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(unavailablePlaintext.count),
+                payloadId: "unavailable"
+            ),
+            for: unavailableKey
+        )
+        let unavailableEntryDirectory = try #require(cache.entryDirectory(for: unavailableKey))
+        let unavailableMetadataURL = unavailableEntryDirectory.appendingPathComponent("metadata.bin")
+        try fileManager.removeItem(at: unavailableMetadataURL)
+        try fileManager.createDirectory(at: unavailableMetadataURL, withIntermediateDirectories: false)
+
+        await cache.store(
+            MessageMediaDownload(
+                data: readablePlaintext,
+                fileName: "readable.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(readablePlaintext.count),
+                payloadId: "readable"
+            ),
+            for: readableKey
+        )
+
+        #expect(!fileManager.fileExists(atPath: unavailableEntryDirectory.path))
+        #expect(try #require(await cache.cachedDownload(for: readableKey)).data == readablePlaintext)
+    }
+
+    @Test func messageMediaDiskCacheCountsInSessionStagingBytesAgainstByteLimit() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let stagedPayload = Data(repeating: 0xab, count: 128 * 1_024)
+        let stagingDirectory = root
+            .appendingPathComponent("staging", isDirectory: true)
+            .appendingPathComponent("active-store", isDirectory: true)
+        let stagingPayloadURL = stagingDirectory.appendingPathComponent("payload.bin")
+        try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        try stagedPayload.write(to: stagingPayloadURL)
+
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 10, maxTotalBytes: UInt64(stagedPayload.count)),
+            sessionStartedAtUnixSeconds: 0
+        )
+        let plaintext = Data("committed media that does not fit beside active staging".utf8)
+        let key = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: plaintext)
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: plaintext,
+                fileName: "committed.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(plaintext.count),
+                payloadId: "committed"
+            ),
+            for: key
+        )
+
+        #expect(fileManager.fileExists(atPath: stagingPayloadURL.path))
+        #expect(await cache.cachedDownload(for: key) == nil)
+    }
+
     @Test func messageMediaDiskCacheAccountPurgeCleansUnreadableEntriesAfterAccountPass() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
## Summary
- Makes `.unavailable` media-cache entries evictable under pressure, ahead of readable entries.
- Counts live `staging/` metadata and payload bytes when enforcing `maxTotalBytes` while keeping the incremental accountant committed-only.
- Serializes preparation through commit per cache instance so concurrent downloads cannot accumulate staged payloads before enforcement.
- Adds regression coverage for unavailable-entry eviction, in-session staging usage, and concurrent-store serialization.

## Verification
- [x] Swift format lint
- [x] macOS project sanity checks
- [x] 444 unit tests
- [x] Release build smoke (arm64)
- [x] Static Analysis
- [x] `git diff --check`

## CI history
The initial run failed format lint and a later run hit an unrelated flaky workspace media-resolution test; both were addressed/retried, and the final head is green. Under Pip policy, this ever-red PR is not eligible for auto-merge.

Fixes #512