### PR TITLE
perf: memoize media cache encryption key

### DIFF
--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -186,6 +186,10 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
     private let directoryResolver: DirectoryResolver
     private let keyProvider: KeyProvider
     private let keyDeleter: KeyDeleter
+    // Keychain reads are synchronous XPC calls. Keep the immutable session key in memory and
+    // serialize first resolution with deletion so a concurrent purge cannot leave a stale key.
+    private let keyLock = NSLock()
+    private var cachedSymmetricKey: SymmetricKey?
     private let timestampProvider: TimestampProvider
     private let evictionPolicy: EvictionPolicy
     // Preparation and commit share one actor-isolated synchronous operation so at most one full
@@ -269,7 +273,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
         sweepStaleStagingDirectoriesIfNeeded(root: root)
         do {
-            symmetricKey = try keyProvider()
+            symmetricKey = try encryptionKey()
         } catch {
             return nil
         }
@@ -307,7 +311,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
             let symmetricKey: SymmetricKey
             do {
-                symmetricKey = try keyProvider()
+                symmetricKey = try encryptionKey()
             } catch {
                 return
             }
@@ -334,7 +338,6 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
 
     func purgeAll(removeEncryptionKey: Bool = false) async {
         let root = try? directoryResolver()
-        let deleteKey = keyDeleter
         let task = beginPurge(scope: .all) { [self] in
             var removalSucceeded = root != nil
             if let root, FileManager.default.fileExists(atPath: root.path) {
@@ -345,7 +348,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
                 }
             }
             if removeEncryptionKey {
-                deleteKey()
+                deleteEncryptionKey()
             }
             // An unresolved root or a failed removal can leave entries on disk — a zero footprint
             // would be a false zero the incremental accountant never reconciles, so nil it instead
@@ -368,7 +371,7 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
         sweepStaleStagingDirectoriesIfNeeded(root: root)
         do {
-            symmetricKey = try keyProvider()
+            symmetricKey = try encryptionKey()
         } catch {
             return
         }
@@ -406,6 +409,24 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
             testingBeforeRemoveStaleStagingDirectories = hook
         }
     #endif
