### PR TITLE
fix: hide peer filenames in playback scratch paths

### DIFF
--- a/whitenoise-mac/Core/MediaPlaybackTempStore.swift
+++ b/whitenoise-mac/Core/MediaPlaybackTempStore.swift
@@ -27,12 +27,6 @@ nonisolated enum MediaPlaybackTempStore {
     private static let directoryName = "WhiteNoiseMediaPlayback"
     private static let voiceRecordingsDirectoryName = "WhiteNoiseVoiceRecordings"
 
-    /// Upper bound, in UTF-8 bytes, for the scratch filename component built by `materialize`.
-    ///
-    /// APFS allows 255 UTF-8 bytes per path component. Keeping our component below that leaves
-    /// room for filesystem normalization differences while still preserving useful peer filenames.
-    static let maxScratchFileComponentBytes = 240
-
     /// Resolves the playback scratch directory inside the app container.
     ///
     /// Mirrors `MarmotStorageRoot`'s Application Support location but lives in a
@@ -114,26 +108,27 @@ nonisolated enum MediaPlaybackTempStore {
         return url
     }
 
-    /// Writes `data` to a per-consumer scratch file for `id`/`fileName` and returns its URL.
+    /// Writes `data` to a per-consumer scratch file for `id` and returns its URL.
     ///
     /// The attachment id contributes a deterministic, collision-resistant stem while
     /// `uniqueID` makes each handoff/playback own an independent file. That prevents a
     /// delayed cleanup from an earlier open from deleting the file a later consumer is
-    /// still reading.
+    /// still reading. The path component contains only the stable attachment stem, UUID,
+    /// and an app-controlled canonical type suffix derived from `mediaType`; peer filenames
+    /// are never embedded because directory entries are not covered by
+    /// `.completeFileProtection`.
     static func materialize(
         data: Data,
         id: String,
-        fileName: String,
-        fallbackExtension: String,
+        mediaType: String,
         directory: URL,
         uniqueID: UUID = UUID(),
         fileManager: FileManager = .default
     ) throws -> URL {
         try MediaProtectedTempDirectory.prepareDirectory(directory, fileManager: fileManager)
-        let prefix = "\(stableStem(for: id))-\(uniqueID.uuidString)-"
-        let byteLimit = max(1, maxScratchFileComponentBytes - prefix.utf8.count)
-        let sanitized = sanitizedFileName(fileName, fallbackExtension: fallbackExtension, byteLimit: byteLimit)
-        let url = directory.appendingPathComponent("\(prefix)\(sanitized)")
+        let stem = "\(stableStem(for: id))-\(uniqueID.uuidString)"
+        let suffix = OutgoingMediaAttachmentPolicy.fileExtension(for: mediaType)
+        let url = directory.appendingPathComponent(stem).appendingPathExtension(suffix)
         try MediaProtectedTempDirectory.writeProtectedData(data, to: url, fileManager: fileManager)
         return url
     }
@@ -201,55 +196,6 @@ nonisolated enum MediaPlaybackTempStore {
 
         let prefix = sanitizedPrefix.isEmpty ? "attachment" : String(sanitizedPrefix)
         return "\(prefix)-\(digest)"
-    }
-
-    static func sanitizedFileName(_ fileName: String, fallbackExtension: String, byteLimit: Int) -> String {
-        let trimmed = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let fallback = "attachment.\(fallbackExtension)"
-        let rawName = trimmed.isEmpty ? fallback : trimmed
-        let illegal = CharacterSet(charactersIn: "/:\\")
-        let components = rawName.components(separatedBy: illegal).filter { !$0.isEmpty }
-        let sanitized = components.joined(separator: "-").trimmingCharacters(in: .whitespacesAndNewlines)
-        let bounded = boundedFileName(sanitized.isEmpty ? fallback : sanitized, byteLimit: byteLimit)
-        return bounded.isEmpty ? fallback : bounded
-    }
-
-    /// Truncates `name` to at most `byteLimit` UTF-8 bytes, keeping a trailing extension
-    /// intact when possible by shortening the stem first.
-    ///
-    /// A peer-supplied `fileName` can be arbitrarily long; without this bound the full
-    /// `"<stem>-<uuid>-<sanitized>"` path component can exceed APFS' 255-byte limit and make
-    /// `data.write(to:)` throw, silently breaking the attachment open/playback.
-    static func boundedFileName(_ name: String, byteLimit: Int) -> String {
-        guard byteLimit > 0, name.utf8.count > byteLimit else { return name }
-
-        let dotIndex = name.lastIndex(of: ".")
-        let stem = dotIndex.map { String(name[..<$0]) } ?? name
-        // Include the leading dot so an empty stem still yields a usable name.
-        let ext = dotIndex.map { String(name[$0...]) } ?? ""
-
-        // Reserve room for the extension; if it alone overruns the budget, drop it and
-        // truncate the whole name so we never exceed the cap.
-        let stemBudget = byteLimit - ext.utf8.count
-        guard stemBudget > 0 else { return truncatedToUTF8ByteLimit(name, byteLimit: byteLimit) }
-        return truncatedToUTF8ByteLimit(stem, byteLimit: stemBudget) + ext
-    }
-
-    /// Returns the longest prefix of `value` whose UTF-8 encoding fits in `byteLimit`,
-    /// never splitting a multi-byte scalar.
-    private static func truncatedToUTF8ByteLimit(_ value: String, byteLimit: Int) -> String {
-        guard byteLimit > 0 else { return "" }
-        guard value.utf8.count > byteLimit else { return value }
-
-        var result = ""
-        var used = 0
-        for character in value {
-            let width = String(character).utf8.count
-            if used + width > byteLimit { break }
-            result.append(character)
-            used += width
-        }
-        return result
     }
 }
 

