### PR TITLE
perf: avoid re-sorting transcript export

### DIFF
--- a/whitenoise-mac/Core/ConversationTranscriptExport.swift
+++ b/whitenoise-mac/Core/ConversationTranscriptExport.swift
@@ -134,11 +134,10 @@ nonisolated enum ConversationTranscriptExport {
     static func makeDocument(
         groupIdHex: String,
         groupName: String,
-        messages: [TimelineMessageRecordFfi],
+        chronologicallySortedMessages messages: [TimelineMessageRecordFfi],
         exportedAt: Date = Date()
     ) -> Document {
-        let ordered = sortChronologically(messages)
-        let events = ordered.enumerated().map { index, record in
+        let events = messages.enumerated().map { index, record in
             Event(
                 index: index,
                 messageIdHex: record.messageIdHex,

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -126,7 +126,7 @@ extension WorkspaceState {
                 let document = ConversationTranscriptExport.makeDocument(
                     groupIdHex: groupIdHex,
                     groupName: groupName,
-                    messages: messages
+                    chronologicallySortedMessages: messages
                 )
                 return (try ConversationTranscriptExport.encodeJSONString(document), document.eventCount)
             }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -12025,16 +12025,6 @@ struct whitenoise_macTests {
         let secondId = String(repeating: "2", count: 64)
         let records = [
             timelineMessage(
-                id: secondId,
-                groupIdHex: "group",
-                sender: String(repeating: "a", count: 64),
-                plaintext: "final answer",
-                kind: 9,
-                tags: [MessageTagFfi(values: ["stream", "abcd"])],
-                recordedAt: 2,
-                agentTextStreamJson: #"{"status":"finalized"}"#
-            ),
-            timelineMessage(
                 id: firstId,
                 groupIdHex: "group",
                 sender: String(repeating: "b", count: 64),
@@ -12044,12 +12034,22 @@ struct whitenoise_macTests {
                 recordedAt: 1,
                 agentTextStreamJson: #"{"status":"started"}"#
             ),
+            timelineMessage(
+                id: secondId,
+                groupIdHex: "group",
+                sender: String(repeating: "a", count: 64),
+                plaintext: "final answer",
+                kind: 9,
+                tags: [MessageTagFfi(values: ["stream", "abcd"])],
+                recordedAt: 2,
+                agentTextStreamJson: #"{"status":"finalized"}"#
+            ),
         ]
 
         let document = ConversationTranscriptExport.makeDocument(
             groupIdHex: "group",
             groupName: "Hermes 2",
-            messages: records,
+            chronologicallySortedMessages: records,
             exportedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
 


### PR DESCRIPTION
## Summary
- build transcript documents directly from the chronological output of `fetchAllMessages`
- make the caller-ordering contract explicit in the `makeDocument` argument label
- align the encoding fixture with the production ordering contract

## Test plan
- [x] structural regression check confirms `makeDocument` no longer calls `sortChronologically`
- [x] `git diff --check`
- [ ] macOS CI (`xcodebuild` is unavailable on this Linux worker)

Fixes #516

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/606">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->