+
+    private func encryptionKey() throws -> SymmetricKey {
+        try keyLock.withLock {
+            if let cachedSymmetricKey {
+                return cachedSymmetricKey
+            }
+            let symmetricKey = try keyProvider()
+            cachedSymmetricKey = symmetricKey
+            return symmetricKey
+        }
+    }
+
+    private func deleteEncryptionKey() {
+        keyLock.withLock {
+            keyDeleter()
+            cachedSymmetricKey = nil
+        }
+    }
 
     private func waitForActivePurge(affecting accountDigest: String? = nil) async {
         while true {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3021,9 +3021,12 @@ struct whitenoise_macTests {
             .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
         defer { try? fileManager.removeItem(at: root) }
 
-        let keyProviderGate = OneShotKeyProviderGate()
         let directoryResolutionCount = AtomicCounter()
         let secondStoreResolvedDirectory = DispatchSemaphore(value: 0)
+        let timestampProviderCalls = AtomicCounter()
+        let firstTimestampProviderCall = DispatchSemaphore(value: 0)
+        let secondTimestampProviderCall = DispatchSemaphore(value: 0)
+        let releaseFirstTimestampProviderCall = DispatchSemaphore(value: 0)
         let cache = MessageMediaDiskCache(
             directoryResolver: {
                 if directoryResolutionCount.increment() == 2 {
@@ -3031,8 +3034,18 @@ struct whitenoise_macTests {
                 }
                 return root
             },
-            keyProvider: keyProviderGate.symmetricKey,
-            keyDeleter: {}
+            keyProvider: { SymmetricKey(data: Data(repeating: 0x42, count: 32)) },
+            keyDeleter: {},
+            timestampProvider: {
+                let call = timestampProviderCalls.increment()
+                if call == 1 {
+                    firstTimestampProviderCall.signal()
+                    releaseFirstTimestampProviderCall.wait()
+                } else if call == 2 {
+                    secondTimestampProviderCall.signal()
+                }
+                return TimeInterval(call)
+            }
         )
         let firstPlaintext = Data("first concurrently stored media".utf8)
         let secondPlaintext = Data("second concurrently stored media".utf8)
@@ -3059,9 +3072,12 @@ struct whitenoise_macTests {
                 for: firstKey
             )
         }
-        await Task.detached {
-            keyProviderGate.waitUntilReached()
-        }.value
+        #expect(
+            await waitForSemaphore(
+                firstTimestampProviderCall,
+                timeout: .now() + .seconds(1)
+            ) == .success
+        )
 
         let secondStore = Task {
             await cache.store(
@@ -3083,13 +3099,19 @@ struct whitenoise_macTests {
             ) == .success
         )
         #expect(
-            await keyProviderGate.waitForSecondCall(timeout: .now() + .milliseconds(200)) == .timedOut
+            await waitForSemaphore(
+                secondTimestampProviderCall,
+                timeout: .now() + .milliseconds(200)
+            ) == .timedOut
         )
-        keyProviderGate.releaseGate()
+        releaseFirstTimestampProviderCall.signal()
         await firstStore.value
         await secondStore.value
         #expect(
-            await keyProviderGate.waitForSecondCall(timeout: .now() + .seconds(1)) == .success
+            await waitForSemaphore(
+                secondTimestampProviderCall,
+                timeout: .now() + .seconds(1)
+            ) == .success
         )
         #expect(try #require(await cache.cachedDownload(for: firstKey)).data == firstPlaintext)
         #expect(try #require(await cache.cachedDownload(for: secondKey)).data == secondPlaintext)
@@ -3483,8 +3505,15 @@ struct whitenoise_macTests {
         defer { try? fileManager.removeItem(at: root) }
 
         let keyProviderGate = OneShotKeyProviderGate()
+        let directoryResolutionCount = AtomicCounter()
+        let purgeResolvedDirectory = DispatchSemaphore(value: 0)
         let cache = MessageMediaDiskCache(
-            directoryResolver: { root },
+            directoryResolver: {
+                if directoryResolutionCount.increment() == 2 {
+                    purgeResolvedDirectory.signal()
+                }
+                return root
+            },
             keyProvider: keyProviderGate.symmetricKey,
             keyDeleter: {}
         )
@@ -3509,8 +3538,17 @@ struct whitenoise_macTests {
             keyProviderGate.waitUntilReached()
         }.value
 
-        await cache.purgeAccount("account-a")
+        let purgeTask = Task {
+            await cache.purgeAccount("account-a")
+        }
+        #expect(
+            await waitForSemaphore(
+                purgeResolvedDirectory,
+                timeout: .now() + .seconds(1)
+            ) == .success
+        )
         keyProviderGate.releaseGate()
+        await purgeTask.value
         await storeTask.value
 
         let restored = try #require(await cache.cachedDownload(for: key))
@@ -3525,8 +3563,15 @@ struct whitenoise_macTests {
         defer { try? fileManager.removeItem(at: root) }
 
         let keyProviderGate = OneShotKeyProviderGate()
+        let directoryResolutionCount = AtomicCounter()
+        let purgeResolvedDirectory = DispatchSemaphore(value: 0)
         let cache = MessageMediaDiskCache(
-            directoryResolver: { root },
+            directoryResolver: {
+                if directoryResolutionCount.increment() == 2 {
+                    purgeResolvedDirectory.signal()
+                }
+                return root
+            },
             keyProvider: keyProviderGate.symmetricKey,
             keyDeleter: {}
         )
@@ -3551,8 +3596,17 @@ struct whitenoise_macTests {
             keyProviderGate.waitUntilReached()
         }.value
 
-        await cache.purgeAccount("account-b")
+        let purgeTask = Task {
+            await cache.purgeAccount("account-b")
+        }
+        #expect(
+            await waitForSemaphore(
+                purgeResolvedDirectory,
+                timeout: .now() + .seconds(1)
+            ) == .success
+        )
         keyProviderGate.releaseGate()
+        await purgeTask.value
         await storeTask.value
 
         #expect(await cache.cachedDownload(for: key) == nil)
@@ -3611,6 +3665,53 @@ struct whitenoise_macTests {
         #expect(await cache.cachedDownload(for: secondKey) == nil)
         #expect(didDeleteKey.value)
         #expect(!fileManager.fileExists(atPath: root.path))
+    }
+
+    @Test func messageMediaDiskCacheMemoizesEncryptionKeyUntilDeletion() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let keyProviderCalls = AtomicCounter()
+        let keyDeleterCalls = AtomicCounter()
+        let cache = MessageMediaDiskCache(
+            directoryResolver: { root },
+            keyProvider: {
+                let call = keyProviderCalls.increment()
+                return SymmetricKey(data: Data(repeating: UInt8(call), count: 32))
+            },
+            keyDeleter: { keyDeleterCalls.increment() }
+        )
+        let plaintext = Data("memoized cache key".utf8)
+        let key = MessageMediaDiskCacheKey(
+            accountId: "account-a",
+            groupIdHex: "group-a",
+            reference: mediaDiskCacheReference(plaintext: plaintext)
+        )
+        let download = MessageMediaDownload(
+            data: plaintext,
+            fileName: "memoized.jpg",
+            mediaType: "image/jpeg",
+            sizeBytes: UInt64(plaintext.count),
+            payloadId: "memoized"
+        )
+
+        await cache.store(download, for: key)
+        #expect(try #require(await cache.cachedDownload(for: key)).data == plaintext)
+        #expect(keyProviderCalls.value == 1)
+
+        await cache.purgeAll()
+        await cache.store(download, for: key)
+        #expect(try #require(await cache.cachedDownload(for: key)).data == plaintext)
+        #expect(keyProviderCalls.value == 1)
+        #expect(keyDeleterCalls.value == 0)
+
+        await cache.purgeAll(removeEncryptionKey: true)
+        #expect(keyDeleterCalls.value == 1)
+        await cache.store(download, for: key)
+        #expect(try #require(await cache.cachedDownload(for: key)).data == plaintext)
+        #expect(keyProviderCalls.value == 2)
     }
 
     @Test func messageMediaDiskCacheRejectsDirectStoreDuringFullWipe() async throws {


### PR DESCRIPTION
## Summary
- memoize the media-cache symmetric key per cache instance
- serialize initial resolution with key deletion so a purge cannot leave stale key state
- invalidate only when purgeAll(removeEncryptionKey: true) deletes the Keychain item
- cover steady-state reuse, post-deletion refresh, and affected concurrency tests

## Checks
- PASS: source-contract assertions for provider call sites and purge invalidation
- PASS: git diff --check
- Not run: Xcode build/tests (Linux worker has no Xcode toolchain)

Fixes #592

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/611">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved message media cache efficiency by reusing encryption keys during an active session.
  - Serialized cache security operations for more consistent behavior during concurrent activity.

- **Security**
  - Encryption keys are cleared when explicitly requested, requiring a new key for subsequent cache operations.

- **Bug Fixes**
  - Improved reliability for concurrent media storage and account purge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->