### PR TITLE
fix: bound stalled media reference resolution

### DIFF
--- a/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
+++ b/whitenoise-mac/Core/MediaAttachmentDownloadLimiter.swift
@@ -10,9 +10,10 @@ import Foundation
 nonisolated enum MediaAttachmentDownloadConcurrency {
     static let maxConcurrentDownloads = 4
 
-    /// Wall-clock ceiling for one attachment's download FFI while holding a limiter slot.
-    /// Matches `RemoteImageURLPolicy.downloadResourceTimeout` so stalled relay fetches cannot
-    /// occupy all download slots indefinitely.
+    /// Wall-clock ceiling for each attachment-loading FFI stage. Reference resolution uses it
+    /// before acquiring a limiter slot; download uses it while holding one. Matches
+    /// `RemoteImageURLPolicy.downloadResourceTimeout` so stalled relay fetches cannot leave the
+    /// UI loading or occupy all download slots indefinitely.
     static let defaultFfiDownloadTimeoutNanoseconds: UInt64 = 60 * 1_000_000_000
 
     #if DEBUG

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -14,6 +14,10 @@ import Observation
 import SwiftUI
 import UserNotifications
 
+private nonisolated struct MediaReferenceIndexTaskFailure: Error {
+    let underlying: Error
+}
+
 @MainActor
 extension WorkspaceState {
     func clearAllComposerDrafts() {
@@ -223,7 +227,8 @@ extension WorkspaceState {
 
         do {
             // Resolve first: the synchronous `listMedia` FFI may stall and must not consume one
-            // of the scarce slots reserved for attachment downloads.
+            // of the scarce slots reserved for attachment downloads. Reference resolution bounds
+            // its wait so cancellation or timeout can unwind while the detached FFI work continues.
             let reference = try await resolvedMediaReference(
                 attachment.reference,
                 accountId: accountId,
@@ -716,26 +721,50 @@ extension WorkspaceState {
         groupIdHex: String,
         client: any MarmotRuntime
     ) async throws -> MediaReferenceIndex {
+        let resolution: MediaReferenceIndexTask
         if let existing = mediaReferenceIndexTasks[cacheKey] {
-            return try await existing.task.value
-        }
-
-        let generation = mediaReferenceIndexGeneration
-        let task = Task.detached(priority: .userInitiated) { [client, accountRef, groupIdHex] in
-            let records = try await WorkspaceState.runFFI {
-                try client.listMedia(accountRef: accountRef, groupIdHex: groupIdHex, limit: nil)
+            resolution = existing
+        } else {
+            mediaReferenceIndexGeneration &+= 1
+            let generation = mediaReferenceIndexGeneration
+            let task = Task.detached(priority: .userInitiated) { [client, accountRef, groupIdHex] in
+                let records = try await WorkspaceState.runFFI {
+                    try client.listMedia(accountRef: accountRef, groupIdHex: groupIdHex, limit: nil)
+                }
+                return MediaReferenceIndex(records: records)
             }
-            return MediaReferenceIndex(records: records)
+            resolution = MediaReferenceIndexTask(generation: generation, task: task)
+            mediaReferenceIndexTasks[cacheKey] = resolution
         }
-        mediaReferenceIndexTasks[cacheKey] = MediaReferenceIndexTask(generation: generation, task: task)
 
+        let generation = resolution.generation
+        let task = resolution.task
         do {
-            let index = try await task.value
+            // Only the detached FFI task is shared and retained. Each caller can stop waiting
+            // without capturing WorkspaceState until the synchronous `listMedia` call returns.
+            let index = try await withMediaAttachmentDownloadTimeout { [task] in
+                do {
+                    return try await task.value
+                } catch {
+                    throw MediaReferenceIndexTaskFailure(underlying: error)
+                }
+            }
             if mediaReferenceIndexTasks[cacheKey]?.generation == generation {
                 mediaReferenceIndexTasks[cacheKey] = nil
                 mediaReferenceIndexes[cacheKey] = index
             }
             return index
+        } catch let failure as MediaReferenceIndexTaskFailure {
+            if mediaReferenceIndexTasks[cacheKey]?.generation == generation {
+                mediaReferenceIndexTasks[cacheKey] = nil
+            }
+            throw failure.underlying
+        } catch let error as CancellationError {
+            // Keep the shared FFI task so a later retry joins it instead of starting another call.
+            throw error
+        } catch let error as MediaAttachmentDownloadTimeoutError {
+            // The synchronous FFI may still complete; preserve it for the same bounded retry path.
+            throw error
         } catch {
             if mediaReferenceIndexTasks[cacheKey]?.generation == generation {
                 mediaReferenceIndexTasks[cacheKey] = nil

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6846,6 +6846,158 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func cancelledMediaReferenceResolutionAllowsAttachmentRetry() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: false
+        )
+        let fixtureID = UUID().uuidString
+        let plaintext = Data(fixtureID.utf8)
+        let timelineReference = mediaAttachmentReference(
+            sourceEpoch: 0,
+            mediaType: "image/png",
+            fileName: "cancelled-resolution-\(fixtureID).png",
+            plaintextSha256: hexSHA256(plaintext)
+        )
+        let resolvedReference = mediaAttachmentReference(
+            sourceEpoch: 7,
+            mediaType: "image/png",
+            fileName: timelineReference.fileName,
+            plaintextSha256: timelineReference.plaintextSha256
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "cancelled-resolution-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: resolvedReference,
+                caption: nil,
+                recordedAt: 1_700_000_000,
+                receivedAt: 1_700_000_000
+            ),
+            download: MediaDownloadResultFfi(
+                plaintext: plaintext,
+                fileName: resolvedReference.fileName,
+                mediaType: resolvedReference.mediaType,
+                sizeBytes: UInt64(plaintext.count)
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let message = MessageItem(
+            id: "cancelled-resolution-message",
+            groupIdHex: "group",
+            senderName: "Alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false,
+            mediaAttachments: [
+                MessageMediaAttachment(
+                    id: "cancelled-resolution-message#0#\(timelineReference.plaintextSha256)",
+                    reference: timelineReference
+                )
+            ]
+        )
+        let attachment = try #require(message.mediaAttachments.first)
+        let stateStore = state.mediaDownloadStateStore(for: message, attachment: attachment)
+
+        func waitForCompletion(of task: Task<Void, Never>, description: String) async -> Bool {
+            do {
+                try await withMediaAttachmentDownloadTimeout(nanoseconds: 1_000_000_000) {
+                    await task.value
+                }
+                return true
+            } catch {
+                Issue.record("Expected \(description) to finish, got \(error)")
+                return false
+            }
+        }
+
+        runtime.listMediaGateEnabled = true
+        let firstLoad = Task { await state.loadMediaAttachment(attachment, for: message) }
+        var retryLoad: Task<Void, Never>?
+        defer {
+            firstLoad.cancel()
+            retryLoad?.cancel()
+            runtime.listMediaGateEnabled = false
+            runtime.releaseListMediaGate()
+        }
+
+        for _ in 0..<100 {
+            if runtime.didReachListMediaGate {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard runtime.didReachListMediaGate else {
+            firstLoad.cancel()
+            runtime.releaseListMediaGate()
+            _ = await waitForCompletion(of: firstLoad, description: "the first attachment load")
+            Issue.record("Expected media reference resolution to reach the fake listMedia gate")
+            return
+        }
+
+        firstLoad.cancel()
+        for _ in 0..<100 {
+            if case .idle = stateStore.state {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard case .idle = stateStore.state else {
+            runtime.releaseListMediaGate()
+            _ = await waitForCompletion(of: firstLoad, description: "the cancelled first attachment load")
+            Issue.record("Expected cancellation to clear the attachment loading state")
+            return
+        }
+
+        let retry = Task { await state.loadMediaAttachment(attachment, for: message) }
+        retryLoad = retry
+        for _ in 0..<100 {
+            if case .loading = stateStore.state {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard case .loading = stateStore.state else {
+            retry.cancel()
+            runtime.releaseListMediaGate()
+            _ = await waitForCompletion(of: firstLoad, description: "the cancelled first attachment load")
+            _ = await waitForCompletion(of: retry, description: "the retried attachment load")
+            Issue.record("Expected a later attachment load to retry reference resolution")
+            return
+        }
+
+        runtime.releaseListMediaGate()
+        let firstLoadFinished = await waitForCompletion(
+            of: firstLoad,
+            description: "the cancelled first attachment load"
+        )
+        let retryFinished = await waitForCompletion(of: retry, description: "the retried attachment load")
+        guard firstLoadFinished, retryFinished else { return }
+
+        guard case .loaded(let download) = stateStore.state else {
+            Issue.record("Expected the retried attachment load to complete")
+            return
+        }
+        #expect(download.data == plaintext)
+        #expect(runtime.listMediaCallCount == 1)
+        #expect(runtime.downloadMediaCallCount == 1)
+    }
+
+    @MainActor
     @Test func mediaAttachmentDownloadTimesOutAndReleasesLimiterSlot() async throws {
         let previousTimeout = MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds
         defer { MediaAttachmentDownloadConcurrency.ffiDownloadTimeoutNanoseconds = previousTimeout }


### PR DESCRIPTION
## Summary
- bound source-epoch-zero media reference waits with the existing cancellation-aware 60-second attachment timeout
- preserve one coalesced `listMedia` task per account/group across waiter cancellation or timeout, without retaining UI loading state or a download-limiter slot
- distinguish underlying task failures from waiter control flow and guard stale cleanup with unique task generations
- add a cancellation regression proving a later attachment load retries and completes

## Verification
- `git diff --check`
- committed-tree conflict-marker and duplicate-symbol sweep
- independent pre-commit concurrency review: passed
- macOS build/tests unavailable on this Linux host; GitHub Mac CI will run the real Swift format, unit-test, release-build, and static-analysis gates

## Context
This fixes the bounded residual identified after #542 moved reference resolution ahead of the download limiter. The branch is rebased onto the merged #542 result.

Fixes #548

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->