### PR TITLE
fix: use singular transcript event status

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -101,8 +101,12 @@ extension WorkspaceState {
                 groupDetailsSnapshot == snapshot
             else { return }
             copyText(export.json)
+            let statusFormat =
+                export.eventCount == 1
+                ? L10n.string("Copied transcript JSON for %d event.")
+                : L10n.string("Copied transcript JSON for %d events.")
             groupTranscriptExportStatus = String(
-                format: L10n.string("Copied transcript JSON for %d events."),
+                format: statusFormat,
                 export.eventCount
             )
         } catch is CancellationError {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1505,7 +1505,7 @@ struct whitenoise_macTests {
         state.groupProfileDraftName = "Private group name"
         state.groupProfileDraftDescription = "Private group description"
         state.groupInviteMemberQuery = "npub1pryvateynvyte"
-        state.groupTranscriptExportStatus = "Copied transcript JSON for 1 events."
+        state.groupTranscriptExportStatus = "Copied transcript JSON for 1 event."
         let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
 
         state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
@@ -13552,7 +13552,7 @@ struct whitenoise_macTests {
         await exportTask.value
 
         #expect(!copiedText.isEmpty)
-        #expect(state.groupTranscriptExportStatus == "Copied transcript JSON for 1 events.")
+        #expect(state.groupTranscriptExportStatus == "Copied transcript JSON for 1 event.")
         #expect(state.groupTranscriptExportTask == nil)
     }
 


### PR DESCRIPTION
## Summary
- use a localized singular completion format for exactly one exported event
- preserve the plural format for zero and multiple events
- update the existing one-event regression expectation

## Testing
- static singular/plural branch assertions pass
- `git diff --check` passes
- macOS/Xcode tests unavailable on this Linux worker; Mac CI will run the native suite

Fixes #566

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected transcript export status messages to use the proper singular wording when exporting one event.
  - Multiple-event exports continue to use plural wording.

- **Tests**
  - Updated validation to confirm the corrected singular message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->