### PR TITLE
fix: harden NIP-05 identifier handling

### DIFF
--- a/whitenoise-mac/Core/NIP05Resolver.swift
+++ b/whitenoise-mac/Core/NIP05Resolver.swift
@@ -42,13 +42,7 @@ struct NIP05Resolver: NIP05Resolving {
             throw NIP05ResolutionError.invalidIdentifier
         }
 
-        var components = URLComponents()
-        components.scheme = "https"
-        components.host = parsed.domain
-        components.path = "/.well-known/nostr.json"
-        components.queryItems = [URLQueryItem(name: "name", value: parsed.name)]
-
-        guard let url = components.url, RemoteImageURLPolicy.isAllowed(url) else {
+        guard let url = parsed.wellKnownRequestURL() else {
             throw NIP05ResolutionError.invalidURL
         }
 
@@ -145,6 +139,10 @@ struct NIP05Identifier: Equatable {
     /// The spec-legal local part, accepted case-insensitively and stored lowercased. Anything
     /// wider (`:`, `/`, …) lets a full profile ref or URL masquerade as a name.
     private static let localPartAlphabet = Set("abcdefghijklmnopqrstuvwxyz0123456789-_.")
+    private static let maxNameUTF8Bytes = 64
+    private static let maxDomainLength = 253
+    private static let maxDomainInputUTF8Bytes = maxDomainLength * 4
+    private static let maxLabelLength = 63
 
     let name: String
     let domain: String
@@ -159,14 +157,10 @@ struct NIP05Identifier: Equatable {
             return nil
         }
 
-        let name = String(trimmed[..<separator]).lowercased()
-        let domain = String(trimmed[trimmed.index(after: separator)...]).lowercased()
-        guard !name.isEmpty,
-            !domain.isEmpty,
-            name.allSatisfy(Self.localPartAlphabet.contains),
-            domain.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
-            domain.rangeOfCharacter(from: CharacterSet(charactersIn: "/:?#[]@\\")) == nil,
-            domain.contains("."),
+        let rawName = String(trimmed[..<separator])
+        let rawDomain = String(trimmed[trimmed.index(after: separator)...])
+        guard let name = Self.validatedName(rawName),
+            let domain = Self.canonicalDomain(from: rawDomain),
             !RemoteImageURLPolicy.isDisallowedHost(domain)
         else {
             return nil
@@ -174,6 +168,120 @@ struct NIP05Identifier: Equatable {
 
         self.name = name
         self.domain = domain
+    }
+
+    func wellKnownRequestURL() -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = domain
+        components.path = "/.well-known/nostr.json"
+        guard
+            let encodedName = name.addingPercentEncoding(
+                withAllowedCharacters: Self.wellKnownNameQueryAllowedCharacters
+            )
+        else {
+            return nil
+        }
+        components.percentEncodedQuery = "name=\(encodedName)"
+        guard let url = components.url, RemoteImageURLPolicy.isAllowed(url) else {
+            return nil
+        }
+        return url
+    }
+
+    private static let domainDelimiterCharacters = CharacterSet(charactersIn: "/:?#[]@\\")
+    private static let uts46LabelSeparators = CharacterSet(charactersIn: ".\u{3002}\u{FF0E}\u{FF61}")
+    private static let wellKnownNameQueryAllowedCharacters = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+
+    private static func validatedName(_ name: String) -> String? {
+        let canonical = name.lowercased()
+        guard !canonical.isEmpty,
+            canonical.utf8.count <= maxNameUTF8Bytes,
+            canonical.allSatisfy(localPartAlphabet.contains)
+        else {
+            return nil
+        }
+        return canonical
+    }
+
+    private static func canonicalDomain(from rawDomain: String) -> String? {
+        let domain = rawDomain.lowercased()
+        guard !domain.isEmpty,
+            domain.utf8.count <= maxDomainInputUTF8Bytes,
+            trailingLabelSeparatorCount(in: domain) <= 1,
+            domain.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+            domain.rangeOfCharacter(from: domainDelimiterCharacters) == nil
+        else {
+            return nil
+        }
+
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = domain
+        guard components.url != nil,
+            let encodedHost = components.encodedHost?.lowercased(),
+            !encodedHost.isEmpty,
+            let decodedHost = components.host
+        else {
+            return nil
+        }
+        components.host = decodedHost
+        guard let roundTrippedHost = components.encodedHost?.lowercased(),
+            roundTrippedHost == encodedHost,
+            !hasUndecodedALabel(encodedHost: encodedHost, decodedHost: decodedHost)
+        else {
+            return nil
+        }
+
+        var canonical = encodedHost
+        if canonical.hasSuffix(".") {
+            canonical.removeLast()
+        }
+        guard !canonical.isEmpty,
+            !canonical.hasSuffix("."),
+            canonical.contains("."),
+            canonical.count <= maxDomainLength,
+            isValidLDHHost(canonical)
+        else {
+            return nil
+        }
+        return canonical
+    }
+
+    private static func trailingLabelSeparatorCount(in domain: String) -> Int {
+        var count = 0
+        for scalar in domain.unicodeScalars.reversed() {
+            guard uts46LabelSeparators.contains(scalar) else { break }
+            count += 1
+        }
+        return count
+    }
+
+    private static func hasUndecodedALabel(encodedHost: String, decodedHost: String) -> Bool {
+        guard encodedHost != decodedHost else {
+            return encodedHost.split(separator: ".").contains { $0.hasPrefix("xn--") }
+        }
+        return false
+    }
+
+    private static func isValidLDHHost(_ host: String) -> Bool {
+        guard host.unicodeScalars.allSatisfy(\.isASCII) else { return false }
+
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard labels.count >= 2 else { return false }
+        for label in labels {
+            guard !label.isEmpty, label.count <= maxLabelLength else { return false }
+            guard label.first != "-", label.last != "-" else { return false }
+            for scalar in label.unicodeScalars {
+                let value = scalar.value
+                let isLetter = (97...122).contains(value)
+                let isDigit = (48...57).contains(value)
+                guard isLetter || isDigit || value == 45 else { return false }
+            }
+        }
+        return true
     }
 }
 

--- a/whitenoise-mac/Core/NIP05Resolver.swift
+++ b/whitenoise-mac/Core/NIP05Resolver.swift
@@ -260,10 +260,14 @@ struct NIP05Identifier: Equatable {
     }
 
     private static func hasUndecodedALabel(encodedHost: String, decodedHost: String) -> Bool {
-        guard encodedHost != decodedHost else {
-            return encodedHost.split(separator: ".").contains { $0.hasPrefix("xn--") }
+        let encodedLabels = encodedHost.split(separator: ".", omittingEmptySubsequences: false)
+        let decodedLabels = decodedHost.split(separator: ".", omittingEmptySubsequences: false)
+        guard encodedLabels.count == decodedLabels.count else {
+            return true
         }
-        return false
+        return zip(encodedLabels, decodedLabels).contains { encoded, decoded in
+            encoded.hasPrefix("xn--") && encoded == decoded
+        }
     }
 
     private static func isValidLDHHost(_ host: String) -> Bool {

--- a/whitenoise-mac/Core/NIP05Resolver.swift
+++ b/whitenoise-mac/Core/NIP05Resolver.swift
@@ -134,8 +134,6 @@ final class NIP05RedirectPolicy: NSObject, URLSessionTaskDelegate {
 }
 
 struct NIP05Identifier: Equatable {
-    /// Mailbox-length ceiling, generous for any legitimate identifier.
-    private static let maxLength = 254
     /// The spec-legal local part, accepted case-insensitively and stored lowercased. Anything
     /// wider (`:`, `/`, …) lets a full profile ref or URL masquerade as a name.
     private static let localPartAlphabet = Set("abcdefghijklmnopqrstuvwxyz0123456789-_.")
@@ -150,7 +148,6 @@ struct NIP05Identifier: Equatable {
     init?(_ rawValue: String) {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
-            trimmed.count <= Self.maxLength,
             trimmed.firstIndex(of: "@") == trimmed.lastIndex(of: "@"),
             let separator = trimmed.firstIndex(of: "@")
         else {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1675,7 +1675,7 @@ struct PureValueTests {
             "átila@example.com",
             "@example.com",
             "name@",
-            String(repeating: "a", count: 250) + "@example.com",  // over the total-length bound
+            String(repeating: "a", count: 250) + "@example.com",  // over the local-part bound
         ] {
             #expect(NIP05Identifier(raw) == nil, "expected rejection for \(String(reflecting: raw))")
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -14452,6 +14452,110 @@ struct whitenoise_macTests {
         #expect(state.resolvedNewChatRecipient?.pictureURL == "https://example.com/avatar.png")
     }
 
+    @Test func nip05IdentifierAcceptsCanonicalASCIIDomains() {
+        // #527: domains must be stored as canonical lowercase ASCII hostnames.
+        let alice = NIP05Identifier("alice@example.com")
+        #expect(alice?.name == "alice")
+        #expect(alice?.domain == "example.com")
+        #expect(NIP05Identifier("bob@EXAMPLE.COM")?.domain == "example.com")
+    }
+
+    @Test func nip05IdentifierNormalizesInternationalDomainsToASCII() throws {
+        // #527: valid IDNs must be converted to Foundation's canonical punycode host form.
+        let identifier = NIP05Identifier("alice@münchen.de")
+        #expect(identifier?.name == "alice")
+        #expect(try #require(identifier?.domain) == "xn--mnchen-3ya.de")
+    }
+
+    @Test func nip05IdentifierCanonicalizesHomographDomains() throws {
+        // #527: U+0261 is not mapped to LATIN SMALL LETTER G under UTS #46, so punycode is stable.
+        let scriptG = "\u{0261}"
+        let identifier = NIP05Identifier("alice@\(scriptG)oogle.com")
+        #expect(identifier?.name == "alice")
+        #expect(try #require(identifier?.domain) == "xn--oogle-qmc.com")
+    }
+
+    @Test func nip05IdentifierCanonicalizesUnicodeLabelSeparators() {
+        // #527: UTS #46 label separators must IDNA-map to canonical ASCII dots.
+        #expect(NIP05Identifier("alice@example\u{3002}com")?.domain == "example.com")
+        #expect(NIP05Identifier("alice@example\u{FF0E}com")?.domain == "example.com")
+        #expect(NIP05Identifier("alice@example\u{FF61}com")?.domain == "example.com")
+    }
+
+    @Test func nip05IdentifierCanonicalizesSingleTrailingRootSeparator() {
+        // #527: at most one terminal root separator may be accepted and stripped.
+        #expect(NIP05Identifier("alice@example.com.")?.domain == "example.com")
+        #expect(NIP05Identifier("alice@example.com\u{3002}")?.domain == "example.com")
+    }
+
+    @Test func nip05IdentifierRejectsMultipleTrailingRootSeparators() {
+        // #527: multiple terminal empty labels must be rejected.
+        #expect(NIP05Identifier("alice@example.com..") == nil)
+        #expect(NIP05Identifier("alice@example.com\u{3002}.") == nil)
+        #expect(NIP05Identifier("alice@example.com.\u{FF0E}") == nil)
+    }
+
+    @Test func nip05IdentifierValidatesALabelRoundTrip() {
+        // #527: reserved xn-- labels must decode/re-encode; malformed A-labels are rejected.
+        #expect(NIP05Identifier("alice@xn--a.com") == nil)
+        #expect(NIP05Identifier("alice@xn--abc.com") == nil)
+        #expect(NIP05Identifier("alice@xn--mnchen-3ya.de")?.domain == "xn--mnchen-3ya.de")
+    }
+
+    @Test func nip05IdentifierRejectsMalformedDomains() {
+        // #527: malformed or non-LDH DNS hostnames must be rejected.
+        #expect(NIP05Identifier("alice@foo..bar.com") == nil)
+        #expect(NIP05Identifier("alice@-example.com") == nil)
+        #expect(NIP05Identifier("alice@ex_ample.com") == nil)
+        #expect(NIP05Identifier("alice@.example.com") == nil)
+        #expect(NIP05Identifier("alice@example") == nil)
+    }
+
+    @Test func nip05IdentifierEnforcesLengthBounds() {
+        // #527: overlong local names, labels, and domains must be rejected.
+        let validName = String(repeating: "a", count: 64)
+        let overlongName = String(repeating: "a", count: 65)
+        #expect(validName.utf8.count == 64)
+        #expect(NIP05Identifier("\(validName)@example.com") != nil)
+        #expect(NIP05Identifier("\(overlongName)@example.com") == nil)
+
+        let validLabel = String(repeating: "a", count: 63)
+        let overlongLabel = String(repeating: "a", count: 64)
+        #expect(NIP05Identifier("alice@\(validLabel).com") != nil)
+        #expect(NIP05Identifier("alice@\(overlongLabel).com") == nil)
+
+        let maxDomain =
+            Array(repeating: String(repeating: "a", count: 42), count: 5).joined(separator: ".")
+            + "." + String(repeating: "b", count: 38)
+        #expect(maxDomain.count == 253)
+        #expect(NIP05Identifier("alice@\(maxDomain)") != nil)
+        #expect(NIP05Identifier("alice@\(maxDomain)x") == nil)
+    }
+
+
+    @Test func nip05IdentifierRejectsQueryMetacharactersInName() {
+        // #527: local names must not be able to inject extra query parameters.
+        #expect(NIP05Identifier("x&foo=bar@example.com") == nil)
+        #expect(NIP05Identifier("x=1@example.com") == nil)
+        #expect(NIP05Identifier("x+1@example.com") == nil)
+        #expect(NIP05Identifier("x%41@example.com") == nil)
+        #expect(NIP05Identifier("x/y@example.com") == nil)
+        #expect(NIP05Identifier("x?y@example.com") == nil)
+    }
+
+    @Test func nip05WellKnownRequestURLUsesSingleStrictlyEncodedQueryItem() throws {
+        // #527: the well-known lookup URL must contain exactly one strictly encoded name item.
+        let identifier = try #require(NIP05Identifier("Alice.Smith_9-a@example.com"))
+        let url = try #require(identifier.wellKnownRequestURL())
+        #expect(url.host == "example.com")
+        #expect(url.path == "/.well-known/nostr.json")
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.percentEncodedQuery == "name=alice.smith_9-a")
+        #expect(components.queryItems?.count == 1)
+        #expect(components.queryItems?.first?.name == "name")
+        #expect(components.queryItems?.first?.value == "alice.smith_9-a")
+    }
+
     @Test func nip05RedirectPolicyRevalidatesRedirectTargets() throws {
         // #448: the resolver's session must re-check every redirect hop against the SSRF host
         // policy, so a public well-known host cannot 3xx the lookup to a private/loopback/

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -14500,6 +14500,9 @@ struct whitenoise_macTests {
         #expect(NIP05Identifier("alice@xn--a.com") == nil)
         #expect(NIP05Identifier("alice@xn--abc.com") == nil)
         #expect(NIP05Identifier("alice@xn--mnchen-3ya.de")?.domain == "xn--mnchen-3ya.de")
+        // Malformed A-labels must be rejected even when another label decodes via IDNA.
+        #expect(NIP05Identifier("alice@münchen.xn--a.com") == nil)
+        #expect(NIP05Identifier("alice@xn--mnchen-3ya.xn--a.com") == nil)
     }
 
     @Test func nip05IdentifierRejectsMalformedDomains() {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -14535,7 +14535,6 @@ struct whitenoise_macTests {
         #expect(NIP05Identifier("alice@\(maxDomain)x") == nil)
     }
 
-
     @Test func nip05IdentifierRejectsQueryMetacharactersInName() {
         // #527: local names must not be able to inject extra query parameters.
         #expect(NIP05Identifier("x&foo=bar@example.com") == nil)


### PR DESCRIPTION
Clean replacement for #552. The intermediate conflict-resolution head on #552 failed Swift format lint before the cleanup commit; Pip policy never merges an ever-red PR. This PR carries the corrected rebased tree at signed head `2e24764` with a clean CI history.

Fixes #527

## Summary
- canonicalize NIP-05 domains through Foundation IDNA/Punycode and validate A-label round trips, LDH syntax, root separators, and DNS length limits
- preserve master's spec-legal lowercase ASCII local-part policy while enforcing independent 64-byte name and 253-character canonical-domain bounds
- construct exactly one strictly encoded `name` query item and reject query metacharacters
- add focused coverage for homographs, Unicode separators, malformed A-labels/domains, length boundaries, and query construction

## Conflict resolution
- rebased onto `dcc06cf`
- kept master's response-size and redirect-hop hardening
- kept master's stricter local-part charset/canonicalization
- ported this PR's IDNA/LDH validation and label-wise malformed A-label check onto the current implementation

## Verification
- predecessor #552 exact-tree Mac CI run 29622346384 passed: Swift format, project sanity, 475 tests, arm64 release smoke, and Static Analysis
- `git diff --check origin/master...HEAD` — passed
- committed-tree conflict-marker scan — passed
- added-line security scan — passed
- changed-file 120-column check — passed
- all three commits have valid `agent-p1p` SSH signatures
- fresh CI on this replacement PR is pending

## Sensitive paths
- `whitenoise-mac/Core/NIP05Resolver.swift` — untrusted identity-resolution input and request URL construction


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->