### PR TITLE
fix: guard member-row last-admin self-demotion

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -645,6 +645,10 @@ extension WorkspaceState {
             let snapshot = groupDetailsSnapshot,
             !hasInFlightGroupDetailsMutation
         else { return }
+        if case .demote = action, member.isSelf {
+            await selfDemoteSelectedGroupAdmin()
+            return
+        }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex
         let generation = beginGroupDetailsMutation()
@@ -662,18 +666,11 @@ extension WorkspaceState {
                     memberRef: member.npub
                 )
             case .demote:
-                if member.isSelf {
-                    result = try await client.selfDemoteAdminDetailed(
-                        accountRef: activeAccount.accountRef,
-                        groupIdHex: groupIdHex
-                    )
-                } else {
-                    result = try await client.demoteAdminDetailed(
-                        accountRef: activeAccount.accountRef,
-                        groupIdHex: groupIdHex,
-                        memberRef: member.npub
-                    )
-                }
+                result = try await client.demoteAdminDetailed(
+                    accountRef: activeAccount.accountRef,
+                    groupIdHex: groupIdHex,
+                    memberRef: member.npub
+                )
             case .remove:
                 result = try await client.removeMembersDetailed(
                     accountRef: activeAccount.accountRef,

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13574,6 +13574,43 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func groupMemberRowSelfDemoteRejectsLastAdminDespiteActionFlagDrift() async throws {
+        // Issue #518: the member-row action is FFI-driven. Even if that flag drifts and exposes
+        // self-demote for the last admin, the client must preserve the same guard as Step Down.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(
+            groupDetailsFixture(selfAccountIdHex: account.accountIdHex),
+            managementState: GroupManagementStateFfi(
+                myAccountIdHex: account.accountIdHex,
+                isSelfAdmin: true,
+                isLastAdmin: true,
+                canInvite: true,
+                canLeave: false,
+                requiresSelfDemoteBeforeLeave: true,
+                memberActions: [
+                    GroupMemberActionStateFfi(
+                        memberIdHex: account.accountIdHex,
+                        isSelf: true,
+                        isAdmin: true,
+                        canRemove: false,
+                        canPromote: false,
+                        canDemote: true
+                    )
+                ]
+            ))
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let selfMember = try #require(state.groupDetailsSnapshot?.members.first(where: \.isSelf))
+        #expect(selfMember.canDemote)
+
+        await state.demoteGroupMember(selfMember)
+
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+        #expect(state.lastError == L10n.string("Make another member an admin before stepping down."))
+        #expect(state.mutatingGroupMemberId == nil)
+    }
+
+    @MainActor
     @Test func groupDetailsArchiveAndLeaveRefreshChatList() async throws {
         let account = desktopAccount()
         let archiveRuntime = FakeMarmotRuntime(accounts: [account])


### PR DESCRIPTION
## Summary
- route member-row self-demotion through the existing guarded step-down path
- prevent stale member-action flags from bypassing the last-admin client check
- add a regression for an FFI action flag that incorrectly allows the last admin to self-demote

## Verification
- git diff --check
- static routing/regression contract verifier passed
- macOS unit tests not run locally: xcodebuild, xcrun, Swift, and swift-format are unavailable on this Linux worker

Fixes #518

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/599">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->