### PR TITLE
fix: bound Markdown display node width

### DIFF
--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -19,19 +19,68 @@ nonisolated struct MarkdownDisplayDocument {
     /// than preserving nested structure.
     fileprivate static let maxDepth = 32
 
+    /// Upper bound on SwiftUI-producing display nodes per message (top-level and nested
+    /// blocks, list items, table rows, and table cells). Inline AST nodes collapse into a
+    /// single `AttributedString`/`Text` and do not consume slots. Prevents attacker-crafted
+    /// wide tables or long lists from materializing thousands of non-lazy `Grid`/`ForEach`
+    /// children in one bubble.
+    static let maxDisplayNodes = 256
+
     init(document: MarkdownDocumentFfi) {
-        self.blocks = Self.makeBlocks(from: document.blocks, remainingDepth: Self.maxDepth)
-        self.truncated = document.truncated
+        var budget = MarkdownDisplayBudget(limit: Self.maxDisplayNodes)
+        self.blocks = Self.makeBlocks(
+            from: document.blocks,
+            remainingDepth: Self.maxDepth,
+            budget: &budget
+        )
+        self.truncated = document.truncated || budget.didTruncate
     }
 
     fileprivate static func makeBlocks(
         from blocks: [MarkdownBlockFfi],
-        remainingDepth: Int
+        remainingDepth: Int,
+        budget: inout MarkdownDisplayBudget
     ) -> [MarkdownDisplayBlockNode] {
         guard remainingDepth > 0 else { return [] }
-        return blocks.enumerated().map { index, block in
-            MarkdownDisplayBlockNode(id: index, block: MarkdownDisplayBlock(block, remainingDepth: remainingDepth))
+        var result: [MarkdownDisplayBlockNode] = []
+        for (index, block) in blocks.enumerated() {
+            guard budget.takeOne() else { break }
+            result.append(
+                MarkdownDisplayBlockNode(
+                    id: index,
+                    block: MarkdownDisplayBlock(block, remainingDepth: remainingDepth, budget: &budget)
+                )
+            )
         }
+        return result
+    }
+}
+
+nonisolated fileprivate struct MarkdownDisplayBudget {
+    private(set) var remaining: Int
+    private(set) var didTruncate = false
+
+    init(limit: Int) {
+        remaining = limit
+    }
+
+    /// Reserves up to `count` display-node slots; returns how many were granted.
+    mutating func take(_ count: Int) -> Int {
+        guard count > 0 else { return 0 }
+        if remaining <= 0 {
+            didTruncate = true
+            return 0
+        }
+        let granted = min(count, remaining)
+        remaining -= granted
+        if granted < count {
+            didTruncate = true
+        }
+        return granted
+    }
+
+    mutating func takeOne() -> Bool {
+        take(1) == 1
     }
 }
 
@@ -50,7 +99,7 @@ nonisolated enum MarkdownDisplayBlock {
     case table(header: [MarkdownDisplayTableCell], rows: [MarkdownDisplayTableRow])
     case mathBlock(String)
 
-    init(_ block: MarkdownBlockFfi, remainingDepth: Int) {
+    fileprivate init(_ block: MarkdownBlockFfi, remainingDepth: Int, budget: inout MarkdownDisplayBudget) {
         switch block {
         case .paragraph(let inlines):
             self = .paragraph(
@@ -66,19 +115,39 @@ nonisolated enum MarkdownDisplayBlock {
         case .codeBlock(_, _, let content):
             self = .codeBlock(content)
         case .blockQuote(let blocks):
-            self = .blockQuote(MarkdownDisplayDocument.makeBlocks(from: blocks, remainingDepth: remainingDepth - 1))
-        case .listBlock(let kind, _, let items):
-            self = .list(items: Self.listItems(kind: kind, items: items, remainingDepth: remainingDepth))
-        case .table(_, let header, let rows):
-            self = .table(
-                header: Self.tableCells(from: header, remainingDepth: remainingDepth),
-                rows: rows.enumerated().map { rowIndex, row in
-                    MarkdownDisplayTableRow(
-                        id: rowIndex,
-                        cells: Self.tableCells(from: row, remainingDepth: remainingDepth)
-                    )
-                }
+            self = .blockQuote(
+                MarkdownDisplayDocument.makeBlocks(
+                    from: blocks,
+                    remainingDepth: remainingDepth - 1,
+                    budget: &budget
+                )
             )
+        case .listBlock(let kind, _, let items):
+            self = .list(
+                items: Self.listItems(
+                    kind: kind,
+                    items: items,
+                    remainingDepth: remainingDepth,
+                    budget: &budget
+                )
+            )
+        case .table(_, let header, let rows):
+            let headerCount = budget.take(header.count)
+            let displayHeader = Self.tableCells(
+                from: Array(header.prefix(headerCount)),
+                remainingDepth: remainingDepth
+            )
+            var displayRows: [MarkdownDisplayTableRow] = []
+            for (rowIndex, row) in rows.enumerated() {
+                guard budget.takeOne() else { break }
+                let cellCount = budget.take(row.count)
+                let cells = Self.tableCells(
+                    from: Array(row.prefix(cellCount)),
+                    remainingDepth: remainingDepth
+                )
+                displayRows.append(MarkdownDisplayTableRow(id: rowIndex, cells: cells))
+            }
+            self = .table(header: displayHeader, rows: displayRows)
         case .mathBlock(let content):
             self = .mathBlock(content)
         @unknown default:
@@ -89,15 +158,25 @@ nonisolated enum MarkdownDisplayBlock {
     private static func listItems(
         kind: MarkdownListKindFfi,
         items: [MarkdownListItemFfi],
-        remainingDepth: Int
+        remainingDepth: Int,
+        budget: inout MarkdownDisplayBudget
     ) -> [MarkdownDisplayListItem] {
-        items.enumerated().map { index, item in
-            MarkdownDisplayListItem(
-                id: index,
-                marker: listMarker(kind: kind, item: item, index: index),
-                blocks: MarkdownDisplayDocument.makeBlocks(from: item.blocks, remainingDepth: remainingDepth - 1)
+        var result: [MarkdownDisplayListItem] = []
+        for (index, item) in items.enumerated() {
+            guard budget.takeOne() else { break }
+            result.append(
+                MarkdownDisplayListItem(
+                    id: index,
+                    marker: listMarker(kind: kind, item: item, index: index),
+                    blocks: MarkdownDisplayDocument.makeBlocks(
+                        from: item.blocks,
+                        remainingDepth: remainingDepth - 1,
+                        budget: &budget
+                    )
+                )
             )
         }
+        return result
     }
 
     private static func listMarker(

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -2058,9 +2058,10 @@ private func markdownDisplayNodeCount(_ document: MarkdownDisplayDocument) -> In
                 partial + 1 + countBlocks(item.blocks)
             }
         case .table(let header, let rows):
-            return header.count + rows.reduce(0) { partial, row in
-                partial + 1 + row.cells.count
-            }
+            return header.count
+                + rows.reduce(0) { partial, row in
+                    partial + 1 + row.cells.count
+                }
         default:
             return 0
         }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1667,6 +1667,62 @@ struct PureValueTests {
         #expect(links(in: attributed).map(\.absoluteString) == ["nostr:\(bech32)"])
     }
 
+    @Test func overWideMarkdownTableBoundsDisplayNodesAndSetsTruncated() async throws {
+        // Regression for whitenoise-mac#517: depth is bounded but sibling width is not.
+        // A single wide table must not materialize thousands of Grid cells.
+        let document = wideMarkdownTable(columns: 50, rows: 50)
+        let display = MarkdownDisplayDocument(document: document)
+
+        #expect(display.truncated)
+        #expect(markdownDisplayNodeCount(display) <= MarkdownDisplayDocument.maxDisplayNodes)
+        guard case .table(let header, let rows) = display.blocks.first?.block else {
+            Issue.record("expected a table block")
+            return
+        }
+        #expect(!header.isEmpty)
+        #expect(header.first?.id == 0)
+        #expect(!rows.isEmpty)
+        #expect(rows.first?.id == 0)
+        #expect(rows.first?.cells.first?.id == 0)
+    }
+
+    @Test func overLongMarkdownListBoundsDisplayNodesAndSetsTruncated() async throws {
+        let document = longMarkdownList(itemCount: 500)
+        let display = MarkdownDisplayDocument(document: document)
+
+        #expect(display.truncated)
+        #expect(markdownDisplayNodeCount(display) <= MarkdownDisplayDocument.maxDisplayNodes)
+        guard case .list(let items) = display.blocks.first?.block else {
+            Issue.record("expected a list block")
+            return
+        }
+        #expect(!items.isEmpty)
+        #expect(items.first?.id == 0)
+        #expect(items.first?.blocks.first?.id == 0)
+    }
+
+    @Test func markdownDisplayPreservesCoreTruncatedFlag() async throws {
+        // Keep the display tree below the node budget so this specifically proves that
+        // an upstream/core truncation signal survives the Swift-side conversion.
+        let document = wideMarkdownTable(columns: 4, rows: 3)
+        let coreTruncated = MarkdownDocumentFfi(blocks: document.blocks, truncated: true)
+        let display = MarkdownDisplayDocument(document: coreTruncated)
+        #expect(display.truncated)
+    }
+
+    @Test func normalMarkdownTableIsNotTruncatedByDisplayBudget() async throws {
+        let document = wideMarkdownTable(columns: 4, rows: 3)
+        let display = MarkdownDisplayDocument(document: document)
+        #expect(!display.truncated)
+        guard case .table(let header, let rows) = display.blocks.first?.block else {
+            Issue.record("expected a table block")
+            return
+        }
+        #expect(header.count == 4)
+        #expect(rows.count == 3)
+        #expect(rows.allSatisfy { $0.cells.count == 4 })
+    }
+
     @MainActor
     @Test func groupImagePreviewURLUsesOpenverseThumbnailOnly() async throws {
         // Regression for whitenoise-mac#315: search-result tiles must connect only to
@@ -1944,6 +2000,73 @@ struct PureValueTests {
         #expect(firstSelectable)
         #expect(!secondSelectable)
     }
+}
+
+private func wideMarkdownTable(columns: Int, rows: Int) -> MarkdownDocumentFfi {
+    let header = (0..<columns).map { column in
+        MarkdownTableCellFfi(inlines: [.text(content: "h\(column)")])
+    }
+    let tableRows = (0..<rows).map { row in
+        (0..<columns).map { column in
+            MarkdownTableCellFfi(inlines: [.text(content: "\(row),\(column)")])
+        }
+    }
+    return MarkdownDocumentFfi(
+        blocks: [
+            .table(
+                alignments: Array(repeating: .left, count: columns),
+                header: header,
+                rows: tableRows
+            )
+        ],
+        truncated: false
+    )
+}
+
+private func longMarkdownList(itemCount: Int) -> MarkdownDocumentFfi {
+    let items = (0..<itemCount).map { index in
+        MarkdownListItemFfi(
+            blocks: [.paragraph(inlines: [.text(content: "item \(index)")])],
+            checked: nil
+        )
+    }
+    return MarkdownDocumentFfi(
+        blocks: [
+            .listBlock(
+                kind: .bullet(marker: "-"),
+                tight: true,
+                items: items
+            )
+        ],
+        truncated: false
+    )
+}
+
+private func markdownDisplayNodeCount(_ document: MarkdownDisplayDocument) -> Int {
+    func countBlocks(_ blocks: [MarkdownDisplayBlockNode]) -> Int {
+        blocks.reduce(0) { total, node in
+            total + 1 + countBlock(node.block)
+        }
+    }
+
+    func countBlock(_ block: MarkdownDisplayBlock) -> Int {
+        switch block {
+        case .blockQuote(let inner):
+            return countBlocks(inner)
+        case .list(let items):
+            return items.reduce(0) { partial, item in
+                partial + 1 + countBlocks(item.blocks)
+            }
+        case .table(let header, let rows):
+            return header.count + rows.reduce(0) { partial, row in
+                partial + 1 + row.cells.count
+            }
+        default:
+            return 0
+        }
+    }
+
+    return countBlocks(document.blocks)
 }
 
 @MainActor


### PR DESCRIPTION
Fixes #517

## Summary
- enforce one 256-node display budget across top-level/nested blocks, list items, table rows, and table cells
- stop traversing retained display siblings when the budget is exhausted and reuse the existing truncation indicator
- cover crafted wide tables, long lists, core truncation preservation, and normal tables with regression tests

## Verification
- `git diff --check` — passed
- changed Swift files checked against the configured 120-column limit — passed
- `scripts/ci/macos-sanity-checks.sh` — unavailable on this Linux worker (`xcodebuild: command not found`)
- macOS format, unit-test, build, and analyze gates — pending PR CI

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/556">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->