### PR TITLE
perf: avoid decrypting media metadata during eviction

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -325,7 +325,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 Self.discardPreparedEntry(prepared)
                 return
             }
-            commitPreparedEntry(prepared, start: start, symmetricKey: symmetricKey)
+            commitPreparedEntry(prepared, start: start)
         }
     }
 
@@ -490,8 +490,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
     private func commitPreparedEntry(
         _ prepared: PreparedEntry,
-        start: AccessHandle,
-        symmetricKey: SymmetricKey
+        start: AccessHandle
     ) {
         // Hold only the narrow filesystem-mutation lock across the slow create/remove/move
         // so generation reads and purge bookkeeping (on `lock`) never block on this commit.
@@ -527,7 +526,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 replacedByteCount: replacedByteCount,
                 root: prepared.root
             )
-            enforceEvictionPolicy(root: prepared.root, symmetricKey: symmetricKey)
+            enforceEvictionPolicy(root: prepared.root)
         } catch {
             try? FileManager.default.removeItem(at: prepared.stagingDirectory)
         }
@@ -748,6 +747,12 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 to: stagingDirectory.appendingPathComponent(payloadFileName),
                 options: [.atomic, .completeFileProtection]
             )
+            // Persist eviction ordering outside the sealed metadata. Reads do not change a
+            // directory's modification date, and moving the staged directory preserves it.
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date(timeIntervalSince1970: cachedAtUnixSeconds)],
+                ofItemAtPath: stagingDirectory.path
+            )
             return PreparedEntry(root: root, stagingDirectory: stagingDirectory, finalDirectory: finalDirectory)
         } catch {
             discardStagingDirectory(stagingDirectory, root: root)
@@ -937,7 +942,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         )
     }
 
