### PR TITLE
fix: reject RFC 8215 local-use image hosts

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -120,7 +120,7 @@ nonisolated enum RemoteImageURLPolicy {
 
     /// Rejects IPv6 literals in non-public ranges: unspecified `::`, loopback `::1`,
     /// ULA `fc00::/7`, link-local `fe80::/10`, multicast `ff00::/8`, documentation
-    /// `2001:db8::/32`, and the IPv4-embedding
+    /// `2001:db8::/32`, RFC 8215 local-use translation `64:ff9b:1::/48`, and the IPv4-embedding
     /// forms (mapped `::ffff:a.b.c.d`, translated `::ffff:0:a.b.c.d`, NAT64 `64:ff9b::a.b.c.d`,
     /// and IPv4-compatible `::a.b.c.d`) whose embedded IPv4 is itself private.
     private static func isPrivateIPv6(_ groups: [UInt16]) -> Bool {
@@ -154,6 +154,10 @@ nonisolated enum RemoteImageURLPolicy {
         // NAT64 well-known prefix `64:ff9b::a.b.c.d`.
         if groups[0] == 0x64, groups[1] == 0xFF9B, groups[2...5].allSatisfy({ $0 == 0 }) {
             return isPrivateIPv4(embeddedIPv4(groups))
+        }
+        // RFC 8215 local-use translation prefix `64:ff9b:1::/48` (distinct from the /96 above).
+        if groups[0] == 0x64, groups[1] == 0xFF9B, groups[2] == 0x0001 {
+            return true
         }
         if groups[0...5].allSatisfy({ $0 == 0 }), groups[6] != 0 || groups[7] != 0 {
             return isPrivateIPv4(embeddedIPv4(groups))

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1768,6 +1768,9 @@ struct PureValueTests {
             "https://[64:ff9b::c0a8:1]/x.png",  // NAT64 well-known prefix around 192.168.0.1
             "https://[64:ff9b::192.168.0.1]/x.png",
             "https://[64:ff9b::7f00:1]/x.png",  // NAT64 around 127.0.0.1
+            "https://[64:ff9b:1::]/x.png",  // RFC 8215 local-use translation prefix, low boundary
+            "https://[64:ff9b:1::1]/x.png",
+            "https://[64:ff9b:1:ffff:ffff:ffff:ffff:ffff]/x.png",  // RFC 8215 /48 high boundary
             "https://[::2]/x.png",  // IPv4-compatible 0.0.0.2, inside 0.0.0.0/8
             "https://[::ffff]/x.png",  // IPv4-compatible 0.0.255.255
             "https://[2001:db8::5]/x.png",  // documentation range 2001:db8::/32, non-routable
@@ -1780,6 +1783,7 @@ struct PureValueTests {
 
         // Embedded-public NAT64 and plain public IPv6 destinations keep loading.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[64:ff9b::808:808]/x.png") != nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[64:ff9b:2::1]/x.png") != nil)  // adjacent to RFC 8215 /48
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[2606:4700:4700::1111]/x.png") != nil)
     }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1783,7 +1783,8 @@ struct PureValueTests {
 
         // Embedded-public NAT64 and plain public IPv6 destinations keep loading.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[64:ff9b::808:808]/x.png") != nil)
-        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[64:ff9b:2::1]/x.png") != nil)  // adjacent to RFC 8215 /48
+        // Adjacent to the RFC 8215 /48.
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[64:ff9b:2::1]/x.png") != nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[2606:4700:4700::1111]/x.png") != nil)
     }
 


### PR DESCRIPTION
Fixes #541

## Summary
- reject the complete RFC 8215 local-use translation prefix `64:ff9b:1::/48` in the shared remote-image host policy
- cover the prefix's low and high boundaries, the reported literal, and the adjacent `64:ff9b:2::1` public control
- keep the RFC 6052 `64:ff9b::/96` behavior unchanged

## Verification
- `git diff --check` — passed
- Python `ipaddress` boundary/control validation — passed; the low/high cases are the exact `/48` boundaries and the adjacent control is outside the prefix
- `bash scripts/ci/macos-sanity-checks.sh` — not runnable on this Linux worker (`xcodebuild: command not found`, exit 127)
- macOS unit tests and Swift format lint — not runnable locally because this worker has neither `xcodebuild` nor `swift`; GitHub Actions will run the repository's macOS CI

## Sensitive paths
None. This is an SSRF URL-literal policy and regression-test change; it does not touch crypto, MLS/CGKA, key handling, trust anchors, authentication flows, or group-state core.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->