### PR TITLE
fix: scope visible-chat notification suppression to account

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -45,7 +45,10 @@ extension WorkspaceState {
 
         guard settings.localNotificationsEnabled else { return }
 
-        if selectedChat?.id == update.groupIdHex, selectedConversationIsVisible() {
+        if activeAccount?.accountIdHex == update.accountIdHex,
+            selectedChat?.id == update.groupIdHex,
+            selectedConversationIsVisible()
+        {
             return
         }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -18378,6 +18378,78 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func activeVisibleChatDoesNotSuppressNotificationForOtherLocalAccountInSameGroup() async throws {
+        // Issue #591: the client-wide notification listener serves every local account.
+        // Suppression must require the update to target the active account; viewing the
+        // same MLS group as account A must not drop a notification addressed to account B.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+        let accountA = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let sharedGroup = directGroup()
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.installNotificationSettings(
+            accountRef: accountA.label,
+            settings: notificationSettings(for: accountA, localEnabled: true)
+        )
+        runtime.installNotificationSettings(
+            accountRef: accountB.label,
+            settings: notificationSettings(for: accountB, localEnabled: true)
+        )
+        UserDefaults.standard.set(accountA.label, forKey: WorkspaceState.activeAccountKey)
+        runtime.installDirectGroup(
+            sharedGroup,
+            selfAccountIdHex: accountA.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == accountA.label)
+        #expect(state.selection == .chat(sharedGroup.groupIdHex))
+
+        await state.handleNotificationUpdate(
+            notificationUpdate(
+                account: accountB,
+                notificationKey: "notice-for-b",
+                groupIdHex: sharedGroup.groupIdHex,
+                senderName: "Alice",
+                previewText: "For account B only."
+            ))
+
+        #expect(notificationCenter.postedRequests.map(\.identifier) == ["notice-for-b"])
+    }
+
+    @MainActor
     @Test func activeSelectedChatNotificationPostsLocalAlertWhenConversationWindowIsHidden() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
Fixes #591

## Summary
- Require the incoming notification account to match the currently active account before suppressing alerts for a visible selected chat.
- Add a regression test for two local identities sharing the same MLS group, proving an update for the non-active identity still posts.
- Preserve existing same-account visible-chat suppression.

## Verification
- `git diff --check`
- Focused source-contract assertions: 5/5 passed
- Xcode build and unit tests unavailable on this Linux host; Mac CI must run the Swift format, unit-test, release-build, and static-analysis gates.

## Sensitive paths
None. Notification presentation and tests only; no crypto, MLS, CGKA, key handling, trust anchors, authentication, or account lifecycle code changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/601">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->