### PR TITLE
fix: preserve transcript export across deep links

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+DeepLinks.swift
+++ b/whitenoise-mac/Core/WorkspaceState+DeepLinks.swift
@@ -45,9 +45,8 @@ extension WorkspaceState {
         Task { await openProfileReferenceFromDeepLink(reference) }
     }
 
-    /// OS-level links are unsolicited. Do not let them interrupt a recording flow or alter a
-    /// New Chat draft; profile links explicitly tapped inside the app still use the normal
-    /// `openProfileReference` behavior.
+    /// OS-level links are unsolicited. Do not let them interrupt active work; profile links
+    /// explicitly tapped inside the app still use the normal `openProfileReference` behavior.
     private func openProfileReferenceFromDeepLink(_ reference: String) async {
         guard !isRecordingVoiceMessage, !isPreparingVoiceRecording else {
             backgroundStatus = L10n.string("Finish the current voice recording before opening this link.")
@@ -57,6 +56,13 @@ extension WorkspaceState {
         guard !(isNewChatComposerVisible && hasInProgressNewChatComposition) else {
             backgroundStatus = L10n.string(
                 "Finish or discard the current New Chat draft before opening this link."
+            )
+            return
+        }
+
+        guard !isExportingGroupTranscript, groupTranscriptExportTask == nil else {
+            backgroundStatus = L10n.string(
+                "Finish copying the current transcript before opening this link."
             )
             return
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13339,6 +13339,72 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func marmotDeepLinkDoesNotCancelInProgressTranscriptExport() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+
+        let firstPageGate = BlockingFfiGate()
+        firstPageGate.isEnabled = true
+        runtime.timelineMessagesHandler = { _ in
+            firstPageGate.passIfArmed()
+            return TimelinePageFfi(
+                messages: [
+                    timelineMessage(
+                        id: String(repeating: "1", count: 64),
+                        groupIdHex: "group",
+                        sender: account.accountIdHex,
+                        plaintext: "message",
+                        recordedAt: 10
+                    )
+                ],
+                hasMoreBefore: false,
+                hasMoreAfter: false
+            )
+        }
+
+        var copiedText = ""
+        let state = WorkspaceState(
+            copyTextHandler: { text, _ in copiedText = text },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        let groupChat = try #require(state.activeChats.first)
+        await state.showGroupDetails(for: groupChat)
+        state.startCopySelectedGroupTranscriptJSON()
+        let exportTask = try #require(state.groupTranscriptExportTask)
+        let deadline = Date().addingTimeInterval(2)
+        while !firstPageGate.didReach && Date() < deadline {
+            await Task.yield()
+        }
+        if !firstPageGate.didReach {
+            firstPageGate.isEnabled = false
+        }
+        #expect(firstPageGate.didReach)
+
+        let blockedStatus = "Finish copying the current transcript before opening this link."
+        state.handleDeepLinkURL(URL(string: "marmot://profile/npub1p0p")!)
+        let deepLinkHandled = await waitFor {
+            state.backgroundStatus == blockedStatus || state.isNewChatComposerVisible
+        }
+
+        #expect(deepLinkHandled)
+        #expect(state.backgroundStatus == blockedStatus)
+        #expect(!state.isNewChatComposerVisible)
+        #expect(state.isGroupDetailsPresented)
+        #expect(state.isExportingGroupTranscript)
+        #expect(state.groupTranscriptExportTask != nil)
+
+        firstPageGate.release()
+        await exportTask.value
+
+        #expect(!copiedText.isEmpty)
+        #expect(state.groupTranscriptExportStatus == "Copied transcript JSON for 1 events.")
+        #expect(state.groupTranscriptExportTask == nil)
+    }
+
+    @MainActor
     @Test func settingsSelectionUsesDetailPaneWithoutChangingAccount() async throws {
         let state = WorkspaceState.preview()
         let accountId = state.activeAccountId


### PR DESCRIPTION
## Summary
- ignores unsolicited OS profile links while a group transcript export is active or queued
- keeps explicitly tapped in-app profile links on the existing navigation path
- adds a regression test that holds an export in flight and verifies the link neither opens New Chat nor prevents clipboard completion

## Test plan
- [x] git diff --check
- [ ] macOS unit tests and swift-format (CI; Xcode toolchain unavailable on Linux worker)

## Integration note
PR #554 independently adds the same OS-only helper for voice-recording and New Chat draft guards. If it merges first, this PR will need a mechanical rebase that unions the guards.

Fixes #558

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented profile deep links from interrupting an in-progress group transcript export.
  * Added a status message instructing you to finish copying the transcript before opening a profile link.
  * Preserved the active group details view and export progress until the export completes.

* **Documentation**
  * Clarified deep-link behavior for system-triggered and in-app profile links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->