### PR TITLE
fix: tear down chats removed by snapshots

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -213,13 +213,22 @@ extension WorkspaceState {
         // both lists are truly removed — clearing drafts for a moved chat drops its composer draft.
         let removedChatIds = previousActiveChatIds.union(previousArchivedChatIds)
             .subtracting(nextActiveChatIds.union(nextArchivedChatIds))
+        let selectedChatWasRemoved: Bool
+        if case .chat(let selectedGroupId) = selection {
+            selectedChatWasRemoved = removedChatIds.contains(selectedGroupId)
+        } else {
+            selectedChatWasRemoved = false
+        }
 
         for groupId in removedChatIds {
-            invalidateGroupMembers(for: groupId)
+            teardownRemovedChatPerChatState(groupIdHex: groupId, accountId: account.id)
         }
-        clearComposerDrafts(for: Array(removedChatIds), accountId: account.id)
-        setChats(sortedChatItems(activeItems), forAccountId: account.id)
+        let sortedActiveItems = sortedChatItems(activeItems)
+        setChats(sortedActiveItems, forAccountId: account.id)
         setArchivedChats(sortedChatItems(archivedItems), forAccountId: account.id)
+        if selectedChatWasRemoved {
+            transitionAfterRemovedSelectedChat(remainingActiveChats: chatsByAccount[account.id] ?? [])
+        }
         dismissGroupImagePickerIfSelectedChatUnavailable()
         cancelVoiceRecordingIfSelectedMembershipEnded()
         ensureSelectedMessageTimelineStore()
@@ -249,7 +258,6 @@ extension WorkspaceState {
             // still happens via `upsertChat` inside `applyChatRow` (issue #251).
             await applyChatRow(row, account: account, shouldEnrich: chatListTriggerRequiresEnrichment(trigger))
         case .removeRow(trigger: _, let groupIdHex):
-            invalidateGroupMembers(for: groupIdHex)
             removeChat(groupIdHex: groupIdHex, account: account)
             removeArchivedChatFromList(chatId: groupIdHex, forAccountId: account.id)
         }
@@ -374,35 +382,51 @@ extension WorkspaceState {
         return groupNameIsBlank && current.title == rawTitle
     }
 
-    func removeChat(groupIdHex: String, account: AccountItem) {
-        guard activeAccountId == account.id else { return }
-
-        let chats = removeChatFromList(chatId: groupIdHex, forAccountId: account.id)
+    /// Clears per-chat cached state when a conversation disappears from the account.
+    /// Does not mutate chat lists or selection — callers own those updates.
+    func teardownRemovedChatPerChatState(groupIdHex: String, accountId: String) {
         cachedMessageChatIds.remove(groupIdHex)
         messageTimelineStores[groupIdHex]?.clear()
         messageTimelineStores[groupIdHex] = nil
         invalidateGroupMembers(for: groupIdHex)
         timelinePagingByChat[groupIdHex] = nil
-        clearComposerDrafts(for: [groupIdHex], accountId: account.id)
+        clearComposerDrafts(for: [groupIdHex], accountId: accountId)
         if timelineInitialLoadGroupId == groupIdHex {
             timelineInitialLoadGroupId = nil
         }
         lastMarkedReadMarkers[groupIdHex] = nil
         lastConfirmedReadMarkers[groupIdHex] = nil
+    }
 
-        guard case .chat(let selectedGroupId) = selection,
-            selectedGroupId == groupIdHex
-        else { return }
-
+    /// After the selected chat was removed, leave its live resources and select the most recent
+    /// remaining active chat.
+    func transitionAfterRemovedSelectedChat(remainingActiveChats: [ChatItem]) {
         leaveActiveConversation()
         closeGroupImagePicker()
-        let nextChat = mostRecentChat(in: chats)
+        let nextChat = mostRecentChat(in: remainingActiveChats)
         selection = nextChat.map { .chat($0.id) }
         pruneMessageCache(keeping: nextChat?.id)
         if let nextChat {
             beginTimelineInitialLoadIfNeeded(groupIdHex: nextChat.id)
             Task { await loadMessages(groupIdHex: nextChat.id) }
         }
+    }
+
+    func removeChat(groupIdHex: String, account: AccountItem) {
+        guard activeAccountId == account.id else { return }
+
+        let wasSelected: Bool
+        if case .chat(let selectedGroupId) = selection {
+            wasSelected = selectedGroupId == groupIdHex
+        } else {
+            wasSelected = false
+        }
+
+        let chats = removeChatFromList(chatId: groupIdHex, forAccountId: account.id)
+        teardownRemovedChatPerChatState(groupIdHex: groupIdHex, accountId: account.id)
+
+        guard wasSelected else { return }
+        transitionAfterRemovedSelectedChat(remainingActiveChats: chats)
     }
 
     func baseChatItem(from row: ChatListRowFfi, account: AccountItem) -> ChatItem {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -14551,6 +14551,75 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func removedSelectedChatFullSnapshotStopsInProgressVoiceRecordingAndClearsPerChatState() async throws {
+        // #507: a reconnect full snapshot can omit the selected chat entirely (not just flip
+        // membership). applyChatRows must run the same per-chat teardown and selected-chat
+        // transition as removeChat, or selection, recording, transcript export, and cached
+        // timeline state can linger after the conversation disappears.
+        let state = WorkspaceState.preview()
+        let account = AccountItem.samples[0]
+        let removedChatId = try #require(state.selectedChat?.id)
+        let sender = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let url = try armInProgressVoiceRecording(on: state)
+        let transcriptExportTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        state.groupTranscriptExportTask = transcriptExportTask
+        defer { transcriptExportTask.cancel() }
+
+        state.cachedMessageChatIds.insert(removedChatId)
+        let removedTimelineStore = try #require(state.messageTimelineStores[removedChatId])
+        #expect(!removedTimelineStore.messages.isEmpty)
+        state.timelinePagingByChat[removedChatId] = TimelinePagingState(
+            hasMoreBefore: true,
+            hasMoreAfter: false,
+            isLoadingBefore: false,
+            isLoadingAfter: false
+        )
+        state.timelineInitialLoadGroupId = removedChatId
+        let marker = ReadMarker(sentAt: Date(), messageId: "m-removed")
+        state.lastMarkedReadMarkers[removedChatId] = marker
+        state.lastConfirmedReadMarkers[removedChatId] = marker
+
+        await state.applyChatRows(
+            [
+                chatListRow(
+                    groupIdHex: "chat-nvk",
+                    title: "NVK",
+                    preview: "Let's keep the left rail fast for account switching.",
+                    sender: sender,
+                    timelineAt: 1_700_000_001
+                ),
+                chatListRow(
+                    groupIdHex: "chat-relays",
+                    title: "Relay Ops",
+                    preview: "EU and US White Noise relays both caught up on the last run.",
+                    sender: sender,
+                    timelineAt: 1_700_000_002
+                ),
+            ],
+            account: account
+        )
+
+        #expect(state.selection != .chat(removedChatId))
+        #expect(state.selection == .chat("chat-relays"))
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+        #expect(transcriptExportTask.isCancelled)
+        await transcriptExportTask.value
+        #expect(!state.cachedMessageChatIds.contains(removedChatId))
+        #expect(state.messageTimelineStores[removedChatId] == nil)
+        #expect(removedTimelineStore.messages.isEmpty)
+        #expect(state.timelinePagingByChat[removedChatId] == nil)
+        #expect(state.timelineInitialLoadGroupId != removedChatId)
+        #expect(state.lastMarkedReadMarkers[removedChatId] == nil)
+        #expect(state.lastConfirmedReadMarkers[removedChatId] == nil)
+    }
+
+    @MainActor
     @Test func endedMembershipBulkRowsUpdateStopsInProgressVoiceRecording() async throws {
         // Sibling of the single-row test above for the bulk snapshot/reconnect path
         // (`applyChatRows`), which also carries membership flips (#311).


### PR DESCRIPTION
Fixes #507

## Summary
- share removed-chat cache, timeline, draft, membership, paging, initial-load, and read-marker teardown between delta and full-snapshot paths
- when a reconnect snapshot drops the selected chat, leave its live conversation resources once and reselect from the final active snapshot
- add regression coverage for ghost selection, hot-mic/plaintext recording cleanup, transcript-export cancellation, and decrypted timeline state cleanup

## Verification
- `git diff --check` — passed
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed
- conflict-marker and duplicate-function static sweeps — passed
- Xcode/Swift checks — not available on this Linux host (`xcodebuild`, `xcrun`, `swift`, `swift-format`, and `plutil` are absent)
- `bash scripts/ci/macos-sanity-checks.sh` — cannot run here; exits 127 at `xcodebuild`

## Sensitive paths
- `whitenoise-mac/Core/WorkspaceState+ChatList.swift` — privacy-sensitive teardown of decrypted timeline cache, plaintext voice recording, transcript export, and read state; no crypto/MLS/key-handling code changed


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/583">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->