### PR TITLE
fix: decouple media reads from staging sweep lock

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -392,6 +392,12 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         func entryDirectory(for key: MessageMediaDiskCacheKey) -> URL? {
             try? Self.entryDirectory(for: key, root: directoryResolver())
         }
+
+        func testingWithFileMutationLock(_ operation: () -> Void) {
+            fileMutationLock.lock()
+            defer { fileMutationLock.unlock() }
+            operation()
+        }
     #endif
 
     private func waitForActivePurge(affecting accountDigest: String? = nil) async {
@@ -430,6 +436,13 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     }
 
     private func sweepStaleStagingDirectoriesIfNeeded(root: URL) {
+        lock.lock()
+        if didSweepStagingDirectories {
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+
         fileMutationLock.lock()
         defer { fileMutationLock.unlock() }
 

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -214,6 +214,9 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private var purgeSequence = 0
     private var purgeTasks: [Int: ActivePurge] = [:]
     private var didSweepStagingDirectories = false
+    #if DEBUG
+        private var testingBeforeRemoveStaleStagingDirectories: (@Sendable () -> Void)?
+    #endif
     // Updated under `fileMutationLock` on commit and eviction. Tracks committed entries only;
     // live staging bytes are sampled separately when enforcing the byte cap.
     // Invalidated when read-path deletions or account purges remove an unknown subset.
@@ -398,6 +401,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             defer { fileMutationLock.unlock() }
             operation()
         }
+
+        func testingSetBeforeStagingSweepHook(_ hook: @escaping @Sendable () -> Void) {
+            testingBeforeRemoveStaleStagingDirectories = hook
+        }
     #endif
 
     private func waitForActivePurge(affecting accountDigest: String? = nil) async {
@@ -451,11 +458,17 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             lock.unlock()
             return
         }
-        didSweepStagingDirectories = true
         let cutoff = sessionStartedAtUnixSeconds
         lock.unlock()
 
+        #if DEBUG
+            testingBeforeRemoveStaleStagingDirectories?()
+        #endif
         Self.removeStaleStagingDirectories(root: root, olderThanUnixSeconds: cutoff)
+
+        lock.lock()
+        didSweepStagingDirectories = true
+        lock.unlock()
     }
 
     private func beginPurge(scope: PurgeScope, _ work: @escaping @Sendable () -> Void) -> PurgeHandle {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3329,6 +3329,105 @@ struct whitenoise_macTests {
         #expect(fileManager.fileExists(atPath: inSessionStagingDirectory.path))
     }
 
+    @Test func messageMediaDiskCacheConcurrentStoreWaitsForInitialStagingSweep() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let stagingRoot = root.appendingPathComponent("staging", isDirectory: true)
+        let staleStagingDirectory = stagingRoot.appendingPathComponent("crash-orphan", isDirectory: true)
+        try fileManager.createDirectory(at: staleStagingDirectory, withIntermediateDirectories: true)
+        try Data("orphaned encrypted payload".utf8).write(
+            to: staleStagingDirectory.appendingPathComponent("payload.bin")
+        )
+        try fileManager.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: staleStagingDirectory.path
+        )
+
+        let sweepGate = BlockingFfiGate()
+        sweepGate.isEnabled = true
+        let directoryResolutionCount = AtomicCounter()
+        let secondStoreResolvedDirectory = DispatchSemaphore(value: 0)
+        let keyProviderEntered = DispatchSemaphore(value: 0)
+        let keyProviderGate = OneShotKeyProviderGate()
+        let cache = MessageMediaDiskCache(
+            directoryResolver: {
+                if directoryResolutionCount.increment() == 2 {
+                    secondStoreResolvedDirectory.signal()
+                }
+                return root
+            },
+            keyProvider: {
+                keyProviderEntered.signal()
+                return try keyProviderGate.symmetricKey()
+            },
+            keyDeleter: {},
+            sessionStartedAtUnixSeconds: 1_000
+        )
+        cache.testingSetBeforeStagingSweepHook { sweepGate.passIfArmed() }
+        let firstPlaintext = Data("first store blocked behind initial staging sweep".utf8)
+        let secondPlaintext = Data("second store must wait for staging sweep".utf8)
+        let firstKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: firstPlaintext, ciphertextByte: 0xa1)
+        )
+        let secondKey = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: secondPlaintext, ciphertextByte: 0xa2)
+        )
+
+        let firstStore = Task {
+            await cache.store(
+                MessageMediaDownload(
+                    data: firstPlaintext,
+                    fileName: "first.jpg",
+                    mediaType: "image/jpeg",
+                    sizeBytes: UInt64(firstPlaintext.count),
+                    payloadId: "first"
+                ),
+                for: firstKey
+            )
+        }
+        while !sweepGate.didReach {
+            await Task.yield()
+        }
+
+        let secondStore = Task {
+            await cache.store(
+                MessageMediaDownload(
+                    data: secondPlaintext,
+                    fileName: "second.jpg",
+                    mediaType: "image/jpeg",
+                    sizeBytes: UInt64(secondPlaintext.count),
+                    payloadId: "second"
+                ),
+                for: secondKey
+            )
+        }
+        #expect(
+            await waitForSemaphore(
+                secondStoreResolvedDirectory,
+                timeout: .now() + .seconds(1)
+            ) == .success
+        )
+        #expect(
+            await waitForSemaphore(keyProviderEntered, timeout: .now() + .milliseconds(200)) == .timedOut
+        )
+
+        sweepGate.release()
+        keyProviderGate.releaseGate()
+        await firstStore.value
+        await secondStore.value
+
+        #expect(try #require(await cache.cachedDownload(for: firstKey)).data == firstPlaintext)
+        #expect(try #require(await cache.cachedDownload(for: secondKey)).data == secondPlaintext)
+        #expect(!fileManager.fileExists(atPath: staleStagingDirectory.path))
+    }
+
     @Test func messageMediaDiskCachePostSweepReadDoesNotWaitForFileMutationLock() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3329,6 +3329,54 @@ struct whitenoise_macTests {
         #expect(fileManager.fileExists(atPath: inSessionStagingDirectory.path))
     }
 
