### PR TITLE
fix: serialize group commits

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -372,7 +372,6 @@ extension WorkspaceState {
         groupImageSearchQuery = ""
         groupImageResults = []
         invalidateGroupImageSearch()
-        isSavingGroupImage = false
 
         closeGroupDetails()
         groupTranscriptExportTask = nil

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -162,8 +162,7 @@ extension WorkspaceState {
         guard let client,
             let activeAccount,
             let snapshot = groupDetailsSnapshot,
-            !isSavingGroupProfile,
-            !hasInFlightGroupDetailsMutation
+            !hasInFlightGroupCommit
         else { return }
         let trimmedName = groupProfileDraftName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedDescription = groupProfileDraftDescription.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -194,7 +193,7 @@ extension WorkspaceState {
         guard let client,
             let activeAccount,
             let snapshot = groupDetailsSnapshot,
-            !hasInFlightGroupDetailsMutation
+            !hasInFlightGroupCommit
         else { return }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex
@@ -283,7 +282,7 @@ extension WorkspaceState {
         guard let client,
             let activeAccount,
             let snapshot = groupDetailsSnapshot,
-            !hasInFlightGroupDetailsMutation
+            !hasInFlightGroupCommit
         else { return }
         guard snapshot.isSelfAdmin, !snapshot.isLastAdmin else {
             lastError = L10n.string("Make another member an admin before stepping down.")
@@ -367,7 +366,11 @@ extension WorkspaceState {
     }
 
     func leaveSelectedGroup() async {
-        guard let client, let activeAccount, let snapshot = groupDetailsSnapshot, !isLeavingGroup else { return }
+        guard let client,
+            let activeAccount,
+            let snapshot = groupDetailsSnapshot,
+            !hasInFlightGroupCommit
+        else { return }
         guard snapshot.canLeave, !snapshot.requiresSelfDemoteBeforeLeave else {
             lastError = L10n.string("Demote yourself from admin before leaving this group.")
             return
@@ -461,7 +464,7 @@ extension WorkspaceState {
             let activeAccount,
             let selectedChat,
             !selectedChat.isDirect,
-            !isSavingGroupImage
+            !hasInFlightGroupCommit
         else { return }
         isSavingGroupImage = true
         defer { isSavingGroupImage = false }
@@ -527,7 +530,7 @@ extension WorkspaceState {
     }
 
     func setDisappearingMessages(groupIdHex: String, seconds: UInt64) async {
-        guard let client, let activeAccount, !isUpdatingDisappearingMessages else { return }
+        guard let client, let activeAccount, !hasInFlightGroupCommit else { return }
         lastError = nil
         isUpdatingDisappearingMessages = true
         defer { isUpdatingDisappearingMessages = false }
@@ -635,15 +638,20 @@ extension WorkspaceState {
         }
     }
 
-    var hasInFlightGroupDetailsMutation: Bool {
-        isSavingGroupProfile || isInvitingGroupMember || mutatingGroupMemberId != nil
+    var hasInFlightGroupCommit: Bool {
+        isSavingGroupProfile
+            || isInvitingGroupMember
+            || mutatingGroupMemberId != nil
+            || isUpdatingDisappearingMessages
+            || isLeavingGroup
+            || isSavingGroupImage
     }
 
     func mutateGroupMember(_ member: GroupMemberItem, action: GroupMemberMutationAction) async {
         guard let client,
             let activeAccount,
             let snapshot = groupDetailsSnapshot,
-            !hasInFlightGroupDetailsMutation
+            !hasInFlightGroupCommit
         else { return }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -145,7 +145,7 @@ struct GroupDetailsSheet: View {
                                 } label: {
                                     Label("Search Web Image", systemImage: "photo.badge.plus")
                                 }
-                                .disabled(workspace.isSavingGroupImage)
+                                .disabled(workspace.hasInFlightGroupCommit)
                             }
 
                             Spacer()
@@ -160,8 +160,7 @@ struct GroupDetailsSheet: View {
                             .nativeGlassProminentButtonStyle()
                             .disabled(
                                 !hasProfileChanges
-                                    || workspace.isSavingGroupProfile
-                                    || workspace.hasInFlightGroupDetailsMutation
+                                    || workspace.hasInFlightGroupCommit
                             )
                         }
                     }
@@ -204,7 +203,7 @@ struct GroupDetailsSheet: View {
                         // Retention changes are group commits — rejected for non-members.
                         // "Delete expired now" below stays enabled: it is a local prune.
                         .disabled(
-                            workspace.isUpdatingDisappearingMessages || snapshot.selfMembership != .member
+                            workspace.hasInFlightGroupCommit || snapshot.selfMembership != .member
                         )
 
                         if snapshot.disappearingMessagesEnabled {
@@ -236,7 +235,7 @@ struct GroupDetailsSheet: View {
                                         systemImage: "person.badge.plus")
                                 }
                                 .disabled(
-                                    workspace.hasInFlightGroupDetailsMutation
+                                    workspace.hasInFlightGroupCommit
                                         || workspace.groupInviteMemberQuery.trimmingCharacters(
                                             in: .whitespacesAndNewlines
                                         ).isEmpty
@@ -263,7 +262,7 @@ struct GroupDetailsSheet: View {
                                 } label: {
                                     Label("Step Down as Admin", systemImage: "star.slash")
                                 }
-                                .disabled(workspace.hasInFlightGroupDetailsMutation || snapshot.isLastAdmin)
+                                .disabled(workspace.hasInFlightGroupCommit || snapshot.isLastAdmin)
                             }
 
                             Button(role: .destructive) {
@@ -274,7 +273,9 @@ struct GroupDetailsSheet: View {
                                     systemImage: "rectangle.portrait.and.arrow.right")
                             }
                             .disabled(
-                                workspace.isLeavingGroup || !snapshot.canLeave || snapshot.requiresSelfDemoteBeforeLeave
+                                workspace.hasInFlightGroupCommit
+                                    || !snapshot.canLeave
+                                    || snapshot.requiresSelfDemoteBeforeLeave
                             )
 
                             Button(role: .destructive) {
@@ -402,7 +403,7 @@ struct GroupDetailsSheet: View {
             Button("Step Down", role: .destructive) {
                 Task { await workspace.selfDemoteSelectedGroupAdmin() }
             }
-            .disabled(workspace.hasInFlightGroupDetailsMutation)
+            .disabled(workspace.hasInFlightGroupCommit)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("You'll stay in the group, but another admin will need to restore your admin status.")
@@ -415,6 +416,7 @@ struct GroupDetailsSheet: View {
             Button("Leave Group", role: .destructive) {
                 Task { await workspace.leaveSelectedGroup() }
             }
+            .disabled(workspace.hasInFlightGroupCommit)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("You will no longer receive messages from this group on this account.")
@@ -563,7 +565,7 @@ struct GroupMemberRow: View {
                         .frame(width: 28, height: 28)
                 }
                 .menuStyle(.borderlessButton)
-                .disabled(workspace.hasInFlightGroupDetailsMutation)
+                .disabled(workspace.hasInFlightGroupCommit)
             }
         }
         .confirmationDialog(
@@ -574,7 +576,7 @@ struct GroupMemberRow: View {
             Button("Remove Member", role: .destructive) {
                 Task { await workspace.removeGroupMember(member) }
             }
-            .disabled(workspace.hasInFlightGroupDetailsMutation)
+            .disabled(workspace.hasInFlightGroupCommit)
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This removes \(PeerDisplayText.templateFragment(member.displayName)) from the group.")
@@ -665,7 +667,7 @@ struct GroupImagePickerSheet: View {
                                 Label("Clear", systemImage: "xmark.circle")
                             }
                             .controlSize(.small)
-                            .disabled(workspace.isSavingGroupImage)
+                            .disabled(workspace.hasInFlightGroupCommit)
                         }
                     }
                     .frame(minHeight: 24)
@@ -690,7 +692,7 @@ struct GroupImagePickerSheet: View {
                                         GroupImageResultTile(result: result)
                                     }
                                     .buttonStyle(.plain)
-                                    .disabled(workspace.isSavingGroupImage)
+                                    .disabled(workspace.hasInFlightGroupCommit)
                                 }
                             }
                             .padding(.vertical, 2)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13243,7 +13243,64 @@ struct whitenoise_macTests {
         #expect(state.isAcceptingGroupInvite)
         #expect(state.isDecliningGroupInvite)
         #expect(state.mutatingGroupMemberId == "member-in-flight")
-        #expect(state.hasInFlightGroupDetailsMutation)
+        #expect(state.hasInFlightGroupCommit)
+    }
+
+    @MainActor
+    @Test func accountScopedUITeardownPreservesOperationOwnedFlags() {
+        // Issue #523 follow-up: account-scoped group UI teardown must not clear operation-owned
+        // group-commit flags while FFI is still suspended.
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+        state.isSavingGroupProfile = true
+        state.isInvitingGroupMember = true
+        state.isLeavingGroup = true
+        state.isSavingGroupImage = true
+        state.isUpdatingDisappearingMessages = true
+        state.mutatingGroupMemberId = "member-in-flight"
+
+        state.resetActiveAccountUIState()
+
+        #expect(state.isSavingGroupProfile)
+        #expect(state.isInvitingGroupMember)
+        #expect(state.isLeavingGroup)
+        #expect(state.isSavingGroupImage)
+        #expect(state.isUpdatingDisappearingMessages)
+        #expect(state.mutatingGroupMemberId == "member-in-flight")
+        #expect(state.hasInFlightGroupCommit)
+    }
+
+    @MainActor
+    @Test func hasInFlightGroupCommitReflectsEachMLSCommitOwnershipState() {
+        // Issue #523: every MLS group-commit operation must contribute to the shared mutex.
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+
+        #expect(!state.hasInFlightGroupCommit)
+
+        state.isSavingGroupProfile = true
+        #expect(state.hasInFlightGroupCommit)
+        state.isSavingGroupProfile = false
+
+        state.isInvitingGroupMember = true
+        #expect(state.hasInFlightGroupCommit)
+        state.isInvitingGroupMember = false
+
+        state.mutatingGroupMemberId = "member-in-flight"
+        #expect(state.hasInFlightGroupCommit)
+        state.mutatingGroupMemberId = nil
+
+        state.isUpdatingDisappearingMessages = true
+        #expect(state.hasInFlightGroupCommit)
+        state.isUpdatingDisappearingMessages = false
+
+        state.isLeavingGroup = true
+        #expect(state.hasInFlightGroupCommit)
+        state.isLeavingGroup = false
+
+        state.isSavingGroupImage = true
+        #expect(state.hasInFlightGroupCommit)
+        state.isSavingGroupImage = false
+
+        #expect(!state.hasInFlightGroupCommit)
     }
 
     @MainActor
@@ -13797,7 +13854,7 @@ struct whitenoise_macTests {
             return
         }
 
-        #expect(state.hasInFlightGroupDetailsMutation)
+        #expect(state.hasInFlightGroupCommit)
         await state.promoteGroupMember(member)
         #expect(runtime.promoteAdminDetailedCallCount == 0)
 
@@ -14015,6 +14072,156 @@ struct whitenoise_macTests {
 
         #expect(runtime.setGroupArchivedCallCount == 1)
         #expect(!state.isArchivingGroup)
+    }
+
+    @MainActor
+    @Test func setDisappearingMessagesDropsWhileMemberMutationIsInFlight() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let member = try #require(state.groupDetailsSnapshot?.members.first(where: { !$0.isSelf }))
+        let groupIdHex = try #require(state.groupDetailsSnapshot?.groupIdHex)
+
+        runtime.groupMutationGateEnabled = true
+        async let firstPromote: Void = state.promoteGroupMember(member)
+        let didSuspendPromote = await waitFor {
+            state.mutatingGroupMemberId == member.id && runtime.didReachGroupMutationGate
+        }
+        guard didSuspendPromote else {
+            runtime.groupMutationGateEnabled = false
+            runtime.releaseGroupMutationGate()
+            await firstPromote
+            Issue.record("Expected member mutation to reach the test gate")
+            return
+        }
+
+        await state.setDisappearingMessages(groupIdHex: groupIdHex, seconds: 86_400)
+        #expect(runtime.updateMessageRetentionCallCount == 0)
+        #expect(!state.isUpdatingDisappearingMessages)
+
+        runtime.releaseGroupMutationGate()
+        await firstPromote
+    }
+
+    @MainActor
+    @Test func saveGroupProfileDropsWhileRetentionUpdateIsInFlight() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let groupIdHex = try #require(state.groupDetailsSnapshot?.groupIdHex)
+
+        runtime.groupMutationGateEnabled = true
+        async let firstRetention: Void = state.setDisappearingMessages(groupIdHex: groupIdHex, seconds: 86_400)
+        let didSuspendRetention = await waitFor {
+            state.isUpdatingDisappearingMessages && runtime.didReachGroupMutationGate
+        }
+        guard didSuspendRetention else {
+            runtime.groupMutationGateEnabled = false
+            runtime.releaseGroupMutationGate()
+            await firstRetention
+            Issue.record("Expected retention update to reach the test gate")
+            return
+        }
+
+        state.groupProfileDraftName = "Renamed While Retaining"
+        state.groupProfileDraftDescription = "Should be ignored until retention finishes"
+        await state.saveGroupProfile()
+        #expect(runtime.updateGroupProfileCallCount == 0)
+        #expect(!state.isSavingGroupProfile)
+
+        runtime.releaseGroupMutationGate()
+        await firstRetention
+    }
+
+    @MainActor
+    @Test func leaveSelectedGroupDropsWhileProfileSaveIsInFlight() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let details = groupDetailsFixture(selfAccountIdHex: account.accountIdHex, selfIsAdmin: false)
+        runtime.installGroupDetails(
+            details,
+            managementState: GroupManagementStateFfi(
+                myAccountIdHex: account.accountIdHex,
+                isSelfAdmin: false,
+                isLastAdmin: false,
+                canInvite: false,
+                canLeave: true,
+                requiresSelfDemoteBeforeLeave: false,
+                memberActions: []
+            )
+        )
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+
+        state.groupProfileDraftName = "Renamed Group"
+        state.groupProfileDraftDescription = "Planning room"
+        runtime.groupMutationGateEnabled = true
+        async let firstSave: Void = state.saveGroupProfile()
+        let didSuspendSave = await waitFor {
+            state.isSavingGroupProfile && runtime.didReachGroupMutationGate
+        }
+        guard didSuspendSave else {
+            runtime.groupMutationGateEnabled = false
+            runtime.releaseGroupMutationGate()
+            await firstSave
+            Issue.record("Expected profile save to reach the test gate")
+            return
+        }
+
+        await state.leaveSelectedGroup()
+        #expect(runtime.leaveGroupCallCount == 0)
+        #expect(!state.isLeavingGroup)
+
+        runtime.releaseGroupMutationGate()
+        await firstSave
+    }
+
+    @MainActor
+    @Test func updateSelectedGroupImageDropsWhileMemberMutationIsInFlight() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let member = try #require(state.groupDetailsSnapshot?.members.first(where: { !$0.isSelf }))
+        guard let groupChat = state.activeChats.first else {
+            Issue.record("Expected a group chat")
+            return
+        }
+
+        let result = GroupImageSearchResult(
+            id: "image-1",
+            title: "Aurora",
+            imageURL: "https://example.com/aurora.jpg",
+            thumbnailURL: "https://example.com/aurora-thumb.jpg",
+            creator: "Open Photographer",
+            license: "by",
+            attribution: nil,
+            sourceURL: "https://example.com/aurora",
+            width: 1024,
+            height: 680
+        )
+
+        runtime.groupMutationGateEnabled = true
+        async let firstPromote: Void = state.promoteGroupMember(member)
+        let didSuspendPromote = await waitFor {
+            state.mutatingGroupMemberId == member.id && runtime.didReachGroupMutationGate
+        }
+        guard didSuspendPromote else {
+            runtime.groupMutationGateEnabled = false
+            runtime.releaseGroupMutationGate()
+            await firstPromote
+            Issue.record("Expected member mutation to reach the test gate")
+            return
+        }
+
+        state.showGroupImagePicker(for: groupChat)
+        await state.setGroupImage(result)
+        #expect(runtime.updateGroupAvatarUrlCallCount == 0)
+        #expect(!state.isSavingGroupImage)
+
+        runtime.releaseGroupMutationGate()
+        await firstPromote
     }
 
     @MainActor
@@ -20527,6 +20734,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         -> SendSummaryFfi
     {
         updateMessageRetentionCallCount += 1
+        await groupMutationGate.passIfArmed()
         lastRetentionSecs = disappearingMessageSecs
         return SendSummaryFfi(published: 1, messageIds: ["retention"])
     }


### PR DESCRIPTION
Fixes #523

## Summary
- replace the partial group-details predicate with one shared mutex covering profile saves, invitations, member changes, retention updates, leave commits, and avatar commits
- gate every MLS group-commit entry point and corresponding group-details controls on that mutex
- preserve operation-owned avatar state across account UI teardown so an in-flight FFI call cannot lose mutex ownership
- add deterministic overlap regressions with bounded gate waits and cleanup

## Verification
- focused shared-mutex source contract: PASS
- post-rebase semantic sweep: PASS
- added-line security scan: PASS
- `git diff --check origin/master...HEAD`: PASS
- independent pre-commit adversarial review: PASS (no security or logic findings)
- `xcodebuild` / Swift tests: not run locally; this Linux host has no Xcode or Swift toolchain. macOS CI is authoritative.

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+Groups.swift` — MLS group-commit serialization
- `whitenoise-mac/Core/WorkspaceState+Account.swift` — preservation of operation-owned group-commit state
- `whitenoise-mac/Views/GroupViews.swift` — group mutation UI gating
- `whitenoise-macTests/whitenoise_macTests.swift` — deterministic overlap coverage


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/577">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->