### PR TITLE
fix: reject superseded timeline projections

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -18,9 +18,9 @@ private enum ComposerMediaUploadPresentation {
     static let uploadedAcknowledgementDelayNanoseconds: UInt64 = 300_000_000
 }
 
-/// Ownership token for subscription, initial-load, or post-send timeline window applies.
-/// Re-checked after every suspension in `applyTimelineWindow` so a superseded listener
-/// or query cannot overwrite a replacement for the same account/chat.
+/// Ownership token for subscription, initial-load, or post-send timeline applies.
+/// Re-checked after every suspension in window and projection paths so a superseded
+/// listener or query cannot overwrite a replacement for the same account/chat.
 enum TimelineWindowOwner {
     case subscription(TimelineMessagesSubscription)
     case loadGeneration(UInt64)
@@ -383,9 +383,10 @@ extension WorkspaceState {
     private func canApplyTimelineWindow(
         groupIdHex: String,
         accountId: String,
-        owner: TimelineWindowOwner
+        owner: TimelineWindowOwner?
     ) -> Bool {
         guard activeAccountId == accountId, selectedChat?.id == groupIdHex else { return false }
+        guard let owner else { return true }
         switch owner {
         case .subscription(let expectedSubscription):
             guard activeTimelineGroupId == groupIdHex,
@@ -437,7 +438,8 @@ extension WorkspaceState {
                 runtimeUpdate.update,
                 groupIdHex: groupIdHex,
                 account: account,
-                client: client
+                client: client,
+                owner: .subscription(subscription)
             )
         }
     }
@@ -450,9 +452,16 @@ extension WorkspaceState {
         _ update: TimelineProjectionUpdateFfi,
         groupIdHex: String,
         account: AccountItem,
-        client: any MarmotRuntime
+        client: any MarmotRuntime,
+        owner: TimelineWindowOwner? = nil
     ) async {
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                owner: owner
+            )
+        else { return }
         guard update.groupIdHex == groupIdHex else { return }
 
         // Partition the delta into upserts (need mapping) and removals. An empty
@@ -488,7 +497,24 @@ extension WorkspaceState {
             )
         }
         let mentionNames = cachedMentionNames(groupIdHex: groupIdHex)
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                owner: owner
+            )
+        else { return }
+
+        #if DEBUG
+            await passTimelineApplyMapGateIfArmed()
+            guard
+                canApplyTimelineWindow(
+                    groupIdHex: groupIdHex,
+                    accountId: account.id,
+                    owner: owner
+                )
+            else { return }
+        #endif
         // Map only the changed records off the main actor (same pure transformation as the
         // window path), then re-check the selection guard after the await before mutating
         // the store (whitenoise-mac#285). Capture the plain `accountIdHex` before hopping
@@ -505,7 +531,13 @@ extension WorkspaceState {
                 mentionNames: mentionNames
             )
         }
-        guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                owner: owner
+            )
+        else { return }
 
         let paging = timelinePagingByChat[groupIdHex] ?? .empty
         // The window is "anchored" to the live head while there is no newer history to
@@ -530,6 +562,15 @@ extension WorkspaceState {
             guard !currentAttachments.isEmpty || !upsert.mediaAttachments.isEmpty else { return false }
             return currentAttachments != upsert.mediaAttachments
         }
+
+        guard
+            canApplyTimelineWindow(
+                groupIdHex: groupIdHex,
+                accountId: account.id,
+                owner: owner
+            )
+        else { return }
+
         if introducesMediaChange {
             clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: groupIdHex)
         }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1165,8 +1165,8 @@ final class WorkspaceState {
             )
         }
 
