### PR TITLE
fix: serialize group profile and member mutations

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -593,7 +593,7 @@ extension WorkspaceState {
     }
 
     var hasInFlightGroupDetailsMutation: Bool {
-        isInvitingGroupMember || mutatingGroupMemberId != nil
+        isSavingGroupProfile || isInvitingGroupMember || mutatingGroupMemberId != nil
     }
 
     func mutateGroupMember(_ member: GroupMemberItem, action: GroupMemberMutationAction) async {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13084,6 +13084,70 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func mutateGroupMemberDropsWhileProfileSaveIsInFlight() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let member = try #require(state.groupDetailsSnapshot?.members.first(where: { !$0.isSelf }))
+
+        state.groupProfileDraftName = "Renamed Group"
+        state.groupProfileDraftDescription = "Planning room"
+        runtime.groupMutationGateEnabled = true
+        async let save: Void = state.saveGroupProfile()
+        let reachedProfileSaveGate = await waitFor {
+            state.isSavingGroupProfile && runtime.didReachGroupMutationGate
+        }
+        #expect(reachedProfileSaveGate)
+        guard reachedProfileSaveGate else {
+            runtime.releaseGroupMutationGate()
+            await save
+            return
+        }
+
+        #expect(state.hasInFlightGroupDetailsMutation)
+        await state.promoteGroupMember(member)
+        #expect(runtime.promoteAdminDetailedCallCount == 0)
+
+        runtime.releaseGroupMutationGate()
+        await save
+    }
+
+    @MainActor
+    @Test func inviteMemberDropsWhileProfileSaveIsInFlight() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        runtime.installNormalizedMemberRef(
+            query: "npub1newmemzer",
+            accountIdHex: "new1234567890new1234567890new1234567890new1234567890new1",
+            npub: "npub1newmemzer"
+        )
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+
+        state.groupProfileDraftName = "Renamed Group"
+        state.groupProfileDraftDescription = "Planning room"
+        state.groupInviteMemberQuery = "npub1newmemzer"
+        runtime.groupMutationGateEnabled = true
+        async let save: Void = state.saveGroupProfile()
+        let reachedProfileSaveGate = await waitFor {
+            state.isSavingGroupProfile && runtime.didReachGroupMutationGate
+        }
+        #expect(reachedProfileSaveGate)
+        guard reachedProfileSaveGate else {
+            runtime.releaseGroupMutationGate()
+            await save
+            return
+        }
+
+        await state.inviteMemberToSelectedGroup()
+        #expect(runtime.inviteMembersDetailedCallCount == 0)
+
+        runtime.releaseGroupMutationGate()
+        await save
+    }
+
+    @MainActor
     @Test func inviteMemberDropsOverlappingDuplicateInvocation() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])


### PR DESCRIPTION
## Summary
- include profile saves in the shared group-details mutation busy state
- block promote, demote, remove, self-demote, and invite entry points while a profile save awaits FFI
- add gated regressions for promotion and invitation attempts during a profile save

## Test plan
- [x] static guard/entry-point regression check on Linux
- [x] git diff --check
- [x] independent pre-commit review
- [ ] macOS PR test plan (GitHub Actions; xcodebuild is unavailable on this Linux worker)

Fixes #506

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->