+    @Test func messageMediaDiskCachePostSweepReadDoesNotWaitForFileMutationLock() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let cache = messageMediaDiskCache(root: root)
+        let plaintext = Data("cached read should not block on file mutation lock".utf8)
+        let reference = mediaDiskCacheReference(plaintext: plaintext)
+        let key = MessageMediaDiskCacheKey(accountId: "account-a", groupIdHex: "group-a", reference: reference)
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "read.png",
+            mediaType: "image/png",
+            sizeBytes: UInt64(plaintext.count),
+            payloadId: "read-lock-test"
+        )
+
+        await cache.store(download, for: key)
+        _ = try #require(await cache.cachedDownload(for: key))
+
+        let lockHeld = DispatchSemaphore(value: 0)
+        let releaseLock = DispatchSemaphore(value: 0)
+        let holderTask = Task.detached {
+            cache.testingWithFileMutationLock {
+                lockHeld.signal()
+                _ = releaseLock.wait(timeout: .now() + 5)
+            }
+        }
+        #expect(await waitForSemaphore(lockHeld, timeout: .now() + 2) == .success)
+
+        let readCompleted = DispatchSemaphore(value: 0)
+        let readTask = Task {
+            let restored = await cache.cachedDownload(for: key)
+            readCompleted.signal()
+            return restored
+        }
+        let readCompletedWhileLockHeld = await waitForSemaphore(readCompleted, timeout: .now() + 2)
+
+        // Release the lock even when the bounded wait fails so the task can finish cleanly.
+        releaseLock.signal()
+        await holderTask.value
+        let restored = try #require(await readTask.value)
+
+        #expect(readCompletedWhileLockHeld == .success)
+        #expect(restored.data == plaintext)
+    }
+
     @Test func messageMediaDiskCacheUnrelatedAccountPurgeDoesNotCancelInFlightStore() async throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory


### PR DESCRIPTION
Fixes #589

Supersedes #603. Its first address-review CI run was red because a DEBUG-only hook used unsupported conditional-compilation syntax inside an initializer parameter list. This replacement starts from the corrected signed head so the ever-red draft cannot be merged.

## Summary
- Short-circuit the one-time stale-staging sweep after it has completed, keeping normal media-cache reads off `fileMutationLock`.
- Publish `didSweepStagingDirectories` only after cleanup returns while `fileMutationLock` remains held, so concurrent stores cannot mutate `staging/` during the initial sweep.
- Add deterministic regressions for both the concurrent first-sweep/store interleaving and the post-sweep nonblocking read path.

## Verification
- Corrected head on #603: Mac PR Checks passed (Swift format, project sanity, full unit-test plan, arm64 release build).
- Corrected head on #603: Static Analysis passed.
- `git diff --check origin/master...HEAD`: passed.
- Both commits are signed and attributed to `agent-p1p`.
- Adversarial review's blocking sweep-publication race is addressed at the corrected head.

## Sensitive paths
None. Media disk-cache synchronization and tests only.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/605">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->