-        /// Issue #529 regression support: when armed, the first `applyTimelineWindow` map pass
-        /// suspends until `releaseTimelineApplyMapGate()` is invoked.
+        /// Timeline ownership regression support: when armed, the first window or projection
+        /// map pass suspends until `releaseTimelineApplyMapGate()` is invoked.
         var timelineApplyMapGateEnabled = false
         private(set) var didReachTimelineApplyMapGate = false
         private var timelineApplyMapGateContinuation: CheckedContinuation<Void, Never>?

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10291,6 +10291,130 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func staleTimelineLiveProjectionApplyDoesNotClobberReplacementSubscriptionWindow() async throws {
+        // Issue #571: live `.projection` applies must carry subscription ownership and re-check
+        // after suspension, matching `.page` (#557) and pagination (#529). A superseded listener's
+        // in-flight projection must not mutate a replacement subscription's authoritative window.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<105).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        let activeAccount = try #require(state.activeAccount)
+        let staleSubscription = try #require(state.activeTimelineSubscription as? FakeTimelineMessagesSubscription)
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "message-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "message-104")
+
+        let staleProjection = TimelineProjectionUpdateFfi(
+            groupIdHex: "direct-group",
+            messages: [],
+            changes: [
+                .upsert(
+                    trigger: .newMessage,
+                    message: timelineMessage(
+                        id: "message-104",
+                        groupIdHex: "direct-group",
+                        sender: aliceId,
+                        plaintext: "Stale projection regression",
+                        recordedAt: baseTime + 104
+                    ))
+            ],
+            chatListRow: nil,
+            chatListTrigger: .newLastMessage
+        )
+
+        state.timelineApplyMapGateEnabled = true
+        async let staleProjectionApply: Void = state.applyTimelineSubscriptionUpdate(
+            .projection(
+                update: RuntimeProjectionUpdateFfi(
+                    accountIdHex: account.accountIdHex,
+                    accountLabel: account.label,
+                    update: staleProjection
+                )),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime,
+            subscription: staleSubscription
+        )
+        let didSuspendApply = await waitFor {
+            state.didReachTimelineApplyMapGate
+        }
+        guard didSuspendApply else {
+            state.timelineApplyMapGateEnabled = false
+            state.releaseTimelineApplyMapGate()
+            _ = await staleProjectionApply
+            Issue.record("Expected live `.projection` apply to reach the map gate")
+            return
+        }
+
+        let replacementMessages = (0..<105).map { index in
+            timelineMessage(
+                id: String(format: "fresh-projection-%03d", index),
+                groupIdHex: "direct-group",
+                sender: aliceId,
+                plaintext: "Fresh projection \(index)",
+                recordedAt: baseTime + UInt64(index)
+            )
+        }
+        let replacement = FakeTimelineMessagesSubscription(
+            messages: replacementMessages,
+            limit: 100,
+            windowCap: 200
+        )
+        state.activeTimelineSubscription = replacement
+        state.activeTimelineGroupId = "direct-group"
+        await state.applyTimelineWindow(
+            replacement.snapshot() ?? emptyTimelinePage(),
+            groupIdHex: "direct-group",
+            account: activeAccount,
+            client: runtime,
+            owner: .subscription(replacement)
+        )
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-projection-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-projection-104")
+        #expect(state.messagesByChat["direct-group"]?.count == 100)
+
+        state.releaseTimelineApplyMapGate()
+        _ = await staleProjectionApply
+
+        #expect(state.messagesByChat["direct-group"]?.first?.id == "fresh-projection-005")
+        #expect(state.messagesByChat["direct-group"]?.last?.id == "fresh-projection-104")
+        #expect(state.messagesByChat["direct-group"]?.count == 100)
+        #expect(state.messagesByChat["direct-group"]?.contains { $0.id == "message-104" } == false)
+        #expect(state.selectedTimelinePaging.hasMoreBefore)
+    }
+
+    @MainActor
     @Test func staleTimelineInitialLoadApplyDoesNotClobberReplacementLoadWindow() async throws {
         // Issue #557: initial-load window applies must re-check load-generation ownership after
         // suspension, matching subscription pagination/live paths (#529). A superseded initial load


### PR DESCRIPTION
Fixes #571

## Summary
- carry the producing timeline subscription into incremental projection applies
- re-check timeline ownership after each suspension and before cache/store mutation
- add a deterministic same-chat listener replacement regression test using the existing timeline map gate

## Verification
- Mac CI `PR Checks` passed (Swift format lint, macOS sanity checks, full PR unit-test plan, arm64 release build)
- Mac CI `Static Analysis` passed
- `git diff --check origin/master...HEAD`
- signed commit verified with `git verify-commit HEAD`

## Sensitive paths
None. Client timeline projection/state only.
