### PR TITLE
perf: avoid sorting transcript pages for cursor

### DIFF
--- a/whitenoise-mac/Core/ConversationTranscriptExport.swift
+++ b/whitenoise-mac/Core/ConversationTranscriptExport.swift
@@ -110,8 +110,10 @@ nonisolated enum ConversationTranscriptExport {
             }
 
             guard page.hasMoreBefore else { break }
-            let orderedPage = sortChronologically(page.messages)
-            guard let oldest = orderedPage.first else {
+            guard let oldest = page.messages.min(by: { lhs, rhs in
+                lhs.timelineAt != rhs.timelineAt ? lhs.timelineAt < rhs.timelineAt
+                                                 : lhs.messageIdHex < rhs.messageIdHex
+            }) else {
                 // `hasMoreBefore` is true but the page is empty, so the `before` cursor
                 // cannot advance. Fail loudly instead of silently truncating history (#139).
                 throw ExportError.emptyPageWithMoreHistory


### PR DESCRIPTION
Fixes #587

## Summary
- replace the per-page chronological sort with a linear `min(by:)` scan
- preserve the `timelineAt` / `messageIdHex` ordering used for cursor advancement
- keep the final chronological sort for the unordered collected dictionary values

## Verification
- `git diff --check` — passed
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed
- confirmed the final `sortChronologically(Array(collectedById.values))` remains
- Xcode, `xcrun swift-format`, and macOS project checks are unavailable on this Linux worker; Mac CI will run them

No new test was added because the optimization has identical observable output and cannot be distinguished from a full sort without timing-sensitive assertions, brittle source inspection, or test-only production hooks. Existing transcript-export tests cover cursor failure handling, cancellation, and chronological output.

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/610">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->