### PR TITLE
fix: clear compose contacts on account teardown

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -99,6 +99,7 @@ extension WorkspaceState {
         chatListFilter = .active
         archivingChatId = nil
         closeNewChatComposer()
+        resetComposeContacts()
         pruneMessageCache(keeping: groupIdHex)
         conversationMetadataByChat.removeAll()
         conversationMetadataGenerationByChat.removeAll()
@@ -365,6 +366,7 @@ extension WorkspaceState {
     private func resetAccountScopedGroupAndNewChatUIState() {
         isNewChatComposerVisible = false
         resetNewChatComposer()
+        resetComposeContacts()
         isResolvingNewChat = false
         isCreatingChat = false
 
@@ -596,6 +598,7 @@ extension WorkspaceState {
         }
 
         accounts = refreshed
+        resetComposeContacts()
         activeAccountId = preferredAccount.id
         invalidateNotificationSettingsOperations()
         UserDefaults.standard.set(preferredAccount.id, forKey: Self.activeAccountKey)

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -280,6 +280,14 @@ extension WorkspaceState {
         creatingDirectChatIdHex = nil
     }
 
+    /// Drops the active account's compose directory and invalidates any refresh that is
+    /// still fetching group rosters, preventing it from restoring contacts after teardown.
+    func resetComposeContacts() {
+        composeContacts = []
+        isLoadingComposeContacts = false
+        composeContactsGeneration &+= 1
+    }
+
     func beginNewChatLookup() -> UInt64 {
         newChatLookupGeneration &+= 1
         return newChatLookupGeneration

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -489,6 +489,17 @@ struct whitenoise_macTests {
             running: false
         )
         runtime.createdAccount = secondary
+        state.composeContacts = [
+            ComposeContact(
+                accountIdHex: String(repeating: "2", count: 64),
+                npub: "npub1primarycontact",
+                displayName: "Primary contact",
+                pictureURL: "https://example.com/primary-contact.png",
+                lastActivity: Date()
+            )
+        ]
+        state.isLoadingComposeContacts = true
+        state.composeContactsGeneration = 41
         state.showLogin()
         state.loginIdentity = "nsec1backup"
         await state.login()
@@ -502,6 +513,9 @@ struct whitenoise_macTests {
         let allAccountsRunning = state.accounts.allSatisfy { $0.isRunning }
         #expect(allAccountsRunning)
         #expect(state.activeAccountId == "Backup Account")
+        #expect(state.composeContacts.isEmpty)
+        #expect(!state.isLoadingComposeContacts)
+        #expect(state.composeContactsGeneration == 42)
     }
 
     @MainActor
@@ -1469,13 +1483,27 @@ struct whitenoise_macTests {
         )
         state.lastMarkedReadMarkers["shared-group"] = marker
         state.lastConfirmedReadMarkers["shared-group"] = marker
+        state.composeContacts = [
+            ComposeContact(
+                accountIdHex: String(repeating: "2", count: 64),
+                npub: "npub1accountacontact",
+                displayName: "Account A contact",
+                pictureURL: "https://example.com/account-a.png",
+                lastActivity: Date()
+            )
+        ]
+        state.isLoadingComposeContacts = true
+        state.composeContactsGeneration = 41
 
         state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
 
-        // Live account switches must not inherit groupIdHex-keyed read markers from
-        // the previous identity. See #429.
+        // Live account switches must not inherit groupIdHex-keyed read markers or the
+        // previous identity's compose-flow contact directory. See #429/#588.
         #expect(state.lastMarkedReadMarkers.isEmpty)
         #expect(state.lastConfirmedReadMarkers.isEmpty)
+        #expect(state.composeContacts.isEmpty)
+        #expect(!state.isLoadingComposeContacts)
+        #expect(state.composeContactsGeneration == 42)
         #expect(state.activeAccountId == backupAccount.id)
     }
 
@@ -1635,12 +1663,23 @@ struct whitenoise_macTests {
         state.newChatDescription = "Private chat description"
         state.newChatRecipient = recipient
         state.newChatRecipients = [recipient]
+        state.composeContacts = [
+            ComposeContact(
+                accountIdHex: recipient.accountIdHex,
+                npub: recipient.npub,
+                displayName: recipient.displayName,
+                pictureURL: recipient.pictureURL,
+                lastActivity: Date()
+            )
+        ]
+        state.isLoadingComposeContacts = true
+        state.composeContactsGeneration = 41
 
         state.resetActiveAccountUIState()
 
         // Sign-out and active-account removal share this reset path; group-scoped
-        // roster/details, invite queries, image-picker results, and new-chat recipients
-        // must not survive account teardown. See #398.
+        // roster/details, invite queries, image-picker results, new-chat recipients,
+        // and the compose contact directory must not survive account teardown. See #398/#588.
         #expect(!state.isGroupDetailsPresented)
         #expect(state.groupDetailsSnapshot == nil)
         #expect(state.groupProfileDraftName.isEmpty)
@@ -1654,6 +1693,9 @@ struct whitenoise_macTests {
         #expect(state.newChatDescription.isEmpty)
         #expect(state.newChatRecipient == nil)
         #expect(state.newChatRecipients.isEmpty)
+        #expect(state.composeContacts.isEmpty)
+        #expect(!state.isLoadingComposeContacts)
+        #expect(state.composeContactsGeneration == 42)
     }
 
     @MainActor
@@ -15901,6 +15943,28 @@ struct whitenoise_macTests {
         #expect(!state.isRecordingVoiceMessage)
         #expect(state.voiceRecordingMeterTask == nil)
         #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @MainActor
+    @Test func resetToNewInstallStateClearsComposeContacts() {
+        let state = WorkspaceState.preview()
+        state.composeContacts = [
+            ComposeContact(
+                accountIdHex: String(repeating: "2", count: 64),
+                npub: "npub1accountacontact",
+                displayName: "Account A contact",
+                pictureURL: "https://example.com/account-a.png",
+                lastActivity: Date()
+            )
+        ]
+        state.isLoadingComposeContacts = true
+        state.composeContactsGeneration = 41
+
+        state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-reset-test")
+
+        #expect(state.composeContacts.isEmpty)
+        #expect(!state.isLoadingComposeContacts)
+        #expect(state.composeContactsGeneration == 42)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- clear the active account's compose contact directory and loading state at every account boundary
- invalidate in-flight roster refreshes so stale peer names, npubs, and avatar URLs cannot be restored after teardown
- cover add-account, live account switch, sign-out/active-account removal, and full local-data wipe paths with regression assertions

## Verification
- `git diff --check`
- tree-sitter Swift parse of all three changed files
- static teardown-contract check across all affected account lifecycle paths
- independent pre-commit review: passed with no security or logic findings
- `xcodebuild` not available on this Linux host; GitHub macOS CI will run formatting, unit tests, release build, and static analysis

Fixes #588


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/613">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->