### PR TITLE
fix: serialize full data wipe with account mutations

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -486,7 +486,7 @@ extension WorkspaceState {
     }
 
     func deleteAllData() async {
-        guard let client, !isDeletingAllData else { return }
+        guard let client, !isAccountMutationInProgress else { return }
 
         isDeletingAllData = true
         lastError = nil

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -816,8 +816,10 @@ final class WorkspaceState {
     var isSavingProfile = false
     var isRemovingAccount = false
     var isSigningOutAccount = false
-    /// True while any account remove, sign-out, or sign-in mutation is in flight.
-    var isAccountMutationInProgress: Bool { isRemovingAccount || isSigningOutAccount }
+    /// True while an account remove, sign-out, sign-in, or full local-data wipe is in flight.
+    var isAccountMutationInProgress: Bool {
+        isRemovingAccount || isSigningOutAccount || isDeletingAllData
+    }
     /// Per-account unread totals keyed by `accountIdHex`, for switcher avatar badges.
     var accountUnreadByIdHex: [String: Int] = [:]
     var isSavingRelays = false

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -1168,7 +1168,7 @@ struct PrivacySecuritySettingsView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.red)
-                .disabled(workspace.isDeletingAllData)
+                .disabled(workspace.isAccountMutationInProgress)
 
                 Text("Reset White Noise to a newly installed state on this Mac.")
                     .foregroundStyle(.secondary)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1221,6 +1221,97 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func deletingAllDataBlocksAccountMutationsMidFlight() async throws {
+        // Regression for whitenoise-mac#590: a full wipe and every account mutation must
+        // share one mutual-exclusion guard.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let signedOut = AccountSummaryFfi(
+            label: "Signed Out Account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary, signedOut])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let desktopAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        let signedOutAccount = try #require(state.accounts.first { $0.id == "Signed Out Account" })
+
+        runtime.onDeleteAllLocalDataMidFlight = {
+            await state.removeAccount(backupAccount)
+            await state.signOutAccount(desktopAccount)
+            await state.signInAccount(signedOutAccount)
+        }
+
+        await state.deleteAllData()
+
+        #expect(runtime.didDeleteAllLocalData)
+        #expect(runtime.removedAccountRefs.isEmpty)
+        #expect(runtime.signOutCallCount == 0)
+        #expect(runtime.signInAccountCallCount == 0)
+        #expect(state.phase == .onboarding)
+    }
+
+    @MainActor
+    @Test func signingOutAccountBlocksDeleteAllDataMidFlight() async throws {
+        // Regression for whitenoise-mac#590: mutual exclusion must also prevent a wipe
+        // from starting after an account mutation has entered its first await.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let desktopAccount = try #require(state.accounts.first { $0.id == "Desktop Account" })
+
+        runtime.onSignOutAccountMidFlight = { _ in
+            await state.deleteAllData()
+        }
+
+        await state.signOutAccount(desktopAccount)
+
+        #expect(runtime.signOutCallCount == 1)
+        #expect(!runtime.didDeleteAllLocalData)
+        #expect(state.accounts.first { $0.id == "Desktop Account" }?.signedOut == true)
+        #expect(state.phase == .ready)
+    }
+
+    @MainActor
     @Test func deleteAllDataResetsToNewInstallState() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",
@@ -19965,6 +20056,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var removedAccountRefs: [String] = []
     private(set) var didDeleteAllLocalData = false
     var deleteAllLocalDataError: Error?
+    /// Optional hook fired after `deleteAllLocalData` starts but before storage is cleared,
+    /// used to simulate a racing account mutation while a full wipe is in flight.
+    var onDeleteAllLocalDataMidFlight: (@Sendable () async -> Void)?
     /// Optional hook fired inside `removeAccount` after the ref is recorded but before the
     /// account is actually dropped, used to simulate a racing UI action (e.g. the user
     /// selecting the account currently being removed) mid-await.
@@ -20410,6 +20504,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func deleteAllLocalData() async throws {
         didDeleteAllLocalData = true
+        await onDeleteAllLocalDataMidFlight?()
         if let deleteAllLocalDataError {
             throw deleteAllLocalDataError
         }


### PR DESCRIPTION
## Summary
- serialize `deleteAllData()` with remove, sign-out, and sign-in mutations through the shared in-flight guard
- disable the full-wipe action while any account mutation is active
- cover wipe-first and mutation-first overlap attempts with regression tests

## Test plan
- [x] `git diff --check`
- [x] mutual-exclusion source contract
- [x] independent pre-commit review
- [ ] macOS PR checks (Linux worker has no Swift/Xcode toolchain)

Fixes #590

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/609">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->