### PR TITLE
fix: preserve post-send timeline refresh ownership

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -18,12 +18,13 @@ private enum ComposerMediaUploadPresentation {
     static let uploadedAcknowledgementDelayNanoseconds: UInt64 = 300_000_000
 }
 
-/// Ownership token for subscription-originated or initial-load timeline window applies.
+/// Ownership token for subscription, initial-load, or post-send timeline window applies.
 /// Re-checked after every suspension in `applyTimelineWindow` so a superseded listener
-/// or load cannot overwrite a replacement for the same account/chat.
+/// or query cannot overwrite a replacement for the same account/chat.
 enum TimelineWindowOwner {
     case subscription(TimelineMessagesSubscription)
     case loadGeneration(UInt64)
+    case postSendRefresh(generation: UInt64, subscription: TimelineMessagesSubscription?)
 }
 
 @MainActor
@@ -295,7 +296,7 @@ extension WorkspaceState {
         groupIdHex: String,
         account: AccountItem,
         client: any MarmotRuntime,
-        owner: TimelineWindowOwner? = nil
+        owner: TimelineWindowOwner
     ) async {
         guard
             canApplyTimelineWindow(
@@ -378,10 +379,9 @@ extension WorkspaceState {
     private func canApplyTimelineWindow(
         groupIdHex: String,
         accountId: String,
-        owner: TimelineWindowOwner?
+        owner: TimelineWindowOwner
     ) -> Bool {
         guard activeAccountId == accountId, selectedChat?.id == groupIdHex else { return false }
-        guard let owner else { return true }
         switch owner {
         case .subscription(let expectedSubscription):
             guard activeTimelineGroupId == groupIdHex,
@@ -390,6 +390,15 @@ extension WorkspaceState {
         case .loadGeneration(let generation):
             guard ownsTimelineLoad(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
             else { return false }
+        case .postSendRefresh(let generation, let expectedSubscription):
+            guard timelinePostSendRefreshGeneration == generation else { return false }
+            if let expectedSubscription {
+                guard activeTimelineGroupId == groupIdHex,
+                    activeTimelineSubscription === expectedSubscription
+                else { return false }
+            } else {
+                guard activeTimelineSubscription == nil, activeTimelineGroupId == nil else { return false }
+            }
         }
         return true
     }
@@ -920,6 +929,7 @@ extension WorkspaceState {
         timelineTaskGroupId = nil
         activeTimelineSubscription = nil
         activeTimelineGroupId = nil
+        timelinePostSendRefreshGeneration &+= 1
     }
 
     func runTimelineListener(
@@ -1080,6 +1090,13 @@ extension WorkspaceState {
         client: any MarmotRuntime
     ) async {
         guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        timelinePostSendRefreshGeneration &+= 1
+        let refreshGeneration = timelinePostSendRefreshGeneration
+        let subscription = activeTimelineGroupId == groupIdHex ? activeTimelineSubscription : nil
+        let owner = TimelineWindowOwner.postSendRefresh(
+            generation: refreshGeneration,
+            subscription: subscription
+        )
         let pageLimit = Self.timelinePageLimit
         do {
             let page = try await runOffMain {
@@ -1096,9 +1113,17 @@ extension WorkspaceState {
                     )
                 )
             }
-            guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
-            await applyTimelineWindow(page, groupIdHex: groupIdHex, account: account, client: client)
+            await applyTimelineWindow(
+                page,
+                groupIdHex: groupIdHex,
+                account: account,
+                client: client,
+                owner: owner
+            )
         } catch {
+            guard
+                canApplyTimelineWindow(groupIdHex: groupIdHex, accountId: account.id, owner: owner)
+            else { return }
             setBackgroundStatus(error.localizedDescription)
         }
     }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -987,6 +987,9 @@ final class WorkspaceState {
     var timelineLoadGroupId: String?
     var timelineLoadAccountId: String?
     var timelineLoadGeneration: UInt64 = 0
+    /// Last-request-wins owner for point-in-time post-send timeline refreshes. A newer refresh or
+    /// listener teardown invalidates older windows before they can replace the selected transcript.
+    var timelinePostSendRefreshGeneration: UInt64 = 0
     /// The live timeline subscription for the open conversation. It owns the
     /// authoritative, bounded, materialized window; scroll-back/forward pagination and
     /// live updates all flow through it (`paginateBackwards` / `paginateForwards` / `next`).

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -9430,7 +9430,8 @@ struct whitenoise_macTests {
             replacementBack.snapshot() ?? emptyTimelinePage(),
             groupIdHex: "direct-group",
             account: activeAccount,
-            client: runtime
+            client: runtime,
+            owner: .subscription(replacementBack)
         )
         #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-back-005")
         #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-back-104")
@@ -9468,7 +9469,8 @@ struct whitenoise_macTests {
             scrolledBackWindow,
             groupIdHex: "direct-group",
             account: activeAccount,
-            client: runtime
+            client: runtime,
+            owner: .subscription(replacementFwd)
         )
         let scrolledBackFirst = try #require(state.messagesByChat["direct-group"]?.first?.id)
         #expect(state.selectedTimelinePaging.hasMoreAfter)
@@ -9510,7 +9512,8 @@ struct whitenoise_macTests {
             replacementForwardWindow,
             groupIdHex: "direct-group",
             account: activeAccount,
-            client: runtime
+            client: runtime,
+            owner: .subscription(replacementForward)
         )
         let replacementForwardFirst = state.messagesByChat["direct-group"]?.first?.id
         let replacementForwardLast = state.messagesByChat["direct-group"]?.last?.id
@@ -9602,7 +9605,8 @@ struct whitenoise_macTests {
             replacement.snapshot() ?? emptyTimelinePage(),
             groupIdHex: "direct-group",
             account: activeAccount,
-            client: runtime
+            client: runtime,
+            owner: .subscription(replacement)
         )
         #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-apply-005")
         #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-apply-104")
@@ -9702,7 +9706,8 @@ struct whitenoise_macTests {
             replacement.snapshot() ?? emptyTimelinePage(),
             groupIdHex: "direct-group",
             account: activeAccount,
-            client: runtime
+            client: runtime,
+            owner: .subscription(replacement)
         )
         #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-page-005")
         #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-page-104")
@@ -9713,6 +9718,108 @@ struct whitenoise_macTests {
         #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-page-005")
         #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-page-104")
         #expect(state.selectedTimelinePaging.hasMoreBefore)
+    }
+
+    @MainActor
+    @Test func stalePostSendRefreshDoesNotClobberReplacementSubscriptionWindow() async throws {
+        // Issue #572: a point-in-time post-send query must retain ownership through mapping.
+        // A replacement listener for the same account/chat can otherwise apply B, only for the
+        // older refresh A to resume and overwrite it because selection itself did not change.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "initial",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Initial",
+                    kind: 9,
+                    recordedAt: 1_700_000_000
+                )
+            ],
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        #expect(state.activeTimelineSubscription != nil)
+
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "stale-refresh",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Stale refresh",
+                    kind: 9,
+                    recordedAt: 1_700_000_001
+                )
+            ],
+            groupIdHex: "direct-group"
+        )
+        state.timelineApplyMapGateEnabled = true
+        async let staleRefresh: Void = state.refreshSelectedTimelineAfterSend(
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime
+        )
+        let didSuspendRefresh = await waitFor {
+            state.didReachTimelineApplyMapGate
+        }
+        guard didSuspendRefresh else {
+            state.timelineApplyMapGateEnabled = false
+            state.releaseTimelineApplyMapGate()
+            _ = await staleRefresh
+            Issue.record("Expected post-send refresh to reach the map gate")
+            return
+        }
+
+        let replacement = FakeTimelineMessagesSubscription(
+            messages: [
+                timelineMessage(
+                    id: "replacement",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Replacement",
+                    recordedAt: 1_700_000_002
+                )
+            ],
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacement
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacement.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime,
+            owner: .subscription(replacement)
+        )
+        #expect(state.messagesByChat["direct-group"]?.map(\.id) == ["replacement"])
+
+        state.releaseTimelineApplyMapGate()
+        _ = await staleRefresh
+
+        #expect(state.messagesByChat["direct-group"]?.map(\.id) == ["replacement"])
     }
 
     @MainActor
@@ -9888,7 +9995,8 @@ struct whitenoise_macTests {
             replacement.snapshot() ?? emptyTimelinePage(),
             groupIdHex: "direct-group",
             account: activeAccount,
-            client: runtime
+            client: runtime,
+            owner: .subscription(replacement)
         )
 
         staleSubscription.releasePaginationGate()


### PR DESCRIPTION
## Summary
- require every full-window timeline apply to carry an explicit owner
- capture a generation and active subscription for each post-send refresh
- reject stale refresh windows after a same-chat listener replacement or newer refresh
- add a deterministic A-to-B-to-A mapping suspension regression

## Test plan
- [x] git diff --check
- [x] all full-window apply callers provide an owner
- [x] all changed Swift files stay within the configured 120-column limit
- [x] macOS CI: format, project sanity, unit tests, release build, and static analysis

Fixes #572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed timeline refreshes after sending messages from overwriting newer conversation data.
  * Improved timeline update validation when listeners stop, restart, or are replaced.
  * Ensured stale refresh results cannot replace content loaded by a newer subscription.

* **Tests**
  * Added coverage for preventing outdated post-send refreshes from clobbering replacement timeline content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->