### PR TITLE
fix: stop offscreen audio playback

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1096,6 +1096,13 @@ struct MessageAudioAttachmentPlayer: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .attachmentRowChrome(isOutgoing: isOutgoing)
+        // Transcript rows are intentionally eager, so scrolling this tile out of the viewport
+        // does not trigger onDisappear. Stop playback here as well so the AVAudioPlayer and
+        // progress monitor do not keep running offscreen.
+        .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+            guard !isVisible else { return }
+            stopPlayback()
+        }
         .onDisappear {
             stopPlayback()
         }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6990,6 +6990,42 @@ struct whitenoise_macTests {
         #expect(normalizedSource.contains("MessageMediaPlaybackFileStore.remove(at:url)"))
     }
 
+    @Test func audioPlayerStopsWhenTileLeavesViewport() throws {
+        // MessageAudioAttachmentPlayer lives inside the deliberately eager transcript VStack,
+        // where scrolling a row away does not trigger onDisappear. Its scroll-visibility hook
+        // must stop playback and cancel the progress monitor through the same stopPlayback path.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+        let playerStart = try #require(source.range(of: "struct MessageAudioAttachmentPlayer: View {"))
+        let rest = source[playerStart.upperBound...]
+        let playerEnd = try #require(rest.range(of: "\nstruct MessageVideoAttachmentPlayer: View {")?.lowerBound)
+        let playerSource = String(source[playerStart.lowerBound..<playerEnd])
+
+        let normalizedSource = playerSource.components(separatedBy: .whitespacesAndNewlines).joined()
+
+        #expect(
+            normalizedSource.contains(
+                ".onScrollVisibilityChange(threshold:0.01){isVisibleinguard!isVisibleelse{return}stopPlayback()}"
+            )
+        )
+        #expect(
+            normalizedSource.contains(
+                "privatefuncstopPlayback(){playbackPreparationID=nil"
+            )
+        )
+        #expect(
+            normalizedSource.contains(
+                "privatefuncfinishPlayback(){playbackMonitor?.cancel()playbackMonitor=nil"
+            )
+        )
+    }
+
     @MainActor
     @Test func loadMediaAttachmentRetriesFromFailedState() async throws {
         let account = AccountSummaryFfi(


### PR DESCRIPTION
Fixes #505

## Summary
- Stop `MessageAudioAttachmentPlayer` through its existing teardown path when an eager transcript tile leaves the scroll viewport.
- Cancel playback preparation/progress monitoring and reset playback even though the non-lazy transcript keeps the row mounted.
- Add a source-contract regression test mirroring the existing video visibility lifecycle test.

The video half of the original issue is already fixed on current `master` by #536; this PR completes the remaining audio path without adding a global playback coordinator.

## Verification
- `git diff --check` — passed.
- Independent Python source-contract validation — 5/5 checks passed (visibility hook, preparation invalidation, monitor cancellation, `onDisappear` fallback, unchanged single video player definition).
- `xcodebuild`, `xcrun`, `swift`, `swift-format`, and `plutil` — unavailable on this Linux host. macOS CI will run formatting, unit tests, build, and static analysis.

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/597">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio playback now stops when an audio tile scrolls out of view, preventing playback from continuing offscreen.
  * Playback monitoring is properly canceled when audio finishes or stops.

* **Tests**
  * Added coverage to verify playback stops when audio tiles leave the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->