### PR TITLE
fix: make image gallery keyboard accessible

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1473,6 +1473,7 @@ struct MessageImageGalleryOverlay: View {
         GeometryReader { geometry in
             ZStack {
                 Color.black.opacity(0.92)
+                    .onTapGesture(perform: onClose)
 
                 imageContent
                     .frame(
@@ -1504,6 +1505,7 @@ struct MessageImageGalleryOverlay: View {
                         .buttonStyle(.plain)
                         .foregroundStyle(.white)
                         .help("Close")
+                        .accessibilityLabel("Close")
                     }
                     .padding(.horizontal, 22)
                     .padding(.top, 18)
@@ -1513,23 +1515,31 @@ struct MessageImageGalleryOverlay: View {
 
                 if canNavigate {
                     HStack {
-                        navigationButton(systemName: "chevron.left", isEnabled: selectedIndex > 0) {
+                        navigationButton(
+                            systemName: "chevron.left",
+                            accessibilityLabel: "Previous image",
+                            isEnabled: selectedIndex > 0
+                        ) {
                             selectedIndex = max(0, selectedIndex - 1)
                         }
+                        .keyboardShortcut(.leftArrow, modifiers: [])
 
                         Spacer()
 
                         navigationButton(
                             systemName: "chevron.right",
+                            accessibilityLabel: "Next image",
                             isEnabled: selectedIndex < presentation.imageAttachments.count - 1
                         ) {
                             selectedIndex = min(presentation.imageAttachments.count - 1, selectedIndex + 1)
                         }
+                        .keyboardShortcut(.rightArrow, modifiers: [])
                     }
                     .padding(.horizontal, 22)
                 }
             }
         }
+        .onExitCommand(perform: onClose)
     }
 
     @ViewBuilder
@@ -1543,6 +1553,7 @@ struct MessageImageGalleryOverlay: View {
 
     private func navigationButton(
         systemName: String,
+        accessibilityLabel: String,
         isEnabled: Bool,
         action: @escaping () -> Void
     ) -> some View {
@@ -1555,7 +1566,8 @@ struct MessageImageGalleryOverlay: View {
         .buttonStyle(.plain)
         .foregroundStyle(.white.opacity(isEnabled ? 0.96 : 0.28))
         .disabled(!isEnabled)
-        .help(systemName == "chevron.left" ? "Previous image" : "Next image")
+        .help(accessibilityLabel)
+        .accessibilityLabel(accessibilityLabel)
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6924,6 +6924,34 @@ struct whitenoise_macTests {
         #expect(tileSource.contains("Task { await workspace.loadMediaAttachment(attachment, for: message) }"))
     }
 
+    @Test func imageGalleryProvidesDismissalNavigationAndAccessibilityAffordances() throws {
+        // MessageImageGalleryOverlay is SwiftUI event wiring, so guard its source contract:
+        // pointer and keyboard users can dismiss it, keyboard users can page through images,
+        // and VoiceOver receives explicit labels for every icon-only control.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+        let overlayStart = try #require(source.range(of: "struct MessageImageGalleryOverlay: View {"))
+        let rest = source[overlayStart.upperBound...]
+        let overlayEnd = try #require(rest.range(of: "\nstruct MessageImageGalleryContent: View {")?.lowerBound)
+        let overlaySource = String(source[overlayStart.lowerBound..<overlayEnd])
+        let normalizedSource = overlaySource.components(separatedBy: .whitespacesAndNewlines).joined()
+
+        #expect(normalizedSource.contains(".onTapGesture(perform:onClose)"))
+        #expect(normalizedSource.contains(".onExitCommand(perform:onClose)"))
+        #expect(normalizedSource.contains(".keyboardShortcut(.leftArrow,modifiers:[])"))
+        #expect(normalizedSource.contains(".keyboardShortcut(.rightArrow,modifiers:[])"))
+        #expect(normalizedSource.contains(".accessibilityLabel(\"Close\")"))
+        #expect(normalizedSource.contains(".accessibilityLabel(accessibilityLabel)"))
+        #expect(overlaySource.contains("accessibilityLabel: \"Previous image\""))
+        #expect(overlaySource.contains("accessibilityLabel: \"Next image\""))
+    }
+
     @Test func automaticMediaDownloadCancelsWhenTileLeavesViewport() throws {
         // AutomaticMediaDownloadModifier is SwiftUI lifecycle wiring, so exercise its source
         // contract directly: the task must be retained and cancelled both on scroll-out and


### PR DESCRIPTION
## Summary
- dismiss the image gallery with Escape or a backdrop click
- add left/right arrow-key navigation
- label the close and navigation controls for VoiceOver
- guard the SwiftUI event-wiring contract with a regression test

## Test plan
- [x] source-contract verification for dismissal, navigation, and accessibility wiring
- [x] git diff --check
- [ ] macOS CI (xcodebuild is unavailable on this Linux worker)

Fixes #594

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/607">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->