--- a/whitenoise-mac/Core/MediaPlaybackTempStore.swift
+++ b/whitenoise-mac/Core/MediaPlaybackTempStore.swift
@@ -114,20 +114,21 @@ nonisolated enum MediaPlaybackTempStore {
     /// `uniqueID` makes each handoff/playback own an independent file. That prevents a
     /// delayed cleanup from an earlier open from deleting the file a later consumer is
     /// still reading. The path component contains only the stable attachment stem, UUID,
-    /// and an app-controlled canonical type suffix derived from `mediaType`; peer filenames
-    /// are never embedded because directory entries are not covered by
-    /// `.completeFileProtection`.
+    /// and an app-controlled canonical type suffix derived from `mediaType` (with
+    /// allowlisted extension inference for generic MIME types); peer basenames are never
+    /// embedded because directory entries are not covered by `.completeFileProtection`.
     static func materialize(
         data: Data,
         id: String,
         mediaType: String,
+        fileName: String? = nil,
         directory: URL,
         uniqueID: UUID = UUID(),
         fileManager: FileManager = .default
     ) throws -> URL {
         try MediaProtectedTempDirectory.prepareDirectory(directory, fileManager: fileManager)
         let stem = "\(stableStem(for: id))-\(uniqueID.uuidString)"
-        let suffix = OutgoingMediaAttachmentPolicy.fileExtension(for: mediaType)
+        let suffix = OutgoingMediaAttachmentPolicy.scratchFileExtension(for: mediaType, fileName: fileName)
         let url = directory.appendingPathComponent(stem).appendingPathExtension(suffix)
         try MediaProtectedTempDirectory.writeProtectedData(data, to: url, fileManager: fileManager)
         return url

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -657,8 +657,23 @@ nonisolated enum OutgoingMediaAttachmentPolicy {
         }
     }
 
-    static func mediaType(forFileExtension fileExtension: String) -> String? {
+    /// App-controlled extension-to-MIME mapping used for scratch suffix inference and as
+    /// the first lookup in `mediaType(forFileExtension:)`. Extensions outside this list
+    /// must not influence scratch paths even when UTType recognizes them.
+    private static func allowlistedMediaType(forFileExtension fileExtension: String) -> String? {
         switch fileExtension.lowercased() {
+        case "gif":
+            return "image/gif"
+        case "heic":
+            return "image/heic"
+        case "jpeg", "jpg":
+            return "image/jpeg"
+        case "png":
+            return "image/png"
+        case "webp":
+            return "image/webp"
+        case "aac":
+            return "audio/aac"
         case "m4a":
             return "audio/mp4"
         case "mp3":
@@ -692,8 +707,15 @@ nonisolated enum OutgoingMediaAttachmentPolicy {
         case "pptx":
             return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
         default:
-            return UTType(filenameExtension: fileExtension.lowercased())?.preferredMIMEType
+            return nil
         }
+    }
+
+    static func mediaType(forFileExtension fileExtension: String) -> String? {
+        if let allowlisted = allowlistedMediaType(forFileExtension: fileExtension) {
+            return allowlisted
+        }
+        return UTType(filenameExtension: fileExtension.lowercased())?.preferredMIMEType
     }
 
     static func fileExtension(for mediaType: String, fileName: String? = nil) -> String {
@@ -749,6 +771,24 @@ nonisolated enum OutgoingMediaAttachmentPolicy {
         default:
             return "bin"
         }
+    }
+
+    /// Canonical scratch-file suffix for decrypted media handoff.
+    ///
+    /// Peer `fileName` is consulted only when `mediaType` is empty or generic
+    /// (`application/octet-stream`). In that case an allowlisted extension maps to a known
+    /// media type and the returned suffix is always app-controlled; peer basename or
+    /// extension text is never copied into the path.
+    static func scratchFileExtension(for mediaType: String, fileName: String?) -> String {
+        let canonical = canonicalMediaType(mediaType)
+        if shouldInferKindFromFileName(canonicalMediaType: canonical),
+            let fileName,
+            let fileExtension = fileName.split(separator: ".").last.map(String.init),
+            let resolved = allowlistedMediaType(forFileExtension: fileExtension)
+        {
+            return Self.fileExtension(for: canonicalMediaType(resolved))
+        }
+        return fileExtension(for: canonical)
     }
 
     static func kind(mediaType: String, fileName: String? = nil) -> MessageMediaKind {

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1241,7 +1241,6 @@ enum MessageMediaPlaybackFileStore {
     /// the consuming action (open/playback) finishes.
     @MainActor
     static func fileURL(attachment: MessageMediaAttachment, download: MessageMediaDownload) async -> URL? {
-        let resolvedFileName = download.fileName.nilIfBlank ?? attachment.fileName
         let resolvedMediaType = download.mediaType.nilIfBlank ?? attachment.mediaType
         let attachmentID = attachment.id
         let data = download.payload.data
@@ -1252,11 +1251,7 @@ enum MessageMediaPlaybackFileStore {
                 return try MediaPlaybackTempStore.materialize(
                     data: data,
                     id: attachmentID,
-                    fileName: resolvedFileName,
-                    fallbackExtension: OutgoingMediaAttachmentPolicy.fileExtension(
-                        for: resolvedMediaType,
-                        fileName: resolvedFileName
-                    ),
+                    mediaType: resolvedMediaType,
                     directory: directory
                 )
             } catch {

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1241,6 +1241,7 @@ enum MessageMediaPlaybackFileStore {
     /// the consuming action (open/playback) finishes.
     @MainActor
     static func fileURL(attachment: MessageMediaAttachment, download: MessageMediaDownload) async -> URL? {
+        let resolvedFileName = download.fileName.nilIfBlank ?? attachment.fileName
         let resolvedMediaType = download.mediaType.nilIfBlank ?? attachment.mediaType
         let attachmentID = attachment.id
         let data = download.payload.data
@@ -1252,6 +1253,7 @@ enum MessageMediaPlaybackFileStore {
                     data: data,
                     id: attachmentID,
                     mediaType: resolvedMediaType,
+                    fileName: resolvedFileName,
                     directory: directory
                 )
             } catch {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2051,6 +2051,38 @@ struct whitenoise_macTests {
         #expect(try Data(contentsOf: url) == Data("secret".utf8))
     }
 
+    @Test func mediaPlaybackTempStoreUsesOnlyBoundedCanonicalPeerSuffixHints() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let attachmentID = "attachment-id"
+        let stem = MediaPlaybackTempStore.stableStem(for: attachmentID)
+        let cases: [(mediaType: String, fileName: String, suffix: String)] = [
+            ("application/octet-stream", "archive.pdf", "pdf"),
+            ("application/octet-stream", "clip.mp4", "mp4"),
+            ("", "clip.mp4", "mp4"),
+            ("application/octet-stream", "photo.jfif", "bin"),
+            ("application/octet-stream", "innocent.HIV-results", "bin"),
+            ("video/mp4", "report.pdf", "mp4"),
+        ]
+
+        for item in cases {
+            let uniqueID = UUID()
+            let url = try MediaPlaybackTempStore.materialize(
+                data: Data("secret".utf8),
+                id: attachmentID,
+                mediaType: item.mediaType,
+                fileName: item.fileName,
+                directory: directory,
+                uniqueID: uniqueID
+            )
+
+            #expect(url.lastPathComponent == "\(stem)-\(uniqueID.uuidString).\(item.suffix)")
+        }
+    }
+
     @Test func mediaPlaybackTempStoreUsesBinSuffixForUnknownMediaType() throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1969,15 +1969,14 @@ struct whitenoise_macTests {
         let url = try MediaPlaybackTempStore.materialize(
             data: Data("secret".utf8),
             id: "attachment-id/with:illegal",
-            fileName: "report.pdf",
-            fallbackExtension: "bin",
+            mediaType: "video/mp4",
             directory: directory,
             uniqueID: firstConsumer
         )
 
         #expect(fileManager.fileExists(atPath: url.path))
-        #expect(url.lastPathComponent.hasSuffix("-report.pdf"))
-        #expect(url.lastPathComponent.contains(firstConsumer.uuidString))
+        let stem = MediaPlaybackTempStore.stableStem(for: "attachment-id/with:illegal")
+        #expect(url.lastPathComponent == "\(stem)-\(firstConsumer.uuidString).mp4")
         #expect(url.deletingLastPathComponent().path == directory.path)
 
         // Re-materializing the same attachment for a later consumer must not reuse the
@@ -1985,8 +1984,7 @@ struct whitenoise_macTests {
         let again = try MediaPlaybackTempStore.materialize(
             data: Data("different".utf8),
             id: "attachment-id/with:illegal",
-            fileName: "report.pdf",
-            fallbackExtension: "bin",
+            mediaType: "video/mp4",
             directory: directory,
             uniqueID: secondConsumer
         )
@@ -2010,16 +2008,14 @@ struct whitenoise_macTests {
         let first = try MediaPlaybackTempStore.materialize(
             data: Data("first".utf8),
             id: firstID,
-            fileName: "report.pdf",
-            fallbackExtension: "bin",
+            mediaType: "application/pdf",
             directory: directory,
             uniqueID: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
         )
         let second = try MediaPlaybackTempStore.materialize(
             data: Data("second".utf8),
             id: secondID,
-            fileName: "report.pdf",
-            fallbackExtension: "bin",
+            mediaType: "application/pdf",
             directory: directory,
             uniqueID: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!
         )
@@ -2032,42 +2028,52 @@ struct whitenoise_macTests {
         #expect(try Data(contentsOf: second) == Data("second".utf8))
     }
 
-    @Test func mediaPlaybackTempStoreBoundsLongPeerFileName() throws {
+    @Test func mediaPlaybackTempStoreUsesCanonicalSuffixWithoutPeerFileName() throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
             .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
         defer { try? fileManager.removeItem(at: directory) }
 
-        // An attacker-controlled attachment name of ~500 characters would otherwise push the
-        // "<stem>-<uuid>-<sanitized>" path component past APFS' 255-byte limit and make the
-        // write throw, silently breaking the open/playback.
-        let longName = String(repeating: "a", count: 500) + ".mp4"
+        let attachmentID = "attachment-id"
+        let uniqueID = UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
+        let stem = MediaPlaybackTempStore.stableStem(for: attachmentID)
         let url = try MediaPlaybackTempStore.materialize(
             data: Data("secret".utf8),
-            id: "attachment-id",
-            fileName: longName,
-            fallbackExtension: "bin",
+            id: attachmentID,
+            mediaType: "application/pdf",
             directory: directory,
-            uniqueID: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!
+            uniqueID: uniqueID
         )
 
         #expect(fileManager.fileExists(atPath: url.path))
-        // The full scratch-file component stays comfortably below APFS' 255-byte limit.
-        #expect(url.lastPathComponent.utf8.count <= MediaPlaybackTempStore.maxScratchFileComponentBytes)
-        // The original extension survives truncation of the stem.
-        #expect(url.lastPathComponent.hasSuffix(".mp4"))
+        #expect(url.lastPathComponent == "\(stem)-\(uniqueID.uuidString).pdf")
+        #expect(url.pathExtension == "pdf")
         #expect(try Data(contentsOf: url) == Data("secret".utf8))
     }
 
-    @Test func mediaPlaybackTempStoreBoundsFileNameKeepsMultiByteExtension() throws {
-        // A multi-byte scalar must never be split when truncating to the byte budget.
-        let longStem = String(repeating: "é", count: 400)
-        let byteLimit = 128
-        let bounded = MediaPlaybackTempStore.boundedFileName("\(longStem).pdf", byteLimit: byteLimit)
-        let expectedStemCount = (byteLimit - ".pdf".utf8.count) / "é".utf8.count
+    @Test func mediaPlaybackTempStoreUsesBinSuffixForUnknownMediaType() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-playback-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
 
-        #expect(bounded.utf8.count <= byteLimit)
-        #expect(bounded == String(repeating: "é", count: expectedStemCount) + ".pdf")
+        let attachmentID = "attachment-id"
+        let uniqueID = UUID(uuidString: "00000000-0000-0000-0000-000000000006")!
+        let stem = MediaPlaybackTempStore.stableStem(for: attachmentID)
+        let adversarialMediaType = "application/HIV-results"
+        let url = try MediaPlaybackTempStore.materialize(
+            data: Data("secret".utf8),
+            id: attachmentID,
+            mediaType: adversarialMediaType,
+            directory: directory,
+            uniqueID: uniqueID
+        )
+
+        #expect(fileManager.fileExists(atPath: url.path))
+        #expect(url.lastPathComponent == "\(stem)-\(uniqueID.uuidString).bin")
+        #expect(url.pathExtension == "bin")
+        #expect(!url.path.contains("HIV-results"))
+        #expect(try Data(contentsOf: url) == Data("secret".utf8))
     }
 
     @Test func mediaPlaybackTempStoreExcludesScratchDirectoryFromBackups() throws {
@@ -2079,8 +2085,7 @@ struct whitenoise_macTests {
         _ = try MediaPlaybackTempStore.materialize(
             data: Data("secret".utf8),
             id: "attachment",
-            fileName: "report.pdf",
-            fallbackExtension: "bin",
+            mediaType: "application/pdf",
             directory: directory
         )
 
@@ -2097,8 +2102,7 @@ struct whitenoise_macTests {
         let url = try MediaPlaybackTempStore.materialize(
             data: Data("bytes".utf8),
             id: "video",
-            fileName: "clip.mp4",
-            fallbackExtension: "mp4",
+            mediaType: "video/mp4",
             directory: directory
         )
         #expect(fileManager.fileExists(atPath: url.path))
@@ -2120,15 +2124,13 @@ struct whitenoise_macTests {
         _ = try MediaPlaybackTempStore.materialize(
             data: Data("a".utf8),
             id: "one",
-            fileName: "a.txt",
-            fallbackExtension: "txt",
+            mediaType: "text/plain",
             directory: directory
         )
         _ = try MediaPlaybackTempStore.materialize(
             data: Data("b".utf8),
             id: "two",
-            fileName: "b.txt",
-            fallbackExtension: "txt",
+            mediaType: "text/plain",
             directory: directory
         )
         #expect(fileManager.fileExists(atPath: directory.path))


### PR DESCRIPTION
Fixes #513

## Summary
- stop passing peer filenames into playback scratch-path construction
- name files from the stable attachment stem, per-consumer UUID, and a fixed MIME-derived suffix
- map unknown/adversarial media types to `.bin` so raw peer text cannot reach directory entries
- remove obsolete peer-filename sanitization and truncation code

The fixed canonical suffix preserves `NSWorkspace`/`AVPlayer` type hints without exposing a peer-chosen basename or arbitrary extension.

## Verification
- `git diff --check` — passed
- static added-line secret/dangerous-code scan — passed (0 findings)
- independent pre-commit review — passed; no security or logic findings
- `scripts/ci/macos-sanity-checks.sh` — unavailable on this Linux host (`xcodebuild: command not found`)
- `xcrun swift-format lint --configuration .swift-format --recursive --parallel --strict whitenoise-mac whitenoise-macTests whitenoise-macUITests` — unavailable on this Linux host (`xcrun: command not found`)
- macOS unit/build/analyze checks — deferred to CI

## Sensitive paths
- `whitenoise-mac/Core/MediaPlaybackTempStore.swift` — decrypted playback scratch-path privacy
- `whitenoise-mac/Views/MessageMediaViews.swift` — attachment playback/open materialization call site
- `whitenoise-macTests/whitenoise_macTests.swift` — privacy regression coverage


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/584">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->