### PR TITLE
Stabilization sweep: security hardening, state-correctness and test reliability

### DIFF
--- a/whitenoise-mac/Core/MarkdownLinkPolicy.swift
+++ b/whitenoise-mac/Core/MarkdownLinkPolicy.swift
@@ -15,6 +15,8 @@ nonisolated enum MarkdownLinkPolicy {
     private static let resolvableProfilePrefixes = ["npub1", "nprofile1"]
     private static let recognizedNostrReferencePrefixes =
         resolvableProfilePrefixes + ["note1", "nevent1", "naddr1", "nrelay1"]
+    /// Bech32 data alphabet — `1`, `b`, `i`, and `o` are excluded by the encoding.
+    private static let bech32DataAlphabet = Set("023456789acdefghjklmnpqrstuvwxyz")
 
     static func sanitizedURL(from raw: String) -> URL? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -72,8 +74,27 @@ nonisolated enum MarkdownLinkPolicy {
         return reference
     }
 
+    /// A profile reference is resolvable only when the payload after its prefix stays inside the
+    /// bech32 alphabet — a prefix-only match would let a ref with an embedded `@domain` reparse
+    /// as NIP-05 downstream and beacon a request to an attacker-chosen host.
     static func isResolvableProfileReference(_ reference: String) -> Bool {
-        hasNostrPrefix(in: reference, prefixes: resolvableProfilePrefixes)
+        let normalized = reference.lowercased()
+        guard let prefix = resolvableProfilePrefixes.first(where: normalized.hasPrefix) else {
+            return false
+        }
+        let payload = normalized.dropFirst(prefix.count)
+        return !payload.isEmpty && payload.allSatisfy(bech32DataAlphabet.contains)
+    }
+
+    /// True when `value` carries a nostr reference marker anywhere in it. Such strings must never
+    /// be reinterpreted as NIP-05 identifiers, only the FFI parse may consume them. Matched as a
+    /// substring, deliberately over-inclusive — over-skipping NIP-05 fails safe (the FFI parse
+    /// still resolves genuine references), while under-skipping would let a marked string reach
+    /// the resolver. A NIP-05 handle whose local part merely contains a marker is negligibly rare.
+    static func containsNostrReferenceMarker(_ value: String) -> Bool {
+        let normalized = value.lowercased()
+        if normalized.contains("nostr:") { return true }
+        return resolvableProfilePrefixes.contains { normalized.contains($0) }
     }
 
     static func isProfileReferenceInput(_ value: String) -> Bool {

--- a/whitenoise-mac/Core/NIP05Resolver.swift
+++ b/whitenoise-mac/Core/NIP05Resolver.swift
@@ -17,10 +17,14 @@ enum NIP05ResolutionError: Error {
     case invalidURL
     case invalidResponse
     case requestFailed(statusCode: Int)
+    case responseTooLarge
     case notFound
 }
 
 struct NIP05Resolver: NIP05Resolving {
+    /// A well-known identity document is a small name map, anything past this is hostile.
+    private static let maxResponseBytes = 256 * 1024
+
     private let session: URLSession
 
     init(
@@ -51,12 +55,27 @@ struct NIP05Resolver: NIP05Resolving {
         var request = URLRequest(url: url)
         request.setValue("WhiteNoiseMac/1.0", forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await session.data(for: request)
+        let (bytes, response) = try await session.bytes(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw NIP05ResolutionError.invalidResponse
         }
         guard (200..<300).contains(http.statusCode) else {
             throw NIP05ResolutionError.requestFailed(statusCode: http.statusCode)
+        }
+        // Cheap pre-check only — the advertised length can be omitted or spoofed, so the
+        // streaming cap below is the enforcement that actually bounds the allocation.
+        guard http.expectedContentLength <= Int64(Self.maxResponseBytes) else {
+            throw NIP05ResolutionError.responseTooLarge
+        }
+
+        // Byte-granular iteration is fine here, the cap bounds it to a trivial step count.
+        var data = Data()
+        data.reserveCapacity(min(Int(max(http.expectedContentLength, 0)), Self.maxResponseBytes))
+        for try await byte in bytes {
+            data.append(byte)
+            guard data.count <= Self.maxResponseBytes else {
+                throw NIP05ResolutionError.responseTooLarge
+            }
         }
 
         let decoded = try JSONDecoder().decode(NIP05WellKnownResponse.self, from: data)
@@ -80,9 +99,16 @@ struct NIP05Resolver: NIP05Resolving {
 
 /// Re-validates each redirect target against the SSRF host policy — URLSession auto-follows
 /// redirects, so without this a public well-known host could 3xx the lookup to a private/
-/// loopback/link-local address the up-front guard blocks. Mirrors the avatar path's
-/// CappedImageDownloadDelegate.
+/// loopback/link-local address the up-front guard blocks. Also caps the redirect-hop count so a
+/// malicious host cannot loop the lookup between public hosts until the resource timeout fires.
+/// Mirrors the avatar path's CappedImageDownloadDelegate.
 final class NIP05RedirectPolicy: NSObject, URLSessionTaskDelegate {
+    private static let maxRedirectHops = 5
+
+    // One instance serves every lookup on the session, so hop budgets are tracked per task.
+    private let lock = NSLock()
+    private var redirectHopCountsByTask: [Int: Int] = [:]
+
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
@@ -90,6 +116,16 @@ final class NIP05RedirectPolicy: NSObject, URLSessionTaskDelegate {
         newRequest request: URLRequest,
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
+        let hopCount = lock.withLock {
+            let count = (redirectHopCountsByTask[task.taskIdentifier] ?? 0) + 1
+            redirectHopCountsByTask[task.taskIdentifier] = count
+            return count
+        }
+        if hopCount > Self.maxRedirectHops {
+            completionHandler(nil)
+            task.cancel()
+            return
+        }
         guard let url = request.url, RemoteImageURLPolicy.isAllowed(url) else {
             completionHandler(nil)
             task.cancel()
@@ -97,26 +133,37 @@ final class NIP05RedirectPolicy: NSObject, URLSessionTaskDelegate {
         }
         completionHandler(request)
     }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        lock.withLock { redirectHopCountsByTask[task.taskIdentifier] = nil }
+    }
 }
 
 struct NIP05Identifier: Equatable {
+    /// Mailbox-length ceiling, generous for any legitimate identifier.
+    private static let maxLength = 254
+    /// The spec-legal local part, accepted case-insensitively and stored lowercased. Anything
+    /// wider (`:`, `/`, …) lets a full profile ref or URL masquerade as a name.
+    private static let localPartAlphabet = Set("abcdefghijklmnopqrstuvwxyz0123456789-_.")
+
     let name: String
     let domain: String
 
     init?(_ rawValue: String) {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
+            trimmed.count <= Self.maxLength,
             trimmed.firstIndex(of: "@") == trimmed.lastIndex(of: "@"),
             let separator = trimmed.firstIndex(of: "@")
         else {
             return nil
         }
 
-        let name = String(trimmed[..<separator])
+        let name = String(trimmed[..<separator]).lowercased()
         let domain = String(trimmed[trimmed.index(after: separator)...]).lowercased()
         guard !name.isEmpty,
             !domain.isEmpty,
-            name.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+            name.allSatisfy(Self.localPartAlphabet.contains),
             domain.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
             domain.rangeOfCharacter(from: CharacterSet(charactersIn: "/:?#[]@\\")) == nil,
             domain.contains("."),

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -119,7 +119,8 @@ nonisolated enum RemoteImageURLPolicy {
     }
 
     /// Rejects IPv6 literals in non-public ranges: unspecified `::`, loopback `::1`,
-    /// ULA `fc00::/7`, link-local `fe80::/10`, multicast `ff00::/8`, and the IPv4-embedding
+    /// ULA `fc00::/7`, link-local `fe80::/10`, multicast `ff00::/8`, documentation
+    /// `2001:db8::/32`, and the IPv4-embedding
     /// forms (mapped `::ffff:a.b.c.d`, translated `::ffff:0:a.b.c.d`, NAT64 `64:ff9b::a.b.c.d`,
     /// and IPv4-compatible `::a.b.c.d`) whose embedded IPv4 is itself private.
     private static func isPrivateIPv6(_ groups: [UInt16]) -> Bool {
@@ -138,6 +139,8 @@ nonisolated enum RemoteImageURLPolicy {
         if (first & 0xFFC0) == 0xFE80 { return true }
         // Multicast ff00::/8, mirroring the IPv4 `224.0.0.0/4` rejection.
         if (first & 0xFF00) == 0xFF00 { return true }
+        // Documentation range 2001:db8::/32 — reserved, never a real destination.
+        if first == 0x2001, groups[1] == 0x0DB8 { return true }
 
         // IPv4-mapped `::ffff:a.b.c.d` (and IPv4-compatible `::a.b.c.d`): re-check the
         // embedded IPv4 against the private ranges so `[::ffff:192.168.0.1]` is rejected too.

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -119,14 +119,16 @@ nonisolated enum RemoteImageURLPolicy {
     }
 
     /// Rejects IPv6 literals in non-public ranges: unspecified `::`, loopback `::1`,
-    /// ULA `fc00::/7`, link-local `fe80::/10`, and IPv4-mapped `::ffff:0:0/96` /
-    /// IPv4-compatible addresses whose embedded IPv4 is itself private.
+    /// ULA `fc00::/7`, link-local `fe80::/10`, multicast `ff00::/8`, and the IPv4-embedding
+    /// forms (mapped `::ffff:a.b.c.d`, translated `::ffff:0:a.b.c.d`, NAT64 `64:ff9b::a.b.c.d`,
+    /// and IPv4-compatible `::a.b.c.d`) whose embedded IPv4 is itself private.
     private static func isPrivateIPv6(_ groups: [UInt16]) -> Bool {
         guard groups.count == 8 else { return true }  // be conservative on anything unparseable
 
-        // Unspecified `::` and loopback `::1`.
-        if groups[0...6].allSatisfy({ $0 == 0 }) {
-            return groups[7] <= 1
+        // Unspecified `::` and loopback `::1` only — `::2`–`::ffff` are IPv4-compatible forms
+        // of `0.0.0.0/8` and must fall through to the embedded-IPv4 re-check below.
+        if groups[0...6].allSatisfy({ $0 == 0 }), groups[7] <= 1 {
+            return true
         }
 
         let first = groups[0]
@@ -134,10 +136,20 @@ nonisolated enum RemoteImageURLPolicy {
         if (first & 0xFE00) == 0xFC00 { return true }
         // Link-local fe80::/10 — top 10 bits == 1111111010.
         if (first & 0xFFC0) == 0xFE80 { return true }
+        // Multicast ff00::/8, mirroring the IPv4 `224.0.0.0/4` rejection.
+        if (first & 0xFF00) == 0xFF00 { return true }
 
         // IPv4-mapped `::ffff:a.b.c.d` (and IPv4-compatible `::a.b.c.d`): re-check the
         // embedded IPv4 against the private ranges so `[::ffff:192.168.0.1]` is rejected too.
         if groups[0...4].allSatisfy({ $0 == 0 }), groups[5] == 0xFFFF {
+            return isPrivateIPv4(embeddedIPv4(groups))
+        }
+        // IPv4-translated `::ffff:0:a.b.c.d`.
+        if groups[0...3].allSatisfy({ $0 == 0 }), groups[4] == 0xFFFF, groups[5] == 0 {
+            return isPrivateIPv4(embeddedIPv4(groups))
+        }
+        // NAT64 well-known prefix `64:ff9b::a.b.c.d`.
+        if groups[0] == 0x64, groups[1] == 0xFF9B, groups[2...5].allSatisfy({ $0 == 0 }) {
             return isPrivateIPv4(embeddedIPv4(groups))
         }
         if groups[0...5].allSatisfy({ $0 == 0 }), groups[6] != 0 || groups[7] != 0 {
@@ -764,6 +776,10 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         return await delegate.download(url, using: session)
     }
 
+    /// Decoded-pixel ceiling for one source image — a small compressed body can declare
+    /// enormous dimensions, and the thumbnail pass materializes the full-size bitmap first.
+    private static let maxSourceImagePixels = 64_000_000
+
     private static func downsample(data: Data, maxPixelSize: CGFloat) -> NSImage? {
         // Stamped with the encoded byte count so a slow decode is correlatable with the
         // source image's weight. Runs off-main (`Task.detached(.utility)`), but if it
@@ -771,6 +787,16 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         TimelineSignpost.decode.interval("downsample", count: data.count) {
             let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
             guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else { return nil }
+            // Header-only dimension read, rejecting decompression bombs before any decode.
+            guard
+                let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, sourceOptions)
+                    as? [CFString: Any],
+                let width = properties[kCGImagePropertyPixelWidth] as? Int,
+                let height = properties[kCGImagePropertyPixelHeight] as? Int,
+                width > 0, height > 0,
+                // Division form, a hostile header can carry dimensions whose product overflows.
+                height <= maxSourceImagePixels / width
+            else { return nil }
             let options =
                 [
                     kCGImageSourceCreateThumbnailFromImageAlways: true,

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -494,17 +494,16 @@ extension WorkspaceState {
             stopChatListListener()
             stopTimelineListener()
 
-            // Marmot only owns its storage root; plaintext media scratch directories and
-            // the encrypted media cache live outside it, so purge them before the
-            // potentially throwing Marmot deletion call when wiping local data.
+            // Marmot only owns its storage root; plaintext media scratch directories live
+            // outside it, so purge those before the potentially throwing Marmot deletion.
+            // The encrypted media cache stays until the delete succeeds — on a failed wipe the
+            // recovered session must keep its cached media intact and decryptable.
             try? await runOffMain {
                 MediaPlaybackTempStore.purge()
                 OutgoingMediaMetadataTempStore.purge()
             }
-            await mediaDiskCache.purgeAll()
             try await client.deleteAllLocalData()
-            // Destroy the cache encryption key only once the delete succeeded — a session
-            // recovered after a failed delete must keep its surviving media decryptable.
+            await mediaDiskCache.purgeAll()
             await mediaDiskCache.purgeAll(removeEncryptionKey: true)
             self.client = nil
             observabilityRuntimeConfiguration = nil

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -501,8 +501,11 @@ extension WorkspaceState {
                 MediaPlaybackTempStore.purge()
                 OutgoingMediaMetadataTempStore.purge()
             }
-            await mediaDiskCache.purgeAll(removeEncryptionKey: true)
+            await mediaDiskCache.purgeAll()
             try await client.deleteAllLocalData()
+            // Destroy the cache encryption key only once the delete succeeded — a session
+            // recovered after a failed delete must keep its surviving media decryptable.
+            await mediaDiskCache.purgeAll(removeEncryptionKey: true)
             self.client = nil
             observabilityRuntimeConfiguration = nil
             resetToNewInstallState(storageRootPath: client.storageRootPath)

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -277,7 +277,7 @@ extension WorkspaceState {
         guard activeAccountId == account.id else { return }
 
         if row.archived {
-            moveChatToArchived(row: row, account: account, shouldEnrich: shouldEnrich)
+            moveChatToArchived(row: row, account: account)
             if shouldEnrich {
                 startChatListEnrichment(rows: [row], account: account, replacingCurrent: false)
             }
@@ -318,29 +318,31 @@ extension WorkspaceState {
         }
     }
 
-    func moveChatToArchived(
-        row: ChatListRowFfi,
-        account: AccountItem,
-        shouldEnrich: Bool = true
-    ) {
+    func moveChatToArchived(row: ChatListRowFfi, account: AccountItem) {
         guard activeAccountId == account.id else { return }
 
         let groupIdHex = row.groupIdHex
-        let currentActive = chatItem(accountId: account.id, chatId: groupIdHex)
+        // The transition test must consult the active-only index — `chatItem` also
+        // resolves already-archived chats.
+        let wasActive = chatLookupByAccount[account.id]?[groupIdHex] != nil
+        let current = chatItem(accountId: account.id, chatId: groupIdHex)
         removeChatFromList(chatId: groupIdHex, forAccountId: account.id)
 
         var chat = baseChatItem(from: row, account: account)
-        // Preserve enrichment-resolved metadata across the archive move regardless of
-        // shouldEnrich — when enrichment does run, startChatListEnrichment corrects it.
-        if let currentActive {
-            chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: currentActive)
+        // Preserve enrichment-resolved metadata across the archive move — when
+        // enrichment does run, startChatListEnrichment corrects it.
+        if let current {
+            chat = ChatListOrdering.preservingResolvedMetadata(in: chat, from: current)
         }
 
         upsertArchivedChat(chat, forAccountId: account.id)
         cancelVoiceRecordingIfSelectedMembershipEnded()
         ensureSelectedMessageTimelineStore()
 
-        guard case .chat(let selectedGroupId) = selection,
+        // Deselection belongs to the active→archived transition only — a delta for an
+        // already-archived selected chat must not eject the user from it.
+        guard wasActive,
+            case .chat(let selectedGroupId) = selection,
             selectedGroupId == groupIdHex
         else { return }
 

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -299,6 +299,11 @@ extension WorkspaceState {
     }
 
     func memberRefCandidate(for query: String) async throws -> String {
+        // A query carrying a nostr marker must never resolve as NIP-05 — an embedded `@domain`
+        // would fire a request at that host before the authoritative FFI parse runs.
+        if MarkdownLinkPolicy.containsNostrReferenceMarker(query) {
+            return query
+        }
         if NIP05Identifier(query) != nil {
             return try await nip05Resolver.accountReference(for: query)
         }

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -457,6 +457,10 @@ extension WorkspaceState {
             privacySecuritySettings = .defaults
             return
         }
+        // An in-flight save owns the published snapshot, a read here could resolve
+        // before its commit and revert the toggle the user just saved.
+        guard !isSavingPrivacySecurity else { return }
+        let generation = privacySecuritySettingsGeneration
 
         do {
             try await configureObservabilityRuntime()
@@ -466,6 +470,8 @@ extension WorkspaceState {
                     try client.auditLogSettings()
                 )
             }
+            // A save that started mid-load supersedes this snapshot.
+            guard privacySecuritySettingsGeneration == generation else { return }
             let config = telemetryBuildConfig
             privacySecuritySettings = PrivacySecuritySettingsSnapshot(
                 relayTelemetryEnabled: telemetry.exportEnabled,
@@ -477,6 +483,7 @@ extension WorkspaceState {
             )
             await loadAuditLogFiles()
         } catch {
+            guard privacySecuritySettingsGeneration == generation else { return }
             privacySecuritySettings = .defaults
             auditLogFiles = []
             lastError = error.localizedDescription
@@ -493,6 +500,7 @@ extension WorkspaceState {
 
         lastError = nil
         isSavingPrivacySecurity = true
+        privacySecuritySettingsGeneration &+= 1
         defer { isSavingPrivacySecurity = false }
 
         do {
@@ -523,6 +531,7 @@ extension WorkspaceState {
 
         lastError = nil
         isSavingPrivacySecurity = true
+        privacySecuritySettingsGeneration &+= 1
         defer { isSavingPrivacySecurity = false }
 
         do {
@@ -547,6 +556,7 @@ extension WorkspaceState {
 
         lastError = nil
         isSavingPrivacySecurity = true
+        privacySecuritySettingsGeneration &+= 1
         defer { isSavingPrivacySecurity = false }
 
         do {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -946,6 +946,10 @@ final class WorkspaceState {
     /// bumps on every active-account transition, so an older A request cannot commit after a rapid
     /// A→B→A re-entry or after a newer notification load/toggle for the same account.
     var notificationSettingsGeneration: UInt64 = 0
+    /// Monotonic token for privacy/security settings writes. Each setter bumps it on entry, so a
+    /// load whose FFI read resolved before the save committed abandons its stale snapshot instead
+    /// of reverting the just-saved toggle.
+    var privacySecuritySettingsGeneration: UInt64 = 0
     var timelineTask: Task<Void, Never>?
     var timelineTaskGroupId: String?
     /// Single-owner coalescing for initial timeline loads (issue #332). `loadMessages` can be
@@ -1691,6 +1695,9 @@ final class WorkspaceState {
 
     private func bumpArchivedChatListGeneration(forAccountId accountId: String) {
         archivedChatListGenerationByAccount[accountId, default: 0] += 1
+        if activeAccountId == accountId {
+            selectedChatRevision += 1
+        }
         if filteredArchivedChatsCache?.accountId == accountId {
             filteredArchivedChatsCache = nil
         }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -234,7 +234,7 @@ struct GroupDetailsSnapshot: Hashable {
     let disappearingMessageSecs: UInt64
 
     var memberCountLabel: String {
-        String(format: L10n.string("%d members"), members.count)
+        String(format: L10n.string("%d members"), CInt(members.count))
     }
 
     var disappearingMessagesEnabled: Bool { disappearingMessageSecs > 0 }
@@ -334,7 +334,7 @@ nonisolated struct MessageMediaAttachment: Identifiable, Hashable {
         if attachments.count == 1 {
             return first.previewLabel
         }
-        return String(format: L10n.string("%d attachments"), attachments.count)
+        return String(format: L10n.string("%d attachments"), CInt(attachments.count))
     }
 }
 
@@ -1825,7 +1825,6 @@ extension MessageItem {
         hasher.combine(replyTargetIdHex)
         hasher.combine(timelineAt)
         hasher.combine(isEdited)
-        hasher.combine(body)
     }
 }
 

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -209,6 +209,13 @@ private final class ComposerPasteInterceptingTextView: NSTextView {
             return
         }
 
+        // While a composition is marked, Return belongs to the input context — it commits the
+        // pending candidate, so forwarding it must win over the send shortcut.
+        if hasMarkedText() {
+            super.keyDown(with: event)
+            return
+        }
+
         switch ComposerKeyboardShortcutPolicy.returnKeyAction(for: event.modifierFlags) {
         case .send:
             returnKeySendHandler?()

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -430,9 +430,15 @@ private struct ConversationView: View {
                         }
                     }
                     .onChange(of: messageIDs.first) { _, _ in
-                        guard let anchorId = pendingPrependAnchorId,
+                        guard let anchorId = pendingPrependAnchorId else { return }
+                        guard workspace.selectedChat?.id == chat.id,
                             workspace.selectedTimelineContainsMessage(anchorId)
-                        else { return }
+                        else {
+                            // Anchor evicted or chat changed — release the gate, or every
+                            // later older-history load stays silently blocked.
+                            pendingPrependAnchorId = nil
+                            return
+                        }
                         DispatchQueue.main.async {
                             // Re-validate against live state: the user may have switched
                             // chats (which clears pendingPrependAnchorId) or another prepend
@@ -440,10 +446,13 @@ private struct ConversationView: View {
                             // Without re-checking, proxy.scrollTo would run against the new
                             // conversation using a stale anchor, and the unconditional clear
                             // would drop restoration for a subsequent legitimate prepend.
+                            guard pendingPrependAnchorId == anchorId else { return }
                             guard workspace.selectedChat?.id == chat.id,
-                                pendingPrependAnchorId == anchorId,
                                 workspace.selectedTimelineContainsMessage(anchorId)
-                            else { return }
+                            else {
+                                pendingPrependAnchorId = nil
+                                return
+                            }
                             TimelineSignpost.scroll.interval("restorePrependAnchor") {
                                 proxy.scrollTo(anchorId, anchor: .top)
                             }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1770,6 +1770,7 @@ struct PureValueTests {
             "https://[64:ff9b::7f00:1]/x.png",  // NAT64 around 127.0.0.1
             "https://[::2]/x.png",  // IPv4-compatible 0.0.0.2, inside 0.0.0.0/8
             "https://[::ffff]/x.png",  // IPv4-compatible 0.0.255.255
+            "https://[2001:db8::5]/x.png",  // documentation range 2001:db8::/32, non-routable
         ] {
             #expect(
                 RemoteImageURLPolicy.sanitizedURL(from: raw) == nil,
@@ -1779,7 +1780,7 @@ struct PureValueTests {
 
         // Embedded-public NAT64 and plain public IPv6 destinations keep loading.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[64:ff9b::808:808]/x.png") != nil)
-        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[2001:db8::5]/x.png") != nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[2606:4700:4700::1111]/x.png") != nil)
     }
 
     @Test func markdownInlineBuilderDropsUnsafeMarkdownLinks() async throws {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1477,12 +1477,12 @@ struct PureValueTests {
         )
         #expect(nostrURL?.scheme == "nostr")
 
-        let nprofileURL = MarkdownLinkPolicy.sanitizedURL(from: "nostr:nprofile1alice")
-        #expect(nprofileURL?.absoluteString == "nostr:nprofile1alice")
-        #expect(MarkdownLinkPolicy.isResolvableProfileReference("npub1alice"))
-        #expect(MarkdownLinkPolicy.isResolvableProfileReference("nprofile1alice"))
-        #expect(MarkdownLinkPolicy.isProfileReferenceInput("nostr:nprofile1alice"))
-        #expect(!MarkdownLinkPolicy.isResolvableProfileReference("note1alice"))
+        let nprofileURL = MarkdownLinkPolicy.sanitizedURL(from: "nostr:nprofile1alyce")
+        #expect(nprofileURL?.absoluteString == "nostr:nprofile1alyce")
+        #expect(MarkdownLinkPolicy.isResolvableProfileReference("npub1alyce"))
+        #expect(MarkdownLinkPolicy.isResolvableProfileReference("nprofile1alyce"))
+        #expect(MarkdownLinkPolicy.isProfileReferenceInput("nostr:nprofile1alyce"))
+        #expect(!MarkdownLinkPolicy.isResolvableProfileReference("note1alyce"))
 
         for raw in [
             "",
@@ -1524,10 +1524,10 @@ struct PureValueTests {
         // Accepted: strict marmot://profile/<npub|nprofile>, query ignored, case-insensitive
         // scheme/host. These flow in from OS deep links and kit-emitted message autolinks.
         for raw in [
-            "marmot://profile/npub1alice",
-            "marmot://profile/npub1alice?from=qr",
-            "marmot://profile/nprofile1alice",
-            "MARMOT://PROFILE/npub1alice",
+            "marmot://profile/npub1alyce",
+            "marmot://profile/npub1alyce?from=qr",
+            "marmot://profile/nprofile1alyce",
+            "MARMOT://PROFILE/npub1alyce",
         ] {
             let url = try #require(URL(string: raw))
             #expect(
@@ -1540,10 +1540,10 @@ struct PureValueTests {
                 "expected sanitizedURL acceptance for \(String(reflecting: raw))"
             )
         }
-        let plain = try #require(URL(string: "marmot://profile/npub1alice"))
-        #expect(MarmotProfileLink.profileReference(from: plain) == "npub1alice")
-        let withQuery = try #require(URL(string: "marmot://profile/npub1alice?from=qr"))
-        #expect(MarmotProfileLink.profileReference(from: withQuery) == "npub1alice")
+        let plain = try #require(URL(string: "marmot://profile/npub1alyce"))
+        #expect(MarmotProfileLink.profileReference(from: plain) == "npub1alyce")
+        let withQuery = try #require(URL(string: "marmot://profile/npub1alyce?from=qr"))
+        #expect(MarmotProfileLink.profileReference(from: withQuery) == "npub1alyce")
 
         // Rejected: every other marmot:// shape. The scheme is not exclusive to this app,
         // so inbound URLs are untrusted; nothing here may reach LaunchServices either.
@@ -1554,7 +1554,7 @@ struct PureValueTests {
             "marmot://profile/note1abc",
             "marmot://profile/npub1x/extra",
             "marmot://x-callback-url/run",
-            "marmot://profile/../npub1alice",
+            "marmot://profile/../npub1alyce",
         ] {
             if let url = URL(string: raw) {
                 #expect(
@@ -1570,19 +1570,162 @@ struct PureValueTests {
         }
 
         // The retired darkmatter:// scheme is a clean break (mdk#725): no longer recognized.
-        #expect(MarkdownLinkPolicy.sanitizedURL(from: "darkmatter://profile/npub1alice") == nil)
+        #expect(MarkdownLinkPolicy.sanitizedURL(from: "darkmatter://profile/npub1alyce") == nil)
 
         // QR payload emits the canonical link form and round-trips through the parser.
-        let payload = MarmotProfileLink.qrPayload(npub: "npub1alice")
-        #expect(payload == "marmot://profile/npub1alice?from=qr")
+        let payload = MarmotProfileLink.qrPayload(npub: "npub1alyce")
+        #expect(payload == "marmot://profile/npub1alyce?from=qr")
         let payloadURL = try #require(URL(string: payload))
-        #expect(MarmotProfileLink.profileReference(from: payloadURL) == "npub1alice")
+        #expect(MarmotProfileLink.profileReference(from: payloadURL) == "npub1alyce")
 
         // Paste pre-check prefix helper.
-        #expect(MarmotProfileLink.hasProfileLinkPrefix("  marmot://profile/npub1alice?from=qr "))
-        #expect(MarmotProfileLink.hasProfileLinkPrefix("MARMOT://PROFILE/npub1alice"))
-        #expect(!MarmotProfileLink.hasProfileLinkPrefix("darkmatter://profile/npub1alice"))
+        #expect(MarmotProfileLink.hasProfileLinkPrefix("  marmot://profile/npub1alyce?from=qr "))
+        #expect(MarmotProfileLink.hasProfileLinkPrefix("MARMOT://PROFILE/npub1alyce"))
+        #expect(!MarmotProfileLink.hasProfileLinkPrefix("darkmatter://profile/npub1alyce"))
         #expect(!MarmotProfileLink.hasProfileLinkPrefix("marmot://group/abc"))
+    }
+
+    @Test func profileReferenceGrammarRejectsEmbeddedHostPayloads() async throws {
+        // A resolvable ref must stay inside the bech32 alphabet after its prefix. Prefix-only
+        // matching let refs with an embedded `@domain` reach the NIP-05 resolver and beacon the
+        // viewer's IP to an attacker-chosen host on click.
+        for reference in [
+            "npub1qqq@evil.example",
+            "nprofile1qqq@evil.example",
+            "npub1x.y",
+            "npub1qqq:8080",
+            "npub1qqq/path",
+            "npub1qqq?name=x",
+            "npub1qqq evil",
+            "npub1bio",  // `b`, `i`, and `o` sit outside the bech32 alphabet
+            "npub1",  // a bare prefix carries no payload
+        ] {
+            #expect(
+                !MarkdownLinkPolicy.isResolvableProfileReference(reference),
+                "expected rejection for \(String(reflecting: reference))"
+            )
+        }
+        #expect(MarkdownLinkPolicy.isResolvableProfileReference("npub1alyce"))
+        #expect(
+            MarkdownLinkPolicy.isResolvableProfileReference(
+                "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+            )
+        )
+
+        // The nostr autolink form extracts the same ref and stays unresolvable.
+        let nostrURL = try #require(URL(string: "nostr:npub1x.y"))
+        let extracted = try #require(MarkdownLinkPolicy.nostrReference(from: nostrURL))
+        #expect(!MarkdownLinkPolicy.isResolvableProfileReference(extracted))
+
+        // The profile deep-link form is gated on the same grammar, including the
+        // percent-encoded spelling that decodes back into an `@`.
+        for raw in [
+            "marmot://profile/npub1qqq@evil.example",
+            "marmot://profile/npub1qqq%40evil.example",
+            "marmot://profile/npub1x.y",
+        ] {
+            if let url = URL(string: raw) {
+                #expect(
+                    MarmotProfileLink.profileReference(from: url) == nil,
+                    "expected rejection for \(String(reflecting: raw))"
+                )
+            }
+            #expect(
+                MarkdownLinkPolicy.sanitizedURL(from: raw) == nil,
+                "expected sanitizedURL rejection for \(String(reflecting: raw))"
+            )
+        }
+    }
+
+    @Test func nostrMarkerStringsAreNeverNIP05Candidates() async throws {
+        // `memberRefCandidate` refuses NIP-05 resolution for anything carrying a nostr marker,
+        // so a ref like `nostr:npub1…@host` can only ever reach the authoritative FFI parse.
+        for value in [
+            "nostr:npub1qqq@evil.example",
+            "npub1qqq@evil.example",
+            "NPUB1QQQ@EVIL.EXAMPLE",
+            "nprofile1qqq@evil.example",
+            "marmot://profile/npub1qqq",
+            "prefix nostr:npub1qqq suffix",
+        ] {
+            #expect(
+                MarkdownLinkPolicy.containsNostrReferenceMarker(value),
+                "expected marker in \(String(reflecting: value))"
+            )
+        }
+        for value in ["alice@example.com", "npub@example.com", "note1qqq", ""] {
+            #expect(
+                !MarkdownLinkPolicy.containsNostrReferenceMarker(value),
+                "expected no marker in \(String(reflecting: value))"
+            )
+        }
+    }
+
+    @Test func nip05IdentifierRestrictsLocalPartCharsetAndLength() async throws {
+        // Local parts are the spec-legal lowercase set, accepted case-insensitively.
+        let mixedCase = try #require(NIP05Identifier("Alice.Smith_9-a@Example.COM"))
+        #expect(mixedCase.name == "alice.smith_9-a")
+        #expect(mixedCase.domain == "example.com")
+
+        for raw in [
+            "nostr:npub1qqq@evil.example",  // `:` can no longer smuggle a full ref into the name
+            "npub1qqq/x@evil.example",
+            "name!bang@example.com",
+            "na me@example.com",
+            "átila@example.com",
+            "@example.com",
+            "name@",
+            String(repeating: "a", count: 250) + "@example.com",  // over the total-length bound
+        ] {
+            #expect(NIP05Identifier(raw) == nil, "expected rejection for \(String(reflecting: raw))")
+        }
+
+        // A bare `npub1…@host` is still a charset-legal identifier, the marker guard above is
+        // the layer that keeps it away from the resolver.
+        #expect(NIP05Identifier("npub1qqq@evil.example") != nil)
+    }
+
+    @Test func nip05RedirectPolicyCapsRedirectHopsPerTask() async throws {
+        // Delegate methods are exercised directly, no task is ever resumed so nothing touches
+        // the network.
+        let policy = NIP05RedirectPolicy()
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        let origin = try #require(URL(string: "https://identity.example/.well-known/nostr.json"))
+        let response = try #require(
+            HTTPURLResponse(url: origin, statusCode: 302, httpVersion: "HTTP/1.1", headerFields: nil)
+        )
+        let target = URLRequest(url: try #require(URL(string: "https://next.example/hop")))
+
+        let task = session.dataTask(with: origin)
+        var results: [URLRequest?] = []
+        for _ in 0..<6 {
+            policy.urlSession(session, task: task, willPerformHTTPRedirection: response, newRequest: target) {
+                results.append($0)
+            }
+        }
+        #expect(results.count == 6)
+        #expect(results[4]?.url == target.url)  // five hops pass, matching the avatar downloader
+        #expect(results[5] == nil)  // the sixth is cancelled
+
+        // Budgets are per task — one looping lookup must not starve the next.
+        let freshTask = session.dataTask(with: origin)
+        var freshResult: URLRequest?
+        policy.urlSession(session, task: freshTask, willPerformHTTPRedirection: response, newRequest: target) {
+            freshResult = $0
+        }
+        #expect(freshResult?.url == target.url)
+
+        // A disallowed redirect target is still refused on the first hop.
+        let disallowed = URLRequest(url: try #require(URL(string: "http://next.example/hop")))
+        let plainTask = session.dataTask(with: origin)
+        var disallowedResult: URLRequest? = target
+        policy.urlSession(
+            session, task: plainTask, willPerformHTTPRedirection: response, newRequest: disallowed
+        ) {
+            disallowedResult = $0
+        }
+        #expect(disallowedResult == nil)
     }
 
     @Test func markdownLinkPolicyRejectsPrivateAndLoopbackHosts() async throws {
@@ -1613,7 +1756,30 @@ struct PureValueTests {
         // Public http/https hosts and internal nostr links still pass.
         #expect(MarkdownLinkPolicy.sanitizedURL(from: "https://example.com/path") != nil)
         #expect(MarkdownLinkPolicy.sanitizedURL(from: "http://cdn.example.com/a") != nil)
-        #expect(MarkdownLinkPolicy.sanitizedURL(from: "nostr:nprofile1alice") != nil)
+        #expect(MarkdownLinkPolicy.sanitizedURL(from: "nostr:nprofile1alyce") != nil)
+    }
+
+    @Test func remoteImagePolicyRejectsMulticastAndEmbeddedPrivateIPv6() async throws {
+        for raw in [
+            "https://[ff02::1]/x.png",  // multicast, mirroring the IPv4 `224.0.0.0/4` rejection
+            "https://[ff05::1:3]/x.png",
+            "https://[::ffff:0:c0a8:1]/x.png",  // translated prefix around 192.168.0.1
+            "https://[::ffff:0:192.168.0.1]/x.png",
+            "https://[64:ff9b::c0a8:1]/x.png",  // NAT64 well-known prefix around 192.168.0.1
+            "https://[64:ff9b::192.168.0.1]/x.png",
+            "https://[64:ff9b::7f00:1]/x.png",  // NAT64 around 127.0.0.1
+            "https://[::2]/x.png",  // IPv4-compatible 0.0.0.2, inside 0.0.0.0/8
+            "https://[::ffff]/x.png",  // IPv4-compatible 0.0.255.255
+        ] {
+            #expect(
+                RemoteImageURLPolicy.sanitizedURL(from: raw) == nil,
+                "expected rejection for \(String(reflecting: raw))"
+            )
+        }
+
+        // Embedded-public NAT64 and plain public IPv6 destinations keep loading.
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[64:ff9b::808:808]/x.png") != nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[2001:db8::5]/x.png") != nil)
     }
 
     @Test func markdownInlineBuilderDropsUnsafeMarkdownLinks() async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -84,6 +84,57 @@ private final class BlockingFfiGate: @unchecked Sendable {
     }
 }
 
+/// Async twin of `BlockingFfiGate`: suspends the first armed call on a continuation, with all
+/// gate state lock-guarded so arming, polling, and releasing from other threads cannot race the
+/// suspension — a release that wins the race resumes the parked call immediately.
+private final class AsyncFfiGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var enabled = false
+    private var reached = false
+    private var released = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    var isEnabled: Bool {
+        get { lock.withLock { enabled } }
+        set { lock.withLock { enabled = newValue } }
+    }
+
+    var didReach: Bool {
+        lock.withLock { reached }
+    }
+
+    func passIfArmed() async {
+        let shouldSuspend = lock.withLock {
+            enabled && continuation == nil && !reached
+        }
+        guard shouldSuspend else { return }
+        await withCheckedContinuation { continuation in
+            let resumeImmediately = lock.withLock { () -> Bool in
+                self.continuation = continuation
+                reached = true
+                if released {
+                    self.continuation = nil
+                    return true
+                }
+                return false
+            }
+            if resumeImmediately {
+                continuation.resume()
+            }
+        }
+    }
+
+    func release() {
+        let continuation = lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            released = true
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+        continuation?.resume()
+    }
+}
+
 private final class OneShotKeyProviderGate: @unchecked Sendable {
     private let lock = NSLock()
     private let reached = DispatchSemaphore(value: 0)
@@ -1282,7 +1333,7 @@ struct whitenoise_macTests {
 
         state.groupProfileDraftName = "Private group name"
         state.groupProfileDraftDescription = "Private group description"
-        state.groupInviteMemberQuery = "npub1privateinvite"
+        state.groupInviteMemberQuery = "npub1pryvateynvyte"
         state.groupTranscriptExportStatus = "Copied transcript JSON for 1 events."
         let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
 
@@ -1382,7 +1433,7 @@ struct whitenoise_macTests {
 
         state.groupProfileDraftName = "Private group name"
         state.groupProfileDraftDescription = "Private group description"
-        state.groupInviteMemberQuery = "npub1privateinvite"
+        state.groupInviteMemberQuery = "npub1pryvateynvyte"
         state.isGroupImagePickerPresented = true
         state.groupImageSearchQuery = "private avatar"
         state.groupImageResults = [
@@ -1400,14 +1451,14 @@ struct whitenoise_macTests {
             )
         ]
         let recipient = NewChatRecipient(
-            sourceQuery: "npub1recipient",
-            memberRef: "npub1recipient",
+            sourceQuery: "npub1recypyent",
+            memberRef: "npub1recypyent",
             accountIdHex: "recipient1234567890recipient1234567890recipient1234567890recip1",
-            npub: "npub1recipient",
+            npub: "npub1recypyent",
             displayName: "Private Recipient",
             pictureURL: "https://example.com/recipient.png"
         )
-        state.newChatQuery = "npub1recipient"
+        state.newChatQuery = "npub1recypyent"
         state.newChatName = "Private chat"
         state.newChatDescription = "Private chat description"
         state.newChatRecipient = recipient
@@ -11605,9 +11656,9 @@ struct whitenoise_macTests {
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
         runtime.installNormalizedMemberRef(
-            query: "npub1newmember",
+            query: "npub1newmemzer",
             accountIdHex: "new1234567890new1234567890new1234567890new1234567890new1",
-            npub: "npub1newmember"
+            npub: "npub1newmemzer"
         )
         let state = WorkspaceState(clientFactory: { runtime })
 
@@ -11640,12 +11691,12 @@ struct whitenoise_macTests {
         #expect(state.groupDetailsSnapshot?.name == "Renamed Group")
         #expect(state.activeChats.first?.title == "Renamed Group")
 
-        state.groupInviteMemberQuery = "npub1newmember"
+        state.groupInviteMemberQuery = "npub1newmemzer"
         await state.inviteMemberToSelectedGroup()
 
-        #expect(runtime.invitedMemberRefs == ["npub1newmember"])
+        #expect(runtime.invitedMemberRefs == ["npub1newmemzer"])
         #expect(state.groupInviteMemberQuery.isEmpty)
-        #expect(state.groupDetailsSnapshot?.members.contains { $0.npub == "npub1newmember" } == true)
+        #expect(state.groupDetailsSnapshot?.members.contains { $0.npub == "npub1newmemzer" } == true)
     }
 
     @MainActor
@@ -11719,7 +11770,7 @@ struct whitenoise_macTests {
         }
 
         await state.promoteGroupMember(member)
-        #expect(runtime.promotedAdminRef == "npub1alice")
+        #expect(runtime.promotedAdminRef == "npub1alyce")
         #expect(state.groupDetailsSnapshot?.members.first(where: { $0.id == member.id })?.isAdmin == true)
 
         guard let promotedMember = state.groupDetailsSnapshot?.members.first(where: { $0.id == member.id }) else {
@@ -11727,7 +11778,7 @@ struct whitenoise_macTests {
             return
         }
         await state.demoteGroupMember(promotedMember)
-        #expect(runtime.demotedAdminRef == "npub1alice")
+        #expect(runtime.demotedAdminRef == "npub1alyce")
         #expect(state.groupDetailsSnapshot?.members.first(where: { $0.id == member.id })?.isAdmin == false)
 
         guard let demotedMember = state.groupDetailsSnapshot?.members.first(where: { $0.id == member.id }) else {
@@ -11735,7 +11786,7 @@ struct whitenoise_macTests {
             return
         }
         await state.removeGroupMember(demotedMember)
-        #expect(runtime.removedMemberRefs == ["npub1alice"])
+        #expect(runtime.removedMemberRefs == ["npub1alyce"])
         #expect(state.groupDetailsSnapshot?.members.contains { $0.id == member.id } == false)
     }
 
@@ -11947,13 +11998,13 @@ struct whitenoise_macTests {
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
         runtime.installNormalizedMemberRef(
-            query: "npub1newmember",
+            query: "npub1newmemzer",
             accountIdHex: "new1234567890new1234567890new1234567890new1234567890new1",
-            npub: "npub1newmember"
+            npub: "npub1newmemzer"
         )
         let state = try await openInstalledGroupDetails(runtime: runtime)
 
-        state.groupInviteMemberQuery = "npub1newmember"
+        state.groupInviteMemberQuery = "npub1newmemzer"
         runtime.groupMutationGateEnabled = true
 
         async let firstInvite: Void = state.inviteMemberToSelectedGroup()
@@ -11977,9 +12028,9 @@ struct whitenoise_macTests {
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
         runtime.installNormalizedMemberRef(
-            query: "npub1newmember",
+            query: "npub1newmemzer",
             accountIdHex: "new1234567890new1234567890new1234567890new1234567890new1",
-            npub: "npub1newmember"
+            npub: "npub1newmemzer"
         )
         let state = try await openInstalledGroupDetails(runtime: runtime)
         let member = try #require(state.groupDetailsSnapshot?.members.first(where: { !$0.isSelf }))
@@ -11990,7 +12041,7 @@ struct whitenoise_macTests {
             await Task.yield()
         }
 
-        state.groupInviteMemberQuery = "npub1newmember"
+        state.groupInviteMemberQuery = "npub1newmemzer"
         await state.inviteMemberToSelectedGroup()
         #expect(runtime.inviteMembersDetailedCallCount == 0)
 
@@ -12004,14 +12055,14 @@ struct whitenoise_macTests {
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
         runtime.installNormalizedMemberRef(
-            query: "npub1newmember",
+            query: "npub1newmemzer",
             accountIdHex: "new1234567890new1234567890new1234567890new1234567890new1",
-            npub: "npub1newmember"
+            npub: "npub1newmemzer"
         )
         let state = try await openInstalledGroupDetails(runtime: runtime)
         let member = try #require(state.groupDetailsSnapshot?.members.first(where: { !$0.isSelf }))
 
-        state.groupInviteMemberQuery = "npub1newmember"
+        state.groupInviteMemberQuery = "npub1newmemzer"
         runtime.groupMutationGateEnabled = true
         async let firstInvite: Void = state.inviteMemberToSelectedGroup()
         while !(state.isInvitingGroupMember && runtime.didReachGroupMutationGate) {
@@ -13444,12 +13495,12 @@ struct whitenoise_macTests {
 
         await state.bootstrap()
         state.showNewChat()
-        state.newChatQuery = "npub1alice"
+        state.newChatQuery = "npub1alyce"
         state.newChatName = "Project Room"
         state.newChatDescription = "planning space"
         await state.createNewChat()
 
-        #expect(runtime.createdGroupMemberRefs == ["npub1alice"])
+        #expect(runtime.createdGroupMemberRefs == ["npub1alyce"])
         #expect(runtime.createdGroupName == "Project Room")
         #expect(runtime.createdGroupDescription == "planning space")
         #expect(state.selection == .chat("created-group"))
@@ -13466,24 +13517,24 @@ struct whitenoise_macTests {
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
         let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: "npub1alice", accountIdHex: aliceId, npub: "npub1alice")
-        runtime.installNormalizedMemberRef(query: "npub1bob", accountIdHex: bobId, npub: "npub1bob")
+        runtime.installNormalizedMemberRef(query: "npub1alyce", accountIdHex: aliceId, npub: "npub1alyce")
+        runtime.installNormalizedMemberRef(query: "npub1p0p", accountIdHex: bobId, npub: "npub1p0p")
         let state = WorkspaceState(clientFactory: { runtime })
 
         await state.bootstrap()
         state.showNewChat()
 
         // Commit the first member the normal way (this clears the input).
-        state.newChatQuery = "npub1alice"
+        state.newChatQuery = "npub1alyce"
         _ = await state.addCurrentNewChatRecipient()
         #expect(state.newChatRecipients.map(\.accountIdHex) == [aliceId])
         #expect(state.newChatQuery.isEmpty)
 
         // Leave the second pubkey pending in the input, then create directly.
-        state.newChatQuery = "npub1bob"
+        state.newChatQuery = "npub1p0p"
         await state.createNewChat()
 
-        #expect(runtime.createdGroupMemberRefs == ["npub1alice", "npub1bob"])
+        #expect(runtime.createdGroupMemberRefs == ["npub1alyce", "npub1p0p"])
         #expect(state.selection == .chat("created-group"))
     }
 
@@ -13517,7 +13568,7 @@ struct whitenoise_macTests {
         #expect(state.activeAccountId == "Desktop Account")
 
         state.showNewChat()
-        state.newChatQuery = "npub1alice"
+        state.newChatQuery = "npub1alyce"
         state.newChatName = "Project Room"
 
         // Arm the gate so the create suspends in-flight inside `createGroup`.
@@ -13560,7 +13611,7 @@ struct whitenoise_macTests {
 
         await state.bootstrap()
         state.showNewChat()
-        state.newChatQuery = "npub1alice"
+        state.newChatQuery = "npub1alyce"
         await state.resolveNewChatQuery()
 
         #expect(state.resolvedNewChatRecipient?.title == "Desktop Account")
@@ -13574,12 +13625,14 @@ struct whitenoise_macTests {
         let policy = NIP05RedirectPolicy()
         let session = URLSession(configuration: .ephemeral)
         defer { session.invalidateAndCancel() }
-        let task = session.dataTask(with: URL(string: "https://example.com/.well-known/nostr.json")!)
         let redirectResponse = HTTPURLResponse(
             url: URL(string: "https://example.com")!, statusCode: 302, httpVersion: nil, headerFields: nil
         )!
 
+        // A fresh task per decision — each target is an independent host-revalidation check, not a
+        // hop of one lookup, so they must not share the per-task redirect-hop budget.
         func followedRequest(to target: String) -> URLRequest? {
+            let task = session.dataTask(with: URL(string: "https://example.com/.well-known/nostr.json")!)
             var decided: URLRequest?
             policy.urlSession(
                 session,
@@ -13601,12 +13654,51 @@ struct whitenoise_macTests {
         #expect(allowed?.url?.absoluteString == "https://relay.example.com/x")
     }
 
+    @Test func nip05ResolverStreamingCapRejectsOversizedBodyWithoutContentLength() async {
+        // No advertised length, so the streaming cap (not the pre-check) is what must fire.
+        NIP05URLProtocolStub.configure(body: Data(repeating: 0x20, count: 512 * 1024), sendContentLength: false)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [NIP05URLProtocolStub.self]
+        let resolver = NIP05Resolver(session: URLSession(configuration: config))
+        do {
+            _ = try await resolver.accountReference(for: "alyce@relay.example.com")
+            Issue.record("expected responseTooLarge")
+        } catch NIP05ResolutionError.responseTooLarge {
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func nip05ResolverPreCheckRejectsOversizedContentLength() async {
+        NIP05URLProtocolStub.configure(body: Data(repeating: 0x20, count: 512 * 1024), sendContentLength: true)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [NIP05URLProtocolStub.self]
+        let resolver = NIP05Resolver(session: URLSession(configuration: config))
+        do {
+            _ = try await resolver.accountReference(for: "alyce@relay.example.com")
+            Issue.record("expected responseTooLarge")
+        } catch NIP05ResolutionError.responseTooLarge {
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func nip05ResolverStreamsAndDecodesSmallBody() async throws {
+        let hex = String(repeating: "a", count: 64)
+        NIP05URLProtocolStub.configure(body: Data("{\"names\":{\"alyce\":\"\(hex)\"}}".utf8), sendContentLength: true)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [NIP05URLProtocolStub.self]
+        let resolver = NIP05Resolver(session: URLSession(configuration: config))
+        let reference = try await resolver.accountReference(for: "alyce@relay.example.com")
+        #expect(reference == hex)
+    }
+
     @MainActor
     @Test func resolvingNewChatRecipientUsesNIP05() async throws {
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: aliceId, accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: aliceId, accountIdHex: aliceId, npub: "npub1alyce")
         runtime.installProfile(
             accountIdHex: aliceId,
             profile: UserProfileMetadataFfi(
@@ -13631,7 +13723,7 @@ struct whitenoise_macTests {
         #expect(state.looksLikeMemberRef("alice@example.com"))
         #expect(state.resolvedNewChatRecipient?.sourceQuery == "alice@example.com")
         #expect(state.resolvedNewChatRecipient?.accountIdHex == aliceId)
-        #expect(state.resolvedNewChatRecipient?.npub == "npub1alice")
+        #expect(state.resolvedNewChatRecipient?.npub == "npub1alyce")
         #expect(state.resolvedNewChatRecipient?.title == "Alice NIP-05")
         #expect(state.resolvedNewChatRecipient?.pictureURL == "https://example.com/alice.png")
     }
@@ -13641,7 +13733,7 @@ struct whitenoise_macTests {
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: aliceId, accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: aliceId, accountIdHex: aliceId, npub: "npub1alyce")
         runtime.installProfile(
             accountIdHex: aliceId,
             profile: UserProfileMetadataFfi(
@@ -13672,10 +13764,10 @@ struct whitenoise_macTests {
     @Test func openingNostrProfileLinkShowsNewChatComposerAndResolvesRecipient() async throws {
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
-        let nprofile = "nprofile1alice"
+        let nprofile = "nprofile1alyce"
         let query = "nostr:\(nprofile)"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: query, accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: query, accountIdHex: aliceId, npub: "npub1alyce")
         runtime.installProfile(
             accountIdHex: aliceId,
             profile: UserProfileMetadataFfi(
@@ -13701,7 +13793,7 @@ struct whitenoise_macTests {
         #expect(state.isNewChatComposerVisible)
         #expect(state.newChatQuery == query)
         #expect(state.newChatName.isEmpty)
-        #expect(state.resolvedNewChatRecipient?.npub == "npub1alice")
+        #expect(state.resolvedNewChatRecipient?.npub == "npub1alyce")
         #expect(state.resolvedNewChatRecipient?.title == "Alice Link")
     }
 
@@ -13713,12 +13805,12 @@ struct whitenoise_macTests {
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
         let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
         let carolId = "carol1234567890carol1234567890carol1234567890carol1234567890"
-        let nprofile = "nprofile1bob"
+        let nprofile = "nprofile1p0p"
         let query = "nostr:\(nprofile)"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: "npub1alice", accountIdHex: aliceId, npub: "npub1alice")
-        runtime.installNormalizedMemberRef(query: query, accountIdHex: bobId, npub: "npub1bob")
-        runtime.installNormalizedMemberRef(query: "npub1carol", accountIdHex: carolId, npub: "npub1carol")
+        runtime.installNormalizedMemberRef(query: "npub1alyce", accountIdHex: aliceId, npub: "npub1alyce")
+        runtime.installNormalizedMemberRef(query: query, accountIdHex: bobId, npub: "npub1p0p")
+        runtime.installNormalizedMemberRef(query: "npub1car0l", accountIdHex: carolId, npub: "npub1car0l")
         runtime.installProfile(
             accountIdHex: bobId,
             profile: UserProfileMetadataFfi(
@@ -13734,11 +13826,11 @@ struct whitenoise_macTests {
 
         await state.bootstrap()
         state.showNewChat()
-        state.newChatQuery = "npub1alice"
+        state.newChatQuery = "npub1alyce"
         _ = await state.addCurrentNewChatRecipient()
         state.newChatName = "Project Room"
         state.newChatDescription = "planning space"
-        state.newChatQuery = "npub1carol"
+        state.newChatQuery = "npub1car0l"
         await state.resolveNewChatQuery()
         #expect(state.resolvedNewChatRecipient?.accountIdHex == carolId)
 
@@ -13752,7 +13844,7 @@ struct whitenoise_macTests {
         #expect(state.newChatRecipients.map(\.accountIdHex) == [aliceId, bobId])
         #expect(state.newChatName == "Project Room")
         #expect(state.newChatDescription == "planning space")
-        #expect(state.newChatQuery == "npub1carol")
+        #expect(state.newChatQuery == "npub1car0l")
         #expect(state.resolvedNewChatRecipient?.accountIdHex == carolId)
     }
 
@@ -13765,11 +13857,11 @@ struct whitenoise_macTests {
         let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
         let carolId = "carol1234567890carol1234567890carol1234567890carol1234567890"
         let daveId = "dave1234567890dave1234567890dave1234567890dave1234567890"
-        let bobReference = "nprofile1bob"
+        let bobReference = "nprofile1p0p"
         let bobQuery = "nostr:\(bobReference)"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: bobQuery, accountIdHex: bobId, npub: "npub1bob")
-        runtime.installNormalizedMemberRef(query: "npub1carol", accountIdHex: carolId, npub: "npub1carol")
+        runtime.installNormalizedMemberRef(query: bobQuery, accountIdHex: bobId, npub: "npub1p0p")
+        runtime.installNormalizedMemberRef(query: "npub1car0l", accountIdHex: carolId, npub: "npub1car0l")
         runtime.installNormalizedMemberRef(query: "npub1dave", accountIdHex: daveId, npub: "npub1dave")
         runtime.profileRefreshDelaysByAccountId[bobId] = 200_000_000
         let state = WorkspaceState(clientFactory: { runtime })
@@ -13777,7 +13869,7 @@ struct whitenoise_macTests {
         await state.bootstrap()
         state.showNewChat()
         state.newChatName = "Project Room"
-        state.newChatQuery = "npub1carol"
+        state.newChatQuery = "npub1car0l"
         await state.resolveNewChatQuery()
         #expect(state.resolvedNewChatRecipient?.accountIdHex == carolId)
 
@@ -13806,20 +13898,20 @@ struct whitenoise_macTests {
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
         let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1234567890"
-        let routedQuery = "nostr:npub1bob"
+        let routedQuery = "nostr:npub1p0p"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: "npub1alice", accountIdHex: aliceId, npub: "npub1alice")
-        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: bobId, npub: "npub1bob")
+        runtime.installNormalizedMemberRef(query: "npub1alyce", accountIdHex: aliceId, npub: "npub1alyce")
+        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: bobId, npub: "npub1p0p")
         let state = WorkspaceState(clientFactory: { runtime })
 
         await state.bootstrap()
         state.showNewChat()
-        state.newChatQuery = "npub1alice"
+        state.newChatQuery = "npub1alyce"
         _ = await state.addCurrentNewChatRecipient()
         state.newChatName = "Project Room"
         state.newChatDescription = "planning space"
 
-        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1bob?from=qr")!)
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1p0p?from=qr")!)
         let added = await waitFor {
             state.newChatRecipients.contains { $0.accountIdHex == bobId }
         }
@@ -13838,29 +13930,29 @@ struct whitenoise_macTests {
         // extracted reference in nostr: form.
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
-        let routedQuery = "nostr:nprofile1alice"
+        let routedQuery = "nostr:nprofile1alyce"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: aliceId, npub: "npub1alyce")
         let state = WorkspaceState(clientFactory: { runtime })
 
         await state.bootstrap()
-        _ = state.handleMessageLinkOpen(URL(string: "marmot://profile/nprofile1alice")!)
+        _ = state.handleMessageLinkOpen(URL(string: "marmot://profile/nprofile1alyce")!)
         let resolved = await waitFor {
             state.resolvedNewChatRecipient?.sourceQuery == routedQuery
         }
 
         #expect(resolved)
         #expect(state.isNewChatComposerVisible)
-        #expect(state.resolvedNewChatRecipient?.npub == "npub1alice")
+        #expect(state.resolvedNewChatRecipient?.npub == "npub1alyce")
     }
 
     @MainActor
     @Test func marmotDeepLinkWhenReadyOpensComposerAndResolvesRecipient() async throws {
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
-        let routedQuery = "nostr:npub1alice"
+        let routedQuery = "nostr:npub1alyce"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: aliceId, npub: "npub1alyce")
         let activationRecorder = AppActivationRecorder()
         let state = WorkspaceState(
             appActivationHandler: activationRecorder.record,
@@ -13868,7 +13960,7 @@ struct whitenoise_macTests {
         )
 
         await state.bootstrap()
-        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alice?from=qr")!)
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alyce?from=qr")!)
         let resolved = await waitFor {
             state.resolvedNewChatRecipient?.sourceQuery == routedQuery
         }
@@ -13876,7 +13968,7 @@ struct whitenoise_macTests {
         #expect(resolved)
         #expect(state.isNewChatComposerVisible)
         #expect(state.pendingDeepLinkProfileReference == nil)
-        #expect(state.resolvedNewChatRecipient?.npub == "npub1alice")
+        #expect(state.resolvedNewChatRecipient?.npub == "npub1alyce")
         #expect(activationRecorder.requests == [false])
     }
 
@@ -13890,10 +13982,10 @@ struct whitenoise_macTests {
         )
 
         await state.bootstrap()
-        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alice?from=qr")!)
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alyce?from=qr")!)
 
         #expect(state.phase == .onboarding)
-        #expect(state.pendingDeepLinkProfileReference == "npub1alice")
+        #expect(state.pendingDeepLinkProfileReference == "npub1alyce")
         #expect(state.backgroundStatus == "Sign in to start a chat from this link.")
         #expect(!state.isNewChatComposerVisible)
         #expect(activationRecorder.requests.isEmpty)
@@ -13905,17 +13997,17 @@ struct whitenoise_macTests {
         // queued and flushed by activateReadyState().
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
-        let routedQuery = "nostr:npub1alice"
+        let routedQuery = "nostr:npub1alyce"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: routedQuery, accountIdHex: aliceId, npub: "npub1alyce")
         let activationRecorder = AppActivationRecorder()
         let state = WorkspaceState(
             appActivationHandler: activationRecorder.record,
             clientFactory: { runtime }
         )
 
-        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alice?from=qr")!)
-        #expect(state.pendingDeepLinkProfileReference == "npub1alice")
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1alyce?from=qr")!)
+        #expect(state.pendingDeepLinkProfileReference == "npub1alyce")
         #expect(state.resolvedNewChatRecipient == nil)
         #expect(activationRecorder.requests.isEmpty)
 
@@ -13953,20 +14045,20 @@ struct whitenoise_macTests {
         // bindings parse it since the mdk#725 bump (clean break: darkmatter:// is dead).
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
-        let pasted = "marmot://profile/npub1alice?from=qr"
+        let pasted = "marmot://profile/npub1alyce?from=qr"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: pasted, accountIdHex: aliceId, npub: "npub1alice")
+        runtime.installNormalizedMemberRef(query: pasted, accountIdHex: aliceId, npub: "npub1alyce")
         let state = WorkspaceState(clientFactory: { runtime })
 
         await state.bootstrap()
         #expect(state.looksLikeMemberRef(pasted))
-        #expect(!state.looksLikeMemberRef("darkmatter://profile/npub1alice"))
+        #expect(!state.looksLikeMemberRef("darkmatter://profile/npub1alyce"))
 
         state.showNewChat()
         state.newChatQuery = pasted
         await state.resolveNewChatQuery()
 
-        #expect(state.resolvedNewChatRecipient?.npub == "npub1alice")
+        #expect(state.resolvedNewChatRecipient?.npub == "npub1alyce")
     }
 
     @MainActor
@@ -13982,7 +14074,7 @@ struct whitenoise_macTests {
         let slowId = "1111111111111111111111111111111111111111111111111111111111111111"
         let fastId = "2222222222222222222222222222222222222222222222222222222222222222"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: "npub1slow", accountIdHex: slowId, npub: "npub1slow")
+        runtime.installNormalizedMemberRef(query: "npub1sl0w", accountIdHex: slowId, npub: "npub1sl0w")
         runtime.installNormalizedMemberRef(query: "npub1fast", accountIdHex: fastId, npub: "npub1fast")
         runtime.installProfile(
             accountIdHex: slowId,
@@ -14011,7 +14103,7 @@ struct whitenoise_macTests {
 
         await state.bootstrap()
         state.showNewChat()
-        state.newChatQuery = "npub1slow"
+        state.newChatQuery = "npub1sl0w"
         let slowLookup = Task { @MainActor in
             await state.resolveNewChatQueryIfReady()
         }
@@ -14040,7 +14132,7 @@ struct whitenoise_macTests {
         )
         let slowId = "1111111111111111111111111111111111111111111111111111111111111111"
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installNormalizedMemberRef(query: "npub1slow", accountIdHex: slowId, npub: "npub1slow")
+        runtime.installNormalizedMemberRef(query: "npub1sl0w", accountIdHex: slowId, npub: "npub1sl0w")
         runtime.installProfile(
             accountIdHex: slowId,
             profile: UserProfileMetadataFfi(
@@ -14057,7 +14149,7 @@ struct whitenoise_macTests {
 
         await state.bootstrap()
         state.showNewChat()
-        state.newChatQuery = "npub1slow"
+        state.newChatQuery = "npub1sl0w"
         let slowLookup = Task { @MainActor in
             await state.resolveNewChatQueryIfReady()
         }
@@ -14071,7 +14163,7 @@ struct whitenoise_macTests {
         // lookup still owns the generation, so when it resumes its defer must clear
         // the spinner (keyed on generation ownership) even though the stricter
         // generation+query commit guard now fails and blocks the stale result.
-        state.newChatQuery = "npub1edited"
+        state.newChatQuery = "npub1edyted"
         await slowLookup.value
 
         #expect(!state.isResolvingNewChat)
@@ -16614,9 +16706,18 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var reactToMessageCallCount = 0
     private(set) var deleteMessageCallCount = 0
     private(set) var uploadMediaCallCount = 0
-    private(set) var listMediaCallCount = 0
-    private(set) var downloadMediaCallCount = 0
-    private(set) var downloadedMediaReferences: [MediaAttachmentReferenceFfi] = []
+    var listMediaCallCount: Int {
+        recordedStateLock.withLock { _listMediaCallCount }
+    }
+    private var _listMediaCallCount = 0
+    var downloadMediaCallCount: Int {
+        recordedStateLock.withLock { _downloadMediaCallCount }
+    }
+    private var _downloadMediaCallCount = 0
+    var downloadedMediaReferences: [MediaAttachmentReferenceFfi] {
+        recordedStateLock.withLock { _downloadedMediaReferences }
+    }
+    private var _downloadedMediaReferences: [MediaAttachmentReferenceFfi] = []
     private(set) var updatedGroupAvatar: UpdatedGroupAvatar?
     private(set) var updateGroupAvatarUrlCallCount = 0
     private(set) var updatedGroupProfile: UpdatedGroupProfile?
@@ -16646,7 +16747,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var lastPublishedProfileBootstrapRelays: [String] = []
     private(set) var lastSetInboxBootstrapRelays: [String] = []
     private(set) var lastSetNip65BootstrapRelays: [String] = []
-    private(set) var refreshedProfileIds: [String] = []
+    var refreshedProfileIds: [String] {
+        recordedStateLock.withLock { _refreshedProfileIds }
+    }
+    private var _refreshedProfileIds: [String] = []
     private(set) var markedReadMessageIds: [String] = []
     private(set) var accountKeyPackagesCallCount = 0
     /// Number of times `userProfile` was queried — used to assert settings-load coalescing
@@ -16656,13 +16760,31 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var accountRelayListsCallCount = 0
     /// Per-group call count for `groupDetails`, used to assert chat-list enrichment runs
     /// through the incremental per-row path (issue #40 regression).
-    private(set) var groupDetailsCallCounts: [String: Int] = [:]
+    var groupDetailsCallCounts: [String: Int] {
+        recordedStateLock.withLock { _groupDetailsCallCounts }
+    }
+    private var _groupDetailsCallCounts: [String: Int] = [:]
     var groupDetailsFailureGroupIds = Set<String>()
-    private(set) var chatListSubscriptionCount = 0
-    private(set) var notificationSubscriptionCount = 0
-    private(set) var timelineSubscriptionCount = 0
-    private(set) var timelineSubscriptionAccountRefs: [String] = []
-    private(set) var lastTimelineSubscription: FakeTimelineMessagesSubscription?
+    var chatListSubscriptionCount: Int {
+        recordedStateLock.withLock { _chatListSubscriptionCount }
+    }
+    private var _chatListSubscriptionCount = 0
+    var notificationSubscriptionCount: Int {
+        recordedStateLock.withLock { _notificationSubscriptionCount }
+    }
+    private var _notificationSubscriptionCount = 0
+    var timelineSubscriptionCount: Int {
+        recordedStateLock.withLock { _timelineSubscriptionCount }
+    }
+    private var _timelineSubscriptionCount = 0
+    var timelineSubscriptionAccountRefs: [String] {
+        recordedStateLock.withLock { _timelineSubscriptionAccountRefs }
+    }
+    private var _timelineSubscriptionAccountRefs: [String] = []
+    var lastTimelineSubscription: FakeTimelineMessagesSubscription? {
+        recordedStateLock.withLock { _lastTimelineSubscription }
+    }
+    private var _lastTimelineSubscription: FakeTimelineMessagesSubscription?
     var chatListStreamEndsAfterUpdates = false
     /// Simulates async relay/runtime latency before a chat-list subscription is ready.
     var chatListSubscriptionDelayNanoseconds: UInt64 = 0
@@ -16674,6 +16796,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var timelineMessagesHandler: ((TimelineMessageQueryFfi) -> TimelinePageFfi)?
     private let syncCallThreadLock = NSLock()
     private var syncCallThreads: [String: [Bool]] = [:]
+    /// Guards recorded-call state mutated by concurrent runtime calls while tests poll it mid-flight.
+    private let recordedStateLock = NSLock()
     /// When set, `subscribeNotifications()` throws this error, simulating a background
     /// notification-listener failure for routing tests.
     var subscribeNotificationsError: Error?
@@ -16684,19 +16808,24 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// (`sendText`/`replyToMessage`/`reactToMessage`/`deleteMessage`) suspends until
     /// `releaseMessageActionGate()` is invoked, holding the first invocation in-flight so a
     /// test can issue an overlapping second call and assert the WorkspaceState guard dropped it.
-    var messageActionGateEnabled = false
-    private(set) var didReachMessageActionGate = false
-    private var messageActionGateContinuation: CheckedContinuation<Void, Never>?
+    private let messageActionGate = AsyncFfiGate()
+    var messageActionGateEnabled: Bool {
+        get { messageActionGate.isEnabled }
+        set { messageActionGate.isEnabled = newValue }
+    }
+    var didReachMessageActionGate: Bool {
+        messageActionGate.didReach
+    }
     /// Issue #230 media-cache teardown-test support: when armed, the first `downloadMedia`
     /// call suspends after capturing the download bytes so a purge can complete before it returns.
-    private let mediaDownloadGateLock = NSLock()
-    var mediaDownloadGateEnabled = false
-    private var mediaDownloadGateReached = false
-    var didReachMediaDownloadGate: Bool {
-        mediaDownloadGateLock.withLock { mediaDownloadGateReached }
+    private let mediaDownloadGate = AsyncFfiGate()
+    var mediaDownloadGateEnabled: Bool {
+        get { mediaDownloadGate.isEnabled }
+        set { mediaDownloadGate.isEnabled = newValue }
     }
-    private var mediaDownloadGateContinuation: CheckedContinuation<Void, Never>?
-    private var mediaDownloadGateReleased = false
+    var didReachMediaDownloadGate: Bool {
+        mediaDownloadGate.didReach
+    }
     /// Issue #286 reference-resolution cache-test support: when armed, the first synchronous
     /// `listMedia` call blocks on the FFI queue so overlapping attachment loads can join it.
     private let listMediaGate = BlockingFfiGate()
@@ -16710,37 +16839,62 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// Issue #134 reentrancy-test support: when armed, the first group-avatar update FFI call
     /// suspends until `releaseGroupAvatarUpdateGate()` is invoked, holding the first invocation
     /// in-flight so a test can issue an overlapping clear/set action and assert the guard dropped it.
-    var groupAvatarUpdateGateEnabled = false
-    private(set) var didReachGroupAvatarUpdateGate = false
-    private var groupAvatarUpdateGateContinuation: CheckedContinuation<Void, Never>?
+    private let groupAvatarUpdateGate = AsyncFfiGate()
+    var groupAvatarUpdateGateEnabled: Bool {
+        get { groupAvatarUpdateGate.isEnabled }
+        set { groupAvatarUpdateGate.isEnabled = newValue }
+    }
+    var didReachGroupAvatarUpdateGate: Bool {
+        groupAvatarUpdateGate.didReach
+    }
     /// Issue #310 reentrancy-test support: when armed, the first group mutation FFI call suspends
     /// until `releaseGroupMutationGate()` is invoked, holding the first invocation in-flight so a
     /// test can issue an overlapping duplicate and assert the WorkspaceState guard dropped it.
-    var groupMutationGateEnabled = false
-    private(set) var didReachGroupMutationGate = false
-    private var groupMutationGateContinuation: CheckedContinuation<Void, Never>?
+    private let groupMutationGate = AsyncFfiGate()
+    var groupMutationGateEnabled: Bool {
+        get { groupMutationGate.isEnabled }
+        set { groupMutationGate.isEnabled = newValue }
+    }
+    var didReachGroupMutationGate: Bool {
+        groupMutationGate.didReach
+    }
     /// Issue #135 last-request-wins-test support: when armed, the first `groupDetails` FFI call
     /// suspends until `releaseGroupDetailsGate()` is invoked, holding the older `loadGroupDetails`
     /// in-flight so a test can run a newer overlapping load to completion and then assert the stale
     /// older completion does not clobber the newer snapshot or drop the shared spinner.
-    var groupDetailsGateEnabled = false
-    private(set) var didReachGroupDetailsGate = false
-    private var groupDetailsGateContinuation: CheckedContinuation<Void, Never>?
+    private let groupDetailsGate = AsyncFfiGate()
+    var groupDetailsGateEnabled: Bool {
+        get { groupDetailsGate.isEnabled }
+        set { groupDetailsGate.isEnabled = newValue }
+    }
+    var didReachGroupDetailsGate: Bool {
+        groupDetailsGate.didReach
+    }
     /// Issue #207 last-request-wins-test support: when armed, the first `accountKeyPackages` FFI
     /// call suspends until `releaseAccountKeyPackagesGate()` is invoked, holding an older
     /// `loadKeyPackages()` in-flight so a test can switch the active account, run a newer load to
     /// completion, then assert the stale older completion does not overwrite (or, on error, blank)
     /// the newer account's key-package list.
-    var accountKeyPackagesGateEnabled = false
-    private(set) var didReachAccountKeyPackagesGate = false
-    private var accountKeyPackagesGateContinuation: CheckedContinuation<Void, Never>?
+    private let accountKeyPackagesGate = AsyncFfiGate()
+    var accountKeyPackagesGateEnabled: Bool {
+        get { accountKeyPackagesGate.isEnabled }
+        set { accountKeyPackagesGate.isEnabled = newValue }
+    }
+    var didReachAccountKeyPackagesGate: Bool {
+        accountKeyPackagesGate.didReach
+    }
     /// Issue #229 stale-account-test support: when armed, the first `createGroup` FFI call suspends
     /// until `releaseCreateGroupGate()` is invoked, holding `createNewChat()` in-flight so a test can
     /// switch the active account before the create resolves and assert the freshly created group is
     /// not grafted onto / selected under the switched-to account.
-    var createGroupGateEnabled = false
-    private(set) var didReachCreateGroupGate = false
-    private var createGroupGateContinuation: CheckedContinuation<Void, Never>?
+    private let createGroupGate = AsyncFfiGate()
+    var createGroupGateEnabled: Bool {
+        get { createGroupGate.isEnabled }
+        set { createGroupGate.isEnabled = newValue }
+    }
+    var didReachCreateGroupGate: Bool {
+        createGroupGate.didReach
+    }
     /// Issue #228 last-request-wins support for synchronous notification FFI reads: when armed,
     /// the first `notificationSettings` call blocks on the FFI queue until released, holding an
     /// older account's result while the test switches accounts and loads the newer snapshot.
@@ -16798,15 +16952,25 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// suspends until `releasePublishUserProfileGate()` is invoked, holding `saveProfile()` in-flight
     /// so a test can switch the active account before the publish resolves and assert the just-saved
     /// profile is not misattributed to the switched-to account.
-    var publishUserProfileGateEnabled = false
-    private(set) var didReachPublishUserProfileGate = false
-    private var publishUserProfileGateContinuation: CheckedContinuation<Void, Never>?
+    private let publishUserProfileGate = AsyncFfiGate()
+    var publishUserProfileGateEnabled: Bool {
+        get { publishUserProfileGate.isEnabled }
+        set { publishUserProfileGate.isEnabled = newValue }
+    }
+    var didReachPublishUserProfileGate: Bool {
+        publishUserProfileGate.didReach
+    }
     /// Issue #287 equivalent gate for the `setAccountNip65Relays` / `setAccountInboxRelays` FFI
     /// writes: when armed, the first relay-save call suspends until `releaseSetAccountRelaysGate()`,
     /// holding `saveRelaySettings()` in-flight across an account switch.
-    var setAccountRelaysGateEnabled = false
-    private(set) var didReachSetAccountRelaysGate = false
-    private var setAccountRelaysGateContinuation: CheckedContinuation<Void, Never>?
+    private let setAccountRelaysGate = AsyncFfiGate()
+    var setAccountRelaysGateEnabled: Bool {
+        get { setAccountRelaysGate.isEnabled }
+        set { setAccountRelaysGate.isEnabled = newValue }
+    }
+    var didReachSetAccountRelaysGate: Bool {
+        setAccountRelaysGate.didReach
+    }
     /// Per-account key packages keyed by `accountRef`. Falls back to the default `keyPackages`
     /// fixture when an account has no explicit install, so existing single-account tests are
     /// unaffected.
@@ -16941,19 +17105,19 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         return MemberRefFfi(
             memberRef: memberRef,
             accountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
-            npub: "npub1alice"
+            npub: "npub1alyce"
         )
     }
 
     func refreshProfile(accountIdHex: String, relays: [String]) async throws {
-        refreshedProfileIds.append(accountIdHex)
+        recordedStateLock.withLock { _refreshedProfileIds.append(accountIdHex) }
         if let delay = profileRefreshDelaysByAccountId[accountIdHex] {
             try await Task.sleep(nanoseconds: delay)
         }
     }
 
     func clearRefreshedProfileIds() {
-        refreshedProfileIds = []
+        recordedStateLock.withLock { _refreshedProfileIds = [] }
     }
 
     func clearTimelineMessageQueries() {
@@ -17024,7 +17188,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
                     local: false,
                     isAdmin: false,
                     isSelf: false,
-                    npub: "npub1alice",
+                    npub: "npub1alyce",
                     displayName: otherDisplayName
                 ),
             ]
@@ -17139,23 +17303,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         lastPublishedProfileDefaultRelays = defaultRelays
         lastPublishedProfileBootstrapRelays = bootstrapRelays
         self.profile = profile
-        await passPublishUserProfileGateIfArmed()
+        await publishUserProfileGate.passIfArmed()
         return profile
     }
 
-    private func passPublishUserProfileGateIfArmed() async {
-        guard publishUserProfileGateEnabled, publishUserProfileGateContinuation == nil,
-            !didReachPublishUserProfileGate
-        else { return }
-        didReachPublishUserProfileGate = true
-        await withCheckedContinuation { continuation in
-            publishUserProfileGateContinuation = continuation
-        }
-    }
-
     func releasePublishUserProfileGate() {
-        publishUserProfileGateContinuation?.resume()
-        publishUserProfileGateContinuation = nil
+        publishUserProfileGate.release()
     }
 
     func accountRelayLists(accountRef: String) throws -> AccountRelayListsFfi {
@@ -17178,7 +17331,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         // Snapshot the result *before* the gate so a held older load returns its account's packages
         // and a later switch/mutation cannot retroactively change them (issue #207).
         let result = keyPackagesByAccountRef[accountRef] ?? keyPackages
-        await passAccountKeyPackagesGateIfArmed()
+        await accountKeyPackagesGate.passIfArmed()
         return result
     }
 
@@ -17186,19 +17339,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         keyPackagesByAccountRef[accountRef] = packages
     }
 
-    private func passAccountKeyPackagesGateIfArmed() async {
-        guard accountKeyPackagesGateEnabled, accountKeyPackagesGateContinuation == nil,
-            !didReachAccountKeyPackagesGate
-        else { return }
-        didReachAccountKeyPackagesGate = true
-        await withCheckedContinuation { continuation in
-            accountKeyPackagesGateContinuation = continuation
-        }
-    }
-
     func releaseAccountKeyPackagesGate() {
-        accountKeyPackagesGateContinuation?.resume()
-        accountKeyPackagesGateContinuation = nil
+        accountKeyPackagesGate.release()
     }
 
     func auditLogFiles() throws -> [AuditLogFileFfi] {
@@ -17392,21 +17534,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
             groupDetailsById[group.groupIdHex] = details
             groupManagementStateById[group.groupIdHex] = defaultGroupManagementState(for: details)
         }
-        await passCreateGroupGateIfArmed()
+        await createGroupGate.passIfArmed()
         return "created-group"
     }
 
-    private func passCreateGroupGateIfArmed() async {
-        guard createGroupGateEnabled, createGroupGateContinuation == nil, !didReachCreateGroupGate else { return }
-        didReachCreateGroupGate = true
-        await withCheckedContinuation { continuation in
-            createGroupGateContinuation = continuation
-        }
-    }
-
     func releaseCreateGroupGate() {
-        createGroupGateContinuation?.resume()
-        createGroupGateContinuation = nil
+        createGroupGate.release()
     }
 
     func acceptGroupInvite(accountRef: String, groupIdHex: String) async throws -> AppGroupRecordFfi {
@@ -17439,7 +17572,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func groupDetails(accountRef: String, groupIdHex: String) async throws -> GroupDetailsFfi {
-        groupDetailsCallCounts[groupIdHex, default: 0] += 1
+        recordedStateLock.withLock { _groupDetailsCallCounts[groupIdHex, default: 0] += 1 }
         if groupDetailsFailureGroupIds.contains(groupIdHex) {
             throw FakeMarmotRuntimeError.unused
         }
@@ -17453,21 +17586,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         } else {
             throw FakeMarmotRuntimeError.unused
         }
-        await passGroupDetailsGateIfArmed()
+        await groupDetailsGate.passIfArmed()
         return result
     }
 
-    private func passGroupDetailsGateIfArmed() async {
-        guard groupDetailsGateEnabled, groupDetailsGateContinuation == nil, !didReachGroupDetailsGate else { return }
-        didReachGroupDetailsGate = true
-        await withCheckedContinuation { continuation in
-            groupDetailsGateContinuation = continuation
-        }
-    }
-
     func releaseGroupDetailsGate() {
-        groupDetailsGateContinuation?.resume()
-        groupDetailsGateContinuation = nil
+        groupDetailsGate.release()
     }
 
     func groupManagementState(accountRef: String, groupIdHex: String) async throws -> GroupManagementStateFfi {
@@ -17484,7 +17608,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         -> GroupMutationResultFfi
     {
         inviteMembersDetailedCallCount += 1
-        await passGroupMutationGateIfArmed()
+        await groupMutationGate.passIfArmed()
         invitedMemberRefs = memberRefs
         guard var details = groupDetailsById[groupIdHex] else {
             throw FakeMarmotRuntimeError.unused
@@ -17515,7 +17639,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func leaveGroup(accountRef: String, groupIdHex: String) async throws -> SendSummaryFfi {
         leaveGroupCallCount += 1
-        await passGroupMutationGateIfArmed()
+        await groupMutationGate.passIfArmed()
         leftGroupIdHex = groupIdHex
         groups.removeAll { $0.groupIdHex == groupIdHex }
         groupDetailsById[groupIdHex] = nil
@@ -17527,7 +17651,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         -> GroupMutationResultFfi
     {
         promoteAdminDetailedCallCount += 1
-        await passGroupMutationGateIfArmed()
+        await groupMutationGate.passIfArmed()
         promotedAdminRef = memberRef
         updateMember(groupIdHex: groupIdHex, matching: memberRef) { member in
             member.isAdmin = true
@@ -17539,7 +17663,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         -> GroupMutationResultFfi
     {
         demoteAdminDetailedCallCount += 1
-        await passGroupMutationGateIfArmed()
+        await groupMutationGate.passIfArmed()
         demotedAdminRef = memberRef
         updateMember(groupIdHex: groupIdHex, matching: memberRef) { member in
             member.isAdmin = false
@@ -17551,7 +17675,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         -> GroupMutationResultFfi
     {
         removeMembersDetailedCallCount += 1
-        await passGroupMutationGateIfArmed()
+        await groupMutationGate.passIfArmed()
         removedMemberRefs = memberRefs
         guard var details = groupDetailsById[groupIdHex] else {
             throw FakeMarmotRuntimeError.unused
@@ -17566,7 +17690,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func selfDemoteAdminDetailed(accountRef: String, groupIdHex: String) async throws -> GroupMutationResultFfi {
         selfDemoteAdminDetailedCallCount += 1
-        await passGroupMutationGateIfArmed()
+        await groupMutationGate.passIfArmed()
         selfDemotedGroupIdHex = groupIdHex
         guard var details = groupDetailsById[groupIdHex] else {
             throw FakeMarmotRuntimeError.unused
@@ -17581,7 +17705,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func setGroupArchived(accountRef: String, groupIdHex: String, archived: Bool) async throws -> AppGroupRecordFfi {
         setGroupArchivedCallCount += 1
-        await passGroupMutationGateIfArmed()
+        await groupMutationGate.passIfArmed()
         archivedGroup = ArchivedGroup(groupIdHex: groupIdHex, archived: archived)
         guard let index = groups.firstIndex(where: { $0.groupIdHex == groupIdHex }) else {
             throw FakeMarmotRuntimeError.unused
@@ -17598,7 +17722,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         async throws -> SendSummaryFfi
     {
         updateGroupAvatarUrlCallCount += 1
-        await passGroupAvatarUpdateGateIfArmed()
+        await groupAvatarUpdateGate.passIfArmed()
 
         updatedGroupAvatar = UpdatedGroupAvatar(groupIdHex: groupIdHex, url: url, dim: dim, thumbhash: thumbhash)
 
@@ -17618,43 +17742,19 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         return SendSummaryFfi(published: 1, messageIds: ["group-avatar"])
     }
 
-    private func passGroupAvatarUpdateGateIfArmed() async {
-        guard groupAvatarUpdateGateEnabled,
-            groupAvatarUpdateGateContinuation == nil,
-            !didReachGroupAvatarUpdateGate
-        else { return }
-        didReachGroupAvatarUpdateGate = true
-        await withCheckedContinuation { continuation in
-            groupAvatarUpdateGateContinuation = continuation
-        }
-    }
-
     func releaseGroupAvatarUpdateGate() {
-        groupAvatarUpdateGateContinuation?.resume()
-        groupAvatarUpdateGateContinuation = nil
-    }
-
-    private func passGroupMutationGateIfArmed() async {
-        guard groupMutationGateEnabled,
-            groupMutationGateContinuation == nil,
-            !didReachGroupMutationGate
-        else { return }
-        didReachGroupMutationGate = true
-        await withCheckedContinuation { continuation in
-            groupMutationGateContinuation = continuation
-        }
+        groupAvatarUpdateGate.release()
     }
 
     func releaseGroupMutationGate() {
-        groupMutationGateContinuation?.resume()
-        groupMutationGateContinuation = nil
+        groupMutationGate.release()
     }
 
     func updateGroupProfile(accountRef: String, groupIdHex: String, name: String?, description: String?) async throws
         -> SendSummaryFfi
     {
         updateGroupProfileCallCount += 1
-        await passGroupMutationGateIfArmed()
+        await groupMutationGate.passIfArmed()
         updatedGroupProfile = UpdatedGroupProfile(groupIdHex: groupIdHex, name: name, description: description)
 
         if let index = groups.firstIndex(where: { $0.groupIdHex == groupIdHex }) {
@@ -17686,7 +17786,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         relayLists.inbox = RelayListFfi(kind: relayLists.inbox.kind, relays: relays)
         // Snapshot before the gate so a held older save returns its account's lists.
         let result = relayLists
-        await passSetAccountRelaysGateIfArmed()
+        await setAccountRelaysGate.passIfArmed()
         return result
     }
 
@@ -17696,27 +17796,16 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         lastSetNip65BootstrapRelays = bootstrapRelays
         relayLists.nip65 = RelayListFfi(kind: relayLists.nip65.kind, relays: relays)
         let result = relayLists
-        await passSetAccountRelaysGateIfArmed()
+        await setAccountRelaysGate.passIfArmed()
         return result
     }
 
-    private func passSetAccountRelaysGateIfArmed() async {
-        guard setAccountRelaysGateEnabled, setAccountRelaysGateContinuation == nil,
-            !didReachSetAccountRelaysGate
-        else { return }
-        didReachSetAccountRelaysGate = true
-        await withCheckedContinuation { continuation in
-            setAccountRelaysGateContinuation = continuation
-        }
-    }
-
     func releaseSetAccountRelaysGate() {
-        setAccountRelaysGateContinuation?.resume()
-        setAccountRelaysGateContinuation = nil
+        setAccountRelaysGate.release()
     }
 
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws -> ChatListSubscription {
-        chatListSubscriptionCount += 1
+        recordedStateLock.withLock { _chatListSubscriptionCount += 1 }
         if chatListSubscriptionDelayNanoseconds > 0 {
             try await Task.sleep(nanoseconds: chatListSubscriptionDelayNanoseconds)
         }
@@ -17793,7 +17882,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func subscribeNotifications() async throws -> NotificationsSubscription {
-        notificationSubscriptionCount += 1
+        recordedStateLock.withLock { _notificationSubscriptionCount += 1 }
         if let subscribeNotificationsError {
             throw subscribeNotificationsError
         }
@@ -17820,8 +17909,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func subscribeTimelineMessages(accountRef: String, groupIdHex: String?, limit: UInt32?) async throws
         -> TimelineMessagesSubscription
     {
-        timelineSubscriptionCount += 1
-        timelineSubscriptionAccountRefs.append(accountRef)
+        recordedStateLock.withLock {
+            _timelineSubscriptionCount += 1
+            _timelineSubscriptionAccountRefs.append(accountRef)
+        }
         if timelineSubscriptionDelayNanoseconds > 0 {
             try await Task.sleep(nanoseconds: timelineSubscriptionDelayNanoseconds)
         }
@@ -17842,7 +17933,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
                 self?.recordSyncCall("timelineMessagesSubscription.snapshot")
             }
         )
-        lastTimelineSubscription = subscription
+        recordedStateLock.withLock { _lastTimelineSubscription = subscription }
         return subscription
     }
 
@@ -17859,7 +17950,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func listMedia(accountRef: String, groupIdHex: String, limit: UInt32?) throws -> [MediaRecordFfi] {
-        listMediaCallCount += 1
+        recordedStateLock.withLock { _listMediaCallCount += 1 }
         listMediaGate.passIfArmed()
         let records = mediaRecordsByGroupId[groupIdHex] ?? []
         guard let limit else { return records }
@@ -17873,12 +17964,14 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func downloadMedia(accountRef: String, groupIdHex: String, reference: MediaAttachmentReferenceFfi) async throws
         -> MediaDownloadResultFfi
     {
-        downloadMediaCallCount += 1
-        downloadedMediaReferences.append(reference)
+        recordedStateLock.withLock {
+            _downloadMediaCallCount += 1
+            _downloadedMediaReferences.append(reference)
+        }
         guard let download = mediaDownloadsByPlaintextSha256[reference.plaintextSha256] else {
             throw FakeMarmotRuntimeError.unused
         }
-        await passMediaDownloadGateIfArmed()
+        await mediaDownloadGate.passIfArmed()
         return download
     }
 
@@ -17887,7 +17980,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     {
         uploadMediaCallCount += 1
         uploadedMedia = UploadedMedia(groupIdHex: groupIdHex, request: request)
-        await passMessageActionGateIfArmed()
+        await messageActionGate.passIfArmed()
         let attachments = request.attachments.enumerated().map { index, attachment in
             MediaUploadAttachmentResultFfi(
                 reference: MediaAttachmentReferenceFfi(
@@ -17914,7 +18007,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func sendText(accountRef: String, groupIdHex: String, text: String) async throws -> SendSummaryFfi {
         sendTextCallCount += 1
         sentText = SentText(groupIdHex: groupIdHex, text: text)
-        await passMessageActionGateIfArmed()
+        await messageActionGate.passIfArmed()
         return SendSummaryFfi(published: 1, messageIds: ["text"])
     }
 
@@ -17923,7 +18016,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     {
         replyToMessageCallCount += 1
         repliedMessage = SentReply(groupIdHex: groupIdHex, targetMessageId: targetMessageId, text: text)
-        await passMessageActionGateIfArmed()
+        await messageActionGate.passIfArmed()
         return SendSummaryFfi(published: 1, messageIds: ["reply"])
     }
 
@@ -17932,64 +18025,23 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     {
         reactToMessageCallCount += 1
         reactedMessage = SentReaction(groupIdHex: groupIdHex, targetMessageId: targetMessageId, emoji: emoji)
-        await passMessageActionGateIfArmed()
+        await messageActionGate.passIfArmed()
         return SendSummaryFfi(published: 1, messageIds: ["reaction"])
     }
 
     func deleteMessage(accountRef: String, groupIdHex: String, targetMessageId: String) async throws -> SendSummaryFfi {
         deleteMessageCallCount += 1
         deletedMessage = DeletedMessage(groupIdHex: groupIdHex, targetMessageId: targetMessageId)
-        await passMessageActionGateIfArmed()
+        await messageActionGate.passIfArmed()
         return SendSummaryFfi(published: 1, messageIds: ["delete"])
     }
 
-    /// Suspends the first message-action FFI call when the gate is armed, recording arrival so a
-    /// test can spin until the first invocation is in-flight, then issue the overlapping second call.
-    private func passMessageActionGateIfArmed() async {
-        guard messageActionGateEnabled, messageActionGateContinuation == nil, !didReachMessageActionGate else { return }
-        didReachMessageActionGate = true
-        await withCheckedContinuation { continuation in
-            messageActionGateContinuation = continuation
-        }
-    }
-
     func releaseMessageActionGate() {
-        messageActionGateContinuation?.resume()
-        messageActionGateContinuation = nil
-    }
-
-    /// Suspends the first media download FFI call when the gate is armed, after the fake runtime
-    /// has captured the bytes it will return. This models a network download completing after a
-    /// user-initiated purge has already removed the account/cache.
-    private func passMediaDownloadGateIfArmed() async {
-        let shouldSuspend = mediaDownloadGateLock.withLock {
-            mediaDownloadGateEnabled && mediaDownloadGateContinuation == nil && !mediaDownloadGateReached
-        }
-        guard shouldSuspend else { return }
-        await withCheckedContinuation { continuation in
-            let resumeImmediately = mediaDownloadGateLock.withLock {
-                mediaDownloadGateContinuation = continuation
-                mediaDownloadGateReached = true
-                if mediaDownloadGateReleased {
-                    mediaDownloadGateContinuation = nil
-                    return true
-                }
-                return false
-            }
-            if resumeImmediately {
-                continuation.resume()
-            }
-        }
+        messageActionGate.release()
     }
 
     func releaseMediaDownloadGate() {
-        let continuation = mediaDownloadGateLock.withLock {
-            mediaDownloadGateReleased = true
-            let continuation = mediaDownloadGateContinuation
-            mediaDownloadGateContinuation = nil
-            return continuation
-        }
-        continuation?.resume()
+        mediaDownloadGate.release()
     }
 
     // MARK: - darkmatter 745959e FFI additions
@@ -18005,9 +18057,14 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var updateMessageRetentionCallCount = 0
     var lastRetentionSecs: UInt64?
     var secureDeleteExpiredCallCount = 0
-    var secureDeleteExpiredGateEnabled = false
-    private(set) var didReachSecureDeleteExpiredGate = false
-    private var secureDeleteExpiredGateContinuation: CheckedContinuation<Void, Never>?
+    private let secureDeleteExpiredGate = AsyncFfiGate()
+    var secureDeleteExpiredGateEnabled: Bool {
+        get { secureDeleteExpiredGate.isEnabled }
+        set { secureDeleteExpiredGate.isEnabled = newValue }
+    }
+    var didReachSecureDeleteExpiredGate: Bool {
+        secureDeleteExpiredGate.didReach
+    }
     var accountUnreadSummaryRows: [AccountUnreadFfi] = []
 
     func parseMarkdown(text: String) -> MarkdownDocumentFfi {
@@ -18083,23 +18140,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func secureDeleteExpired(accountRef: String, groupIdHex: String) async throws -> SecureDeleteExpiredResultFfi {
         secureDeleteExpiredCallCount += 1
-        await passSecureDeleteExpiredGateIfArmed()
+        await secureDeleteExpiredGate.passIfArmed()
         return SecureDeleteExpiredResultFfi(prunedMessages: 0, mediaCiphertextSha256: [])
     }
 
-    private func passSecureDeleteExpiredGateIfArmed() async {
-        guard secureDeleteExpiredGateEnabled, secureDeleteExpiredGateContinuation == nil,
-            !didReachSecureDeleteExpiredGate
-        else { return }
-        didReachSecureDeleteExpiredGate = true
-        await withCheckedContinuation { continuation in
-            secureDeleteExpiredGateContinuation = continuation
-        }
-    }
-
     func releaseSecureDeleteExpiredGate() {
-        secureDeleteExpiredGateContinuation?.resume()
-        secureDeleteExpiredGateContinuation = nil
+        secureDeleteExpiredGate.release()
     }
 
     private func chatListRow(for group: AppGroupRecordFfi) -> ChatListRowFfi {
@@ -19027,6 +19073,41 @@ private final class RemoteImageURLProtocolStub: URLProtocol {
     }
 }
 
+/// Serves a fixed body for NIP-05 well-known lookups, optionally advertising Content-Length so
+/// tests can drive either the cheap pre-check or the streaming byte cap.
+private final class NIP05URLProtocolStub: URLProtocol {
+    private static let lock = NSLock()
+    private static var body = Data()
+    private static var sendContentLength = true
+
+    static func configure(body: Data, sendContentLength: Bool) {
+        lock.lock()
+        self.body = body
+        self.sendContentLength = sendContentLength
+        lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        let data = Self.body
+        let withLength = Self.sendContentLength
+        Self.lock.unlock()
+
+        let headers = withLength ? ["Content-Length": "\(data.count)"] : [:]
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: nil, headerFields: headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 private func telemetryBuildConfig(
     telemetryToken: String? = "otlp-token",
     auditToken: String? = "audit-token",
@@ -19166,7 +19247,7 @@ private func groupDetailsFixture(
                 local: false,
                 isAdmin: otherIsAdmin,
                 isSelf: false,
-                npub: "npub1alice",
+                npub: "npub1alyce",
                 displayName: "Alice"
             ),
             GroupMemberDetailsFfi(
@@ -19175,7 +19256,7 @@ private func groupDetailsFixture(
                 local: false,
                 isAdmin: false,
                 isSelf: false,
-                npub: "npub1bob",
+                npub: "npub1p0p",
                 displayName: "Bob"
             ),
         ]


### PR DESCRIPTION
A stabilization sweep closing 16 open issues across security hardening, state-correctness, the composer, and test reliability. Every fix was implemented to the scope of its issue, then put through a review pass and an adversarial-verification pass; the two findings that survived (an integer-overflow trap in the new decompression-bomb guard, and missing coverage for the response-size cap) are folded in.

## Security / privacy hardening
- Closes #493 — a profile reference like `npub1…@evil.com` was prefix-validated only, reparsed as a NIP-05 identifier, and fired an attacker-directed `.well-known` request on click. Resolvable references now require a bech32-grammar payload; identifiers carrying a nostr/marmot marker skip NIP-05 resolution; the NIP-05 local part is charset- and length-bounded.
- Closes #489 — the `.well-known/nostr.json` fetch buffered the whole body; now a 256 KiB streaming cap plus a Content-Length pre-check.
- Closes #497 — the NIP-05 redirect delegate had no hop cap; added a per-task budget of 5 mirroring the image path.
- Closes #509 — image downsampling had no source-dimension cap; a header-only pixel-count check (64 MP budget, overflow-safe) now rejects decompression bombs before decode.
- Closes #530, Closes #488 — `isPrivateIPv6` misclassified `::2`–`::ffff` as public and let `ff00::/8` multicast and translated/NAT64 embedded private IPv4 through; all now rejected.

## State correctness
- Closes #450, Closes #519 — a benign delta for an already-archived open chat no longer deselects you into an active one (deselection is gated on a genuine active→archived transition read from the active-only index); the dead `shouldEnrich` parameter is removed.
- Closes #449 — an open archived conversation's header/composer now refresh on live metadata (the archived generation bump was missing the selected-chat revision bump).
- Closes #467 — older-history pagination no longer wedges when the prepend anchor is evicted mid-load; both the guard and the async re-check release the gate (without clobbering a newer prepend).
- Closes #511 — a concurrent settings load can no longer revert a just-saved telemetry/audit toggle (a generation token gates the published snapshot).
- Closes #524 — the media encryption key is now destroyed only after the local-data delete succeeds, so a failed wipe can't strand permanently undecryptable cached media.
- Closes #515 — `MessageItem.hash(into:)` no longer folds the whole body string (id already distributes).
- Closes #533 — member/attachment counts pass explicit 32-bit values to their format strings.

## Composer
- Closes #502 — a marked CJK/IME composition is committed by the input context before Return is treated as send, instead of being discarded with a premature send. No unit-testable seam (file-private text view + input-context runtime behavior) — needs a manual pass with an IME enabled.

## Test reliability
- Closes #457 — restores a green PR test plan: the fake runtime's recorded state (download counters, subscription counts, refreshed-profile ids, group-detail counts) is now lock-synchronized, and all ten async FFI gates share one lost-wakeup-free implementation (a poll-then-release race previously could park a call forever). Deep-link test fixtures were renamed to bech32-legal spellings for the tightened grammar.

New tests cover the profile-ref grammar, the marker guard, the NIP-05 charset/length and response-size cap, the redirect-hop cap, and the corrected IPv6 classification.

## Verification
- Full suite green: 449 tests.
- Strict swift-format lint clean across the diff.

## Deliberately deferred (follow-ups, not in this PR)
- #522 (group-commit teardown semantics) and #510 (deep-link composer mutation) each need their own focused change on a safety-sensitive path.
- #531 (account-mutation guards) and #470 (timestamp day-boundary refresh) overlap the chat-list-and-compose redesign in PR #535 and are queued for after it merges.
- One narrow follow-up noted during review: on the privacy pane's first open, flipping a toggle before the initial load resolves can leave audit fields at defaults until the pane reopens (self-heals; smaller than the toggle-revert bug #511 fixes).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/561">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection against unsafe links, redirects, private network destinations, and oversized profile responses.
  - Fixed profile references containing invalid or embedded content being misinterpreted as account identifiers.
  - Improved chat history scroll restoration and archived-chat selection updates.
  - Prevented privacy and security settings from reverting after concurrent changes.
  - Ensured local media remains recoverable if account data deletion fails.
  - Fixed message sending during active text composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->