### PR TITLE
fix: strip controls from peer display text

### DIFF
--- a/whitenoise-mac/Core/PeerDisplayText.swift
+++ b/whitenoise-mac/Core/PeerDisplayText.swift
@@ -5,12 +5,21 @@ nonisolated enum PeerDisplayText {
     private static let firstStrongIsolate = "\u{2068}"
     private static let popDirectionalIsolate = "\u{2069}"
 
-    /// Strips Unicode format controls (`Cf`), including bidi embedding/override/isolate
+    /// Strips Unicode format controls (`Cf`), control characters (`Cc`), and line/
+    /// paragraph separators (`Zl`/`Zp`), including bidi embedding/override/isolate
     /// scalars (U+202A–U+202E, U+2066–U+2069), then treats an all-blank result as absent.
     static func sanitize(_ text: String?) -> String? {
         guard let text else { return nil }
         let filtered = String(
-            String.UnicodeScalarView(text.unicodeScalars.filter { $0.properties.generalCategory != .format })
+            String.UnicodeScalarView(
+                text.unicodeScalars.filter { scalar in
+                    switch scalar.properties.generalCategory {
+                    case .format, .control, .lineSeparator, .paragraphSeparator:
+                        return false
+                    default:
+                        return true
+                    }
+                })
         )
         return filtered.nilIfBlank
     }

--- a/whitenoise-macTests/PeerDisplayTextTests.swift
+++ b/whitenoise-macTests/PeerDisplayTextTests.swift
@@ -20,6 +20,26 @@ private func isolated(_ text: String) -> String {
 
 @Suite(.serialized)
 struct PeerDisplayTextTests {
+    @Test func sanitizeStripsControlCharsAndLineSeparators() async throws {
+        #expect(PeerDisplayText.sanitize("Alice\tBob") == "AliceBob")
+        #expect(PeerDisplayText.sanitize("Alice\nBob") == "AliceBob")
+        #expect(PeerDisplayText.sanitize("Alice\rBob") == "AliceBob")
+        #expect(PeerDisplayText.sanitize("Alice\r\nBob") == "AliceBob")
+        #expect(PeerDisplayText.sanitize("\u{0000}Alice") == "Alice")
+        #expect(PeerDisplayText.sanitize("Alice\u{007F}") == "Alice")
+        #expect(PeerDisplayText.sanitize("Alice\u{0080}Bob") == "AliceBob")
+        #expect(PeerDisplayText.sanitize("Alice\u{2028}Bob") == "AliceBob")
+        #expect(PeerDisplayText.sanitize("Alice\u{2029}Bob") == "AliceBob")
+        #expect(PeerDisplayText.sanitize("Alice Bob") == "Alice Bob")
+
+        let spoofedSender = "Trusted Admin\nSpoofed second line"
+        let sanitized = try #require(PeerDisplayText.sanitize(spoofedSender))
+        #expect(sanitized == "Trusted AdminSpoofed second line")
+        #expect(!sanitized.unicodeScalars.contains { $0.properties.generalCategory == .control })
+        #expect(!sanitized.unicodeScalars.contains { $0.properties.generalCategory == .lineSeparator })
+        #expect(!sanitized.unicodeScalars.contains { $0.properties.generalCategory == .paragraphSeparator })
+    }
+
     @Test func sanitizeStripsBidiAndFormatControls() async throws {
         let malicious = "\(rtlOverride)Alice\(ltrIsolate)"
         #expect(PeerDisplayText.sanitize(malicious) == "Alice")


### PR DESCRIPTION
Fixes #521

Supersedes #574, which was retired after its first CI run exposed a swift-format failure. This replacement uses a fresh branch and signed commit with the formatter-required closure layout.

## Summary
- Reject Unicode control characters (`Cc`) and line/paragraph separators (`Zl`/`Zp`) from peer-controlled display and group names, in addition to the existing format-control filtering.
- Add focused regression coverage for TAB/CR/LF, C0/C1 controls, U+2028/U+2029, the multiline notification-spoofing shape, and preservation of ordinary spaces.
- Leave the separate ZWJ/ZWNJ behavior tracked by #496 unchanged.

## Verification
- `git diff --check`
- Portable Unicode-category regression harness: current predicate failed 10/11 attack cases; updated predicate passed 11/11.
- Static analysis passed on the retired PR's identical production/test logic; that run stopped before unit tests because of the now-fixed swift-format layout.
- Swift/Xcode checks cannot run on this Linux worker. GitHub's macOS CI runs the repository's exact format, unit-test, build, and static-analysis gates.

## Sensitive paths
None. This changes display-text sanitization only; no crypto, MLS/CGKA, key handling, trust-anchor, auth, or group-state core paths are touched.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/576">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->