-    private func enforceEvictionPolicy(root: URL, symmetricKey: SymmetricKey) {
+    private func enforceEvictionPolicy(root: URL) {
         guard let tracked = trackedFootprint else { return }
         let trackedTotalBytes = Self.addingWithSaturation(
             tracked.byteCount,
@@ -948,7 +953,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 || trackedTotalBytes > evictionPolicy.maxTotalBytes
         else { return }
 
-        let scan = Self.cacheScan(root: root, symmetricKey: symmetricKey)
+        let scan = Self.cacheScan(root: root)
         var entries = scan.removableEntries
         var committedBytes = scan.committedFootprint.byteCount
         var totalBytes = Self.addingWithSaturation(committedBytes, scan.stagingByteCount)
@@ -1018,7 +1023,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         return CacheFootprint(entryCount: entryCount, byteCount: byteCount)
     }
 
-    private static func cacheScan(root: URL, symmetricKey: SymmetricKey) -> CacheScan {
+    private static func cacheScan(root: URL) -> CacheScan {
         let stagedBytes = stagingByteCount(root: root)
         guard
             let shardDirectories = try? FileManager.default.contentsOfDirectory(
@@ -1048,24 +1053,9 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
             for entryDirectory in entryDirectories where isDirectory(entryDirectory) {
                 let entryByteCount = entryByteCount(at: entryDirectory)
-                let cachedAtUnixSeconds: TimeInterval
-                switch metadataStatus(in: entryDirectory, symmetricKey: symmetricKey) {
-                case .readable(let metadata):
-                    cachedAtUnixSeconds = metadata.cachedAtUnixSeconds
-                    entryCount += 1
-                    byteCount = addingWithSaturation(byteCount, entryByteCount)
-                case .corrupt:
-                    try? FileManager.default.removeItem(at: entryDirectory)
-                    removeEmptyDirectory(shardDirectory)
-                    continue
-                case .unavailable:
-                    // Cache entries are disposable under pressure. If metadata is temporarily
-                    // unreadable or belongs to a newer format, reclaim it before evicting a
-                    // readable entry; otherwise its bytes can keep the cache over cap forever.
-                    cachedAtUnixSeconds = -Double.infinity
-                    entryCount += 1
-                    byteCount = addingWithSaturation(byteCount, entryByteCount)
-                }
+                let cachedAtUnixSeconds = evictionTimestamp(for: entryDirectory)
+                entryCount += 1
+                byteCount = addingWithSaturation(byteCount, entryByteCount)
 
                 entries.append(
                     CacheEntry(
@@ -1081,6 +1071,21 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             committedFootprint: CacheFootprint(entryCount: entryCount, byteCount: byteCount),
             stagingByteCount: stagedBytes
         )
+    }
+
+    private static func evictionTimestamp(for entryDirectory: URL) -> TimeInterval {
+        let metadataURL = entryDirectory.appendingPathComponent(metadataFileName)
+        guard
+            (try? metadataURL.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true,
+            let modifiedAt = try? entryDirectory.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate
+        else {
+            // Entries without a normal metadata file or readable timestamp are disposable under
+            // pressure. Reclaim them before entries with known ordering.
+            return -Double.infinity
+        }
+        return modifiedAt.timeIntervalSince1970
     }
 
     private static func stagingByteCount(root: URL) -> UInt64 {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2868,23 +2868,41 @@ struct whitenoise_macTests {
             .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
         defer { try? fileManager.removeItem(at: root) }
 
+        let cachedAtCounter = AtomicCounter()
         let cache = messageMediaDiskCache(
             root: root,
-            evictionPolicy: .init(maxEntryCount: 1, maxTotalBytes: UInt64.max)
+            evictionPolicy: .init(maxEntryCount: 2, maxTotalBytes: UInt64.max),
+            timestampProvider: { TimeInterval(cachedAtCounter.increment()) }
         )
-        let unavailablePlaintext = Data("temporarily unavailable cached media".utf8)
         let readablePlaintext = Data("readable cached media".utf8)
-        let unavailableKey = MessageMediaDiskCacheKey(
-            accountId: "account-a",
-            groupIdHex: "group-a",
-            reference: mediaDiskCacheReference(plaintext: unavailablePlaintext, ciphertextByte: 0xa1)
-        )
+        let unavailablePlaintext = Data("temporarily unavailable cached media".utf8)
+        let pressurePlaintext = Data("pressure-triggering cached media".utf8)
         let readableKey = MessageMediaDiskCacheKey(
             accountId: "account-a",
             groupIdHex: "group-a",
-            reference: mediaDiskCacheReference(plaintext: readablePlaintext, ciphertextByte: 0xa2)
+            reference: mediaDiskCacheReference(plaintext: readablePlaintext, ciphertextByte: 0xa1)
+        )
+        let unavailableKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: unavailablePlaintext, ciphertextByte: 0xa2)
+        )
+        let pressureKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: pressurePlaintext, ciphertextByte: 0xa3)
         )
 
+        await cache.store(
+            MessageMediaDownload(
+                data: readablePlaintext,
+                fileName: "readable.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(readablePlaintext.count),
+                payloadId: "readable"
+            ),
+            for: readableKey
+        )
         await cache.store(
             MessageMediaDownload(
                 data: unavailablePlaintext,
@@ -2899,20 +2917,25 @@ struct whitenoise_macTests {
         let unavailableMetadataURL = unavailableEntryDirectory.appendingPathComponent("metadata.bin")
         try fileManager.removeItem(at: unavailableMetadataURL)
         try fileManager.createDirectory(at: unavailableMetadataURL, withIntermediateDirectories: false)
+        try fileManager.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2)],
+            ofItemAtPath: unavailableEntryDirectory.path
+        )
 
         await cache.store(
             MessageMediaDownload(
-                data: readablePlaintext,
-                fileName: "readable.jpg",
+                data: pressurePlaintext,
+                fileName: "pressure.jpg",
                 mediaType: "image/jpeg",
-                sizeBytes: UInt64(readablePlaintext.count),
-                payloadId: "readable"
+                sizeBytes: UInt64(pressurePlaintext.count),
+                payloadId: "pressure"
             ),
-            for: readableKey
+            for: pressureKey
         )
 
         #expect(!fileManager.fileExists(atPath: unavailableEntryDirectory.path))
         #expect(try #require(await cache.cachedDownload(for: readableKey)).data == readablePlaintext)
+        #expect(try #require(await cache.cachedDownload(for: pressureKey)).data == pressurePlaintext)
     }
 
     @Test func messageMediaDiskCacheCountsInSessionStagingBytesAgainstByteLimit() async throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2441,13 +2441,10 @@ struct whitenoise_macTests {
         #expect(!fileManager.fileExists(atPath: entryDirectory.path))
     }
 
-    @Test func messageMediaDiskCacheReadDeletionMaintainsTrackedFootprint() async throws {
-        // Since #444 isolates entries by (ciphertext, plaintext) hash, the read path no longer
-        // deletes a colliding stale entry — but it still deletes an entry whose sealed metadata
-        // cannot be opened, and must invalidate the tracked footprint when it does. Otherwise
-        // the next store sees an inflated count, runs a full eviction scan, and that scan sweeps
-        // an untouched corrupt sentinel early. The sentinel surviving proves the read deletion
-        // kept the footprint honest (no spurious scan).
+    @Test func messageMediaDiskCacheReadDeletionDoesNotEvictUnrelatedEntry() async throws {
+        // The read path deletes an entry whose sealed metadata cannot be opened. A subsequent
+        // store must reconcile that deletion without evicting an unrelated entry when the actual
+        // cache remains at the entry cap.
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
@@ -2500,8 +2497,8 @@ struct whitenoise_macTests {
         )
         let victimEntryDirectory = try #require(cache.entryDirectory(for: victimKey))
         let sentinelEntryDirectory = try #require(cache.entryDirectory(for: sentinelKey))
-        // Corrupt both sealed metadata blobs: reading the victim must delete it (exercising the
-        // read-path deletion), while the sentinel is only ever removed by a full eviction scan.
+        // Corrupt both sealed metadata blobs. Reading the victim exercises read-path deletion;
+        // the unrelated sentinel must remain untouched by the subsequent store.
         try Data("not sealed metadata".utf8).write(to: victimEntryDirectory.appendingPathComponent("metadata.bin"))
         try Data("not sealed metadata".utf8).write(to: sentinelEntryDirectory.appendingPathComponent("metadata.bin"))
 
@@ -2655,6 +2652,75 @@ struct whitenoise_macTests {
 
         let cacheFiles = try fileManager.subpathsOfDirectory(atPath: root.path)
         #expect(cacheFiles.filter { $0.hasSuffix("payload.bin") }.count == 2)
+    }
+
+    @Test func messageMediaDiskCacheEvictionUsesPersistedTimestampWithoutOpeningMetadata() async throws {
+        // Eviction ordering comes from the entry directory timestamp, not encrypted metadata.
+        // Corrupting the newest survivor distinguishes those paths: decrypting metadata would
+        // discard it, while the persisted ordering correctly evicts the older readable entry.
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cachedAtCounter = AtomicCounter()
+        let cache = messageMediaDiskCache(
+            root: root,
+            evictionPolicy: .init(maxEntryCount: 2, maxTotalBytes: UInt64.max),
+            timestampProvider: { TimeInterval(cachedAtCounter.increment()) }
+        )
+        let plaintexts = (0..<4).map { Data("cached media \($0)".utf8) }
+        let keys = plaintexts.enumerated().map { index, plaintext in
+            MessageMediaDiskCacheKey(
+                accountId: "account-a",
+                groupIdHex: "group-a",
+                reference: mediaDiskCacheReference(
+                    plaintext: plaintext,
+                    ciphertextByte: UInt8(0xb0 + index)
+                )
+            )
+        }
+
+        for index in 0..<3 {
+            await cache.store(
+                MessageMediaDownload(
+                    data: plaintexts[index],
+                    fileName: "photo-\(index).jpg",
+                    mediaType: "image/jpeg",
+                    sizeBytes: UInt64(plaintexts[index].count),
+                    payloadId: "photo-\(index)"
+                ),
+                for: keys[index]
+            )
+        }
+
+        let secondEntryDirectory = try #require(cache.entryDirectory(for: keys[1]))
+        let thirdEntryDirectory = try #require(cache.entryDirectory(for: keys[2]))
+        let thirdModifiedAt = try #require(
+            thirdEntryDirectory.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate
+        )
+        #expect(thirdModifiedAt.timeIntervalSince1970 == 3)
+        #expect(await cache.cachedDownload(for: keys[0]) == nil)
+        try Data("not sealed metadata".utf8).write(
+            to: thirdEntryDirectory.appendingPathComponent("metadata.bin")
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: plaintexts[3],
+                fileName: "photo-3.jpg",
+                mediaType: "image/jpeg",
+                sizeBytes: UInt64(plaintexts[3].count),
+                payloadId: "photo-3"
+            ),
+            for: keys[3]
+        )
+
+        #expect(!fileManager.fileExists(atPath: secondEntryDirectory.path))
+        #expect(fileManager.fileExists(atPath: thirdEntryDirectory.path))
+        #expect(try #require(await cache.cachedDownload(for: keys[3])).data == plaintexts[3])
     }
 
     @Test func messageMediaDiskCacheReplaceEntryDoesNotEvictOthersAtEntryLimit() async throws {


### PR DESCRIPTION
## Summary
- persist each cache entry timestamp in its directory modification date
- order pressure eviction with filesystem metadata instead of decrypting and decoding every metadata record
- retain structural-unavailable priority and add regression coverage for encrypted-metadata independence

## Test plan
- [x] git diff --check
- [x] independent staged-diff review
- [x] macOS unit tests and release build smoke (GitHub Actions; exact-head Mac CI passed)

Fixes #508

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/573">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->