### PR TITLE
fix: reject superseded timeline windows

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Navigation.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Navigation.swift
@@ -31,6 +31,7 @@ extension WorkspaceState {
     func selectChat(_ chat: ChatItem) {
         leaveActiveConversation()
         stopTimelineListener()
+        cancelTimelineLoad()
         clearEnteredLoginIdentity()
         selection = .chat(chat.id)
         closeNewChatComposer()
@@ -88,6 +89,7 @@ extension WorkspaceState {
     func showSettings(_ page: SettingsPage = .profile) {
         leaveActiveConversation()
         stopTimelineListener()
+        cancelTimelineLoad()
         clearEnteredLoginIdentity()
         selection = .settings(page)
         closeNewChatComposer()

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -18,6 +18,14 @@ private enum ComposerMediaUploadPresentation {
     static let uploadedAcknowledgementDelayNanoseconds: UInt64 = 300_000_000
 }
 
+/// Ownership token for subscription-originated or initial-load timeline window applies.
+/// Re-checked after every suspension in `applyTimelineWindow` so a superseded listener
+/// or load cannot overwrite a replacement for the same account/chat.
+enum TimelineWindowOwner {
+    case subscription(TimelineMessagesSubscription)
+    case loadGeneration(UInt64)
+}
+
 @MainActor
 extension WorkspaceState {
     func loadMessages(groupIdHex: String) async {
@@ -139,7 +147,16 @@ extension WorkspaceState {
                     hasMoreBefore: false,
                     hasMoreAfter: false
                 )
-            await applyTimelineWindow(page, groupIdHex: groupIdHex, account: activeAccount, client: client)
+            await applyTimelineWindow(
+                page,
+                groupIdHex: groupIdHex,
+                account: activeAccount,
+                client: client,
+                owner: .loadGeneration(generation)
+            )
+            guard canContinueTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex),
+                selectedChat?.id == groupIdHex
+            else { return }
             // Start the listener first (it tears down any prior listener, which would clear
             // these), then record the subscription so scroll-back pagination can reach it.
             // `startTimelineListener` can bail without starting a task (e.g. selection changed
@@ -214,7 +231,7 @@ extension WorkspaceState {
                 groupIdHex: groupIdHex,
                 account: activeAccount,
                 client: client,
-                expectedTimelineSubscription: subscription
+                owner: .subscription(subscription)
             )
         } catch {
             guard activeAccountId == activeAccount.id,
@@ -258,7 +275,7 @@ extension WorkspaceState {
                 groupIdHex: groupIdHex,
                 account: activeAccount,
                 client: client,
-                expectedTimelineSubscription: subscription
+                owner: .subscription(subscription)
             )
         } catch {
             guard activeAccountId == activeAccount.id,
@@ -278,13 +295,13 @@ extension WorkspaceState {
         groupIdHex: String,
         account: AccountItem,
         client: any MarmotRuntime,
-        expectedTimelineSubscription: TimelineMessagesSubscription? = nil
+        owner: TimelineWindowOwner? = nil
     ) async {
         guard
             canApplyTimelineWindow(
                 groupIdHex: groupIdHex,
                 accountId: account.id,
-                expectedTimelineSubscription: expectedTimelineSubscription
+                owner: owner
             )
         else { return }
         let senderProfiles = await TimelineSignpost.mapping.asyncInterval(
@@ -301,7 +318,7 @@ extension WorkspaceState {
             canApplyTimelineWindow(
                 groupIdHex: groupIdHex,
                 accountId: account.id,
-                expectedTimelineSubscription: expectedTimelineSubscription
+                owner: owner
             )
         else { return }
 
@@ -311,7 +328,7 @@ extension WorkspaceState {
                 canApplyTimelineWindow(
                     groupIdHex: groupIdHex,
                     accountId: account.id,
-                    expectedTimelineSubscription: expectedTimelineSubscription
+                    owner: owner
                 )
             else { return }
         #endif
@@ -336,7 +353,7 @@ extension WorkspaceState {
             canApplyTimelineWindow(
                 groupIdHex: groupIdHex,
                 accountId: account.id,
-                expectedTimelineSubscription: expectedTimelineSubscription
+                owner: owner
             )
         else { return }
 
@@ -361,12 +378,17 @@ extension WorkspaceState {
     private func canApplyTimelineWindow(
         groupIdHex: String,
         accountId: String,
-        expectedTimelineSubscription: TimelineMessagesSubscription?
+        owner: TimelineWindowOwner?
     ) -> Bool {
         guard activeAccountId == accountId, selectedChat?.id == groupIdHex else { return false }
-        if let expectedTimelineSubscription {
+        guard let owner else { return true }
+        switch owner {
+        case .subscription(let expectedSubscription):
             guard activeTimelineGroupId == groupIdHex,
-                activeTimelineSubscription === expectedTimelineSubscription
+                activeTimelineSubscription === expectedSubscription
+            else { return false }
+        case .loadGeneration(let generation):
+            guard ownsTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
             else { return false }
         }
         return true
@@ -385,11 +407,18 @@ extension WorkspaceState {
         _ update: TimelineSubscriptionUpdateFfi,
         groupIdHex: String,
         account: AccountItem,
-        client: any MarmotRuntime
+        client: any MarmotRuntime,
+        subscription: TimelineMessagesSubscription
     ) async {
         switch update {
         case .page(let page):
-            await applyTimelineWindow(page, groupIdHex: groupIdHex, account: account, client: client)
+            await applyTimelineWindow(
+                page,
+                groupIdHex: groupIdHex,
+                account: account,
+                client: client,
+                owner: .subscription(subscription)
+            )
         case .projection(let runtimeUpdate):
             await applyTimelineProjection(
                 runtimeUpdate.update,
@@ -782,7 +811,8 @@ extension WorkspaceState {
                             page,
                             groupIdHex: groupIdHex,
                             account: account,
-                            client: client
+                            client: client,
+                            owner: .subscription(subscription)
                         )
                     }
                 }
@@ -806,7 +836,8 @@ extension WorkspaceState {
                         update,
                         groupIdHex: groupIdHex,
                         account: account,
-                        client: client
+                        client: client,
+                        subscription: subscription
                     )
                 }
             } catch is CancellationError {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -9380,6 +9380,204 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func staleTimelineLivePageApplyDoesNotClobberReplacementSubscriptionWindow() async throws {
+        // Issue #557: non-pagination window applies (live `.page`, reconnect snapshot, initial
+        // load) must carry ownership through `applyTimelineWindow` and re-check after suspension,
+        // matching pagination (#529). A superseded listener's `.page` apply must not overwrite a
+        // replacement subscription for the same account/chat.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        let staleSubscription = try #require(state.activeTimelineSubscription as? FakeTimelineMessagesSubscription)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "message-005")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+
+        let stalePage = staleSubscription.snapshot() ?? emptyTimelinePage()
+
+        state.timelineApplyMapGateEnabled = true
+        async let stalePageApply: Void = state.applyTimelineSubscriptionUpdate(
+            .page(page: stalePage),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime,
+            subscription: staleSubscription
+        )
+        let didSuspendApply = await waitFor {
+            state.didReachTimelineApplyMapGate
+        }
+        guard didSuspendApply else {
+            state.timelineApplyMapGateEnabled = false
+            state.releaseTimelineApplyMapGate()
+            _ = await stalePageApply
+            Issue.record("Expected live `.page` apply to reach the map gate")
+            return
+        }
+
+        let replacementMessages = (0..<105).map { index in
+            timelineMessage(
+                id: String(format: "fresh-page-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh page \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacement = FakeTimelineMessagesSubscription(
+            messages: replacementMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacement
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacement.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-page-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-page-104")
+
+        state.releaseTimelineApplyMapGate()
+        _ = await stalePageApply
+
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-page-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-page-104")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+    }
+
+    @MainActor
+    @Test func staleTimelineInitialLoadApplyDoesNotClobberReplacementLoadWindow() async throws {
+        // Issue #557: initial-load window applies must re-check load-generation ownership after
+        // suspension, matching subscription pagination/live paths (#529). A superseded initial load
+        // must not overwrite a replacement load for the same account/chat.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "message-005")
+        let directChat = try #require(state.activeChats.first(where: { $0.id == "direct-group" }))
+
+        state.stopTimelineListener()
+        state.messageTimelineStores["direct-group"]?.clear()
+
+        state.timelineApplyMapGateEnabled = true
+        async let staleInitialLoad: Void = state.loadMessages(groupIdHex: "direct-group")
+        let didSuspendApply = await waitFor {
+            state.didReachTimelineApplyMapGate
+        }
+        guard didSuspendApply else {
+            state.timelineApplyMapGateEnabled = false
+            state.releaseTimelineApplyMapGate()
+            _ = await staleInitialLoad
+            Issue.record("Expected initial-load apply to reach the map gate")
+            return
+        }
+
+        // Production leave/re-enter: Settings tears down the in-flight owner, then selecting the
+        // same chat starts a replacement load instead of joining the suspended initial load.
+        state.showSettings()
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "fresh-load-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Fresh load \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        state.selectChat(directChat)
+        let didLoadReplacement = await waitFor {
+            state.messagesByChat["direct-group"]?.first?.id == "fresh-load-005"
+        }
+        guard didLoadReplacement else {
+            state.timelineApplyMapGateEnabled = false
+            state.releaseTimelineApplyMapGate()
+            _ = await staleInitialLoad
+            Issue.record("Expected replacement initial load to materialize via selectChat")
+            return
+        }
+        let replacementSubscription = try #require(state.activeTimelineSubscription)
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-load-104")
+
+        state.releaseTimelineApplyMapGate()
+        _ = await staleInitialLoad
+
+        #expect(state.activeTimelineSubscription === replacementSubscription)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-load-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-load-104")
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+    }
+
+    @MainActor
     @Test func staleTimelinePaginationErrorDoesNotSurfaceAfterSubscriptionReplacement() async throws {
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"


### PR DESCRIPTION
Fixes #557

Supersedes #568, which was retired under the never-merge-ever-red-CI policy after its addressed head hit a GitHub macOS runner I/O error while Xcode wrote DerivedData. This replacement uses a fresh branch and one signed commit based directly on current `master`.

## Summary
- Carry explicit subscription or load-generation ownership through initial, live-page, reconnect, and pagination full-window timeline applies.
- Re-check ownership after each suspension before mutating the selected chat's timeline.
- Invalidate in-flight initial-load ownership when chat or Settings navigation supersedes the current conversation.
- Add deterministic same-chat A→B→A regressions for stale live-page and initial-load applies; the initial-load test drives the real Settings → same-chat navigation path and proves B is visible before releasing A.

## Verification
- `git diff --check origin/master...HEAD`
- Replacement commit is signed and based directly on current `origin/master`.
- Post-rebase committed-tree conflict-marker, duplicate-symbol, critical-owner-path, and changed-line 120-column sweeps passed.
- PR #568's addressed head passed strict Swift formatting, macOS project sanity checks, and Xcode Static Analysis. Its unit-test job aborted before compilation with `NSPOSIXErrorDomain Code=5` while writing `DerivedData/.../manifest.json`; the clean replacement CI must run the full suite.
- Xcode is unavailable on this Linux worker.

## Sensitive paths
None. This changes Swift client timeline ownership/navigation and regression tests; no crypto, MLS/CGKA, key handling, trust-anchor, authentication, or group-state core paths are touched.

## Follow-ups
The adversarial review tracked ownerless incremental projection and post-send refresh races separately in #571 and #572.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/579">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->