### PR TITLE
fix: localize member count plurals

### DIFF
--- a/whitenoise-mac/Core/L10n.swift
+++ b/whitenoise-mac/Core/L10n.swift
@@ -35,6 +35,22 @@ nonisolated enum L10n {
         return Bundle.main.localizedString(forKey: key, value: key, table: nil)
     }
 
+    static func plural(_ key: String, _ count: Int64) -> String {
+        let locale = AppLanguage.currentLocale
+        return formatPlural(string(key), count: count, locale: locale)
+    }
+
+    static func plural(
+        _ key: String,
+        _ count: Int64,
+        locale: Locale,
+        baseBundle: Bundle = .main
+    ) -> String {
+        let bundle = localizedBundle(for: locale, in: baseBundle) ?? baseBundle
+        let format = bundle.localizedString(forKey: key, value: key, table: nil)
+        return formatPlural(format, count: count, locale: locale)
+    }
+
     /// Clear the cached localized bundle so the next `string(_:)` call re-resolves
     /// it for the current language preference. Called from
     /// `AppLanguage.refreshCachedLocale()` whenever the preference or effective
@@ -61,7 +77,7 @@ nonisolated enum L10n {
         }
     }
 
-    private static func localizedBundle(for locale: Locale) -> Bundle? {
+    private static func localizedBundle(for locale: Locale, in baseBundle: Bundle = .main) -> Bundle? {
         let identifier = locale.identifier.replacingOccurrences(of: "_", with: "-")
         let parts = identifier.split(separator: "-").map(String.init)
         var candidates = [identifier]
@@ -73,12 +89,18 @@ nonisolated enum L10n {
         }
 
         for candidate in candidates {
-            if let path = Bundle.main.path(forResource: candidate, ofType: "lproj"),
+            if let path = baseBundle.path(forResource: candidate, ofType: "lproj"),
                 let bundle = Bundle(path: path)
             {
                 return bundle
             }
         }
         return nil
+    }
+
+    private static func formatPlural(_ format: String, count: Int64, locale: Locale) -> String {
+        withVaList([count]) {
+            NSString(format: format, locale: locale, arguments: $0) as String
+        }
     }
 }

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -512,60 +512,281 @@
       }
     },
     "%lld members" : {
+      "comment" : "A count of members in a chat.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld-Mitglieder"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld Mitglied"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld Mitglieder"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld member"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld members"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Miembros de %lld"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld miembro"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld miembros"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Membres %lld"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld membre"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld membres"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Membri %lld"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld membro"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld membri"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Membros %lld"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld membro"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld membros"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Участники %lld"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld участника"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld участников"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld участник"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld участника"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld üyeler"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld üye"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 成员"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld 位成员"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld 成員"
+            "value" : "%#@count@"
+          },
+          "substitutions" : {
+            "count" : {
+              "argNum" : 1,
+              "formatSpecifier" : "lld",
+              "variations" : {
+                "plural" : {
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%lld 位成員"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -234,7 +234,7 @@ struct GroupDetailsSnapshot: Hashable {
     let disappearingMessageSecs: UInt64
 
     var memberCountLabel: String {
-        String(format: L10n.string("%d members"), CInt(members.count))
+        L10n.plural("%lld members", Int64(members.count))
     }
 
     var disappearingMessagesEnabled: Bool { disappearingMessageSecs > 0 }

--- a/whitenoise-mac/Views/ComposeFlowViews.swift
+++ b/whitenoise-mac/Views/ComposeFlowViews.swift
@@ -225,7 +225,7 @@ struct ChooseMembersPanelView: View {
             GlassSeparator(axis: .horizontal)
 
             HStack {
-                Text(String(format: L10n.string("%d members"), CInt(workspace.newChatRecipients.count)))
+                Text(L10n.plural("%lld members", Int64(workspace.newChatRecipients.count)))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Spacer()
@@ -328,7 +328,7 @@ struct NameGroupPanelView: View {
                     disappearingRow
 
                     VStack(alignment: .leading, spacing: 4) {
-                        Text(String(format: L10n.string("%d members"), CInt(workspace.newChatRecipients.count)))
+                        Text(L10n.plural("%lld members", Int64(workspace.newChatRecipients.count)))
                             .font(MessagesType.sectionHeader)
                             .foregroundStyle(.secondary)
                         ForEach(workspace.newChatRecipients, id: \.accountIdHex) { member in

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3445,6 +3445,29 @@ struct whitenoise_macTests {
         #expect(L10n.string("Save") == "Guardar")
     }
 
+    @Test func memberCountLocalizationUsesLocalePluralRules() {
+        let russian = Locale(identifier: "ru")
+        #expect(L10n.plural("%lld members", Int64(1), locale: russian) == "1 участник")
+        #expect(L10n.plural("%lld members", Int64(2), locale: russian) == "2 участника")
+        #expect(L10n.plural("%lld members", Int64(5), locale: russian) == "5 участников")
+        #expect(L10n.plural("%lld members", Int64(21), locale: russian) == "21 участник")
+        #expect(L10n.plural("%lld members", Int64(2), locale: Locale(identifier: "tr")) == "2 üye")
+    }
+
+    @MainActor
+    @Test func memberCountLocalizationUsesSelectedAppLanguage() async throws {
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
+
+        UserDefaults.standard.set(AppLanguage.russian.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
+        #expect(L10n.plural("%lld members", Int64(2)) == "2 участника")
+
+        UserDefaults.standard.set(AppLanguage.turkish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
+        #expect(L10n.plural("%lld members", Int64(2)) == "2 üye")
+    }
+
     @MainActor
     @Test func localizedStringBundleCacheInvalidatesOnLanguageChange() async throws {
         // Regression for the residual half of #28 (#117): `L10n.string` caches the


### PR DESCRIPTION
## Summary
- add locale-aware plural formatting while preserving the selected-language bundle cache
- route all current member-count labels through the %lld plural key
- define whole-phrase plural variants for every supported locale, including Russian one/few/many/other and Turkish numeric wording

## Verification
- added regression coverage for Russian plural categories, Turkish wording, and selected app-language switching
- JSON/catalog structural validation passed; only the %lld members catalog entry changed
- independent pre-commit review passed with no security or logic findings
- xcodebuild is unavailable on this Linux worker; Mac CI provides compile/test/format validation

Fixes #504

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/582">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->