### PR TITLE
fix: preserve privacy settings on runtime failure

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -462,8 +462,16 @@ extension WorkspaceState {
         guard !isSavingPrivacySecurity else { return }
         let generation = privacySecuritySettingsGeneration
 
+        // Runtime configuration is best-effort for this read: a transient failure must not
+        // hide the persisted telemetry and audit settings from the user.
+        var observabilityConfigurationError: Error?
         do {
             try await configureObservabilityRuntime()
+        } catch {
+            observabilityConfigurationError = error
+        }
+
+        do {
             let (telemetry, auditLog) = try await runOffMain {
                 (
                     try client.relayTelemetrySettings(),
@@ -481,6 +489,9 @@ extension WorkspaceState {
                 telemetryCredentialsAvailable: config.telemetryCredentialsAvailable,
                 auditLogCredentialsAvailable: config.auditLogCredentialsAvailable
             )
+            if let observabilityConfigurationError {
+                lastError = observabilityConfigurationError.localizedDescription
+            }
             await loadAuditLogFiles()
         } catch {
             guard privacySecuritySettingsGeneration == generation else { return }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -17798,6 +17798,48 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func privacySecuritySettingsLoadSurvivesObservabilityConfigurationFailure() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        var buildConfig = telemetryBuildConfig(environment: "production")
+        let state = WorkspaceState(
+            telemetryBuildConfigProvider: { buildConfig },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(!state.privacySecuritySettings.relayTelemetryEnabled)
+        #expect(!state.privacySecuritySettings.auditLoggingEnabled)
+        #expect(state.auditLogFiles.isEmpty)
+
+        runtime.storedRelayTelemetrySettings = RelayTelemetrySettingsFfi(
+            exportEnabled: true,
+            exportIntervalSeconds: 120
+        )
+        runtime.storedAuditLogSettings = AuditLogSettingsFfi(enabled: true, dataMode: .fullData)
+        runtime.storedAuditLogFiles = [
+            AuditLogFileFfi(
+                accountRef: account.label,
+                path: "/tmp/audit-1.jsonl",
+                fileName: "audit-1.jsonl",
+                sizeBytes: 512,
+                modifiedAtMs: 1_800_000_000_000
+            )
+        ]
+        buildConfig = telemetryBuildConfig(environment: "staging")
+        runtime.telemetryInstallIdError = FakeMarmotRuntimeError.observabilityConfigurationFailed
+
+        await state.loadPrivacySecuritySettings()
+
+        #expect(state.privacySecuritySettings.relayTelemetryEnabled)
+        #expect(state.privacySecuritySettings.relayTelemetryIntervalSeconds == 120)
+        #expect(state.privacySecuritySettings.auditLoggingEnabled)
+        #expect(state.privacySecuritySettings.auditFullDataLogging)
+        #expect(state.auditLogFiles.map(\.path) == ["/tmp/audit-1.jsonl"])
+        #expect(state.lastError == "Observability configuration failed.")
+    }
+
+    @MainActor
     @Test func privacySecuritySettingsLoadDoesNotOverwriteNewerTelemetrySave() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -19962,6 +20004,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var relayTelemetryRuntimeConfig: RelayTelemetryRuntimeConfigFfi?
     private(set) var relayTelemetryRuntimeConfigSetCallCount = 0
     private(set) var telemetryInstallIdCallCount = 0
+    var telemetryInstallIdError: Error?
     private(set) var removedAccountRefs: [String] = []
     private(set) var didDeleteAllLocalData = false
     var deleteAllLocalDataError: Error?
@@ -20405,6 +20448,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func telemetryInstallId() throws -> String {
         telemetryInstallIdCallCount += 1
         recordSyncCall("telemetryInstallId")
+        if let telemetryInstallIdError {
+            throw telemetryInstallIdError
+        }
         return "test-install-id"
     }
 
@@ -21165,6 +21211,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 private enum FakeMarmotRuntimeError: Error, LocalizedError {
     case missingCreatedAccount
     case auditLogDeleteFailed
+    case observabilityConfigurationFailed
     case unused
 
     var errorDescription: String? {
@@ -21173,6 +21220,8 @@ private enum FakeMarmotRuntimeError: Error, LocalizedError {
             return "Missing created account."
         case .auditLogDeleteFailed:
             return "Audit log delete failed."
+        case .observabilityConfigurationFailed:
+            return "Observability configuration failed."
         case .unused:
             return "Unused fake runtime error."
         }


### PR DESCRIPTION
## Summary
- Treat observability runtime configuration as best-effort during privacy/security reads.
- Continue loading persisted telemetry settings, audit settings, and audit files after a transient configuration failure.
- Surface the configuration error without replacing stored UI state with defaults.

## Test plan
- Added a regression test covering a telemetry install-ID failure after persisted settings change.
- git diff --check passes.
- macOS unit/build checks require Xcode and will run in CI; this Linux worker has no Xcode toolchain.

Fixes #514

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/608">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->