### PR TITLE
Unified message deletion with a per-scope confirmation

### DIFF
--- a/Vendored/MarmotKit/MARMOT_VERSION
+++ b/Vendored/MarmotKit/MARMOT_VERSION
@@ -1,6 +1,6 @@
-mdk-sha: f9ef165a
+mdk-sha: f3ece0e3
 mdk-branch: master
-built-at: 2026-07-09T18:25:01Z
+built-at: 2026-07-18T23:25:58Z
 uniffi-version: 0.28.3
 macos-targets: aarch64-apple-darwin
 macos-deployment-target: 15.6

--- a/Vendored/MarmotKit/MarmotKit.xcframework/macos-arm64/Headers/marmot_uniffiFFI.h
+++ b/Vendored/MarmotKit/MarmotKit.xcframework/macos-arm64/Headers/marmot_uniffiFFI.h
@@ -253,42 +253,42 @@ typedef void (*UniffiForeignFutureCompleteVoid)(uint64_t, UniffiForeignFutureStr
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD0
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD0
-typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod0)(uint64_t, RustBuffer* _Nonnull,
+typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod0)(uint64_t, RustBuffer* _Nonnull, 
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD1
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD1
-typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod1)(uint64_t, RustBuffer, RustBuffer* _Nonnull,
+typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod1)(uint64_t, RustBuffer, RustBuffer* _Nonnull, 
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD2
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD2
-typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod2)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull,
+typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod2)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull, 
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD3
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD3
-typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod3)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull,
+typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod3)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull, 
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD4
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD4
-typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod4)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull,
+typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod4)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull, 
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD5
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_EXTERNAL_ACCOUNT_SIGNER_FFI_METHOD5
-typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod5)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull,
+typedef void (*UniffiCallbackInterfaceExternalAccountSignerFfiMethod5)(uint64_t, RustBuffer, RustBuffer, RustBuffer* _Nonnull, 
         RustCallStatus *_Nonnull uniffiCallStatus
     );
 
@@ -466,6 +466,11 @@ void uniffi_marmot_uniffi_fn_free_marmot(void*_Nonnull ptr, RustCallStatus *_Non
 void*_Nonnull uniffi_marmot_uniffi_fn_constructor_marmot_new(RustBuffer root_path, RustBuffer relay_urls, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_CONSTRUCTOR_MARMOT_NEW_WITH_CURSOR_PERSISTENCE
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_CONSTRUCTOR_MARMOT_NEW_WITH_CURSOR_PERSISTENCE
+void*_Nonnull uniffi_marmot_uniffi_fn_constructor_marmot_new_with_cursor_persistence(RustBuffer root_path, RustBuffer relay_urls, RustBuffer cursor_persistence, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_ACCEPT_GROUP_INVITE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_ACCEPT_GROUP_INVITE
 uint64_t uniffi_marmot_uniffi_fn_method_marmot_accept_group_invite(void*_Nonnull ptr, RustBuffer account_ref, RustBuffer group_id_hex
@@ -564,6 +569,11 @@ uint64_t uniffi_marmot_uniffi_fn_method_marmot_delete_group_local(void*_Nonnull 
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_DELETE_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_DELETE_MESSAGE
 uint64_t uniffi_marmot_uniffi_fn_method_marmot_delete_message(void*_Nonnull ptr, RustBuffer account_ref, RustBuffer group_id_hex, RustBuffer target_message_id
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_DELETE_MESSAGE_DRAFT
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_DELETE_MESSAGE_DRAFT
+void uniffi_marmot_uniffi_fn_method_marmot_delete_message_draft(void*_Nonnull ptr, RustBuffer account_ref, RustBuffer group_id_hex, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_DEMOTE_ADMIN
@@ -674,6 +684,16 @@ uint64_t uniffi_marmot_uniffi_fn_method_marmot_login_external_signer(void*_Nonnu
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_MARK_TIMELINE_MESSAGE_READ
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_MARK_TIMELINE_MESSAGE_READ
 RustBuffer uniffi_marmot_uniffi_fn_method_marmot_mark_timeline_message_read(void*_Nonnull ptr, RustBuffer account_ref, RustBuffer group_id_hex, RustBuffer message_id_hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_MESSAGE_DRAFT
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_MESSAGE_DRAFT
+RustBuffer uniffi_marmot_uniffi_fn_method_marmot_message_draft(void*_Nonnull ptr, RustBuffer account_ref, RustBuffer group_id_hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_MESSAGE_DRAFTS
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_MESSAGE_DRAFTS
+RustBuffer uniffi_marmot_uniffi_fn_method_marmot_message_drafts(void*_Nonnull ptr, RustBuffer account_ref, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_MESSAGES
@@ -814,6 +834,11 @@ uint64_t uniffi_marmot_uniffi_fn_method_marmot_retry_hydrate_quarantined_group(v
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_REVEAL_NSEC
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_REVEAL_NSEC
 RustBuffer uniffi_marmot_uniffi_fn_method_marmot_reveal_nsec(void*_Nonnull ptr, RustBuffer account_ref, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_SAVE_MESSAGE_DRAFT
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_SAVE_MESSAGE_DRAFT
+RustBuffer uniffi_marmot_uniffi_fn_method_marmot_save_message_draft(void*_Nonnull ptr, RustBuffer account_ref, RustBuffer group_id_hex, RustBuffer content, RustBuffer reply_to_message_id_hex, RustBuffer media_attachments, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_SECURE_DELETE_EXPIRED
@@ -999,6 +1024,11 @@ uint64_t uniffi_marmot_uniffi_fn_method_marmot_upsert_push_registration(void*_No
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_USER_PROFILE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_USER_PROFILE
 RustBuffer uniffi_marmot_uniffi_fn_method_marmot_user_profile(void*_Nonnull ptr, RustBuffer account_id_hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_USER_PROFILE_WEBSITE
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_USER_PROFILE_WEBSITE
+RustBuffer uniffi_marmot_uniffi_fn_method_marmot_user_profile_website(void*_Nonnull ptr, RustBuffer account_id_hex, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_FN_METHOD_MARMOT_WATCH_AGENT_TEXT_STREAM
@@ -1359,805 +1389,841 @@ void ffi_marmot_uniffi_rust_future_complete_void(uint64_t handle, RustCallStatus
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_AGENTSTREAMSUBSCRIPTION_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_AGENTSTREAMSUBSCRIPTION_NEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_agentstreamsubscription_next(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_AGENTSTREAMSUBSCRIPTION_STREAM_ID_HEX
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_AGENTSTREAMSUBSCRIPTION_STREAM_ID_HEX
 uint16_t uniffi_marmot_uniffi_checksum_method_agentstreamsubscription_stream_id_hex(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATLISTSUBSCRIPTION_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATLISTSUBSCRIPTION_NEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_chatlistsubscription_next(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATLISTSUBSCRIPTION_NEXT_UPDATE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATLISTSUBSCRIPTION_NEXT_UPDATE
 uint16_t uniffi_marmot_uniffi_checksum_method_chatlistsubscription_next_update(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATLISTSUBSCRIPTION_SNAPSHOT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATLISTSUBSCRIPTION_SNAPSHOT
 uint16_t uniffi_marmot_uniffi_checksum_method_chatlistsubscription_snapshot(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATSSUBSCRIPTION_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATSSUBSCRIPTION_NEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_chatssubscription_next(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATSSUBSCRIPTION_SNAPSHOT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_CHATSSUBSCRIPTION_SNAPSHOT
 uint16_t uniffi_marmot_uniffi_checksum_method_chatssubscription_snapshot(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EVENTSSUBSCRIPTION_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EVENTSSUBSCRIPTION_NEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_eventssubscription_next(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_PUBLIC_KEY
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_PUBLIC_KEY
 uint16_t uniffi_marmot_uniffi_checksum_method_externalaccountsignerffi_public_key(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_SIGN_EVENT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_SIGN_EVENT
 uint16_t uniffi_marmot_uniffi_checksum_method_externalaccountsignerffi_sign_event(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_NIP04_ENCRYPT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_NIP04_ENCRYPT
 uint16_t uniffi_marmot_uniffi_checksum_method_externalaccountsignerffi_nip04_encrypt(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_NIP04_DECRYPT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_NIP04_DECRYPT
 uint16_t uniffi_marmot_uniffi_checksum_method_externalaccountsignerffi_nip04_decrypt(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_NIP44_ENCRYPT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_NIP44_ENCRYPT
 uint16_t uniffi_marmot_uniffi_checksum_method_externalaccountsignerffi_nip44_encrypt(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_NIP44_DECRYPT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_EXTERNALACCOUNTSIGNERFFI_NIP44_DECRYPT
 uint16_t uniffi_marmot_uniffi_checksum_method_externalaccountsignerffi_nip44_decrypt(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_GROUPSTATESUBSCRIPTION_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_GROUPSTATESUBSCRIPTION_NEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_groupstatesubscription_next(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_GROUPSTATESUBSCRIPTION_SNAPSHOT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_GROUPSTATESUBSCRIPTION_SNAPSHOT
 uint16_t uniffi_marmot_uniffi_checksum_method_groupstatesubscription_snapshot(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCEPT_GROUP_INVITE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCEPT_GROUP_INVITE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_accept_group_invite(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_ID_HEX
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_ID_HEX
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_account_id_hex(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_INBOX_RELAYS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_INBOX_RELAYS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_account_inbox_relays(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_KEY_PACKAGES
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_KEY_PACKAGES
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_account_key_packages(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_NIP65_RELAYS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_NIP65_RELAYS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_account_nip65_relays(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_RELAY_LISTS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_RELAY_LISTS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_account_relay_lists(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_UNREAD_SUMMARY
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_ACCOUNT_UNREAD_SUMMARY
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_account_unread_summary(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_AUDIT_LOG_FILES
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_AUDIT_LOG_FILES
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_audit_log_files(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_AUDIT_LOG_SETTINGS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_AUDIT_LOG_SETTINGS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_audit_log_settings(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CATCH_UP_ACCOUNTS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CATCH_UP_ACCOUNTS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_catch_up_accounts(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CHAT_LIST
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CHAT_LIST
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_chat_list(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CLEAR_PUSH_REGISTRATION
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CLEAR_PUSH_REGISTRATION
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_clear_push_registration(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_COLLECT_NOTIFICATIONS_AFTER_WAKE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_COLLECT_NOTIFICATIONS_AFTER_WAKE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_collect_notifications_after_wake(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CREATE_GROUP
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CREATE_GROUP
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_create_group(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CREATE_IDENTITY
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_CREATE_IDENTITY
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_create_identity(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DECLINE_GROUP_INVITE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DECLINE_GROUP_INVITE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_decline_group_invite(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_ACCOUNT_KEY_PACKAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_ACCOUNT_KEY_PACKAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_delete_account_key_package(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_AUDIT_LOG_FILE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_AUDIT_LOG_FILE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_delete_audit_log_file(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_GROUP_LOCAL
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_GROUP_LOCAL
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_delete_group_local(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_MESSAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_delete_message(void
-
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_MESSAGE_DRAFT
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DELETE_MESSAGE_DRAFT
+uint16_t uniffi_marmot_uniffi_checksum_method_marmot_delete_message_draft(void
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DEMOTE_ADMIN
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DEMOTE_ADMIN
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_demote_admin(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DEMOTE_ADMIN_DETAILED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DEMOTE_ADMIN_DETAILED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_demote_admin_detailed(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DISPLAY_NAME
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DISPLAY_NAME
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_display_name(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DOWNLOAD_GROUP_BLOSSOM_IMAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DOWNLOAD_GROUP_BLOSSOM_IMAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_download_group_blossom_image(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DOWNLOAD_MEDIA
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_DOWNLOAD_MEDIA
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_download_media(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_EDIT_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_EDIT_MESSAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_edit_message(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_EXPORT_ENCRYPTED_SECRET_KEY
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_EXPORT_ENCRYPTED_SECRET_KEY
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_export_encrypted_secret_key(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_DETAILS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_DETAILS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_group_details(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_MANAGEMENT_STATE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_MANAGEMENT_STATE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_group_management_state(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_MEMBERS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_MEMBERS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_group_members(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_MLS_STATE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_MLS_STATE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_group_mls_state(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_PUSH_DEBUG_INFO
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_GROUP_PUSH_DEBUG_INFO
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_group_push_debug_info(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_INITIALIZE_CHAT_READ_STATE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_INITIALIZE_CHAT_READ_STATE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_initialize_chat_read_state(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_INVITE_MEMBERS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_INVITE_MEMBERS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_invite_members(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_INVITE_MEMBERS_DETAILED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_INVITE_MEMBERS_DETAILED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_invite_members_detailed(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_IS_STOPPING
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_IS_STOPPING
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_is_stopping(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LEAVE_GROUP
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LEAVE_GROUP
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_leave_group(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LIST_ACCOUNTS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LIST_ACCOUNTS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_list_accounts(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LIST_MEDIA
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LIST_MEDIA
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_list_media(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LOGIN
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LOGIN
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_login(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LOGIN_EXTERNAL_SIGNER
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_LOGIN_EXTERNAL_SIGNER
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_login_external_signer(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_MARK_TIMELINE_MESSAGE_READ
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_MARK_TIMELINE_MESSAGE_READ
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_mark_timeline_message_read(void
-
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_MESSAGE_DRAFT
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_MESSAGE_DRAFT
+uint16_t uniffi_marmot_uniffi_checksum_method_marmot_message_draft(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_MESSAGE_DRAFTS
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_MESSAGE_DRAFTS
+uint16_t uniffi_marmot_uniffi_checksum_method_marmot_message_drafts(void
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_MESSAGES
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_MESSAGES
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_messages(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_NORMALIZE_MEMBER_REF
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_NORMALIZE_MEMBER_REF
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_normalize_member_ref(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_NOTIFICATION_SETTINGS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_NOTIFICATION_SETTINGS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_notification_settings(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_NPUB
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_NPUB
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_npub(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PARSE_MARKDOWN
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PARSE_MARKDOWN
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_parse_markdown(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_POST_AUDIT_LOG_FILE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_POST_AUDIT_LOG_FILE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_post_audit_log_file(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_POST_AUDIT_LOG_TRACKER_UPDATE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_POST_AUDIT_LOG_TRACKER_UPDATE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_post_audit_log_tracker_update(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PROMOTE_ADMIN
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PROMOTE_ADMIN
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_promote_admin(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PROMOTE_ADMIN_DETAILED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PROMOTE_ADMIN_DETAILED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_promote_admin_detailed(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PUBLISH_NEW_KEY_PACKAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PUBLISH_NEW_KEY_PACKAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_publish_new_key_package(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PUBLISH_RELAY_LISTS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PUBLISH_RELAY_LISTS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_publish_relay_lists(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PUBLISH_USER_PROFILE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PUBLISH_USER_PROFILE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_publish_user_profile(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PUSH_REGISTRATION
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_PUSH_REGISTRATION
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_push_registration(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_QUARANTINED_GROUPS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_QUARANTINED_GROUPS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_quarantined_groups(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REACT_TO_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REACT_TO_MESSAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_react_to_message(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REFRESH_PROFILE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REFRESH_PROFILE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_refresh_profile(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REGISTER_EXTERNAL_SIGNER
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REGISTER_EXTERNAL_SIGNER
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_register_external_signer(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_RELAY_HEALTH
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_RELAY_HEALTH
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_relay_health(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_RELAY_TELEMETRY_SETTINGS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_RELAY_TELEMETRY_SETTINGS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_relay_telemetry_settings(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REMOVE_ACCOUNT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REMOVE_ACCOUNT
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_remove_account(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REMOVE_MEMBERS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REMOVE_MEMBERS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_remove_members(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REMOVE_MEMBERS_DETAILED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REMOVE_MEMBERS_DETAILED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_remove_members_detailed(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REPLACE_ENCRYPTED_MEDIA_BLOB_ENDPOINTS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REPLACE_ENCRYPTED_MEDIA_BLOB_ENDPOINTS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_replace_encrypted_media_blob_endpoints(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REPLY_TO_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REPLY_TO_MESSAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_reply_to_message(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REPUBLISH_KEY_PACKAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REPUBLISH_KEY_PACKAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_republish_key_package(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_RETRY_GROUP_CONVERGENCE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_RETRY_GROUP_CONVERGENCE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_retry_group_convergence(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_RETRY_HYDRATE_QUARANTINED_GROUP
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_RETRY_HYDRATE_QUARANTINED_GROUP
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_retry_hydrate_quarantined_group(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REVEAL_NSEC
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_REVEAL_NSEC
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_reveal_nsec(void
-
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SAVE_MESSAGE_DRAFT
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SAVE_MESSAGE_DRAFT
+uint16_t uniffi_marmot_uniffi_checksum_method_marmot_save_message_draft(void
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SECURE_DELETE_EXPIRED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SECURE_DELETE_EXPIRED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_secure_delete_expired(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SELF_DEMOTE_ADMIN
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SELF_DEMOTE_ADMIN
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_self_demote_admin(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SELF_DEMOTE_ADMIN_DETAILED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SELF_DEMOTE_ADMIN_DETAILED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_self_demote_admin_detailed(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SEND_MEDIA_ATTACHMENTS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SEND_MEDIA_ATTACHMENTS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_send_media_attachments(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SEND_MEDIA_REFERENCE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SEND_MEDIA_REFERENCE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_send_media_reference(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SEND_TEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SEND_TEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_send_text(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_ACCOUNT_INBOX_RELAYS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_ACCOUNT_INBOX_RELAYS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_account_inbox_relays(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_ACCOUNT_NIP65_RELAYS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_ACCOUNT_NIP65_RELAYS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_account_nip65_relays(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_AUDIT_LOG_SETTINGS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_AUDIT_LOG_SETTINGS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_audit_log_settings(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_AUDIT_LOG_TRACKER_CONFIG
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_AUDIT_LOG_TRACKER_CONFIG
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_audit_log_tracker_config(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_GROUP_ARCHIVED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_GROUP_ARCHIVED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_group_archived(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_LOCAL_NOTIFICATIONS_ENABLED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_LOCAL_NOTIFICATIONS_ENABLED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_local_notifications_enabled(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_NATIVE_PUSH_ENABLED
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_NATIVE_PUSH_ENABLED
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_native_push_enabled(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_RELAY_TELEMETRY_RUNTIME_CONFIG
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_RELAY_TELEMETRY_RUNTIME_CONFIG
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_relay_telemetry_runtime_config(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_RELAY_TELEMETRY_SETTINGS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SET_RELAY_TELEMETRY_SETTINGS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_set_relay_telemetry_settings(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SHUTDOWN
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SHUTDOWN
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_shutdown(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SIGN_IN_ACCOUNT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SIGN_IN_ACCOUNT
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_sign_in_account(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SIGN_OUT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SIGN_OUT
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_sign_out(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SIGN_OUT_AND_WIPE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SIGN_OUT_AND_WIPE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_sign_out_and_wipe(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_START
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_START
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_start(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_START_AGENT_TEXT_STREAM
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_START_AGENT_TEXT_STREAM
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_start_agent_text_stream(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_CHAT_LIST
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_CHAT_LIST
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_subscribe_chat_list(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_CHATS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_CHATS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_subscribe_chats(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_EVENTS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_EVENTS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_subscribe_events(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_GROUP_STATE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_GROUP_STATE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_subscribe_group_state(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_MESSAGES
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_MESSAGES
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_subscribe_messages(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_NOTIFICATIONS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_NOTIFICATIONS
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_subscribe_notifications(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_TIMELINE_MESSAGES
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_SUBSCRIBE_TIMELINE_MESSAGES
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_subscribe_timeline_messages(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_TELEMETRY_INSTALL_ID
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_TELEMETRY_INSTALL_ID
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_telemetry_install_id(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_TIMELINE_MESSAGES
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_TIMELINE_MESSAGES
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_timeline_messages(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UNREACT_FROM_MESSAGE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UNREACT_FROM_MESSAGE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_unreact_from_message(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPDATE_GROUP_AVATAR_URL
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPDATE_GROUP_AVATAR_URL
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_update_group_avatar_url(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPDATE_GROUP_PROFILE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPDATE_GROUP_PROFILE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_update_group_profile(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPDATE_MESSAGE_RETENTION
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPDATE_MESSAGE_RETENTION
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_update_message_retention(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPLOAD_MEDIA
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPLOAD_MEDIA
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_upload_media(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPSERT_PUSH_REGISTRATION
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_UPSERT_PUSH_REGISTRATION
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_upsert_push_registration(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_USER_PROFILE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_USER_PROFILE
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_user_profile(void
-
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_USER_PROFILE_WEBSITE
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_USER_PROFILE_WEBSITE
+uint16_t uniffi_marmot_uniffi_checksum_method_marmot_user_profile_website(void
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_WATCH_AGENT_TEXT_STREAM
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MARMOT_WATCH_AGENT_TEXT_STREAM
 uint16_t uniffi_marmot_uniffi_checksum_method_marmot_watch_agent_text_stream(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MESSAGESSUBSCRIPTION_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MESSAGESSUBSCRIPTION_NEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_messagessubscription_next(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MESSAGESSUBSCRIPTION_SNAPSHOT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_MESSAGESSUBSCRIPTION_SNAPSHOT
 uint16_t uniffi_marmot_uniffi_checksum_method_messagessubscription_snapshot(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_NOTIFICATIONSSUBSCRIPTION_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_NOTIFICATIONSSUBSCRIPTION_NEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_notificationssubscription_next(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_NEXT
 uint16_t uniffi_marmot_uniffi_checksum_method_timelinemessagessubscription_next(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_NEXT_UPDATE
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_NEXT_UPDATE
 uint16_t uniffi_marmot_uniffi_checksum_method_timelinemessagessubscription_next_update(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_PAGINATE_BACKWARDS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_PAGINATE_BACKWARDS
 uint16_t uniffi_marmot_uniffi_checksum_method_timelinemessagessubscription_paginate_backwards(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_PAGINATE_FORWARDS
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_PAGINATE_FORWARDS
 uint16_t uniffi_marmot_uniffi_checksum_method_timelinemessagessubscription_paginate_forwards(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_SNAPSHOT
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_METHOD_TIMELINEMESSAGESSUBSCRIPTION_SNAPSHOT
 uint16_t uniffi_marmot_uniffi_checksum_method_timelinemessagessubscription_snapshot(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_CONSTRUCTOR_MARMOT_NEW
 #define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_CONSTRUCTOR_MARMOT_NEW
 uint16_t uniffi_marmot_uniffi_checksum_constructor_marmot_new(void
-
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_CONSTRUCTOR_MARMOT_NEW_WITH_CURSOR_PERSISTENCE
+#define UNIFFI_FFIDEF_UNIFFI_MARMOT_UNIFFI_CHECKSUM_CONSTRUCTOR_MARMOT_NEW_WITH_CURSOR_PERSISTENCE
+uint16_t uniffi_marmot_uniffi_checksum_constructor_marmot_new_with_cursor_persistence(void
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_FFI_MARMOT_UNIFFI_UNIFFI_CONTRACT_VERSION
 #define UNIFFI_FFIDEF_FFI_MARMOT_UNIFFI_UNIFFI_CONTRACT_VERSION
 uint32_t ffi_marmot_uniffi_uniffi_contract_version(void
-
+    
 );
 #endif
 

--- a/Vendored/MarmotKit/Sources/MarmotKit/MarmotKit.swift
+++ b/Vendored/MarmotKit/Sources/MarmotKit/MarmotKit.swift
@@ -479,6 +479,22 @@ fileprivate struct FfiConverterInt64: FfiConverterPrimitive {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterDouble: FfiConverterPrimitive {
+    typealias FfiType = Double
+    typealias SwiftType = Double
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Double {
+        return try lift(readDouble(&buf))
+    }
+
+    public static func write(_ value: Double, into buf: inout [UInt8]) {
+        writeDouble(&buf, lower(value))
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterBool : FfiConverter {
     typealias FfiType = Int8
     typealias SwiftType = Bool
@@ -568,14 +584,14 @@ fileprivate struct FfiConverterData: FfiConverterRustBuffer {
  * after which it returns `None`.
  */
 public protocol AgentStreamSubscriptionProtocol : AnyObject {
-
+    
     func next() async  -> AgentStreamUpdateFfi?
-
+    
     /**
      * The resolved stream id this watch is following (hex).
      */
     func streamIdHex()  -> String
-
+    
 }
 
 /**
@@ -630,16 +646,16 @@ open class AgentStreamSubscription:
         try! rustCall { uniffi_marmot_uniffi_fn_free_agentstreamsubscription(pointer, $0) }
     }
 
+    
 
-
-
+    
 open func next()async  -> AgentStreamUpdateFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_agentstreamsubscription_next(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -647,10 +663,10 @@ open func next()async  -> AgentStreamUpdateFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeAgentStreamUpdateFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
     /**
      * The resolved stream id this watch is following (hex).
      */
@@ -660,7 +676,7 @@ open func streamIdHex() -> String {
     )
 })
 }
-
+    
 
 }
 
@@ -719,13 +735,13 @@ public func FfiConverterTypeAgentStreamSubscription_lower(_ value: AgentStreamSu
 
 
 public protocol ChatListSubscriptionProtocol : AnyObject {
-
+    
     func next() async  -> ChatListRowFfi?
-
+    
     func nextUpdate() async  -> ChatListSubscriptionUpdateFfi?
-
+    
     func snapshot()  -> [ChatListRowFfi]
-
+    
 }
 
 open class ChatListSubscription:
@@ -775,16 +791,16 @@ open class ChatListSubscription:
         try! rustCall { uniffi_marmot_uniffi_fn_free_chatlistsubscription(pointer, $0) }
     }
 
+    
 
-
-
+    
 open func next()async  -> ChatListRowFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_chatlistsubscription_next(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -792,17 +808,17 @@ open func next()async  -> ChatListRowFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeChatListRowFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
 open func nextUpdate()async  -> ChatListSubscriptionUpdateFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_chatlistsubscription_next_update(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -810,17 +826,17 @@ open func nextUpdate()async  -> ChatListSubscriptionUpdateFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeChatListSubscriptionUpdateFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
 open func snapshot() -> [ChatListRowFfi] {
     return try!  FfiConverterSequenceTypeChatListRowFfi.lift(try! rustCall() {
     uniffi_marmot_uniffi_fn_method_chatlistsubscription_snapshot(self.uniffiClonePointer(),$0
     )
 })
 }
-
+    
 
 }
 
@@ -879,11 +895,11 @@ public func FfiConverterTypeChatListSubscription_lower(_ value: ChatListSubscrip
 
 
 public protocol ChatsSubscriptionProtocol : AnyObject {
-
+    
     func next() async  -> AppGroupRecordFfi?
-
+    
     func snapshot()  -> [AppGroupRecordFfi]
-
+    
 }
 
 open class ChatsSubscription:
@@ -933,16 +949,16 @@ open class ChatsSubscription:
         try! rustCall { uniffi_marmot_uniffi_fn_free_chatssubscription(pointer, $0) }
     }
 
+    
 
-
-
+    
 open func next()async  -> AppGroupRecordFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_chatssubscription_next(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -950,17 +966,17 @@ open func next()async  -> AppGroupRecordFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeAppGroupRecordFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
 open func snapshot() -> [AppGroupRecordFfi] {
     return try!  FfiConverterSequenceTypeAppGroupRecordFfi.lift(try! rustCall() {
     uniffi_marmot_uniffi_fn_method_chatssubscription_snapshot(self.uniffiClonePointer(),$0
     )
 })
 }
-
+    
 
 }
 
@@ -1025,9 +1041,9 @@ public func FfiConverterTypeChatsSubscription_lower(_ value: ChatsSubscription) 
  * the per-account chats/messages subscriptions).
  */
 public protocol EventsSubscriptionProtocol : AnyObject {
-
+    
     func next() async  -> MarmotEventFfi?
-
+    
 }
 
 /**
@@ -1083,16 +1099,16 @@ open class EventsSubscription:
         try! rustCall { uniffi_marmot_uniffi_fn_free_eventssubscription(pointer, $0) }
     }
 
+    
 
-
-
+    
 open func next()async  -> MarmotEventFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_eventssubscription_next(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -1100,10 +1116,10 @@ open func next()async  -> MarmotEventFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeMarmotEventFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
 
 }
 
@@ -1162,12 +1178,12 @@ public func FfiConverterTypeEventsSubscription_lower(_ value: EventsSubscription
 
 
 public protocol ExternalAccountSignerFfi : AnyObject {
-
+    
     /**
      * Return the signer account public key as hex or npub.
      */
     func publicKey() throws  -> String
-
+    
     /**
      * Sign a serialized unsigned Nostr event and return the signed event JSON.
      *
@@ -1175,7 +1191,7 @@ public protocol ExternalAccountSignerFfi : AnyObject {
      * Blossom upload auth, and account identity proofs.
      */
     func signEvent(unsignedEventJson: String) throws  -> String
-
+    
     /**
      * NIP-04 encrypt/decrypt support for legacy Nostr surfaces.
      *
@@ -1183,16 +1199,16 @@ public protocol ExternalAccountSignerFfi : AnyObject {
      * support it should return a clear unsupported signer error.
      */
     func nip04Encrypt(publicKey: String, content: String) throws  -> String
-
+    
     func nip04Decrypt(publicKey: String, encryptedContent: String) throws  -> String
-
+    
     /**
      * NIP-44 encrypt/decrypt support for gift-wrap and encrypted app data.
      */
     func nip44Encrypt(publicKey: String, content: String) throws  -> String
-
+    
     func nip44Decrypt(publicKey: String, payload: String) throws  -> String
-
+    
 }
 
 open class ExternalAccountSignerFfiImpl:
@@ -1242,9 +1258,9 @@ open class ExternalAccountSignerFfiImpl:
         try! rustCall { uniffi_marmot_uniffi_fn_free_externalaccountsignerffi(pointer, $0) }
     }
 
+    
 
-
-
+    
     /**
      * Return the signer account public key as hex or npub.
      */
@@ -1254,7 +1270,7 @@ open func publicKey()throws  -> String {
     )
 })
 }
-
+    
     /**
      * Sign a serialized unsigned Nostr event and return the signed event JSON.
      *
@@ -1268,7 +1284,7 @@ open func signEvent(unsignedEventJson: String)throws  -> String {
     )
 })
 }
-
+    
     /**
      * NIP-04 encrypt/decrypt support for legacy Nostr surfaces.
      *
@@ -1283,7 +1299,7 @@ open func nip04Encrypt(publicKey: String, content: String)throws  -> String {
     )
 })
 }
-
+    
 open func nip04Decrypt(publicKey: String, encryptedContent: String)throws  -> String {
     return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
     uniffi_marmot_uniffi_fn_method_externalaccountsignerffi_nip04_decrypt(self.uniffiClonePointer(),
@@ -1292,7 +1308,7 @@ open func nip04Decrypt(publicKey: String, encryptedContent: String)throws  -> St
     )
 })
 }
-
+    
     /**
      * NIP-44 encrypt/decrypt support for gift-wrap and encrypted app data.
      */
@@ -1304,7 +1320,7 @@ open func nip44Encrypt(publicKey: String, content: String)throws  -> String {
     )
 })
 }
-
+    
 open func nip44Decrypt(publicKey: String, payload: String)throws  -> String {
     return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
     uniffi_marmot_uniffi_fn_method_externalaccountsignerffi_nip44_decrypt(self.uniffiClonePointer(),
@@ -1313,7 +1329,7 @@ open func nip44Decrypt(publicKey: String, payload: String)throws  -> String {
     )
 })
 }
-
+    
 
 }
 // Magic number for the Rust proxy to call using the same mechanism as every other method,
@@ -1344,7 +1360,7 @@ fileprivate struct UniffiCallbackInterfaceExternalAccountSignerFfi {
                 )
             }
 
-
+            
             let writeReturn = { uniffiOutReturn.pointee = FfiConverterString.lower($0) }
             uniffiTraitInterfaceCallWithError(
                 callStatus: uniffiCallStatus,
@@ -1369,7 +1385,7 @@ fileprivate struct UniffiCallbackInterfaceExternalAccountSignerFfi {
                 )
             }
 
-
+            
             let writeReturn = { uniffiOutReturn.pointee = FfiConverterString.lower($0) }
             uniffiTraitInterfaceCallWithError(
                 callStatus: uniffiCallStatus,
@@ -1396,7 +1412,7 @@ fileprivate struct UniffiCallbackInterfaceExternalAccountSignerFfi {
                 )
             }
 
-
+            
             let writeReturn = { uniffiOutReturn.pointee = FfiConverterString.lower($0) }
             uniffiTraitInterfaceCallWithError(
                 callStatus: uniffiCallStatus,
@@ -1423,7 +1439,7 @@ fileprivate struct UniffiCallbackInterfaceExternalAccountSignerFfi {
                 )
             }
 
-
+            
             let writeReturn = { uniffiOutReturn.pointee = FfiConverterString.lower($0) }
             uniffiTraitInterfaceCallWithError(
                 callStatus: uniffiCallStatus,
@@ -1450,7 +1466,7 @@ fileprivate struct UniffiCallbackInterfaceExternalAccountSignerFfi {
                 )
             }
 
-
+            
             let writeReturn = { uniffiOutReturn.pointee = FfiConverterString.lower($0) }
             uniffiTraitInterfaceCallWithError(
                 callStatus: uniffiCallStatus,
@@ -1477,7 +1493,7 @@ fileprivate struct UniffiCallbackInterfaceExternalAccountSignerFfi {
                 )
             }
 
-
+            
             let writeReturn = { uniffiOutReturn.pointee = FfiConverterString.lower($0) }
             uniffiTraitInterfaceCallWithError(
                 callStatus: uniffiCallStatus,
@@ -1558,11 +1574,11 @@ public func FfiConverterTypeExternalAccountSignerFfi_lower(_ value: ExternalAcco
 
 
 public protocol GroupStateSubscriptionProtocol : AnyObject {
-
+    
     func next() async  -> AppGroupRecordFfi?
-
+    
     func snapshot()  -> AppGroupRecordFfi?
-
+    
 }
 
 open class GroupStateSubscription:
@@ -1612,16 +1628,16 @@ open class GroupStateSubscription:
         try! rustCall { uniffi_marmot_uniffi_fn_free_groupstatesubscription(pointer, $0) }
     }
 
+    
 
-
-
+    
 open func next()async  -> AppGroupRecordFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_groupstatesubscription_next(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -1629,17 +1645,17 @@ open func next()async  -> AppGroupRecordFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeAppGroupRecordFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
 open func snapshot() -> AppGroupRecordFfi? {
     return try!  FfiConverterOptionTypeAppGroupRecordFfi.lift(try! rustCall() {
     uniffi_marmot_uniffi_fn_method_groupstatesubscription_snapshot(self.uniffiClonePointer(),$0
     )
 })
 }
-
+    
 
 }
 
@@ -1698,32 +1714,32 @@ public func FfiConverterTypeGroupStateSubscription_lower(_ value: GroupStateSubs
 
 
 public protocol MarmotProtocol : AnyObject {
-
+    
     func acceptGroupInvite(accountRef: String, groupIdHex: String) async throws  -> AppGroupRecordFfi
-
+    
     /**
      * Normalize a public-key reference (npub or hex) to canonical hex.
      * `None` if it isn't a valid public key. Used to resolve a scanned or
      * deep-linked npub back to the account id the rest of the API expects.
      */
     func accountIdHex(reference: String)  -> String?
-
+    
     func accountInboxRelays(accountRef: String) throws  -> [String]
-
+    
     /**
      * List the local and relay-discovered Marmot KeyPackage publications for
      * `account_ref`.
      */
     func accountKeyPackages(accountRef: String, bootstrapRelays: [String]) async throws  -> [AccountKeyPackageFfi]
-
+    
     func accountNip65Relays(accountRef: String) throws  -> [String]
-
+    
     /**
      * Per-account relay lists: the NIP-65 and inbox lists the account has
      * published, plus the configured default/bootstrap sets.
      */
     func accountRelayLists(accountRef: String) throws  -> AccountRelayListsFfi
-
+    
     /**
      * Per-account unread aggregate for the account-switcher badge
      * (mdk#461). Each entry's `unread_count` is read from that
@@ -1734,49 +1750,49 @@ public protocol MarmotProtocol : AnyObject {
      * `list_accounts`.
      */
     func accountUnreadSummary() throws  -> [AccountUnreadFfi]
-
+    
     /**
      * Local JSONL audit logs available for explicit forensic upload.
      */
     func auditLogFiles() throws  -> [AuditLogFileFfi]
-
+    
     /**
      * Local forensic audit-log recording settings. Recording is opt-in and only
      * applies to account sessions opened after the setting is enabled.
      */
     func auditLogSettings() throws  -> AuditLogSettingsFfi
-
-    func catchUpAccounts() async throws
-
+    
+    func catchUpAccounts() async throws 
+    
     /**
      * Durable chat-list rows for fast app launch. Rows include the group
      * title/avatar, last kind-9 preview, unread count, and read anchors.
      */
     func chatList(accountRef: String, includeArchived: Bool) throws  -> [ChatListRowFfi]
-
-    func clearPushRegistration(accountRef: String) async throws
-
+    
+    func clearPushRegistration(accountRef: String) async throws 
+    
     func collectNotificationsAfterWake(maxWaitMs: UInt32, source: NotificationWakeSourceFfi) async throws  -> BackgroundNotificationCollectionFfi
-
+    
     /**
      * Create a new MLS group with `name` and the given members. Members are
      * referenced by `npub` or hex account id. Returns the group id as hex.
      */
     func createGroup(accountRef: String, name: String, memberRefs: [String], description: String?) async throws  -> String
-
+    
     /**
      * Create a brand-new Nostr identity, store its secret in the platform
      * keychain, and publish initial relay lists + key package.
      */
     func createIdentity(defaultRelays: [String], bootstrapRelays: [String]) async throws  -> AccountSummaryFfi
-
+    
     func declineGroupInvite(accountRef: String, groupIdHex: String) async throws  -> GroupInviteDeclineResultFfi
-
+    
     /**
      * Publish a NIP-09 deletion for a KeyPackage event.
      */
     func deleteAccountKeyPackage(accountRef: String, eventIdHex: String, relays: [String]) async throws  -> UInt64
-
+    
     /**
      * Delete one local JSONL audit log file (e.g. behind a "clear audit log"
      * button).
@@ -1788,7 +1804,7 @@ public protocol MarmotProtocol : AnyObject {
      * `still_recording` is `false`. Pass a `path` from `audit_log_files()`.
      */
     func deleteAuditLogFile(path: String) async throws  -> AuditLogDeleteResultFfi
-
+    
     /**
      * Delete this group's local app data without performing an MLS leave. The
      * caller should cancel any active UI subscriptions for the group before
@@ -1800,21 +1816,26 @@ public protocol MarmotProtocol : AnyObject {
      * Returns true if any local rows or a live route were removed.
      */
     func deleteGroupLocal(accountRef: String, groupIdHex: String) async throws  -> Bool
-
+    
     /**
      * Mark `target_message_id` deleted for the whole group. This is a
      * tombstone — the original stays in everyone's store; clients render a
      * "message deleted" placeholder.
      */
     func deleteMessage(accountRef: String, groupIdHex: String, targetMessageId: String) async throws  -> SendSummaryFfi
-
+    
+    /**
+     * Delete a saved composer draft. This is a no-op when no draft exists.
+     */
+    func deleteMessageDraft(accountRef: String, groupIdHex: String) throws 
+    
     /**
      * Revoke `member_ref`'s admin rights.
      */
     func demoteAdmin(accountRef: String, groupIdHex: String, memberRef: String) async throws  -> SendSummaryFfi
-
+    
     func demoteAdminDetailed(accountRef: String, groupIdHex: String, memberRef: String) async throws  -> GroupMutationResultFfi
-
+    
     /**
      * Best-effort cached display name for an account id. Returns the Nostr
      * kind:0 display_name/name when the runtime has projected one, or the
@@ -1822,7 +1843,7 @@ public protocol MarmotProtocol : AnyObject {
      * `None` when nothing is known yet — call `refresh_directory` to fetch.
      */
     func displayName(accountIdHex: String)  -> String?
-
+    
     /**
      * Fetch and decrypt the group's encrypted Blossom avatar
      * (`marmot.group.blossom.image.v1`) into raw image bytes (PNG/JPEG/…).
@@ -1832,13 +1853,13 @@ public protocol MarmotProtocol : AnyObject {
      * for rendering.
      */
     func downloadGroupBlossomImage(accountRef: String, groupIdHex: String) async throws  -> Data
-
+    
     /**
      * Fetch an encrypted media blob and decrypt it using the group's
      * encrypted media component secret.
      */
     func downloadMedia(accountRef: String, groupIdHex: String, reference: MediaAttachmentReferenceFfi) async throws  -> MediaDownloadResultFfi
-
+    
     /**
      * Edit `target_message_id` by publishing a kind-1009 event that
      * references it and carries the replacement plaintext in `content`.
@@ -1852,7 +1873,7 @@ public protocol MarmotProtocol : AnyObject {
      * projection and resolve the latest text per target message id.
      */
     func editMessage(accountRef: String, groupIdHex: String, targetMessageId: String, content: String) async throws  -> SendSummaryFfi
-
+    
     /**
      * Export the active account's private key as a password-encrypted NIP-49
      * `ncryptsec1...` bech32 backup string (mdk#544).
@@ -1864,70 +1885,70 @@ public protocol MarmotProtocol : AnyObject {
      * not returned to the host app.
      */
     func exportEncryptedSecretKey(accountRef: String, passphrase: String) throws  -> String
-
+    
     /**
      * Group plus enriched member rows for detail screens.
      */
     func groupDetails(accountRef: String, groupIdHex: String) async throws  -> GroupDetailsFfi
-
+    
     /**
      * Current caller permissions plus per-member action availability.
      */
     func groupManagementState(accountRef: String, groupIdHex: String) async throws  -> GroupManagementStateFfi
-
+    
     /**
      * Membership roster for `group_id_hex`.
      */
     func groupMembers(accountRef: String, groupIdHex: String) async throws  -> [AppGroupMemberRecordFfi]
-
+    
     /**
      * Current MLS state (epoch, member count, required components) for the
      * conversation developer/debug view.
      */
     func groupMlsState(accountRef: String, groupIdHex: String) async throws  -> AppGroupMlsStateFfi
-
+    
     func groupPushDebugInfo(accountRef: String, groupIdHex: String) async throws  -> GroupPushDebugInfoFfi
-
+    
     /**
      * Establish the unread baseline the first time a user opens a group.
      * Existing kind-9 history remains read; later remote kind-9 messages count
      * until marked visible via `mark_timeline_message_read`.
      */
     func initializeChatReadState(accountRef: String, groupIdHex: String) throws  -> ChatListRowFfi?
-
+    
     func inviteMembers(accountRef: String, groupIdHex: String, memberRefs: [String]) async throws  -> SendSummaryFfi
-
+    
     func inviteMembersDetailed(accountRef: String, groupIdHex: String, memberRefs: [String]) async throws  -> GroupMutationResultFfi
-
+    
     /**
      * True once shutdown has started. Host apps can use this to avoid
      * launching more subscriptions or account work while they are moving to
      * the background.
      */
     func isStopping()  -> Bool
-
+    
     func leaveGroup(accountRef: String, groupIdHex: String) async throws  -> SendSummaryFfi
-
+    
     /**
      * All accounts known to the runtime, in stable order. `running` is
      * `false` for accounts that haven't been brought up by the current
      * process yet.
      */
     func listAccounts() throws  -> [AccountSummaryFfi]
-
+    
     /**
      * Typed media references projected from group message history. Host apps
      * can pass a returned `reference` back to `download_media`.
      */
     func listMedia(accountRef: String, groupIdHex: String, limit: UInt32?) throws  -> [MediaRecordFfi]
-
+    
     /**
      * Log in with an existing identity. `identity` can be an `nsec` (private
      * key) for a local-signing account, or an `npub` to track a public
      * identity without local signing.
      */
     func login(identity: String, defaultRelays: [String], bootstrapRelays: [String]) async throws  -> AccountSummaryFfi
-
+    
     /**
      * Log in with an external account signer such as Amber/NIP-55.
      *
@@ -1938,81 +1959,94 @@ public protocol MarmotProtocol : AnyObject {
      * publish, decrypt welcomes, or start its worker.
      */
     func loginExternalSigner(publicKey: String, signer: ExternalAccountSignerFfi, defaultRelays: [String], bootstrapRelays: [String]) async throws  -> AccountSummaryFfi
-
+    
     /**
      * Mark a kind-9 timeline message visible/read. Own kind-9 messages can
      * advance the marker too, which clears any earlier unread messages.
      */
     func markTimelineMessageRead(accountRef: String, groupIdHex: String, messageIdHex: String) throws  -> ChatListRowFfi?
-
+    
+    /**
+     * The saved composer draft for an account and MLS group, if one exists.
+     */
+    func messageDraft(accountRef: String, groupIdHex: String) throws  -> MessageDraftFfi?
+    
+    /**
+     * Metadata-only saved composer drafts for an account, newest-updated
+     * first. Attachment plaintext is intentionally omitted from this list;
+     * call `messageDraft` when restoring one selected composer. Hosts must
+     * delete empty or sent drafts; deleting a group also removes its draft.
+     */
+    func messageDrafts(accountRef: String) throws  -> [MessageDraftSummaryFfi]
+    
     /**
      * Initial history fetch for a group (or, when `group_id_hex` is None,
      * the account-wide tail). Used to populate the conversation view before
      * the subscription stream takes over.
      */
     func messages(accountRef: String, groupIdHex: String?, limit: UInt32?) throws  -> [AppMessageRecordFfi]
-
+    
     /**
      * Normalize a member reference for group-management UI. Accepts hex,
      * `npub`, `nostr:npub...`, and `marmot://profile/...` references.
      */
     func normalizeMemberRef(memberRef: String) throws  -> MemberRefFfi
-
+    
     func notificationSettings(accountRef: String) throws  -> NotificationSettingsFfi
-
+    
     /**
      * Convert a hex account id (Nostr public key) into its `npub…` bech32
      * form for display. `None` if the hex isn't a valid public key.
      */
     func npub(accountIdHex: String)  -> String?
-
+    
     /**
      * Parse plaintext message content into the same Markdown AST returned on
      * message and timeline records. Useful for draft previews and host-side
      * fallback rendering.
      */
     func parseMarkdown(text: String)  -> MarkdownDocumentFfi
-
+    
     /**
      * POST one selected JSONL audit log to a forensic analyzer endpoint.
      */
     func postAuditLogFile(path: String, endpoint: String) async throws  -> AuditLogUploadResultFfi
-
+    
     /**
      * POST all local audit logs to the configured tracker when audit logging is
      * enabled. This is safe for host apps to call unconditionally; disabled or
      * unconfigured states return a structured skip result.
      */
     func postAuditLogTrackerUpdate() async throws  -> AuditLogTrackerUpdateResultFfi
-
+    
     /**
      * Grant admin rights to `member_ref` (npub or hex). Requires the caller
      * to be an admin; publishes a group state update.
      */
     func promoteAdmin(accountRef: String, groupIdHex: String, memberRef: String) async throws  -> SendSummaryFfi
-
+    
     func promoteAdminDetailed(accountRef: String, groupIdHex: String, memberRef: String) async throws  -> GroupMutationResultFfi
-
+    
     /**
      * Publish a new fresh KeyPackage for `account_ref`.
      */
     func publishNewKeyPackage(accountRef: String) async throws  -> UInt64
-
+    
     /**
      * Publish (or re-publish) the NIP-65 and inbox relay lists for
      * `account_ref`. Idempotent — safe to call on every launch.
      */
-    func publishRelayLists(accountRef: String, defaultRelays: [String], bootstrapRelays: [String]) async throws
-
+    func publishRelayLists(accountRef: String, defaultRelays: [String], bootstrapRelays: [String]) async throws 
+    
     /**
      * Publish the Nostr kind:0 metadata for `account_ref`. The returned
      * metadata is what marmot-app actually published (any server-applied
      * defaults are reflected here).
      */
     func publishUserProfile(accountRef: String, profile: UserProfileMetadataFfi, defaultRelays: [String], bootstrapRelays: [String]) async throws  -> UserProfileMetadataFfi
-
+    
     func pushRegistration(accountRef: String) throws  -> PushRegistrationFfi?
-
+    
     /**
      * Stored groups that failed session-open hydration and were skipped so the
      * rest of the account could open (mdk#151 / #417). These groups are
@@ -2023,19 +2057,19 @@ public protocol MarmotProtocol : AnyObject {
      * [`Self::retry_hydrate_quarantined_group`].
      */
     func quarantinedGroups(accountRef: String) async throws  -> [AppQuarantinedGroupFfi]
-
+    
     /**
      * React to `target_message_id` with `emoji` (an "add" reaction).
      */
     func reactToMessage(accountRef: String, groupIdHex: String, targetMessageId: String, emoji: String) async throws  -> SendSummaryFfi
-
+    
     /**
      * Fetch and cache an account's own Nostr kind:0 profile from `relays`.
      * After this resolves, `user_profile` / `display_name` return the
      * freshly-fetched metadata (name, picture, etc.) for that account.
      */
-    func refreshProfile(accountIdHex: String, relays: [String]) async throws
-
+    func refreshProfile(accountIdHex: String, relays: [String]) async throws 
+    
     /**
      * Re-register an external signer for an already-known external account.
      *
@@ -2043,48 +2077,48 @@ public protocol MarmotProtocol : AnyObject {
      * new account; it only installs the signer callback so runtime work can
      * resume for the account.
      */
-    func registerExternalSigner(accountRef: String, signer: ExternalAccountSignerFfi) async throws
-
+    func registerExternalSigner(accountRef: String, signer: ExternalAccountSignerFfi) async throws 
+    
     /**
      * Live relay-plane connection health (connected / connecting /
      * disconnected counts, etc.) for the relay diagnostics view.
      */
     func relayHealth() async  -> RelayHealthFfi
-
+    
     /**
      * Device-wide relay telemetry export settings. Export is opt-in and stays
      * inert until `export_enabled` is true and runtime/default config supplies
      * a valid OTLP endpoint, bearer token, and resource attributes.
      */
     func relayTelemetrySettings() throws  -> RelayTelemetrySettingsFfi
-
+    
     /**
      * Remove a local-signing account from this device.
      */
-    func removeAccount(accountRef: String) async throws
-
+    func removeAccount(accountRef: String) async throws 
+    
     func removeMembers(accountRef: String, groupIdHex: String, memberRefs: [String]) async throws  -> SendSummaryFfi
-
+    
     func removeMembersDetailed(accountRef: String, groupIdHex: String, memberRefs: [String]) async throws  -> GroupMutationResultFfi
-
+    
     /**
      * Replace the group's encrypted-media default blob endpoints as a full
      * `marmot.group.encrypted-media.v1` component update. Requires the caller
      * to be an admin.
      */
     func replaceEncryptedMediaBlobEndpoints(accountRef: String, groupIdHex: String, endpoints: [AppBlobEndpointFfi]) async throws  -> SendSummaryFfi
-
+    
     /**
      * Send `text` as a reply that quotes `target_message_id`.
      */
     func replyToMessage(accountRef: String, groupIdHex: String, targetMessageId: String, text: String) async throws  -> SendSummaryFfi
-
+    
     /**
      * Re-publish the latest cached KeyPackage when possible, otherwise
      * publish a fresh one.
      */
     func republishKeyPackage(accountRef: String) async throws  -> UInt64
-
+    
     /**
      * Re-attempt publishing a group's pending (committed-but-undelivered)
      * commit(s) without minting a new event.
@@ -2100,7 +2134,7 @@ public protocol MarmotProtocol : AnyObject {
      * nothing was pending or publishing is still failing.
      */
     func retryGroupConvergence(accountRef: String, groupIdHex: String) async throws  -> SendSummaryFfi
-
+    
     /**
      * Re-attempt hydration of a single quarantined group (mdk#426).
      *
@@ -2112,7 +2146,7 @@ public protocol MarmotProtocol : AnyObject {
      * currently quarantined.
      */
     func retryHydrateQuarantinedGroup(accountRef: String, groupIdHex: String) async throws  -> Bool
-
+    
     /**
      * Export the active account's raw private key in canonical `nsec1...`
      * bech32 form for an in-app key-backup display (mdk#543).
@@ -2128,7 +2162,12 @@ public protocol MarmotProtocol : AnyObject {
      * / cross-account refs via the existing keystore validation.
      */
     func revealNsec(accountRef: String) throws  -> String
-
+    
+    /**
+     * Upsert a composer draft into the account's encrypted SQLCipher store.
+     */
+    func saveMessageDraft(accountRef: String, groupIdHex: String, content: String, replyToMessageIdHex: String?, mediaAttachments: [MessageDraftAttachmentFfi]) throws  -> MessageDraftFfi
+    
     /**
      * Securely scrub and prune expired disappearing-message plaintext for a
      * group according to its active retention component. The media hash list
@@ -2136,37 +2175,37 @@ public protocol MarmotProtocol : AnyObject {
      * decrypted-media disk caches keyed by ciphertext hash.
      */
     func secureDeleteExpired(accountRef: String, groupIdHex: String) async throws  -> SecureDeleteExpiredResultFfi
-
+    
     /**
      * Step down as an admin of `group_id_hex` (demote the active account).
      */
     func selfDemoteAdmin(accountRef: String, groupIdHex: String) async throws  -> SendSummaryFfi
-
+    
     func selfDemoteAdminDetailed(accountRef: String, groupIdHex: String) async throws  -> GroupMutationResultFfi
-
+    
     /**
      * Send already-uploaded encrypted media attachments as a kind-9 chat
      * carrying ordered NIP-92 `imeta` tags.
      */
     func sendMediaAttachments(accountRef: String, groupIdHex: String, attachments: [MediaAttachmentReferenceFfi], caption: String?) async throws  -> SendSummaryFfi
-
+    
     /**
      * Backward-compatible single-attachment send helper. Prefer
      * `send_media_attachments` for new callers so one chat can carry ordered
      * mixed media attachments.
      */
     func sendMediaReference(accountRef: String, groupIdHex: String, reference: MediaAttachmentReferenceFfi, caption: String?) async throws  -> SendSummaryFfi
-
+    
     /**
      * Send a plain UTF-8 text message. Structured payloads (reactions,
      * replies, deletes, media) go through dedicated methods.
      */
     func sendText(accountRef: String, groupIdHex: String, text: String) async throws  -> SendSummaryFfi
-
+    
     func setAccountInboxRelays(accountRef: String, relays: [String], bootstrapRelays: [String]) async throws  -> AccountRelayListsFfi
-
+    
     func setAccountNip65Relays(accountRef: String, relays: [String], bootstrapRelays: [String]) async throws  -> AccountRelayListsFfi
-
+    
     /**
      * Persist local forensic audit-log recording settings and return the stored
      * value.
@@ -2176,7 +2215,7 @@ public protocol MarmotProtocol : AnyObject {
      * stops it and closes the file — no session reopen required.
      */
     func setAuditLogSettings(settings: AuditLogSettingsFfi) async throws  -> AuditLogSettingsFfi
-
+    
     /**
      * Supply non-persisted audit tracker upload metadata: optional Goggles
      * upload URL override, bearer token from the host app, and optional human
@@ -2186,38 +2225,38 @@ public protocol MarmotProtocol : AnyObject {
      * bearer token back across FFI: secrets flow in, not out.
      */
     func setAuditLogTrackerConfig(config: AuditLogTrackerConfigFfi) throws  -> AuditLogTrackerConfigFfi
-
+    
     /**
      * Flag a group archived (or restore it). Local-only projection state —
      * it does not change membership or publish anything. The chats list
      * filters archived groups unless `include_archived` is set.
      */
     func setGroupArchived(accountRef: String, groupIdHex: String, archived: Bool) async throws  -> AppGroupRecordFfi
-
+    
     func setLocalNotificationsEnabled(accountRef: String, enabled: Bool) throws  -> NotificationSettingsFfi
-
+    
     func setNativePushEnabled(accountRef: String, enabled: Bool) async throws  -> NotificationSettingsFfi
-
+    
     /**
      * Supply non-persisted OTLP runtime metadata: optional metrics URL
      * override, bearer token from the host app's build-time secret, and
      * resource attributes from the platform shell.
      */
-    func setRelayTelemetryRuntimeConfig(config: RelayTelemetryRuntimeConfigFfi) async throws
-
+    func setRelayTelemetryRuntimeConfig(config: RelayTelemetryRuntimeConfigFfi) async throws 
+    
     /**
      * Persist device-wide relay telemetry export settings and return the
      * normalized settings that were stored.
      */
     func setRelayTelemetrySettings(settings: RelayTelemetrySettingsFfi) async throws  -> RelayTelemetrySettingsFfi
-
+    
     /**
      * Tear the runtime down. Drops all subscriptions; long-lived
      * [`EventsSubscription`] / [`ChatsSubscription`] / etc. instances on the
      * host side will see their `next()` return `None` shortly after.
      */
-    func shutdown() async
-
+    func shutdown() async 
+    
     /**
      * Re-activate a non-destructively signed-out local account. This clears
      * the durable signed-out marker and starts the account worker again; relay
@@ -2225,7 +2264,7 @@ public protocol MarmotProtocol : AnyObject {
      * commands after sign-in.
      */
     func signInAccount(accountRef: String) async throws  -> AccountSummaryFfi
-
+    
     /**
      * Non-destructive sign-out: deactivate the account on this device and,
      * when `delete_key_packages` is `true` (the default behavior in the UI),
@@ -2244,7 +2283,7 @@ public protocol MarmotProtocol : AnyObject {
      * sign-in" hint (mdk#477).
      */
     func signOut(accountRef: String, deleteKeyPackages: Bool) async throws  -> SignOutOutcomeFfi
-
+    
     /**
      * Destructive sign-out: leave every active MLS group (best-effort), delete
      * the account's relay-published KeyPackages, then wipe all local state for
@@ -2255,13 +2294,13 @@ public protocol MarmotProtocol : AnyObject {
      * partial-failure sheet (mdk#478).
      */
     func signOutAndWipe(accountRef: String) async throws  -> WipeOutcomeFfi
-
+    
     /**
      * Bring the runtime online: reconcile known accounts, start workers,
      * subscribe to transport events.
      */
-    func start() async throws
-
+    func start() async throws 
+    
     /**
      * Anchor a live agent text stream start in the encrypted group history.
      * Host apps pass the broker candidate(s) they will publish to, such as
@@ -2269,13 +2308,13 @@ public protocol MarmotProtocol : AnyObject {
      * generate a 32-byte stream id.
      */
     func startAgentTextStream(accountRef: String, groupIdHex: String, streamIdHex: String?, quicCandidates: [String]) async throws  -> AgentStreamStartFfi
-
+    
     /**
      * Per-account durable chat-list projection. Async for the same
      * tokio-runtime reason as [`Marmot::subscribe_chats`].
      */
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws  -> ChatListSubscription
-
+    
     /**
      * Per-account chats list. Emits whenever a group's projection changes.
      *
@@ -2286,20 +2325,20 @@ public protocol MarmotProtocol : AnyObject {
      * the subscribe methods that spawn must be async.
      */
     func subscribeChats(accountRef: String, includeArchived: Bool) async throws  -> ChatsSubscription
-
+    
     /**
      * Top-level event firehose. One subscription, every account, every event
      * type. Useful for global diagnostics; specific UIs prefer the
      * per-account chats/messages/group-state subscriptions below.
      */
     func subscribeEvents()  -> EventsSubscription
-
+    
     /**
      * Member/profile/roster changes for one group. Async for the same
      * tokio-runtime reason as [`Marmot::subscribe_chats`].
      */
     func subscribeGroupState(accountRef: String, groupIdHex: String) async throws  -> GroupStateSubscription
-
+    
     /**
      * Messages for a specific group (when `group_id_hex` is `Some`) or
      * every message across the account (when `None`). `limit` caps the initial
@@ -2307,22 +2346,22 @@ public protocol MarmotProtocol : AnyObject {
      * Async for the same tokio-runtime reason as [`Marmot::subscribe_chats`].
      */
     func subscribeMessages(accountRef: String, groupIdHex: String?, limit: UInt32?) async throws  -> MessagesSubscription
-
+    
     func subscribeNotifications() async throws  -> NotificationsSubscription
-
+    
     /**
      * Live materialized timeline updates for a group or account-wide tail.
      * The snapshot and each update are full pages for the supplied query.
      */
     func subscribeTimelineMessages(accountRef: String, groupIdHex: String?, limit: UInt32?) async throws  -> TimelineMessagesSubscription
-
+    
     /**
      * Stable random identifier for this app install, suitable for the OTLP
      * `service.instance.id` resource attribute. Separate from audit-log device
      * identity.
      */
     func telemetryInstallId() throws  -> String
-
+    
     /**
      * Materialized conversation timeline for a group or account-wide tail.
      *
@@ -2340,21 +2379,21 @@ public protocol MarmotProtocol : AnyObject {
      * thread. Retained for one-shot diagnostics/tooling only.
      */
     func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi) throws  -> TimelinePageFfi
-
+    
     /**
      * Remove this account's reaction from `target_message_id`.
      */
     func unreactFromMessage(accountRef: String, groupIdHex: String, targetMessageId: String) async throws  -> SendSummaryFfi
-
+    
     /**
      * Set (or clear, with `url = None`) the group's URL-based avatar
      * (`marmot.group.avatar-url.v1`). The URL is validated (https-only, no
      * localhost/private hosts) and normalized before it is committed.
      */
     func updateGroupAvatarUrl(accountRef: String, groupIdHex: String, url: String?, dim: String?, thumbhash: String?) async throws  -> SendSummaryFfi
-
+    
     func updateGroupProfile(accountRef: String, groupIdHex: String, name: String?, description: String?) async throws  -> SendSummaryFfi
-
+    
     /**
      * Set the per-group disappearing-message retention, wrapping the engine's
      * `update_message_retention`. `disappearing_message_secs` of `0` disables
@@ -2362,15 +2401,15 @@ public protocol MarmotProtocol : AnyObject {
      * passthrough over the already-public engine API (mdk#571).
      */
     func updateMessageRetention(accountRef: String, groupIdHex: String, disappearingMessageSecs: UInt64) async throws  -> SendSummaryFfi
-
+    
     /**
      * Encrypt plaintext attachments, upload the ciphertext blobs, and
      * optionally send the resulting media references into the group.
      */
     func uploadMedia(accountRef: String, groupIdHex: String, request: MediaUploadRequestFfi) async throws  -> MediaUploadResultFfi
-
+    
     func upsertPushRegistration(accountRef: String, platform: PushPlatformFfi, rawToken: String, serverPubkeyHex: String, relayHint: String?) async throws  -> PushRegistrationFfi
-
+    
     /**
      * Full cached Nostr kind:0 profile for an account id (name, display
      * name, about, picture, nip05, lud16), if the runtime has one
@@ -2379,7 +2418,16 @@ public protocol MarmotProtocol : AnyObject {
      * `refresh_directory`. Returns `None` when nothing is cached yet.
      */
     func userProfile(accountIdHex: String) throws  -> UserProfileMetadataFfi?
-
+    
+    /**
+     * Cached Nostr kind:0 `website` metadata for an account id, when it is a
+     * string. The generic profile record intentionally exposes the fields the
+     * host can publish; this read-only accessor preserves arbitrary kind:0
+     * metadata while still making the standard website field available to
+     * profile presentation surfaces.
+     */
+    func userProfileWebsite(accountIdHex: String) throws  -> String?
+    
     /**
      * Watch a live agent text stream over the brokered QUIC channel. Pass
      * `stream_id_hex = None` to follow the latest stream in the group (the
@@ -2394,7 +2442,7 @@ public protocol MarmotProtocol : AnyObject {
      * `subscribe_messages`.
      */
     func watchAgentTextStream(accountRef: String, groupIdHex: String, streamIdHex: String?, serverCertDer: Data?, insecureLocal: Bool) async throws  -> AgentStreamSubscription
-
+    
 }
 
 open class Marmot:
@@ -2462,9 +2510,32 @@ public convenience init(rootPath: String, relayUrls: [String])throws  {
         try! rustCall { uniffi_marmot_uniffi_fn_free_marmot(pointer, $0) }
     }
 
+    
+    /**
+     * Open the Marmot app with an explicit durable transport-cursor policy.
+     * Identical to [`Marmot::new`] except for the policy; `new` itself is
+     * [`CursorPersistenceFfi::Advance`].
+     *
+     * Wake-collection processes — the iOS NSE constructing one `Marmot` per
+     * push around [`Marmot::collect_notifications_after_wake`], and the
+     * notification reply/mark-read action paths — construct with
+     * [`CursorPersistenceFfi::Frozen`]: the pass still ingests, decrypts, and
+     * projects everything, but a sub-second drain on cold sockets can never
+     * ratchet the durable `since` floor past events it did not receive (the
+     * wake-collection trigger). Foreground app processes keep [`Marmot::new`].
+     */
+public static func newWithCursorPersistence(rootPath: String, relayUrls: [String], cursorPersistence: CursorPersistenceFfi)throws  -> Marmot {
+    return try  FfiConverterTypeMarmot.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
+    uniffi_marmot_uniffi_fn_constructor_marmot_new_with_cursor_persistence(
+        FfiConverterString.lower(rootPath),
+        FfiConverterSequenceString.lower(relayUrls),
+        FfiConverterTypeCursorPersistenceFfi.lower(cursorPersistence),$0
+    )
+})
+}
+    
 
-
-
+    
 open func acceptGroupInvite(accountRef: String, groupIdHex: String)async throws  -> AppGroupRecordFfi {
     return
         try  await uniffiRustCallAsync(
@@ -2481,7 +2552,7 @@ open func acceptGroupInvite(accountRef: String, groupIdHex: String)async throws 
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Normalize a public-key reference (npub or hex) to canonical hex.
      * `None` if it isn't a valid public key. Used to resolve a scanned or
@@ -2494,7 +2565,7 @@ open func accountIdHex(reference: String) -> String? {
     )
 })
 }
-
+    
 open func accountInboxRelays(accountRef: String)throws  -> [String] {
     return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
     uniffi_marmot_uniffi_fn_method_marmot_account_inbox_relays(self.uniffiClonePointer(),
@@ -2502,7 +2573,7 @@ open func accountInboxRelays(accountRef: String)throws  -> [String] {
     )
 })
 }
-
+    
     /**
      * List the local and relay-discovered Marmot KeyPackage publications for
      * `account_ref`.
@@ -2523,7 +2594,7 @@ open func accountKeyPackages(accountRef: String, bootstrapRelays: [String])async
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func accountNip65Relays(accountRef: String)throws  -> [String] {
     return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
     uniffi_marmot_uniffi_fn_method_marmot_account_nip65_relays(self.uniffiClonePointer(),
@@ -2531,7 +2602,7 @@ open func accountNip65Relays(accountRef: String)throws  -> [String] {
     )
 })
 }
-
+    
     /**
      * Per-account relay lists: the NIP-65 and inbox lists the account has
      * published, plus the configured default/bootstrap sets.
@@ -2543,7 +2614,7 @@ open func accountRelayLists(accountRef: String)throws  -> AccountRelayListsFfi {
     )
 })
 }
-
+    
     /**
      * Per-account unread aggregate for the account-switcher badge
      * (mdk#461). Each entry's `unread_count` is read from that
@@ -2559,7 +2630,7 @@ open func accountUnreadSummary()throws  -> [AccountUnreadFfi] {
     )
 })
 }
-
+    
     /**
      * Local JSONL audit logs available for explicit forensic upload.
      */
@@ -2569,7 +2640,7 @@ open func auditLogFiles()throws  -> [AuditLogFileFfi] {
     )
 })
 }
-
+    
     /**
      * Local forensic audit-log recording settings. Recording is opt-in and only
      * applies to account sessions opened after the setting is enabled.
@@ -2580,14 +2651,14 @@ open func auditLogSettings()throws  -> AuditLogSettingsFfi {
     )
 })
 }
-
+    
 open func catchUpAccounts()async throws  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_marmot_catch_up_accounts(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_void,
@@ -2597,7 +2668,7 @@ open func catchUpAccounts()async throws  {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Durable chat-list rows for fast app launch. Rows include the group
      * title/avatar, last kind-9 preview, unread count, and read anchors.
@@ -2610,7 +2681,7 @@ open func chatList(accountRef: String, includeArchived: Bool)throws  -> [ChatLis
     )
 })
 }
-
+    
 open func clearPushRegistration(accountRef: String)async throws  {
     return
         try  await uniffiRustCallAsync(
@@ -2627,7 +2698,7 @@ open func clearPushRegistration(accountRef: String)async throws  {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func collectNotificationsAfterWake(maxWaitMs: UInt32, source: NotificationWakeSourceFfi)async throws  -> BackgroundNotificationCollectionFfi {
     return
         try  await uniffiRustCallAsync(
@@ -2644,7 +2715,7 @@ open func collectNotificationsAfterWake(maxWaitMs: UInt32, source: NotificationW
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Create a new MLS group with `name` and the given members. Members are
      * referenced by `npub` or hex account id. Returns the group id as hex.
@@ -2665,7 +2736,7 @@ open func createGroup(accountRef: String, name: String, memberRefs: [String], de
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Create a brand-new Nostr identity, store its secret in the platform
      * keychain, and publish initial relay lists + key package.
@@ -2686,7 +2757,7 @@ open func createIdentity(defaultRelays: [String], bootstrapRelays: [String])asyn
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func declineGroupInvite(accountRef: String, groupIdHex: String)async throws  -> GroupInviteDeclineResultFfi {
     return
         try  await uniffiRustCallAsync(
@@ -2703,7 +2774,7 @@ open func declineGroupInvite(accountRef: String, groupIdHex: String)async throws
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Publish a NIP-09 deletion for a KeyPackage event.
      */
@@ -2723,7 +2794,7 @@ open func deleteAccountKeyPackage(accountRef: String, eventIdHex: String, relays
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Delete one local JSONL audit log file (e.g. behind a "clear audit log"
      * button).
@@ -2750,7 +2821,7 @@ open func deleteAuditLogFile(path: String)async throws  -> AuditLogDeleteResultF
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Delete this group's local app data without performing an MLS leave. The
      * caller should cancel any active UI subscriptions for the group before
@@ -2777,7 +2848,7 @@ open func deleteGroupLocal(accountRef: String, groupIdHex: String)async throws  
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Mark `target_message_id` deleted for the whole group. This is a
      * tombstone — the original stays in everyone's store; clients render a
@@ -2799,7 +2870,18 @@ open func deleteMessage(accountRef: String, groupIdHex: String, targetMessageId:
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
+    /**
+     * Delete a saved composer draft. This is a no-op when no draft exists.
+     */
+open func deleteMessageDraft(accountRef: String, groupIdHex: String)throws  {try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
+    uniffi_marmot_uniffi_fn_method_marmot_delete_message_draft(self.uniffiClonePointer(),
+        FfiConverterString.lower(accountRef),
+        FfiConverterString.lower(groupIdHex),$0
+    )
+}
+}
+    
     /**
      * Revoke `member_ref`'s admin rights.
      */
@@ -2819,7 +2901,7 @@ open func demoteAdmin(accountRef: String, groupIdHex: String, memberRef: String)
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func demoteAdminDetailed(accountRef: String, groupIdHex: String, memberRef: String)async throws  -> GroupMutationResultFfi {
     return
         try  await uniffiRustCallAsync(
@@ -2836,7 +2918,7 @@ open func demoteAdminDetailed(accountRef: String, groupIdHex: String, memberRef:
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Best-effort cached display name for an account id. Returns the Nostr
      * kind:0 display_name/name when the runtime has projected one, or the
@@ -2850,7 +2932,7 @@ open func displayName(accountIdHex: String) -> String? {
     )
 })
 }
-
+    
     /**
      * Fetch and decrypt the group's encrypted Blossom avatar
      * (`marmot.group.blossom.image.v1`) into raw image bytes (PNG/JPEG/…).
@@ -2875,7 +2957,7 @@ open func downloadGroupBlossomImage(accountRef: String, groupIdHex: String)async
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Fetch an encrypted media blob and decrypt it using the group's
      * encrypted media component secret.
@@ -2896,7 +2978,7 @@ open func downloadMedia(accountRef: String, groupIdHex: String, reference: Media
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Edit `target_message_id` by publishing a kind-1009 event that
      * references it and carries the replacement plaintext in `content`.
@@ -2925,7 +3007,7 @@ open func editMessage(accountRef: String, groupIdHex: String, targetMessageId: S
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Export the active account's private key as a password-encrypted NIP-49
      * `ncryptsec1...` bech32 backup string (mdk#544).
@@ -2944,7 +3026,7 @@ open func exportEncryptedSecretKey(accountRef: String, passphrase: String)throws
     )
 })
 }
-
+    
     /**
      * Group plus enriched member rows for detail screens.
      */
@@ -2964,7 +3046,7 @@ open func groupDetails(accountRef: String, groupIdHex: String)async throws  -> G
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Current caller permissions plus per-member action availability.
      */
@@ -2984,7 +3066,7 @@ open func groupManagementState(accountRef: String, groupIdHex: String)async thro
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Membership roster for `group_id_hex`.
      */
@@ -3004,7 +3086,7 @@ open func groupMembers(accountRef: String, groupIdHex: String)async throws  -> [
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Current MLS state (epoch, member count, required components) for the
      * conversation developer/debug view.
@@ -3025,7 +3107,7 @@ open func groupMlsState(accountRef: String, groupIdHex: String)async throws  -> 
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func groupPushDebugInfo(accountRef: String, groupIdHex: String)async throws  -> GroupPushDebugInfoFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3042,7 +3124,7 @@ open func groupPushDebugInfo(accountRef: String, groupIdHex: String)async throws
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Establish the unread baseline the first time a user opens a group.
      * Existing kind-9 history remains read; later remote kind-9 messages count
@@ -3056,7 +3138,7 @@ open func initializeChatReadState(accountRef: String, groupIdHex: String)throws 
     )
 })
 }
-
+    
 open func inviteMembers(accountRef: String, groupIdHex: String, memberRefs: [String])async throws  -> SendSummaryFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3073,7 +3155,7 @@ open func inviteMembers(accountRef: String, groupIdHex: String, memberRefs: [Str
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func inviteMembersDetailed(accountRef: String, groupIdHex: String, memberRefs: [String])async throws  -> GroupMutationResultFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3090,7 +3172,7 @@ open func inviteMembersDetailed(accountRef: String, groupIdHex: String, memberRe
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * True once shutdown has started. Host apps can use this to avoid
      * launching more subscriptions or account work while they are moving to
@@ -3102,7 +3184,7 @@ open func isStopping() -> Bool {
     )
 })
 }
-
+    
 open func leaveGroup(accountRef: String, groupIdHex: String)async throws  -> SendSummaryFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3119,7 +3201,7 @@ open func leaveGroup(accountRef: String, groupIdHex: String)async throws  -> Sen
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * All accounts known to the runtime, in stable order. `running` is
      * `false` for accounts that haven't been brought up by the current
@@ -3131,7 +3213,7 @@ open func listAccounts()throws  -> [AccountSummaryFfi] {
     )
 })
 }
-
+    
     /**
      * Typed media references projected from group message history. Host apps
      * can pass a returned `reference` back to `download_media`.
@@ -3145,7 +3227,7 @@ open func listMedia(accountRef: String, groupIdHex: String, limit: UInt32?)throw
     )
 })
 }
-
+    
     /**
      * Log in with an existing identity. `identity` can be an `nsec` (private
      * key) for a local-signing account, or an `npub` to track a public
@@ -3167,7 +3249,7 @@ open func login(identity: String, defaultRelays: [String], bootstrapRelays: [Str
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Log in with an external account signer such as Amber/NIP-55.
      *
@@ -3193,7 +3275,7 @@ open func loginExternalSigner(publicKey: String, signer: ExternalAccountSignerFf
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Mark a kind-9 timeline message visible/read. Own kind-9 messages can
      * advance the marker too, which clears any earlier unread messages.
@@ -3207,7 +3289,33 @@ open func markTimelineMessageRead(accountRef: String, groupIdHex: String, messag
     )
 })
 }
-
+    
+    /**
+     * The saved composer draft for an account and MLS group, if one exists.
+     */
+open func messageDraft(accountRef: String, groupIdHex: String)throws  -> MessageDraftFfi? {
+    return try  FfiConverterOptionTypeMessageDraftFfi.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
+    uniffi_marmot_uniffi_fn_method_marmot_message_draft(self.uniffiClonePointer(),
+        FfiConverterString.lower(accountRef),
+        FfiConverterString.lower(groupIdHex),$0
+    )
+})
+}
+    
+    /**
+     * Metadata-only saved composer drafts for an account, newest-updated
+     * first. Attachment plaintext is intentionally omitted from this list;
+     * call `messageDraft` when restoring one selected composer. Hosts must
+     * delete empty or sent drafts; deleting a group also removes its draft.
+     */
+open func messageDrafts(accountRef: String)throws  -> [MessageDraftSummaryFfi] {
+    return try  FfiConverterSequenceTypeMessageDraftSummaryFfi.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
+    uniffi_marmot_uniffi_fn_method_marmot_message_drafts(self.uniffiClonePointer(),
+        FfiConverterString.lower(accountRef),$0
+    )
+})
+}
+    
     /**
      * Initial history fetch for a group (or, when `group_id_hex` is None,
      * the account-wide tail). Used to populate the conversation view before
@@ -3222,7 +3330,7 @@ open func messages(accountRef: String, groupIdHex: String?, limit: UInt32?)throw
     )
 })
 }
-
+    
     /**
      * Normalize a member reference for group-management UI. Accepts hex,
      * `npub`, `nostr:npub...`, and `marmot://profile/...` references.
@@ -3234,7 +3342,7 @@ open func normalizeMemberRef(memberRef: String)throws  -> MemberRefFfi {
     )
 })
 }
-
+    
 open func notificationSettings(accountRef: String)throws  -> NotificationSettingsFfi {
     return try  FfiConverterTypeNotificationSettingsFfi.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
     uniffi_marmot_uniffi_fn_method_marmot_notification_settings(self.uniffiClonePointer(),
@@ -3242,7 +3350,7 @@ open func notificationSettings(accountRef: String)throws  -> NotificationSetting
     )
 })
 }
-
+    
     /**
      * Convert a hex account id (Nostr public key) into its `npub…` bech32
      * form for display. `None` if the hex isn't a valid public key.
@@ -3254,7 +3362,7 @@ open func npub(accountIdHex: String) -> String? {
     )
 })
 }
-
+    
     /**
      * Parse plaintext message content into the same Markdown AST returned on
      * message and timeline records. Useful for draft previews and host-side
@@ -3267,7 +3375,7 @@ open func parseMarkdown(text: String) -> MarkdownDocumentFfi {
     )
 })
 }
-
+    
     /**
      * POST one selected JSONL audit log to a forensic analyzer endpoint.
      */
@@ -3287,7 +3395,7 @@ open func postAuditLogFile(path: String, endpoint: String)async throws  -> Audit
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * POST all local audit logs to the configured tracker when audit logging is
      * enabled. This is safe for host apps to call unconditionally; disabled or
@@ -3299,7 +3407,7 @@ open func postAuditLogTrackerUpdate()async throws  -> AuditLogTrackerUpdateResul
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_marmot_post_audit_log_tracker_update(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -3309,7 +3417,7 @@ open func postAuditLogTrackerUpdate()async throws  -> AuditLogTrackerUpdateResul
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Grant admin rights to `member_ref` (npub or hex). Requires the caller
      * to be an admin; publishes a group state update.
@@ -3330,7 +3438,7 @@ open func promoteAdmin(accountRef: String, groupIdHex: String, memberRef: String
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func promoteAdminDetailed(accountRef: String, groupIdHex: String, memberRef: String)async throws  -> GroupMutationResultFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3347,7 +3455,7 @@ open func promoteAdminDetailed(accountRef: String, groupIdHex: String, memberRef
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Publish a new fresh KeyPackage for `account_ref`.
      */
@@ -3367,7 +3475,7 @@ open func publishNewKeyPackage(accountRef: String)async throws  -> UInt64 {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Publish (or re-publish) the NIP-65 and inbox relay lists for
      * `account_ref`. Idempotent — safe to call on every launch.
@@ -3388,7 +3496,7 @@ open func publishRelayLists(accountRef: String, defaultRelays: [String], bootstr
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Publish the Nostr kind:0 metadata for `account_ref`. The returned
      * metadata is what marmot-app actually published (any server-applied
@@ -3410,7 +3518,7 @@ open func publishUserProfile(accountRef: String, profile: UserProfileMetadataFfi
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func pushRegistration(accountRef: String)throws  -> PushRegistrationFfi? {
     return try  FfiConverterOptionTypePushRegistrationFfi.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
     uniffi_marmot_uniffi_fn_method_marmot_push_registration(self.uniffiClonePointer(),
@@ -3418,7 +3526,7 @@ open func pushRegistration(accountRef: String)throws  -> PushRegistrationFfi? {
     )
 })
 }
-
+    
     /**
      * Stored groups that failed session-open hydration and were skipped so the
      * rest of the account could open (mdk#151 / #417). These groups are
@@ -3444,7 +3552,7 @@ open func quarantinedGroups(accountRef: String)async throws  -> [AppQuarantinedG
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * React to `target_message_id` with `emoji` (an "add" reaction).
      */
@@ -3464,7 +3572,7 @@ open func reactToMessage(accountRef: String, groupIdHex: String, targetMessageId
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Fetch and cache an account's own Nostr kind:0 profile from `relays`.
      * After this resolves, `user_profile` / `display_name` return the
@@ -3486,7 +3594,7 @@ open func refreshProfile(accountIdHex: String, relays: [String])async throws  {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Re-register an external signer for an already-known external account.
      *
@@ -3510,7 +3618,7 @@ open func registerExternalSigner(accountRef: String, signer: ExternalAccountSign
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Live relay-plane connection health (connected / connecting /
      * disconnected counts, etc.) for the relay diagnostics view.
@@ -3521,7 +3629,7 @@ open func relayHealth()async  -> RelayHealthFfi {
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_marmot_relay_health(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -3529,10 +3637,10 @@ open func relayHealth()async  -> RelayHealthFfi {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterTypeRelayHealthFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
     /**
      * Device-wide relay telemetry export settings. Export is opt-in and stays
      * inert until `export_enabled` is true and runtime/default config supplies
@@ -3544,7 +3652,7 @@ open func relayTelemetrySettings()throws  -> RelayTelemetrySettingsFfi {
     )
 })
 }
-
+    
     /**
      * Remove a local-signing account from this device.
      */
@@ -3564,7 +3672,7 @@ open func removeAccount(accountRef: String)async throws  {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func removeMembers(accountRef: String, groupIdHex: String, memberRefs: [String])async throws  -> SendSummaryFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3581,7 +3689,7 @@ open func removeMembers(accountRef: String, groupIdHex: String, memberRefs: [Str
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func removeMembersDetailed(accountRef: String, groupIdHex: String, memberRefs: [String])async throws  -> GroupMutationResultFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3598,7 +3706,7 @@ open func removeMembersDetailed(accountRef: String, groupIdHex: String, memberRe
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Replace the group's encrypted-media default blob endpoints as a full
      * `marmot.group.encrypted-media.v1` component update. Requires the caller
@@ -3620,7 +3728,7 @@ open func replaceEncryptedMediaBlobEndpoints(accountRef: String, groupIdHex: Str
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Send `text` as a reply that quotes `target_message_id`.
      */
@@ -3640,7 +3748,7 @@ open func replyToMessage(accountRef: String, groupIdHex: String, targetMessageId
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Re-publish the latest cached KeyPackage when possible, otherwise
      * publish a fresh one.
@@ -3661,7 +3769,7 @@ open func republishKeyPackage(accountRef: String)async throws  -> UInt64 {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Re-attempt publishing a group's pending (committed-but-undelivered)
      * commit(s) without minting a new event.
@@ -3692,7 +3800,7 @@ open func retryGroupConvergence(accountRef: String, groupIdHex: String)async thr
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Re-attempt hydration of a single quarantined group (mdk#426).
      *
@@ -3719,7 +3827,7 @@ open func retryHydrateQuarantinedGroup(accountRef: String, groupIdHex: String)as
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Export the active account's raw private key in canonical `nsec1...`
      * bech32 form for an in-app key-backup display (mdk#543).
@@ -3741,7 +3849,22 @@ open func revealNsec(accountRef: String)throws  -> String {
     )
 })
 }
-
+    
+    /**
+     * Upsert a composer draft into the account's encrypted SQLCipher store.
+     */
+open func saveMessageDraft(accountRef: String, groupIdHex: String, content: String, replyToMessageIdHex: String?, mediaAttachments: [MessageDraftAttachmentFfi])throws  -> MessageDraftFfi {
+    return try  FfiConverterTypeMessageDraftFfi.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
+    uniffi_marmot_uniffi_fn_method_marmot_save_message_draft(self.uniffiClonePointer(),
+        FfiConverterString.lower(accountRef),
+        FfiConverterString.lower(groupIdHex),
+        FfiConverterString.lower(content),
+        FfiConverterOptionString.lower(replyToMessageIdHex),
+        FfiConverterSequenceTypeMessageDraftAttachmentFfi.lower(mediaAttachments),$0
+    )
+})
+}
+    
     /**
      * Securely scrub and prune expired disappearing-message plaintext for a
      * group according to its active retention component. The media hash list
@@ -3764,7 +3887,7 @@ open func secureDeleteExpired(accountRef: String, groupIdHex: String)async throw
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Step down as an admin of `group_id_hex` (demote the active account).
      */
@@ -3784,7 +3907,7 @@ open func selfDemoteAdmin(accountRef: String, groupIdHex: String)async throws  -
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func selfDemoteAdminDetailed(accountRef: String, groupIdHex: String)async throws  -> GroupMutationResultFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3801,7 +3924,7 @@ open func selfDemoteAdminDetailed(accountRef: String, groupIdHex: String)async t
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Send already-uploaded encrypted media attachments as a kind-9 chat
      * carrying ordered NIP-92 `imeta` tags.
@@ -3822,7 +3945,7 @@ open func sendMediaAttachments(accountRef: String, groupIdHex: String, attachmen
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Backward-compatible single-attachment send helper. Prefer
      * `send_media_attachments` for new callers so one chat can carry ordered
@@ -3844,7 +3967,7 @@ open func sendMediaReference(accountRef: String, groupIdHex: String, reference: 
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Send a plain UTF-8 text message. Structured payloads (reactions,
      * replies, deletes, media) go through dedicated methods.
@@ -3865,7 +3988,7 @@ open func sendText(accountRef: String, groupIdHex: String, text: String)async th
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func setAccountInboxRelays(accountRef: String, relays: [String], bootstrapRelays: [String])async throws  -> AccountRelayListsFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3882,7 +4005,7 @@ open func setAccountInboxRelays(accountRef: String, relays: [String], bootstrapR
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func setAccountNip65Relays(accountRef: String, relays: [String], bootstrapRelays: [String])async throws  -> AccountRelayListsFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3899,7 +4022,7 @@ open func setAccountNip65Relays(accountRef: String, relays: [String], bootstrapR
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Persist local forensic audit-log recording settings and return the stored
      * value.
@@ -3924,7 +4047,7 @@ open func setAuditLogSettings(settings: AuditLogSettingsFfi)async throws  -> Aud
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Supply non-persisted audit tracker upload metadata: optional Goggles
      * upload URL override, bearer token from the host app, and optional human
@@ -3940,7 +4063,7 @@ open func setAuditLogTrackerConfig(config: AuditLogTrackerConfigFfi)throws  -> A
     )
 })
 }
-
+    
     /**
      * Flag a group archived (or restore it). Local-only projection state —
      * it does not change membership or publish anything. The chats list
@@ -3962,7 +4085,7 @@ open func setGroupArchived(accountRef: String, groupIdHex: String, archived: Boo
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func setLocalNotificationsEnabled(accountRef: String, enabled: Bool)throws  -> NotificationSettingsFfi {
     return try  FfiConverterTypeNotificationSettingsFfi.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
     uniffi_marmot_uniffi_fn_method_marmot_set_local_notifications_enabled(self.uniffiClonePointer(),
@@ -3971,7 +4094,7 @@ open func setLocalNotificationsEnabled(accountRef: String, enabled: Bool)throws 
     )
 })
 }
-
+    
 open func setNativePushEnabled(accountRef: String, enabled: Bool)async throws  -> NotificationSettingsFfi {
     return
         try  await uniffiRustCallAsync(
@@ -3988,7 +4111,7 @@ open func setNativePushEnabled(accountRef: String, enabled: Bool)async throws  -
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Supply non-persisted OTLP runtime metadata: optional metrics URL
      * override, bearer token from the host app's build-time secret, and
@@ -4010,7 +4133,7 @@ open func setRelayTelemetryRuntimeConfig(config: RelayTelemetryRuntimeConfigFfi)
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Persist device-wide relay telemetry export settings and return the
      * normalized settings that were stored.
@@ -4031,7 +4154,7 @@ open func setRelayTelemetrySettings(settings: RelayTelemetrySettingsFfi)async th
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Tear the runtime down. Drops all subscriptions; long-lived
      * [`EventsSubscription`] / [`ChatsSubscription`] / etc. instances on the
@@ -4043,7 +4166,7 @@ open func shutdown()async  {
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_marmot_shutdown(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_void,
@@ -4051,10 +4174,10 @@ open func shutdown()async  {
             freeFunc: ffi_marmot_uniffi_rust_future_free_void,
             liftFunc: { $0 },
             errorHandler: nil
-
+            
         )
 }
-
+    
     /**
      * Re-activate a non-destructively signed-out local account. This clears
      * the durable signed-out marker and starts the account worker again; relay
@@ -4077,7 +4200,7 @@ open func signInAccount(accountRef: String)async throws  -> AccountSummaryFfi {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Non-destructive sign-out: deactivate the account on this device and,
      * when `delete_key_packages` is `true` (the default behavior in the UI),
@@ -4111,7 +4234,7 @@ open func signOut(accountRef: String, deleteKeyPackages: Bool)async throws  -> S
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Destructive sign-out: leave every active MLS group (best-effort), delete
      * the account's relay-published KeyPackages, then wipe all local state for
@@ -4137,7 +4260,7 @@ open func signOutAndWipe(accountRef: String)async throws  -> WipeOutcomeFfi {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Bring the runtime online: reconcile known accounts, start workers,
      * subscribe to transport events.
@@ -4148,7 +4271,7 @@ open func start()async throws  {
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_marmot_start(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_void,
@@ -4158,7 +4281,7 @@ open func start()async throws  {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Anchor a live agent text stream start in the encrypted group history.
      * Host apps pass the broker candidate(s) they will publish to, such as
@@ -4181,7 +4304,7 @@ open func startAgentTextStream(accountRef: String, groupIdHex: String, streamIdH
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Per-account durable chat-list projection. Async for the same
      * tokio-runtime reason as [`Marmot::subscribe_chats`].
@@ -4202,7 +4325,7 @@ open func subscribeChatList(accountRef: String, includeArchived: Bool)async thro
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Per-account chats list. Emits whenever a group's projection changes.
      *
@@ -4228,7 +4351,7 @@ open func subscribeChats(accountRef: String, includeArchived: Bool)async throws 
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Top-level event firehose. One subscription, every account, every event
      * type. Useful for global diagnostics; specific UIs prefer the
@@ -4240,7 +4363,7 @@ open func subscribeEvents() -> EventsSubscription {
     )
 })
 }
-
+    
     /**
      * Member/profile/roster changes for one group. Async for the same
      * tokio-runtime reason as [`Marmot::subscribe_chats`].
@@ -4261,7 +4384,7 @@ open func subscribeGroupState(accountRef: String, groupIdHex: String)async throw
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Messages for a specific group (when `group_id_hex` is `Some`) or
      * every message across the account (when `None`). `limit` caps the initial
@@ -4284,14 +4407,14 @@ open func subscribeMessages(accountRef: String, groupIdHex: String?, limit: UInt
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func subscribeNotifications()async throws  -> NotificationsSubscription {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_marmot_subscribe_notifications(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_pointer,
@@ -4301,7 +4424,7 @@ open func subscribeNotifications()async throws  -> NotificationsSubscription {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Live materialized timeline updates for a group or account-wide tail.
      * The snapshot and each update are full pages for the supplied query.
@@ -4322,7 +4445,7 @@ open func subscribeTimelineMessages(accountRef: String, groupIdHex: String?, lim
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Stable random identifier for this app install, suitable for the OTLP
      * `service.instance.id` resource attribute. Separate from audit-log device
@@ -4334,7 +4457,7 @@ open func telemetryInstallId()throws  -> String {
     )
 })
 }
-
+    
     /**
      * Materialized conversation timeline for a group or account-wide tail.
      *
@@ -4359,7 +4482,7 @@ open func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi)th
     )
 })
 }
-
+    
     /**
      * Remove this account's reaction from `target_message_id`.
      */
@@ -4379,7 +4502,7 @@ open func unreactFromMessage(accountRef: String, groupIdHex: String, targetMessa
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Set (or clear, with `url = None`) the group's URL-based avatar
      * (`marmot.group.avatar-url.v1`). The URL is validated (https-only, no
@@ -4401,7 +4524,7 @@ open func updateGroupAvatarUrl(accountRef: String, groupIdHex: String, url: Stri
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func updateGroupProfile(accountRef: String, groupIdHex: String, name: String?, description: String?)async throws  -> SendSummaryFfi {
     return
         try  await uniffiRustCallAsync(
@@ -4418,7 +4541,7 @@ open func updateGroupProfile(accountRef: String, groupIdHex: String, name: Strin
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Set the per-group disappearing-message retention, wrapping the engine's
      * `update_message_retention`. `disappearing_message_secs` of `0` disables
@@ -4441,7 +4564,7 @@ open func updateMessageRetention(accountRef: String, groupIdHex: String, disappe
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Encrypt plaintext attachments, upload the ciphertext blobs, and
      * optionally send the resulting media references into the group.
@@ -4462,7 +4585,7 @@ open func uploadMedia(accountRef: String, groupIdHex: String, request: MediaUplo
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func upsertPushRegistration(accountRef: String, platform: PushPlatformFfi, rawToken: String, serverPubkeyHex: String, relayHint: String?)async throws  -> PushRegistrationFfi {
     return
         try  await uniffiRustCallAsync(
@@ -4479,7 +4602,7 @@ open func upsertPushRegistration(accountRef: String, platform: PushPlatformFfi, 
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Full cached Nostr kind:0 profile for an account id (name, display
      * name, about, picture, nip05, lud16), if the runtime has one
@@ -4494,7 +4617,22 @@ open func userProfile(accountIdHex: String)throws  -> UserProfileMetadataFfi? {
     )
 })
 }
-
+    
+    /**
+     * Cached Nostr kind:0 `website` metadata for an account id, when it is a
+     * string. The generic profile record intentionally exposes the fields the
+     * host can publish; this read-only accessor preserves arbitrary kind:0
+     * metadata while still making the standard website field available to
+     * profile presentation surfaces.
+     */
+open func userProfileWebsite(accountIdHex: String)throws  -> String? {
+    return try  FfiConverterOptionString.lift(try rustCallWithError(FfiConverterTypeMarmotKitError.lift) {
+    uniffi_marmot_uniffi_fn_method_marmot_user_profile_website(self.uniffiClonePointer(),
+        FfiConverterString.lower(accountIdHex),$0
+    )
+})
+}
+    
     /**
      * Watch a live agent text stream over the brokered QUIC channel. Pass
      * `stream_id_hex = None` to follow the latest stream in the group (the
@@ -4524,7 +4662,7 @@ open func watchAgentTextStream(accountRef: String, groupIdHex: String, streamIdH
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 
 }
 
@@ -4583,11 +4721,11 @@ public func FfiConverterTypeMarmot_lower(_ value: Marmot) -> UnsafeMutableRawPoi
 
 
 public protocol MessagesSubscriptionProtocol : AnyObject {
-
+    
     func next() async  -> MessageUpdateFfi?
-
+    
     func snapshot()  -> [AppMessageRecordFfi]
-
+    
 }
 
 open class MessagesSubscription:
@@ -4637,16 +4775,16 @@ open class MessagesSubscription:
         try! rustCall { uniffi_marmot_uniffi_fn_free_messagessubscription(pointer, $0) }
     }
 
+    
 
-
-
+    
 open func next()async  -> MessageUpdateFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_messagessubscription_next(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -4654,17 +4792,17 @@ open func next()async  -> MessageUpdateFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeMessageUpdateFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
 open func snapshot() -> [AppMessageRecordFfi] {
     return try!  FfiConverterSequenceTypeAppMessageRecordFfi.lift(try! rustCall() {
     uniffi_marmot_uniffi_fn_method_messagessubscription_snapshot(self.uniffiClonePointer(),$0
     )
 })
 }
-
+    
 
 }
 
@@ -4723,9 +4861,9 @@ public func FfiConverterTypeMessagesSubscription_lower(_ value: MessagesSubscrip
 
 
 public protocol NotificationsSubscriptionProtocol : AnyObject {
-
+    
     func next() async  -> NotificationUpdateFfi?
-
+    
 }
 
 open class NotificationsSubscription:
@@ -4775,16 +4913,16 @@ open class NotificationsSubscription:
         try! rustCall { uniffi_marmot_uniffi_fn_free_notificationssubscription(pointer, $0) }
     }
 
+    
 
-
-
+    
 open func next()async  -> NotificationUpdateFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_notificationssubscription_next(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -4792,10 +4930,10 @@ open func next()async  -> NotificationUpdateFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeNotificationUpdateFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
 
 }
 
@@ -4864,7 +5002,7 @@ public func FfiConverterTypeNotificationsSubscription_lower(_ value: Notificatio
  * either blocking the other.
  */
 public protocol TimelineMessagesSubscriptionProtocol : AnyObject {
-
+    
     /**
      * Await the next live update and return the resulting authoritative window.
      * Windowing (ordering, dedup, head-anchoring while scrolled back, and the
@@ -4873,9 +5011,9 @@ public protocol TimelineMessagesSubscriptionProtocol : AnyObject {
      * [`next_update`](Self::next_update) instead to receive the raw delta.
      */
     func next() async  -> TimelinePageFfi?
-
+    
     func nextUpdate() async  -> TimelineSubscriptionUpdateFfi?
-
+    
     /**
      * Extend the materialized window toward older history by up to `count`
      * messages and return the new window. The returned page is already sorted,
@@ -4887,7 +5025,7 @@ public protocol TimelineMessagesSubscriptionProtocol : AnyObject {
      * unlike the synchronous `Marmot::timeline_messages`).
      */
     func paginateBackwards(count: UInt32) async throws  -> TimelinePageFfi
-
+    
     /**
      * Extend the materialized window toward the live head by up to `count`
      * messages and return the new window. Reaching the head re-anchors the
@@ -4895,9 +5033,9 @@ public protocol TimelineMessagesSubscriptionProtocol : AnyObject {
      * guarantees as [`paginate_backwards`](Self::paginate_backwards).
      */
     func paginateForwards(count: UInt32) async throws  -> TimelinePageFfi
-
+    
     func snapshot()  -> TimelinePageFfi?
-
+    
 }
 
 /**
@@ -4957,9 +5095,9 @@ open class TimelineMessagesSubscription:
         try! rustCall { uniffi_marmot_uniffi_fn_free_timelinemessagessubscription(pointer, $0) }
     }
 
+    
 
-
-
+    
     /**
      * Await the next live update and return the resulting authoritative window.
      * Windowing (ordering, dedup, head-anchoring while scrolled back, and the
@@ -4973,7 +5111,7 @@ open func next()async  -> TimelinePageFfi? {
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_timelinemessagessubscription_next(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -4981,17 +5119,17 @@ open func next()async  -> TimelinePageFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeTimelinePageFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
 open func nextUpdate()async  -> TimelineSubscriptionUpdateFfi? {
     return
         try!  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_marmot_uniffi_fn_method_timelinemessagessubscription_next_update(
                     self.uniffiClonePointer()
-
+                    
                 )
             },
             pollFunc: ffi_marmot_uniffi_rust_future_poll_rust_buffer,
@@ -4999,10 +5137,10 @@ open func nextUpdate()async  -> TimelineSubscriptionUpdateFfi? {
             freeFunc: ffi_marmot_uniffi_rust_future_free_rust_buffer,
             liftFunc: FfiConverterOptionTypeTimelineSubscriptionUpdateFfi.lift,
             errorHandler: nil
-
+            
         )
 }
-
+    
     /**
      * Extend the materialized window toward older history by up to `count`
      * messages and return the new window. The returned page is already sorted,
@@ -5029,7 +5167,7 @@ open func paginateBackwards(count: UInt32)async throws  -> TimelinePageFfi {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
     /**
      * Extend the materialized window toward the live head by up to `count`
      * messages and return the new window. Reaching the head re-anchors the
@@ -5052,14 +5190,14 @@ open func paginateForwards(count: UInt32)async throws  -> TimelinePageFfi {
             errorHandler: FfiConverterTypeMarmotKitError.lift
         )
 }
-
+    
 open func snapshot() -> TimelinePageFfi? {
     return try!  FfiConverterOptionTypeTimelinePageFfi.lift(try! rustCall() {
     uniffi_marmot_uniffi_fn_method_timelinemessagessubscription_snapshot(self.uniffiClonePointer(),$0
     )
 })
 }
-
+    
 
 }
 
@@ -5202,15 +5340,15 @@ public struct FfiConverterTypeAccountKeyPackageFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AccountKeyPackageFfi {
         return
             try AccountKeyPackageFfi(
-                accountRef: FfiConverterOptionString.read(from: &buf),
-                accountIdHex: FfiConverterString.read(from: &buf),
-                keyPackageId: FfiConverterString.read(from: &buf),
-                keyPackageRefHex: FfiConverterString.read(from: &buf),
-                eventIdHex: FfiConverterString.read(from: &buf),
-                publishedAt: FfiConverterUInt64.read(from: &buf),
-                keyPackageBytes: FfiConverterUInt64.read(from: &buf),
-                sourceRelays: FfiConverterSequenceString.read(from: &buf),
-                local: FfiConverterBool.read(from: &buf),
+                accountRef: FfiConverterOptionString.read(from: &buf), 
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                keyPackageId: FfiConverterString.read(from: &buf), 
+                keyPackageRefHex: FfiConverterString.read(from: &buf), 
+                eventIdHex: FfiConverterString.read(from: &buf), 
+                publishedAt: FfiConverterUInt64.read(from: &buf), 
+                keyPackageBytes: FfiConverterUInt64.read(from: &buf), 
+                sourceRelays: FfiConverterSequenceString.read(from: &buf), 
+                local: FfiConverterBool.read(from: &buf), 
                 relay: FfiConverterBool.read(from: &buf)
         )
     }
@@ -5308,11 +5446,11 @@ public struct FfiConverterTypeAccountRelayListsFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AccountRelayListsFfi {
         return
             try AccountRelayListsFfi(
-                complete: FfiConverterBool.read(from: &buf),
-                missing: FfiConverterSequenceTypeMissingRelayListKindFfi.read(from: &buf),
-                defaultRelays: FfiConverterSequenceString.read(from: &buf),
-                bootstrapRelays: FfiConverterSequenceString.read(from: &buf),
-                nip65: FfiConverterTypeRelayListFfi.read(from: &buf),
+                complete: FfiConverterBool.read(from: &buf), 
+                missing: FfiConverterSequenceTypeMissingRelayListKindFfi.read(from: &buf), 
+                defaultRelays: FfiConverterSequenceString.read(from: &buf), 
+                bootstrapRelays: FfiConverterSequenceString.read(from: &buf), 
+                nip65: FfiConverterTypeRelayListFfi.read(from: &buf), 
                 inbox: FfiConverterTypeRelayListFfi.read(from: &buf)
         )
     }
@@ -5406,11 +5544,11 @@ public struct FfiConverterTypeAccountSummaryFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AccountSummaryFfi {
         return
             try AccountSummaryFfi(
-                label: FfiConverterString.read(from: &buf),
-                accountIdHex: FfiConverterString.read(from: &buf),
-                localSigning: FfiConverterBool.read(from: &buf),
-                externalSigning: FfiConverterBool.read(from: &buf),
-                signedOut: FfiConverterBool.read(from: &buf),
+                label: FfiConverterString.read(from: &buf), 
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                localSigning: FfiConverterBool.read(from: &buf), 
+                externalSigning: FfiConverterBool.read(from: &buf), 
+                signedOut: FfiConverterBool.read(from: &buf), 
                 running: FfiConverterBool.read(from: &buf)
         )
     }
@@ -5464,13 +5602,13 @@ public struct AccountUnreadFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(accountIdHex: String,
+    public init(accountIdHex: String, 
         /**
          * Total unread messages across all unarchived conversations.
-         */unreadCount: UInt64,
+         */unreadCount: UInt64, 
         /**
          * Number of unarchived conversations with at least one unread message.
-         */unreadConversations: UInt64,
+         */unreadConversations: UInt64, 
         /**
          * Whether the account has any unread message at all.
          */hasUnread: Bool) {
@@ -5516,9 +5654,9 @@ public struct FfiConverterTypeAccountUnreadFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AccountUnreadFfi {
         return
             try AccountUnreadFfi(
-                accountIdHex: FfiConverterString.read(from: &buf),
-                unreadCount: FfiConverterUInt64.read(from: &buf),
-                unreadConversations: FfiConverterUInt64.read(from: &buf),
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                unreadCount: FfiConverterUInt64.read(from: &buf), 
+                unreadConversations: FfiConverterUInt64.read(from: &buf), 
                 hasUnread: FfiConverterBool.read(from: &buf)
         )
     }
@@ -5592,8 +5730,8 @@ public struct FfiConverterTypeAgentStreamStartFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AgentStreamStartFfi {
         return
             try AgentStreamStartFfi(
-                streamIdHex: FfiConverterString.read(from: &buf),
-                published: FfiConverterUInt32.read(from: &buf),
+                streamIdHex: FfiConverterString.read(from: &buf), 
+                published: FfiConverterUInt32.read(from: &buf), 
                 messageIds: FfiConverterSequenceString.read(from: &buf)
         )
     }
@@ -5660,7 +5798,7 @@ public struct FfiConverterTypeAppBlobEndpointFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppBlobEndpointFfi {
         return
             try AppBlobEndpointFfi(
-                locatorKind: FfiConverterString.read(from: &buf),
+                locatorKind: FfiConverterString.read(from: &buf), 
                 baseUrl: FfiConverterString.read(from: &buf)
         )
     }
@@ -5750,11 +5888,11 @@ public struct FfiConverterTypeAppGroupEncryptedMediaComponentFfi: FfiConverterRu
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppGroupEncryptedMediaComponentFfi {
         return
             try AppGroupEncryptedMediaComponentFfi(
-                componentId: FfiConverterUInt32.read(from: &buf),
-                component: FfiConverterString.read(from: &buf),
-                required: FfiConverterBool.read(from: &buf),
-                mediaFormat: FfiConverterString.read(from: &buf),
-                allowedLocatorKinds: FfiConverterSequenceString.read(from: &buf),
+                componentId: FfiConverterUInt32.read(from: &buf), 
+                component: FfiConverterString.read(from: &buf), 
+                required: FfiConverterBool.read(from: &buf), 
+                mediaFormat: FfiConverterString.read(from: &buf), 
+                allowedLocatorKinds: FfiConverterSequenceString.read(from: &buf), 
                 defaultBlobEndpoints: FfiConverterSequenceTypeAppBlobEndpointFfi.read(from: &buf)
         )
     }
@@ -5830,8 +5968,8 @@ public struct FfiConverterTypeAppGroupMemberRecordFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppGroupMemberRecordFfi {
         return
             try AppGroupMemberRecordFfi(
-                memberIdHex: FfiConverterString.read(from: &buf),
-                account: FfiConverterOptionString.read(from: &buf),
+                memberIdHex: FfiConverterString.read(from: &buf), 
+                account: FfiConverterOptionString.read(from: &buf), 
                 local: FfiConverterBool.read(from: &buf)
         )
     }
@@ -5914,9 +6052,9 @@ public struct FfiConverterTypeAppGroupMlsStateFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppGroupMlsStateFfi {
         return
             try AppGroupMlsStateFfi(
-                groupIdHex: FfiConverterString.read(from: &buf),
-                epoch: FfiConverterUInt64.read(from: &buf),
-                memberCount: FfiConverterUInt32.read(from: &buf),
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                epoch: FfiConverterUInt64.read(from: &buf), 
+                memberCount: FfiConverterUInt32.read(from: &buf), 
                 requiredAppComponents: FfiConverterSequenceUInt16.read(from: &buf)
         )
     }
@@ -5984,20 +6122,20 @@ public struct AppGroupRecordFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(groupIdHex: String, endpoint: String, name: String, description: String, admins: [String], relays: [String], nostrGroupIdHex: String,
+    public init(groupIdHex: String, endpoint: String, name: String, description: String, admins: [String], relays: [String], nostrGroupIdHex: String, 
         /**
          * URL-based group avatar (`marmot.group.avatar-url.v1`), `None` when absent.
          * When set it takes precedence over a Blossom image avatar.
-         */avatarUrl: String?, avatarDim: String?, avatarThumbhash: String?,
+         */avatarUrl: String?, avatarDim: String?, avatarThumbhash: String?, 
         /**
          * Content hash of the encrypted Blossom avatar
          * (`marmot.group.blossom.image.v1`), `None` when absent. Doubles as a
          * cache key; fetch + decrypt via `Marmot::download_group_blossom_image`.
-         */imageHashHex: String?, encryptedMedia: AppGroupEncryptedMediaComponentFfi,
+         */imageHashHex: String?, encryptedMedia: AppGroupEncryptedMediaComponentFfi, 
         /**
          * Per-group disappearing-message retention in seconds
          * (`marmot.group.message-retention.v1`). `0` means messages never expire.
-         */disappearingMessageSecs: UInt64, archived: Bool, pendingConfirmation: Bool,
+         */disappearingMessageSecs: UInt64, archived: Bool, pendingConfirmation: Bool, 
         /**
          * Whether the local account is still a member of this group, and if not,
          * whether it left voluntarily or was removed.
@@ -6114,23 +6252,23 @@ public struct FfiConverterTypeAppGroupRecordFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppGroupRecordFfi {
         return
             try AppGroupRecordFfi(
-                groupIdHex: FfiConverterString.read(from: &buf),
-                endpoint: FfiConverterString.read(from: &buf),
-                name: FfiConverterString.read(from: &buf),
-                description: FfiConverterString.read(from: &buf),
-                admins: FfiConverterSequenceString.read(from: &buf),
-                relays: FfiConverterSequenceString.read(from: &buf),
-                nostrGroupIdHex: FfiConverterString.read(from: &buf),
-                avatarUrl: FfiConverterOptionString.read(from: &buf),
-                avatarDim: FfiConverterOptionString.read(from: &buf),
-                avatarThumbhash: FfiConverterOptionString.read(from: &buf),
-                imageHashHex: FfiConverterOptionString.read(from: &buf),
-                encryptedMedia: FfiConverterTypeAppGroupEncryptedMediaComponentFfi.read(from: &buf),
-                disappearingMessageSecs: FfiConverterUInt64.read(from: &buf),
-                archived: FfiConverterBool.read(from: &buf),
-                pendingConfirmation: FfiConverterBool.read(from: &buf),
-                selfMembership: FfiConverterTypeSelfMembershipFfi.read(from: &buf),
-                welcomerAccountIdHex: FfiConverterOptionString.read(from: &buf),
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                endpoint: FfiConverterString.read(from: &buf), 
+                name: FfiConverterString.read(from: &buf), 
+                description: FfiConverterString.read(from: &buf), 
+                admins: FfiConverterSequenceString.read(from: &buf), 
+                relays: FfiConverterSequenceString.read(from: &buf), 
+                nostrGroupIdHex: FfiConverterString.read(from: &buf), 
+                avatarUrl: FfiConverterOptionString.read(from: &buf), 
+                avatarDim: FfiConverterOptionString.read(from: &buf), 
+                avatarThumbhash: FfiConverterOptionString.read(from: &buf), 
+                imageHashHex: FfiConverterOptionString.read(from: &buf), 
+                encryptedMedia: FfiConverterTypeAppGroupEncryptedMediaComponentFfi.read(from: &buf), 
+                disappearingMessageSecs: FfiConverterUInt64.read(from: &buf), 
+                archived: FfiConverterBool.read(from: &buf), 
+                pendingConfirmation: FfiConverterBool.read(from: &buf), 
+                selfMembership: FfiConverterTypeSelfMembershipFfi.read(from: &buf), 
+                welcomerAccountIdHex: FfiConverterOptionString.read(from: &buf), 
                 viaWelcomeMessageIdHex: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -6193,10 +6331,10 @@ public struct AppMessageRecordFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(messageIdHex: String, direction: String, groupIdHex: String, sender: String, plaintext: String, contentTokens: MarkdownDocumentFfi,
+    public init(messageIdHex: String, direction: String, groupIdHex: String, sender: String, plaintext: String, contentTokens: MarkdownDocumentFfi, 
         /**
          * Nostr `kind` of the inner Marmot app event (9 chat, 7 reaction, …).
-         */kind: UInt64,
+         */kind: UInt64, 
         /**
          * Nostr `tags` of the inner Marmot app event.
          */tags: [MessageTagFfi], recordedAt: UInt64, receivedAt: UInt64) {
@@ -6272,15 +6410,15 @@ public struct FfiConverterTypeAppMessageRecordFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppMessageRecordFfi {
         return
             try AppMessageRecordFfi(
-                messageIdHex: FfiConverterString.read(from: &buf),
-                direction: FfiConverterString.read(from: &buf),
-                groupIdHex: FfiConverterString.read(from: &buf),
-                sender: FfiConverterString.read(from: &buf),
-                plaintext: FfiConverterString.read(from: &buf),
-                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf),
-                kind: FfiConverterUInt64.read(from: &buf),
-                tags: FfiConverterSequenceTypeMessageTagFfi.read(from: &buf),
-                recordedAt: FfiConverterUInt64.read(from: &buf),
+                messageIdHex: FfiConverterString.read(from: &buf), 
+                direction: FfiConverterString.read(from: &buf), 
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                sender: FfiConverterString.read(from: &buf), 
+                plaintext: FfiConverterString.read(from: &buf), 
+                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf), 
+                kind: FfiConverterUInt64.read(from: &buf), 
+                tags: FfiConverterSequenceTypeMessageTagFfi.read(from: &buf), 
+                recordedAt: FfiConverterUInt64.read(from: &buf), 
                 receivedAt: FfiConverterUInt64.read(from: &buf)
         )
     }
@@ -6360,7 +6498,7 @@ public struct FfiConverterTypeAppQuarantinedGroupFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppQuarantinedGroupFfi {
         return
             try AppQuarantinedGroupFfi(
-                groupIdHex: FfiConverterString.read(from: &buf),
+                groupIdHex: FfiConverterString.read(from: &buf), 
                 reason: FfiConverterTypeAppGroupHydrationQuarantineReasonFfi.read(from: &buf)
         )
     }
@@ -6512,10 +6650,10 @@ public struct FfiConverterTypeAuditLogFileFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AuditLogFileFfi {
         return
             try AuditLogFileFfi(
-                accountRef: FfiConverterString.read(from: &buf),
-                path: FfiConverterString.read(from: &buf),
-                fileName: FfiConverterString.read(from: &buf),
-                sizeBytes: FfiConverterUInt64.read(from: &buf),
+                accountRef: FfiConverterString.read(from: &buf), 
+                path: FfiConverterString.read(from: &buf), 
+                fileName: FfiConverterString.read(from: &buf), 
+                sizeBytes: FfiConverterUInt64.read(from: &buf), 
                 modifiedAtMs: FfiConverterOptionUInt64.read(from: &buf)
         )
     }
@@ -6584,7 +6722,7 @@ public struct FfiConverterTypeAuditLogSettingsFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AuditLogSettingsFfi {
         return
             try AuditLogSettingsFfi(
-                enabled: FfiConverterBool.read(from: &buf),
+                enabled: FfiConverterBool.read(from: &buf), 
                 dataMode: FfiConverterTypeAuditDataModeFfi.read(from: &buf)
         )
     }
@@ -6662,8 +6800,8 @@ public struct FfiConverterTypeAuditLogTrackerConfigFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AuditLogTrackerConfigFfi {
         return
             try AuditLogTrackerConfigFfi(
-                endpoint: FfiConverterOptionString.read(from: &buf),
-                authorizationBearerToken: FfiConverterOptionString.read(from: &buf),
+                endpoint: FfiConverterOptionString.read(from: &buf), 
+                authorizationBearerToken: FfiConverterOptionString.read(from: &buf), 
                 source: FfiConverterTypeAuditLogUploadSourceFfi.read(from: &buf)
         )
     }
@@ -6736,8 +6874,8 @@ public struct FfiConverterTypeAuditLogTrackerUpdateResultFfi: FfiConverterRustBu
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AuditLogTrackerUpdateResultFfi {
         return
             try AuditLogTrackerUpdateResultFfi(
-                enabled: FfiConverterBool.read(from: &buf),
-                uploaded: FfiConverterSequenceTypeAuditLogUploadResultFfi.read(from: &buf),
+                enabled: FfiConverterBool.read(from: &buf), 
+                uploaded: FfiConverterSequenceTypeAuditLogUploadResultFfi.read(from: &buf), 
                 skippedReason: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -6810,8 +6948,8 @@ public struct FfiConverterTypeAuditLogUploadResultFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AuditLogUploadResultFfi {
         return
             try AuditLogUploadResultFfi(
-                path: FfiConverterString.read(from: &buf),
-                status: FfiConverterUInt16.read(from: &buf),
+                path: FfiConverterString.read(from: &buf), 
+                status: FfiConverterUInt16.read(from: &buf), 
                 bytesSent: FfiConverterUInt64.read(from: &buf)
         )
     }
@@ -6884,8 +7022,8 @@ public struct FfiConverterTypeAuditLogUploadSourceFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AuditLogUploadSourceFfi {
         return
             try AuditLogUploadSourceFfi(
-                deviceLabel: FfiConverterOptionString.read(from: &buf),
-                platform: FfiConverterOptionString.read(from: &buf),
+                deviceLabel: FfiConverterOptionString.read(from: &buf), 
+                platform: FfiConverterOptionString.read(from: &buf), 
                 appVersion: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -6958,8 +7096,8 @@ public struct FfiConverterTypeBackgroundNotificationCollectionFfi: FfiConverterR
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> BackgroundNotificationCollectionFfi {
         return
             try BackgroundNotificationCollectionFfi(
-                status: FfiConverterTypeNotificationCollectionStatusFfi.read(from: &buf),
-                notifications: FfiConverterSequenceTypeNotificationUpdateFfi.read(from: &buf),
+                status: FfiConverterTypeNotificationCollectionStatusFfi.read(from: &buf), 
+                notifications: FfiConverterSequenceTypeNotificationUpdateFfi.read(from: &buf), 
                 error: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -7055,10 +7193,10 @@ public struct FfiConverterTypeChatListAvatarFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ChatListAvatarFfi {
         return
             try ChatListAvatarFfi(
-                imageHashHex: FfiConverterString.read(from: &buf),
-                imageKeyHex: FfiConverterString.read(from: &buf),
-                imageNonceHex: FfiConverterString.read(from: &buf),
-                imageUploadKeyHex: FfiConverterString.read(from: &buf),
+                imageHashHex: FfiConverterString.read(from: &buf), 
+                imageKeyHex: FfiConverterString.read(from: &buf), 
+                imageNonceHex: FfiConverterString.read(from: &buf), 
+                imageUploadKeyHex: FfiConverterString.read(from: &buf), 
                 mediaType: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -7163,13 +7301,13 @@ public struct FfiConverterTypeChatListMessagePreviewFfi: FfiConverterRustBuffer 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ChatListMessagePreviewFfi {
         return
             try ChatListMessagePreviewFfi(
-                messageIdHex: FfiConverterString.read(from: &buf),
-                sender: FfiConverterString.read(from: &buf),
-                senderDisplayName: FfiConverterOptionString.read(from: &buf),
-                plaintext: FfiConverterString.read(from: &buf),
-                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf),
-                kind: FfiConverterUInt64.read(from: &buf),
-                timelineAt: FfiConverterUInt64.read(from: &buf),
+                messageIdHex: FfiConverterString.read(from: &buf), 
+                sender: FfiConverterString.read(from: &buf), 
+                senderDisplayName: FfiConverterOptionString.read(from: &buf), 
+                plaintext: FfiConverterString.read(from: &buf), 
+                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf), 
+                kind: FfiConverterUInt64.read(from: &buf), 
+                timelineAt: FfiConverterUInt64.read(from: &buf), 
                 deleted: FfiConverterBool.read(from: &buf)
         )
     }
@@ -7227,7 +7365,7 @@ public struct ChatListRowFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(groupIdHex: String, archived: Bool, pendingConfirmation: Bool, title: String, groupName: String, avatarUrl: String?, avatar: ChatListAvatarFfi?, lastMessage: ChatListMessagePreviewFfi?, unreadCount: UInt64, hasUnread: Bool, unreadMentionCount: UInt64, unreadMention: Bool, firstUnreadMessageIdHex: String?, lastReadMessageIdHex: String?, lastReadTimelineAt: UInt64?, updatedAt: UInt64,
+    public init(groupIdHex: String, archived: Bool, pendingConfirmation: Bool, title: String, groupName: String, avatarUrl: String?, avatar: ChatListAvatarFfi?, lastMessage: ChatListMessagePreviewFfi?, unreadCount: UInt64, hasUnread: Bool, unreadMentionCount: UInt64, unreadMention: Bool, firstUnreadMessageIdHex: String?, lastReadMessageIdHex: String?, lastReadTimelineAt: UInt64?, updatedAt: UInt64, 
         /**
          * Whether the local account is still a member of this group, and if not,
          * whether it left voluntarily or was removed.
@@ -7339,22 +7477,22 @@ public struct FfiConverterTypeChatListRowFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ChatListRowFfi {
         return
             try ChatListRowFfi(
-                groupIdHex: FfiConverterString.read(from: &buf),
-                archived: FfiConverterBool.read(from: &buf),
-                pendingConfirmation: FfiConverterBool.read(from: &buf),
-                title: FfiConverterString.read(from: &buf),
-                groupName: FfiConverterString.read(from: &buf),
-                avatarUrl: FfiConverterOptionString.read(from: &buf),
-                avatar: FfiConverterOptionTypeChatListAvatarFfi.read(from: &buf),
-                lastMessage: FfiConverterOptionTypeChatListMessagePreviewFfi.read(from: &buf),
-                unreadCount: FfiConverterUInt64.read(from: &buf),
-                hasUnread: FfiConverterBool.read(from: &buf),
-                unreadMentionCount: FfiConverterUInt64.read(from: &buf),
-                unreadMention: FfiConverterBool.read(from: &buf),
-                firstUnreadMessageIdHex: FfiConverterOptionString.read(from: &buf),
-                lastReadMessageIdHex: FfiConverterOptionString.read(from: &buf),
-                lastReadTimelineAt: FfiConverterOptionUInt64.read(from: &buf),
-                updatedAt: FfiConverterUInt64.read(from: &buf),
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                archived: FfiConverterBool.read(from: &buf), 
+                pendingConfirmation: FfiConverterBool.read(from: &buf), 
+                title: FfiConverterString.read(from: &buf), 
+                groupName: FfiConverterString.read(from: &buf), 
+                avatarUrl: FfiConverterOptionString.read(from: &buf), 
+                avatar: FfiConverterOptionTypeChatListAvatarFfi.read(from: &buf), 
+                lastMessage: FfiConverterOptionTypeChatListMessagePreviewFfi.read(from: &buf), 
+                unreadCount: FfiConverterUInt64.read(from: &buf), 
+                hasUnread: FfiConverterBool.read(from: &buf), 
+                unreadMentionCount: FfiConverterUInt64.read(from: &buf), 
+                unreadMention: FfiConverterBool.read(from: &buf), 
+                firstUnreadMessageIdHex: FfiConverterOptionString.read(from: &buf), 
+                lastReadMessageIdHex: FfiConverterOptionString.read(from: &buf), 
+                lastReadTimelineAt: FfiConverterOptionUInt64.read(from: &buf), 
+                updatedAt: FfiConverterUInt64.read(from: &buf), 
                 selfMembership: FfiConverterTypeSelfMembershipFfi.read(from: &buf)
         )
     }
@@ -7435,7 +7573,7 @@ public struct FfiConverterTypeGroupDetailsFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupDetailsFfi {
         return
             try GroupDetailsFfi(
-                group: FfiConverterTypeAppGroupRecordFfi.read(from: &buf),
+                group: FfiConverterTypeAppGroupRecordFfi.read(from: &buf), 
                 members: FfiConverterSequenceTypeGroupMemberDetailsFfi.read(from: &buf)
         )
     }
@@ -7501,7 +7639,7 @@ public struct FfiConverterTypeGroupInviteDeclineResultFfi: FfiConverterRustBuffe
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupInviteDeclineResultFfi {
         return
             try GroupInviteDeclineResultFfi(
-                group: FfiConverterTypeAppGroupRecordFfi.read(from: &buf),
+                group: FfiConverterTypeAppGroupRecordFfi.read(from: &buf), 
                 summary: FfiConverterTypeSendSummaryFfi.read(from: &buf)
         )
     }
@@ -7567,7 +7705,7 @@ public struct FfiConverterTypeGroupLeaveFailureFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupLeaveFailureFfi {
         return
             try GroupLeaveFailureFfi(
-                groupIdHex: FfiConverterString.read(from: &buf),
+                groupIdHex: FfiConverterString.read(from: &buf), 
                 reason: FfiConverterString.read(from: &buf)
         )
     }
@@ -7663,12 +7801,12 @@ public struct FfiConverterTypeGroupManagementStateFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupManagementStateFfi {
         return
             try GroupManagementStateFfi(
-                myAccountIdHex: FfiConverterString.read(from: &buf),
-                isSelfAdmin: FfiConverterBool.read(from: &buf),
-                isLastAdmin: FfiConverterBool.read(from: &buf),
-                canInvite: FfiConverterBool.read(from: &buf),
-                canLeave: FfiConverterBool.read(from: &buf),
-                requiresSelfDemoteBeforeLeave: FfiConverterBool.read(from: &buf),
+                myAccountIdHex: FfiConverterString.read(from: &buf), 
+                isSelfAdmin: FfiConverterBool.read(from: &buf), 
+                isLastAdmin: FfiConverterBool.read(from: &buf), 
+                canInvite: FfiConverterBool.read(from: &buf), 
+                canLeave: FfiConverterBool.read(from: &buf), 
+                requiresSelfDemoteBeforeLeave: FfiConverterBool.read(from: &buf), 
                 memberActions: FfiConverterSequenceTypeGroupMemberActionStateFfi.read(from: &buf)
         )
     }
@@ -7763,11 +7901,11 @@ public struct FfiConverterTypeGroupMemberActionStateFfi: FfiConverterRustBuffer 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupMemberActionStateFfi {
         return
             try GroupMemberActionStateFfi(
-                memberIdHex: FfiConverterString.read(from: &buf),
-                isSelf: FfiConverterBool.read(from: &buf),
-                isAdmin: FfiConverterBool.read(from: &buf),
-                canRemove: FfiConverterBool.read(from: &buf),
-                canPromote: FfiConverterBool.read(from: &buf),
+                memberIdHex: FfiConverterString.read(from: &buf), 
+                isSelf: FfiConverterBool.read(from: &buf), 
+                isAdmin: FfiConverterBool.read(from: &buf), 
+                canRemove: FfiConverterBool.read(from: &buf), 
+                canPromote: FfiConverterBool.read(from: &buf), 
                 canDemote: FfiConverterBool.read(from: &buf)
         )
     }
@@ -7867,12 +8005,12 @@ public struct FfiConverterTypeGroupMemberDetailsFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupMemberDetailsFfi {
         return
             try GroupMemberDetailsFfi(
-                memberIdHex: FfiConverterString.read(from: &buf),
-                account: FfiConverterOptionString.read(from: &buf),
-                local: FfiConverterBool.read(from: &buf),
-                isAdmin: FfiConverterBool.read(from: &buf),
-                isSelf: FfiConverterBool.read(from: &buf),
-                npub: FfiConverterString.read(from: &buf),
+                memberIdHex: FfiConverterString.read(from: &buf), 
+                account: FfiConverterOptionString.read(from: &buf), 
+                local: FfiConverterBool.read(from: &buf), 
+                isAdmin: FfiConverterBool.read(from: &buf), 
+                isSelf: FfiConverterBool.read(from: &buf), 
+                npub: FfiConverterString.read(from: &buf), 
                 displayName: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -7949,8 +8087,8 @@ public struct FfiConverterTypeGroupMutationResultFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupMutationResultFfi {
         return
             try GroupMutationResultFfi(
-                summary: FfiConverterTypeSendSummaryFfi.read(from: &buf),
-                details: FfiConverterTypeGroupDetailsFfi.read(from: &buf),
+                summary: FfiConverterTypeSendSummaryFfi.read(from: &buf), 
+                details: FfiConverterTypeGroupDetailsFfi.read(from: &buf), 
                 managementState: FfiConverterTypeGroupManagementStateFfi.read(from: &buf)
         )
     }
@@ -8047,12 +8185,12 @@ public struct FfiConverterTypeGroupPushDebugInfoFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupPushDebugInfoFfi {
         return
             try GroupPushDebugInfoFfi(
-                totalTokenCount: FfiConverterUInt32.read(from: &buf),
-                activeTokenCount: FfiConverterUInt32.read(from: &buf),
-                staleTokenCount: FfiConverterUInt32.read(from: &buf),
-                missingRelayHintCount: FfiConverterUInt32.read(from: &buf),
-                lastTokenListUpdatedAtMs: FfiConverterOptionInt64.read(from: &buf),
-                localRegistration: FfiConverterTypeLocalPushRegistrationDebugFfi.read(from: &buf),
+                totalTokenCount: FfiConverterUInt32.read(from: &buf), 
+                activeTokenCount: FfiConverterUInt32.read(from: &buf), 
+                staleTokenCount: FfiConverterUInt32.read(from: &buf), 
+                missingRelayHintCount: FfiConverterUInt32.read(from: &buf), 
+                lastTokenListUpdatedAtMs: FfiConverterOptionInt64.read(from: &buf), 
+                localRegistration: FfiConverterTypeLocalPushRegistrationDebugFfi.read(from: &buf), 
                 tokens: FfiConverterSequenceTypeGroupPushTokenDebugEntryFfi.read(from: &buf)
         )
     }
@@ -8171,15 +8309,15 @@ public struct FfiConverterTypeGroupPushTokenDebugEntryFfi: FfiConverterRustBuffe
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupPushTokenDebugEntryFfi {
         return
             try GroupPushTokenDebugEntryFfi(
-                memberIdHex: FfiConverterString.read(from: &buf),
-                leafIndex: FfiConverterUInt32.read(from: &buf),
-                platform: FfiConverterTypePushPlatformFfi.read(from: &buf),
-                tokenFingerprint: FfiConverterString.read(from: &buf),
-                serverPubkeyHex: FfiConverterString.read(from: &buf),
-                hasRelayHint: FfiConverterBool.read(from: &buf),
-                activeLeaf: FfiConverterBool.read(from: &buf),
-                memberMatchesActiveLeaf: FfiConverterBool.read(from: &buf),
-                isLocalMember: FfiConverterBool.read(from: &buf),
+                memberIdHex: FfiConverterString.read(from: &buf), 
+                leafIndex: FfiConverterUInt32.read(from: &buf), 
+                platform: FfiConverterTypePushPlatformFfi.read(from: &buf), 
+                tokenFingerprint: FfiConverterString.read(from: &buf), 
+                serverPubkeyHex: FfiConverterString.read(from: &buf), 
+                hasRelayHint: FfiConverterBool.read(from: &buf), 
+                activeLeaf: FfiConverterBool.read(from: &buf), 
+                memberMatchesActiveLeaf: FfiConverterBool.read(from: &buf), 
+                isLocalMember: FfiConverterBool.read(from: &buf), 
                 updatedAtMs: FfiConverterInt64.read(from: &buf)
         )
     }
@@ -8237,15 +8375,15 @@ public struct GroupSystemEventFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(systemType: String,
+    public init(systemType: String, 
         /**
          * Human-readable fallback from the row content. Prefer rendering from
          * `system_type` plus the structured fields so clients can localize and
          * render the local account as "you".
-         */text: String, actorAccountIdHex: String?, subjectAccountIdHex: String?, name: String?, oldName: String?,
+         */text: String, actorAccountIdHex: String?, subjectAccountIdHex: String?, name: String?, oldName: String?, 
         /**
          * Previous disappearing-message retention in seconds; `0` means off.
-         */oldRetentionSeconds: UInt64?,
+         */oldRetentionSeconds: UInt64?, 
         /**
          * New disappearing-message retention in seconds; `0` means off.
          */newRetentionSeconds: UInt64?) {
@@ -8311,13 +8449,13 @@ public struct FfiConverterTypeGroupSystemEventFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupSystemEventFfi {
         return
             try GroupSystemEventFfi(
-                systemType: FfiConverterString.read(from: &buf),
-                text: FfiConverterString.read(from: &buf),
-                actorAccountIdHex: FfiConverterOptionString.read(from: &buf),
-                subjectAccountIdHex: FfiConverterOptionString.read(from: &buf),
-                name: FfiConverterOptionString.read(from: &buf),
-                oldName: FfiConverterOptionString.read(from: &buf),
-                oldRetentionSeconds: FfiConverterOptionUInt64.read(from: &buf),
+                systemType: FfiConverterString.read(from: &buf), 
+                text: FfiConverterString.read(from: &buf), 
+                actorAccountIdHex: FfiConverterOptionString.read(from: &buf), 
+                subjectAccountIdHex: FfiConverterOptionString.read(from: &buf), 
+                name: FfiConverterOptionString.read(from: &buf), 
+                oldName: FfiConverterOptionString.read(from: &buf), 
+                oldRetentionSeconds: FfiConverterOptionUInt64.read(from: &buf), 
                 newRetentionSeconds: FfiConverterOptionUInt64.read(from: &buf)
         )
     }
@@ -8389,7 +8527,7 @@ public struct FfiConverterTypeLocalCleanupReportFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LocalCleanupReportFfi {
         return
             try LocalCleanupReportFfi(
-                completed: FfiConverterBool.read(from: &buf),
+                completed: FfiConverterBool.read(from: &buf), 
                 reason: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -8479,11 +8617,11 @@ public struct FfiConverterTypeLocalPushRegistrationDebugFfi: FfiConverterRustBuf
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> LocalPushRegistrationDebugFfi {
         return
             try LocalPushRegistrationDebugFfi(
-                registered: FfiConverterBool.read(from: &buf),
-                shareable: FfiConverterBool.read(from: &buf),
-                localNotificationsEnabled: FfiConverterBool.read(from: &buf),
-                nativePushEnabled: FfiConverterBool.read(from: &buf),
-                localLeafIndex: FfiConverterOptionUInt32.read(from: &buf),
+                registered: FfiConverterBool.read(from: &buf), 
+                shareable: FfiConverterBool.read(from: &buf), 
+                localNotificationsEnabled: FfiConverterBool.read(from: &buf), 
+                nativePushEnabled: FfiConverterBool.read(from: &buf), 
+                localLeafIndex: FfiConverterOptionUInt32.read(from: &buf), 
                 localTokenCached: FfiConverterBool.read(from: &buf)
         )
     }
@@ -8524,7 +8662,7 @@ public struct MarkdownDocumentFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(blocks: [MarkdownBlockFfi],
+    public init(blocks: [MarkdownBlockFfi], 
         /**
          * True when the input exceeded the FFI Markdown safety cap and `blocks`
          * were parsed from a UTF-8-boundary prefix.
@@ -8561,7 +8699,7 @@ public struct FfiConverterTypeMarkdownDocumentFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownDocumentFfi {
         return
             try MarkdownDocumentFfi(
-                blocks: FfiConverterSequenceTypeMarkdownBlockFfi.read(from: &buf),
+                blocks: FfiConverterSequenceTypeMarkdownBlockFfi.read(from: &buf), 
                 truncated: FfiConverterBool.read(from: &buf)
         )
     }
@@ -8598,7 +8736,7 @@ public struct MarkdownListItemFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(blocks: [MarkdownBlockFfi],
+    public init(blocks: [MarkdownBlockFfi], 
         /**
          * `None` for plain bullets/ordered items, `Some(false)` for `[ ]`,
          * `Some(true)` for `[x]`.
@@ -8635,7 +8773,7 @@ public struct FfiConverterTypeMarkdownListItemFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownListItemFfi {
         return
             try MarkdownListItemFfi(
-                blocks: FfiConverterSequenceTypeMarkdownBlockFfi.read(from: &buf),
+                blocks: FfiConverterSequenceTypeMarkdownBlockFfi.read(from: &buf), 
                 checked: FfiConverterOptionBool.read(from: &buf)
         )
     }
@@ -8701,7 +8839,7 @@ public struct FfiConverterTypeMarkdownNostrEntityFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownNostrEntityFfi {
         return
             try MarkdownNostrEntityFfi(
-                hrp: FfiConverterTypeMarkdownNostrHrpFfi.read(from: &buf),
+                hrp: FfiConverterTypeMarkdownNostrHrpFfi.read(from: &buf), 
                 bech32: FfiConverterString.read(from: &buf)
         )
     }
@@ -8873,15 +9011,15 @@ public struct FfiConverterTypeMediaAttachmentReferenceFfi: FfiConverterRustBuffe
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MediaAttachmentReferenceFfi {
         return
             try MediaAttachmentReferenceFfi(
-                locators: FfiConverterSequenceTypeMediaLocatorFfi.read(from: &buf),
-                ciphertextSha256: FfiConverterString.read(from: &buf),
-                plaintextSha256: FfiConverterString.read(from: &buf),
-                nonceHex: FfiConverterString.read(from: &buf),
-                fileName: FfiConverterString.read(from: &buf),
-                mediaType: FfiConverterString.read(from: &buf),
-                version: FfiConverterString.read(from: &buf),
-                sourceEpoch: FfiConverterUInt64.read(from: &buf),
-                dim: FfiConverterOptionString.read(from: &buf),
+                locators: FfiConverterSequenceTypeMediaLocatorFfi.read(from: &buf), 
+                ciphertextSha256: FfiConverterString.read(from: &buf), 
+                plaintextSha256: FfiConverterString.read(from: &buf), 
+                nonceHex: FfiConverterString.read(from: &buf), 
+                fileName: FfiConverterString.read(from: &buf), 
+                mediaType: FfiConverterString.read(from: &buf), 
+                version: FfiConverterString.read(from: &buf), 
+                sourceEpoch: FfiConverterUInt64.read(from: &buf), 
+                dim: FfiConverterOptionString.read(from: &buf), 
                 thumbhash: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -8967,9 +9105,9 @@ public struct FfiConverterTypeMediaDownloadResultFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MediaDownloadResultFfi {
         return
             try MediaDownloadResultFfi(
-                plaintext: FfiConverterData.read(from: &buf),
-                fileName: FfiConverterString.read(from: &buf),
-                mediaType: FfiConverterString.read(from: &buf),
+                plaintext: FfiConverterData.read(from: &buf), 
+                fileName: FfiConverterString.read(from: &buf), 
+                mediaType: FfiConverterString.read(from: &buf), 
                 sizeBytes: FfiConverterUInt64.read(from: &buf)
         )
     }
@@ -9037,7 +9175,7 @@ public struct FfiConverterTypeMediaLocatorFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MediaLocatorFfi {
         return
             try MediaLocatorFfi(
-                kind: FfiConverterString.read(from: &buf),
+                kind: FfiConverterString.read(from: &buf), 
                 value: FfiConverterString.read(from: &buf)
         )
     }
@@ -9145,14 +9283,14 @@ public struct FfiConverterTypeMediaRecordFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MediaRecordFfi {
         return
             try MediaRecordFfi(
-                messageIdHex: FfiConverterString.read(from: &buf),
-                attachmentIndex: FfiConverterUInt32.read(from: &buf),
-                direction: FfiConverterString.read(from: &buf),
-                groupIdHex: FfiConverterString.read(from: &buf),
-                sender: FfiConverterString.read(from: &buf),
-                reference: FfiConverterTypeMediaAttachmentReferenceFfi.read(from: &buf),
-                caption: FfiConverterOptionString.read(from: &buf),
-                recordedAt: FfiConverterUInt64.read(from: &buf),
+                messageIdHex: FfiConverterString.read(from: &buf), 
+                attachmentIndex: FfiConverterUInt32.read(from: &buf), 
+                direction: FfiConverterString.read(from: &buf), 
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                sender: FfiConverterString.read(from: &buf), 
+                reference: FfiConverterTypeMediaAttachmentReferenceFfi.read(from: &buf), 
+                caption: FfiConverterOptionString.read(from: &buf), 
+                recordedAt: FfiConverterUInt64.read(from: &buf), 
                 receivedAt: FfiConverterUInt64.read(from: &buf)
         )
     }
@@ -9243,10 +9381,10 @@ public struct FfiConverterTypeMediaUploadAttachmentRequestFfi: FfiConverterRustB
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MediaUploadAttachmentRequestFfi {
         return
             try MediaUploadAttachmentRequestFfi(
-                fileName: FfiConverterString.read(from: &buf),
-                mediaType: FfiConverterString.read(from: &buf),
-                plaintext: FfiConverterData.read(from: &buf),
-                dim: FfiConverterOptionString.read(from: &buf),
+                fileName: FfiConverterString.read(from: &buf), 
+                mediaType: FfiConverterString.read(from: &buf), 
+                plaintext: FfiConverterData.read(from: &buf), 
+                dim: FfiConverterOptionString.read(from: &buf), 
                 thumbhash: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -9315,7 +9453,7 @@ public struct FfiConverterTypeMediaUploadAttachmentResultFfi: FfiConverterRustBu
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MediaUploadAttachmentResultFfi {
         return
             try MediaUploadAttachmentResultFfi(
-                reference: FfiConverterTypeMediaAttachmentReferenceFfi.read(from: &buf),
+                reference: FfiConverterTypeMediaAttachmentReferenceFfi.read(from: &buf), 
                 encryptedSizeBytes: FfiConverterUInt64.read(from: &buf)
         )
     }
@@ -9393,9 +9531,9 @@ public struct FfiConverterTypeMediaUploadRequestFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MediaUploadRequestFfi {
         return
             try MediaUploadRequestFfi(
-                attachments: FfiConverterSequenceTypeMediaUploadAttachmentRequestFfi.read(from: &buf),
-                caption: FfiConverterOptionString.read(from: &buf),
-                send: FfiConverterBool.read(from: &buf),
+                attachments: FfiConverterSequenceTypeMediaUploadAttachmentRequestFfi.read(from: &buf), 
+                caption: FfiConverterOptionString.read(from: &buf), 
+                send: FfiConverterBool.read(from: &buf), 
                 blossomServer: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -9463,7 +9601,7 @@ public struct FfiConverterTypeMediaUploadResultFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MediaUploadResultFfi {
         return
             try MediaUploadResultFfi(
-                attachments: FfiConverterSequenceTypeMediaUploadAttachmentResultFfi.read(from: &buf),
+                attachments: FfiConverterSequenceTypeMediaUploadAttachmentResultFfi.read(from: &buf), 
                 sent: FfiConverterOptionTypeSendSummaryFfi.read(from: &buf)
         )
     }
@@ -9535,8 +9673,8 @@ public struct FfiConverterTypeMemberRefFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MemberRefFfi {
         return
             try MemberRefFfi(
-                memberRef: FfiConverterString.read(from: &buf),
-                accountIdHex: FfiConverterString.read(from: &buf),
+                memberRef: FfiConverterString.read(from: &buf), 
+                accountIdHex: FfiConverterString.read(from: &buf), 
                 npub: FfiConverterString.read(from: &buf)
         )
     }
@@ -9561,6 +9699,411 @@ public func FfiConverterTypeMemberRefFfi_lift(_ buf: RustBuffer) throws -> Membe
 #endif
 public func FfiConverterTypeMemberRefFfi_lower(_ value: MemberRefFfi) -> RustBuffer {
     return FfiConverterTypeMemberRefFfi.lower(value)
+}
+
+
+/**
+ * One fully hydrated draft attachment crossing the host boundary.
+ */
+public struct MessageDraftAttachmentFfi {
+    public var id: String
+    public var fileName: String
+    public var mediaType: String
+    public var plaintext: Data
+    public var dim: String?
+    public var thumbhash: String?
+    public var durationSeconds: Double?
+    public var waveformSamples: [Double]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, fileName: String, mediaType: String, plaintext: Data, dim: String?, thumbhash: String?, durationSeconds: Double?, waveformSamples: [Double]) {
+        self.id = id
+        self.fileName = fileName
+        self.mediaType = mediaType
+        self.plaintext = plaintext
+        self.dim = dim
+        self.thumbhash = thumbhash
+        self.durationSeconds = durationSeconds
+        self.waveformSamples = waveformSamples
+    }
+}
+
+
+
+extension MessageDraftAttachmentFfi: Equatable, Hashable {
+    public static func ==(lhs: MessageDraftAttachmentFfi, rhs: MessageDraftAttachmentFfi) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.fileName != rhs.fileName {
+            return false
+        }
+        if lhs.mediaType != rhs.mediaType {
+            return false
+        }
+        if lhs.plaintext != rhs.plaintext {
+            return false
+        }
+        if lhs.dim != rhs.dim {
+            return false
+        }
+        if lhs.thumbhash != rhs.thumbhash {
+            return false
+        }
+        if lhs.durationSeconds != rhs.durationSeconds {
+            return false
+        }
+        if lhs.waveformSamples != rhs.waveformSamples {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(fileName)
+        hasher.combine(mediaType)
+        hasher.combine(plaintext)
+        hasher.combine(dim)
+        hasher.combine(thumbhash)
+        hasher.combine(durationSeconds)
+        hasher.combine(waveformSamples)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMessageDraftAttachmentFfi: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MessageDraftAttachmentFfi {
+        return
+            try MessageDraftAttachmentFfi(
+                id: FfiConverterString.read(from: &buf), 
+                fileName: FfiConverterString.read(from: &buf), 
+                mediaType: FfiConverterString.read(from: &buf), 
+                plaintext: FfiConverterData.read(from: &buf), 
+                dim: FfiConverterOptionString.read(from: &buf), 
+                thumbhash: FfiConverterOptionString.read(from: &buf), 
+                durationSeconds: FfiConverterOptionDouble.read(from: &buf), 
+                waveformSamples: FfiConverterSequenceDouble.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: MessageDraftAttachmentFfi, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.fileName, into: &buf)
+        FfiConverterString.write(value.mediaType, into: &buf)
+        FfiConverterData.write(value.plaintext, into: &buf)
+        FfiConverterOptionString.write(value.dim, into: &buf)
+        FfiConverterOptionString.write(value.thumbhash, into: &buf)
+        FfiConverterOptionDouble.write(value.durationSeconds, into: &buf)
+        FfiConverterSequenceDouble.write(value.waveformSamples, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMessageDraftAttachmentFfi_lift(_ buf: RustBuffer) throws -> MessageDraftAttachmentFfi {
+    return try FfiConverterTypeMessageDraftAttachmentFfi.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMessageDraftAttachmentFfi_lower(_ value: MessageDraftAttachmentFfi) -> RustBuffer {
+    return FfiConverterTypeMessageDraftAttachmentFfi.lower(value)
+}
+
+
+/**
+ * Attachment metadata for a draft-list preview. Plaintext bytes are omitted.
+ */
+public struct MessageDraftAttachmentSummaryFfi {
+    public var id: String
+    public var fileName: String
+    public var mediaType: String
+    public var plaintextSize: UInt64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String, fileName: String, mediaType: String, plaintextSize: UInt64) {
+        self.id = id
+        self.fileName = fileName
+        self.mediaType = mediaType
+        self.plaintextSize = plaintextSize
+    }
+}
+
+
+
+extension MessageDraftAttachmentSummaryFfi: Equatable, Hashable {
+    public static func ==(lhs: MessageDraftAttachmentSummaryFfi, rhs: MessageDraftAttachmentSummaryFfi) -> Bool {
+        if lhs.id != rhs.id {
+            return false
+        }
+        if lhs.fileName != rhs.fileName {
+            return false
+        }
+        if lhs.mediaType != rhs.mediaType {
+            return false
+        }
+        if lhs.plaintextSize != rhs.plaintextSize {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(fileName)
+        hasher.combine(mediaType)
+        hasher.combine(plaintextSize)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMessageDraftAttachmentSummaryFfi: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MessageDraftAttachmentSummaryFfi {
+        return
+            try MessageDraftAttachmentSummaryFfi(
+                id: FfiConverterString.read(from: &buf), 
+                fileName: FfiConverterString.read(from: &buf), 
+                mediaType: FfiConverterString.read(from: &buf), 
+                plaintextSize: FfiConverterUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: MessageDraftAttachmentSummaryFfi, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.fileName, into: &buf)
+        FfiConverterString.write(value.mediaType, into: &buf)
+        FfiConverterUInt64.write(value.plaintextSize, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMessageDraftAttachmentSummaryFfi_lift(_ buf: RustBuffer) throws -> MessageDraftAttachmentSummaryFfi {
+    return try FfiConverterTypeMessageDraftAttachmentSummaryFfi.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMessageDraftAttachmentSummaryFfi_lower(_ value: MessageDraftAttachmentSummaryFfi) -> RustBuffer {
+    return FfiConverterTypeMessageDraftAttachmentSummaryFfi.lower(value)
+}
+
+
+/**
+ * One fully hydrated composer draft returned for a selected group.
+ */
+public struct MessageDraftFfi {
+    public var groupIdHex: String
+    public var content: String
+    public var replyToMessageIdHex: String?
+    public var mediaAttachments: [MessageDraftAttachmentFfi]
+    public var createdAtMs: Int64
+    public var updatedAtMs: Int64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(groupIdHex: String, content: String, replyToMessageIdHex: String?, mediaAttachments: [MessageDraftAttachmentFfi], createdAtMs: Int64, updatedAtMs: Int64) {
+        self.groupIdHex = groupIdHex
+        self.content = content
+        self.replyToMessageIdHex = replyToMessageIdHex
+        self.mediaAttachments = mediaAttachments
+        self.createdAtMs = createdAtMs
+        self.updatedAtMs = updatedAtMs
+    }
+}
+
+
+
+extension MessageDraftFfi: Equatable, Hashable {
+    public static func ==(lhs: MessageDraftFfi, rhs: MessageDraftFfi) -> Bool {
+        if lhs.groupIdHex != rhs.groupIdHex {
+            return false
+        }
+        if lhs.content != rhs.content {
+            return false
+        }
+        if lhs.replyToMessageIdHex != rhs.replyToMessageIdHex {
+            return false
+        }
+        if lhs.mediaAttachments != rhs.mediaAttachments {
+            return false
+        }
+        if lhs.createdAtMs != rhs.createdAtMs {
+            return false
+        }
+        if lhs.updatedAtMs != rhs.updatedAtMs {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(groupIdHex)
+        hasher.combine(content)
+        hasher.combine(replyToMessageIdHex)
+        hasher.combine(mediaAttachments)
+        hasher.combine(createdAtMs)
+        hasher.combine(updatedAtMs)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMessageDraftFfi: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MessageDraftFfi {
+        return
+            try MessageDraftFfi(
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                content: FfiConverterString.read(from: &buf), 
+                replyToMessageIdHex: FfiConverterOptionString.read(from: &buf), 
+                mediaAttachments: FfiConverterSequenceTypeMessageDraftAttachmentFfi.read(from: &buf), 
+                createdAtMs: FfiConverterInt64.read(from: &buf), 
+                updatedAtMs: FfiConverterInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: MessageDraftFfi, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.groupIdHex, into: &buf)
+        FfiConverterString.write(value.content, into: &buf)
+        FfiConverterOptionString.write(value.replyToMessageIdHex, into: &buf)
+        FfiConverterSequenceTypeMessageDraftAttachmentFfi.write(value.mediaAttachments, into: &buf)
+        FfiConverterInt64.write(value.createdAtMs, into: &buf)
+        FfiConverterInt64.write(value.updatedAtMs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMessageDraftFfi_lift(_ buf: RustBuffer) throws -> MessageDraftFfi {
+    return try FfiConverterTypeMessageDraftFfi.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMessageDraftFfi_lower(_ value: MessageDraftFfi) -> RustBuffer {
+    return FfiConverterTypeMessageDraftFfi.lower(value)
+}
+
+
+/**
+ * Metadata-only draft-list row. Use `messageDraft` to hydrate one selected
+ * composer and its attachment plaintext.
+ */
+public struct MessageDraftSummaryFfi {
+    public var groupIdHex: String
+    public var content: String
+    public var replyToMessageIdHex: String?
+    public var mediaAttachments: [MessageDraftAttachmentSummaryFfi]
+    public var createdAtMs: Int64
+    public var updatedAtMs: Int64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(groupIdHex: String, content: String, replyToMessageIdHex: String?, mediaAttachments: [MessageDraftAttachmentSummaryFfi], createdAtMs: Int64, updatedAtMs: Int64) {
+        self.groupIdHex = groupIdHex
+        self.content = content
+        self.replyToMessageIdHex = replyToMessageIdHex
+        self.mediaAttachments = mediaAttachments
+        self.createdAtMs = createdAtMs
+        self.updatedAtMs = updatedAtMs
+    }
+}
+
+
+
+extension MessageDraftSummaryFfi: Equatable, Hashable {
+    public static func ==(lhs: MessageDraftSummaryFfi, rhs: MessageDraftSummaryFfi) -> Bool {
+        if lhs.groupIdHex != rhs.groupIdHex {
+            return false
+        }
+        if lhs.content != rhs.content {
+            return false
+        }
+        if lhs.replyToMessageIdHex != rhs.replyToMessageIdHex {
+            return false
+        }
+        if lhs.mediaAttachments != rhs.mediaAttachments {
+            return false
+        }
+        if lhs.createdAtMs != rhs.createdAtMs {
+            return false
+        }
+        if lhs.updatedAtMs != rhs.updatedAtMs {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(groupIdHex)
+        hasher.combine(content)
+        hasher.combine(replyToMessageIdHex)
+        hasher.combine(mediaAttachments)
+        hasher.combine(createdAtMs)
+        hasher.combine(updatedAtMs)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeMessageDraftSummaryFfi: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MessageDraftSummaryFfi {
+        return
+            try MessageDraftSummaryFfi(
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                content: FfiConverterString.read(from: &buf), 
+                replyToMessageIdHex: FfiConverterOptionString.read(from: &buf), 
+                mediaAttachments: FfiConverterSequenceTypeMessageDraftAttachmentSummaryFfi.read(from: &buf), 
+                createdAtMs: FfiConverterInt64.read(from: &buf), 
+                updatedAtMs: FfiConverterInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: MessageDraftSummaryFfi, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.groupIdHex, into: &buf)
+        FfiConverterString.write(value.content, into: &buf)
+        FfiConverterOptionString.write(value.replyToMessageIdHex, into: &buf)
+        FfiConverterSequenceTypeMessageDraftAttachmentSummaryFfi.write(value.mediaAttachments, into: &buf)
+        FfiConverterInt64.write(value.createdAtMs, into: &buf)
+        FfiConverterInt64.write(value.updatedAtMs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMessageDraftSummaryFfi_lift(_ buf: RustBuffer) throws -> MessageDraftSummaryFfi {
+    return try FfiConverterTypeMessageDraftSummaryFfi.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeMessageDraftSummaryFfi_lower(_ value: MessageDraftSummaryFfi) -> RustBuffer {
+    return FfiConverterTypeMessageDraftSummaryFfi.lower(value)
 }
 
 
@@ -9678,9 +10221,9 @@ public struct FfiConverterTypeNotificationSettingsFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NotificationSettingsFfi {
         return
             try NotificationSettingsFfi(
-                accountRef: FfiConverterString.read(from: &buf),
-                accountIdHex: FfiConverterString.read(from: &buf),
-                localNotificationsEnabled: FfiConverterBool.read(from: &buf),
+                accountRef: FfiConverterString.read(from: &buf), 
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                localNotificationsEnabled: FfiConverterBool.read(from: &buf), 
                 nativePushEnabled: FfiConverterBool.read(from: &buf)
         )
     }
@@ -9838,22 +10381,22 @@ public struct FfiConverterTypeNotificationUpdateFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NotificationUpdateFfi {
         return
             try NotificationUpdateFfi(
-                notificationKey: FfiConverterString.read(from: &buf),
-                conversationKey: FfiConverterString.read(from: &buf),
-                trigger: FfiConverterTypeNotificationTriggerFfi.read(from: &buf),
-                accountRef: FfiConverterString.read(from: &buf),
-                accountIdHex: FfiConverterString.read(from: &buf),
-                groupIdHex: FfiConverterString.read(from: &buf),
-                groupName: FfiConverterOptionString.read(from: &buf),
-                isDm: FfiConverterBool.read(from: &buf),
-                isMention: FfiConverterBool.read(from: &buf),
-                messageIdHex: FfiConverterOptionString.read(from: &buf),
-                sender: FfiConverterTypeNotificationUserFfi.read(from: &buf),
-                receiver: FfiConverterTypeNotificationUserFfi.read(from: &buf),
-                previewText: FfiConverterOptionString.read(from: &buf),
-                reactionEmoji: FfiConverterOptionString.read(from: &buf),
-                reactedToPreview: FfiConverterOptionString.read(from: &buf),
-                timestampMs: FfiConverterInt64.read(from: &buf),
+                notificationKey: FfiConverterString.read(from: &buf), 
+                conversationKey: FfiConverterString.read(from: &buf), 
+                trigger: FfiConverterTypeNotificationTriggerFfi.read(from: &buf), 
+                accountRef: FfiConverterString.read(from: &buf), 
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                groupName: FfiConverterOptionString.read(from: &buf), 
+                isDm: FfiConverterBool.read(from: &buf), 
+                isMention: FfiConverterBool.read(from: &buf), 
+                messageIdHex: FfiConverterOptionString.read(from: &buf), 
+                sender: FfiConverterTypeNotificationUserFfi.read(from: &buf), 
+                receiver: FfiConverterTypeNotificationUserFfi.read(from: &buf), 
+                previewText: FfiConverterOptionString.read(from: &buf), 
+                reactionEmoji: FfiConverterOptionString.read(from: &buf), 
+                reactedToPreview: FfiConverterOptionString.read(from: &buf), 
+                timestampMs: FfiConverterInt64.read(from: &buf), 
                 isFromSelf: FfiConverterBool.read(from: &buf)
         )
     }
@@ -9940,8 +10483,8 @@ public struct FfiConverterTypeNotificationUserFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NotificationUserFfi {
         return
             try NotificationUserFfi(
-                accountIdHex: FfiConverterString.read(from: &buf),
-                displayName: FfiConverterOptionString.read(from: &buf),
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                displayName: FfiConverterOptionString.read(from: &buf), 
                 pictureUrl: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -10050,14 +10593,14 @@ public struct FfiConverterTypePushRegistrationFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PushRegistrationFfi {
         return
             try PushRegistrationFfi(
-                accountRef: FfiConverterString.read(from: &buf),
-                accountIdHex: FfiConverterString.read(from: &buf),
-                platform: FfiConverterTypePushPlatformFfi.read(from: &buf),
-                tokenFingerprint: FfiConverterString.read(from: &buf),
-                serverPubkeyHex: FfiConverterString.read(from: &buf),
-                relayHint: FfiConverterOptionString.read(from: &buf),
-                createdAtMs: FfiConverterInt64.read(from: &buf),
-                updatedAtMs: FfiConverterInt64.read(from: &buf),
+                accountRef: FfiConverterString.read(from: &buf), 
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                platform: FfiConverterTypePushPlatformFfi.read(from: &buf), 
+                tokenFingerprint: FfiConverterString.read(from: &buf), 
+                serverPubkeyHex: FfiConverterString.read(from: &buf), 
+                relayHint: FfiConverterOptionString.read(from: &buf), 
+                createdAtMs: FfiConverterInt64.read(from: &buf), 
+                updatedAtMs: FfiConverterInt64.read(from: &buf), 
                 lastSharedAtMs: FfiConverterOptionInt64.read(from: &buf)
         )
     }
@@ -10116,13 +10659,13 @@ public struct ReceivedMessageFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(messageIdHex: String, groupIdHex: String, sender: String, senderDisplayName: String?, plaintext: String, contentTokens: MarkdownDocumentFfi,
+    public init(messageIdHex: String, groupIdHex: String, sender: String, senderDisplayName: String?, plaintext: String, contentTokens: MarkdownDocumentFfi, 
         /**
          * Nostr `kind` of the inner Marmot app event.
-         */kind: UInt64,
+         */kind: UInt64, 
         /**
          * Nostr `tags` of the inner Marmot app event.
-         */tags: [MessageTagFfi],
+         */tags: [MessageTagFfi], 
         /**
          * Source-event timestamp (seconds since epoch) for the MLS-delivered
          * message. Clients should sort the timeline by this value so chronology
@@ -10196,14 +10739,14 @@ public struct FfiConverterTypeReceivedMessageFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ReceivedMessageFfi {
         return
             try ReceivedMessageFfi(
-                messageIdHex: FfiConverterString.read(from: &buf),
-                groupIdHex: FfiConverterString.read(from: &buf),
-                sender: FfiConverterString.read(from: &buf),
-                senderDisplayName: FfiConverterOptionString.read(from: &buf),
-                plaintext: FfiConverterString.read(from: &buf),
-                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf),
-                kind: FfiConverterUInt64.read(from: &buf),
-                tags: FfiConverterSequenceTypeMessageTagFfi.read(from: &buf),
+                messageIdHex: FfiConverterString.read(from: &buf), 
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                sender: FfiConverterString.read(from: &buf), 
+                senderDisplayName: FfiConverterOptionString.read(from: &buf), 
+                plaintext: FfiConverterString.read(from: &buf), 
+                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf), 
+                kind: FfiConverterUInt64.read(from: &buf), 
+                tags: FfiConverterSequenceTypeMessageTagFfi.read(from: &buf), 
                 recordedAt: FfiConverterUInt64.read(from: &buf)
         )
     }
@@ -10276,7 +10819,7 @@ public struct FfiConverterTypeRelayFailureFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RelayFailureFfi {
         return
             try RelayFailureFfi(
-                eventIdHex: FfiConverterString.read(from: &buf),
+                eventIdHex: FfiConverterString.read(from: &buf), 
                 reason: FfiConverterString.read(from: &buf)
         )
     }
@@ -10405,17 +10948,17 @@ public struct FfiConverterTypeRelayHealthFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RelayHealthFfi {
         return
             try RelayHealthFfi(
-                sdkBacked: FfiConverterBool.read(from: &buf),
-                totalRelays: FfiConverterUInt32.read(from: &buf),
-                initialized: FfiConverterUInt32.read(from: &buf),
-                pending: FfiConverterUInt32.read(from: &buf),
-                connecting: FfiConverterUInt32.read(from: &buf),
-                connected: FfiConverterUInt32.read(from: &buf),
-                disconnected: FfiConverterUInt32.read(from: &buf),
-                terminated: FfiConverterUInt32.read(from: &buf),
-                banned: FfiConverterUInt32.read(from: &buf),
-                sleeping: FfiConverterUInt32.read(from: &buf),
-                connectionAttempts: FfiConverterUInt32.read(from: &buf),
+                sdkBacked: FfiConverterBool.read(from: &buf), 
+                totalRelays: FfiConverterUInt32.read(from: &buf), 
+                initialized: FfiConverterUInt32.read(from: &buf), 
+                pending: FfiConverterUInt32.read(from: &buf), 
+                connecting: FfiConverterUInt32.read(from: &buf), 
+                connected: FfiConverterUInt32.read(from: &buf), 
+                disconnected: FfiConverterUInt32.read(from: &buf), 
+                terminated: FfiConverterUInt32.read(from: &buf), 
+                banned: FfiConverterUInt32.read(from: &buf), 
+                sleeping: FfiConverterUInt32.read(from: &buf), 
+                connectionAttempts: FfiConverterUInt32.read(from: &buf), 
                 connectionSuccesses: FfiConverterUInt32.read(from: &buf)
         )
     }
@@ -10491,7 +11034,7 @@ public struct FfiConverterTypeRelayListFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RelayListFfi {
         return
             try RelayListFfi(
-                kind: FfiConverterUInt64.read(from: &buf),
+                kind: FfiConverterUInt64.read(from: &buf), 
                 relays: FfiConverterSequenceString.read(from: &buf)
         )
     }
@@ -10587,12 +11130,12 @@ public struct FfiConverterTypeRelayTelemetryResourceFfi: FfiConverterRustBuffer 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RelayTelemetryResourceFfi {
         return
             try RelayTelemetryResourceFfi(
-                serviceVersion: FfiConverterString.read(from: &buf),
-                serviceInstanceId: FfiConverterString.read(from: &buf),
-                deploymentEnvironment: FfiConverterString.read(from: &buf),
-                tenant: FfiConverterString.read(from: &buf),
-                osType: FfiConverterString.read(from: &buf),
-                osVersion: FfiConverterString.read(from: &buf),
+                serviceVersion: FfiConverterString.read(from: &buf), 
+                serviceInstanceId: FfiConverterString.read(from: &buf), 
+                deploymentEnvironment: FfiConverterString.read(from: &buf), 
+                tenant: FfiConverterString.read(from: &buf), 
+                osType: FfiConverterString.read(from: &buf), 
+                osVersion: FfiConverterString.read(from: &buf), 
                 deviceModelIdentifier: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -10674,8 +11217,8 @@ public struct FfiConverterTypeRelayTelemetryRuntimeConfigFfi: FfiConverterRustBu
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RelayTelemetryRuntimeConfigFfi {
         return
             try RelayTelemetryRuntimeConfigFfi(
-                otlpEndpoint: FfiConverterOptionString.read(from: &buf),
-                authorizationBearerToken: FfiConverterOptionString.read(from: &buf),
+                otlpEndpoint: FfiConverterOptionString.read(from: &buf), 
+                authorizationBearerToken: FfiConverterOptionString.read(from: &buf), 
                 resource: FfiConverterOptionTypeRelayTelemetryResourceFfi.read(from: &buf)
         )
     }
@@ -10742,7 +11285,7 @@ public struct FfiConverterTypeRelayTelemetrySettingsFfi: FfiConverterRustBuffer 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RelayTelemetrySettingsFfi {
         return
             try RelayTelemetrySettingsFfi(
-                exportEnabled: FfiConverterBool.read(from: &buf),
+                exportEnabled: FfiConverterBool.read(from: &buf), 
                 exportIntervalSeconds: FfiConverterUInt64.read(from: &buf)
         )
     }
@@ -10814,8 +11357,8 @@ public struct FfiConverterTypeRuntimeMessageReceivedFfi: FfiConverterRustBuffer 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RuntimeMessageReceivedFfi {
         return
             try RuntimeMessageReceivedFfi(
-                accountIdHex: FfiConverterString.read(from: &buf),
-                accountLabel: FfiConverterString.read(from: &buf),
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                accountLabel: FfiConverterString.read(from: &buf), 
                 message: FfiConverterTypeReceivedMessageFfi.read(from: &buf)
         )
     }
@@ -10888,8 +11431,8 @@ public struct FfiConverterTypeRuntimeProjectionUpdateFfi: FfiConverterRustBuffer
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RuntimeProjectionUpdateFfi {
         return
             try RuntimeProjectionUpdateFfi(
-                accountIdHex: FfiConverterString.read(from: &buf),
-                accountLabel: FfiConverterString.read(from: &buf),
+                accountIdHex: FfiConverterString.read(from: &buf), 
+                accountLabel: FfiConverterString.read(from: &buf), 
                 update: FfiConverterTypeTimelineProjectionUpdateFfi.read(from: &buf)
         )
     }
@@ -10956,7 +11499,7 @@ public struct FfiConverterTypeSecureDeleteExpiredResultFfi: FfiConverterRustBuff
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SecureDeleteExpiredResultFfi {
         return
             try SecureDeleteExpiredResultFfi(
-                prunedMessages: FfiConverterUInt64.read(from: &buf),
+                prunedMessages: FfiConverterUInt64.read(from: &buf), 
                 mediaCiphertextSha256: FfiConverterSequenceString.read(from: &buf)
         )
     }
@@ -11022,7 +11565,7 @@ public struct FfiConverterTypeSendSummaryFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SendSummaryFfi {
         return
             try SendSummaryFfi(
-                published: FfiConverterUInt32.read(from: &buf),
+                published: FfiConverterUInt32.read(from: &buf), 
                 messageIds: FfiConverterSequenceString.read(from: &buf)
         )
     }
@@ -11077,10 +11620,10 @@ public struct SignOutOutcomeFfi {
         /**
          * Relay-published KeyPackage events successfully deleted. `0` when
          * `deleteKeyPackages` was `false`.
-         */keyPackagesDeleted: UInt32,
+         */keyPackagesDeleted: UInt32, 
         /**
          * Per-relay KeyPackage deletion (or discovery) failures. Best-effort.
-         */keyPackageFailures: [RelayFailureFfi],
+         */keyPackageFailures: [RelayFailureFfi], 
         /**
          * Local teardown (worker shutdown, subscription deactivation, in-memory
          * cache eviction) result. Never removes on-disk state.
@@ -11122,8 +11665,8 @@ public struct FfiConverterTypeSignOutOutcomeFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SignOutOutcomeFfi {
         return
             try SignOutOutcomeFfi(
-                keyPackagesDeleted: FfiConverterUInt32.read(from: &buf),
-                keyPackageFailures: FfiConverterSequenceTypeRelayFailureFfi.read(from: &buf),
+                keyPackagesDeleted: FfiConverterUInt32.read(from: &buf), 
+                keyPackageFailures: FfiConverterSequenceTypeRelayFailureFfi.read(from: &buf), 
                 localCleanup: FfiConverterTypeLocalCleanupReportFfi.read(from: &buf)
         )
     }
@@ -11220,12 +11763,12 @@ public struct FfiConverterTypeTimelineMessageQueryFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineMessageQueryFfi {
         return
             try TimelineMessageQueryFfi(
-                groupIdHex: FfiConverterOptionString.read(from: &buf),
-                search: FfiConverterOptionString.read(from: &buf),
-                before: FfiConverterOptionUInt64.read(from: &buf),
-                beforeMessageId: FfiConverterOptionString.read(from: &buf),
-                after: FfiConverterOptionUInt64.read(from: &buf),
-                afterMessageId: FfiConverterOptionString.read(from: &buf),
+                groupIdHex: FfiConverterOptionString.read(from: &buf), 
+                search: FfiConverterOptionString.read(from: &buf), 
+                before: FfiConverterOptionUInt64.read(from: &buf), 
+                beforeMessageId: FfiConverterOptionString.read(from: &buf), 
+                after: FfiConverterOptionUInt64.read(from: &buf), 
+                afterMessageId: FfiConverterOptionString.read(from: &buf), 
                 limit: FfiConverterOptionUInt32.read(from: &buf)
         )
     }
@@ -11312,7 +11855,7 @@ public struct TimelineMessageRecordFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(messageIdHex: String,
+    public init(messageIdHex: String, 
         /**
          * Delivery marker for own (`direction == "sent"`) messages. An own send
          * commits and projects locally *before* it publishes, so a message that
@@ -11324,7 +11867,7 @@ public struct TimelineMessageRecordFfi {
          * without minting a duplicate, call `retry_group_convergence` rather than
          * re-sending the text. For received messages this is the originating event
          * id and is always `Some(..)`.
-         */sourceMessageIdHex: String?, direction: String, groupIdHex: String, sender: String, plaintext: String, contentTokens: MarkdownDocumentFfi, kind: UInt64, tags: [MessageTagFfi], timelineAt: UInt64, receivedAt: UInt64, replyToMessageIdHex: String?, replyPreview: TimelineReplyPreviewFfi?, mediaJson: String?,
+         */sourceMessageIdHex: String?, direction: String, groupIdHex: String, sender: String, plaintext: String, contentTokens: MarkdownDocumentFfi, kind: UInt64, tags: [MessageTagFfi], timelineAt: UInt64, receivedAt: UInt64, replyToMessageIdHex: String?, replyPreview: TimelineReplyPreviewFfi?, mediaJson: String?, 
         /**
          * Fully-resolved, downloadable media references for this message, built
          * from its `imeta` tags + its own `source_epoch` using the same resolution
@@ -11332,11 +11875,11 @@ public struct TimelineMessageRecordFfi {
          * `media` resolve identically for the same message). Empty when the message
          * has no media; a malformed `imeta` attachment is dropped while the message
          * still appears as text.
-         */media: [MediaAttachmentReferenceFfi], agentTextStreamJson: String?,
+         */media: [MediaAttachmentReferenceFfi], agentTextStreamJson: String?, 
         /**
          * Parsed view of kind-1210 group system rows. `None` for chat, reactions,
          * stream rows, and malformed/free-text kind-1210 assertions.
-         */groupSystem: GroupSystemEventFfi?, reactions: TimelineReactionSummaryFfi, deleted: Bool, deletedByMessageIdHex: String?,
+         */groupSystem: GroupSystemEventFfi?, reactions: TimelineReactionSummaryFfi, deleted: Bool, deletedByMessageIdHex: String?, 
         /**
          * Set when convergence invalidated this message (it landed on a losing
          * branch). The message is kept as a "did not reach the group" tombstone
@@ -11470,26 +12013,26 @@ public struct FfiConverterTypeTimelineMessageRecordFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineMessageRecordFfi {
         return
             try TimelineMessageRecordFfi(
-                messageIdHex: FfiConverterString.read(from: &buf),
-                sourceMessageIdHex: FfiConverterOptionString.read(from: &buf),
-                direction: FfiConverterString.read(from: &buf),
-                groupIdHex: FfiConverterString.read(from: &buf),
-                sender: FfiConverterString.read(from: &buf),
-                plaintext: FfiConverterString.read(from: &buf),
-                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf),
-                kind: FfiConverterUInt64.read(from: &buf),
-                tags: FfiConverterSequenceTypeMessageTagFfi.read(from: &buf),
-                timelineAt: FfiConverterUInt64.read(from: &buf),
-                receivedAt: FfiConverterUInt64.read(from: &buf),
-                replyToMessageIdHex: FfiConverterOptionString.read(from: &buf),
-                replyPreview: FfiConverterOptionTypeTimelineReplyPreviewFfi.read(from: &buf),
-                mediaJson: FfiConverterOptionString.read(from: &buf),
-                media: FfiConverterSequenceTypeMediaAttachmentReferenceFfi.read(from: &buf),
-                agentTextStreamJson: FfiConverterOptionString.read(from: &buf),
-                groupSystem: FfiConverterOptionTypeGroupSystemEventFfi.read(from: &buf),
-                reactions: FfiConverterTypeTimelineReactionSummaryFfi.read(from: &buf),
-                deleted: FfiConverterBool.read(from: &buf),
-                deletedByMessageIdHex: FfiConverterOptionString.read(from: &buf),
+                messageIdHex: FfiConverterString.read(from: &buf), 
+                sourceMessageIdHex: FfiConverterOptionString.read(from: &buf), 
+                direction: FfiConverterString.read(from: &buf), 
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                sender: FfiConverterString.read(from: &buf), 
+                plaintext: FfiConverterString.read(from: &buf), 
+                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf), 
+                kind: FfiConverterUInt64.read(from: &buf), 
+                tags: FfiConverterSequenceTypeMessageTagFfi.read(from: &buf), 
+                timelineAt: FfiConverterUInt64.read(from: &buf), 
+                receivedAt: FfiConverterUInt64.read(from: &buf), 
+                replyToMessageIdHex: FfiConverterOptionString.read(from: &buf), 
+                replyPreview: FfiConverterOptionTypeTimelineReplyPreviewFfi.read(from: &buf), 
+                mediaJson: FfiConverterOptionString.read(from: &buf), 
+                media: FfiConverterSequenceTypeMediaAttachmentReferenceFfi.read(from: &buf), 
+                agentTextStreamJson: FfiConverterOptionString.read(from: &buf), 
+                groupSystem: FfiConverterOptionTypeGroupSystemEventFfi.read(from: &buf), 
+                reactions: FfiConverterTypeTimelineReactionSummaryFfi.read(from: &buf), 
+                deleted: FfiConverterBool.read(from: &buf), 
+                deletedByMessageIdHex: FfiConverterOptionString.read(from: &buf), 
                 invalidationStatus: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -11580,8 +12123,8 @@ public struct FfiConverterTypeTimelinePageFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelinePageFfi {
         return
             try TimelinePageFfi(
-                messages: FfiConverterSequenceTypeTimelineMessageRecordFfi.read(from: &buf),
-                hasMoreBefore: FfiConverterBool.read(from: &buf),
+                messages: FfiConverterSequenceTypeTimelineMessageRecordFfi.read(from: &buf), 
+                hasMoreBefore: FfiConverterBool.read(from: &buf), 
                 hasMoreAfter: FfiConverterBool.read(from: &buf)
         )
     }
@@ -11666,10 +12209,10 @@ public struct FfiConverterTypeTimelineProjectionUpdateFfi: FfiConverterRustBuffe
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineProjectionUpdateFfi {
         return
             try TimelineProjectionUpdateFfi(
-                groupIdHex: FfiConverterString.read(from: &buf),
-                messages: FfiConverterSequenceTypeTimelineMessageRecordFfi.read(from: &buf),
-                changes: FfiConverterSequenceTypeTimelineMessageChangeFfi.read(from: &buf),
-                chatListRow: FfiConverterOptionTypeChatListRowFfi.read(from: &buf),
+                groupIdHex: FfiConverterString.read(from: &buf), 
+                messages: FfiConverterSequenceTypeTimelineMessageRecordFfi.read(from: &buf), 
+                changes: FfiConverterSequenceTypeTimelineMessageChangeFfi.read(from: &buf), 
+                chatListRow: FfiConverterOptionTypeChatListRowFfi.read(from: &buf), 
                 chatListTrigger: FfiConverterTypeChatListUpdateTriggerFfi.read(from: &buf)
         )
     }
@@ -11712,7 +12255,7 @@ public struct TimelineReactionEmojiFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(emoji: String,
+    public init(emoji: String, 
         /**
          * Number of distinct senders that reacted with this emoji
          * (`== senders.len()`), surfaced so clients render the tally without
@@ -11756,8 +12299,8 @@ public struct FfiConverterTypeTimelineReactionEmojiFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineReactionEmojiFfi {
         return
             try TimelineReactionEmojiFfi(
-                emoji: FfiConverterString.read(from: &buf),
-                count: FfiConverterUInt32.read(from: &buf),
+                emoji: FfiConverterString.read(from: &buf), 
+                count: FfiConverterUInt32.read(from: &buf), 
                 senders: FfiConverterSequenceString.read(from: &buf)
         )
     }
@@ -11832,7 +12375,7 @@ public struct FfiConverterTypeTimelineReactionSummaryFfi: FfiConverterRustBuffer
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineReactionSummaryFfi {
         return
             try TimelineReactionSummaryFfi(
-                byEmoji: FfiConverterSequenceTypeTimelineReactionEmojiFfi.read(from: &buf),
+                byEmoji: FfiConverterSequenceTypeTimelineReactionEmojiFfi.read(from: &buf), 
                 userReactions: FfiConverterSequenceTypeTimelineUserReactionFfi.read(from: &buf)
         )
     }
@@ -11878,7 +12421,7 @@ public struct TimelineReplyPreviewFfi {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(messageIdHex: String, sender: String, plaintext: String, contentTokens: MarkdownDocumentFfi, kind: UInt64, mediaJson: String?,
+    public init(messageIdHex: String, sender: String, plaintext: String, contentTokens: MarkdownDocumentFfi, kind: UInt64, mediaJson: String?, 
         /**
          * Fully-resolved, downloadable media references for the previewed message,
          * built from its `imeta` tags + its own `source_epoch` using the same
@@ -11952,14 +12495,14 @@ public struct FfiConverterTypeTimelineReplyPreviewFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineReplyPreviewFfi {
         return
             try TimelineReplyPreviewFfi(
-                messageIdHex: FfiConverterString.read(from: &buf),
-                sender: FfiConverterString.read(from: &buf),
-                plaintext: FfiConverterString.read(from: &buf),
-                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf),
-                kind: FfiConverterUInt64.read(from: &buf),
-                mediaJson: FfiConverterOptionString.read(from: &buf),
-                media: FfiConverterSequenceTypeMediaAttachmentReferenceFfi.read(from: &buf),
-                agentTextStreamJson: FfiConverterOptionString.read(from: &buf),
+                messageIdHex: FfiConverterString.read(from: &buf), 
+                sender: FfiConverterString.read(from: &buf), 
+                plaintext: FfiConverterString.read(from: &buf), 
+                contentTokens: FfiConverterTypeMarkdownDocumentFfi.read(from: &buf), 
+                kind: FfiConverterUInt64.read(from: &buf), 
+                mediaJson: FfiConverterOptionString.read(from: &buf), 
+                media: FfiConverterSequenceTypeMediaAttachmentReferenceFfi.read(from: &buf), 
+                agentTextStreamJson: FfiConverterOptionString.read(from: &buf), 
                 deleted: FfiConverterBool.read(from: &buf)
         )
     }
@@ -12050,10 +12593,10 @@ public struct FfiConverterTypeTimelineUserReactionFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineUserReactionFfi {
         return
             try TimelineUserReactionFfi(
-                reactionMessageIdHex: FfiConverterString.read(from: &buf),
-                targetMessageIdHex: FfiConverterString.read(from: &buf),
-                sender: FfiConverterString.read(from: &buf),
-                emoji: FfiConverterString.read(from: &buf),
+                reactionMessageIdHex: FfiConverterString.read(from: &buf), 
+                targetMessageIdHex: FfiConverterString.read(from: &buf), 
+                sender: FfiConverterString.read(from: &buf), 
+                emoji: FfiConverterString.read(from: &buf), 
                 reactedAt: FfiConverterUInt64.read(from: &buf)
         )
     }
@@ -12146,11 +12689,11 @@ public struct FfiConverterTypeUserProfileMetadataFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UserProfileMetadataFfi {
         return
             try UserProfileMetadataFfi(
-                name: FfiConverterOptionString.read(from: &buf),
-                displayName: FfiConverterOptionString.read(from: &buf),
-                about: FfiConverterOptionString.read(from: &buf),
-                picture: FfiConverterOptionString.read(from: &buf),
-                nip05: FfiConverterOptionString.read(from: &buf),
+                name: FfiConverterOptionString.read(from: &buf), 
+                displayName: FfiConverterOptionString.read(from: &buf), 
+                about: FfiConverterOptionString.read(from: &buf), 
+                picture: FfiConverterOptionString.read(from: &buf), 
+                nip05: FfiConverterOptionString.read(from: &buf), 
                 lud16: FfiConverterOptionString.read(from: &buf)
         )
     }
@@ -12213,16 +12756,16 @@ public struct WipeOutcomeFfi {
     public init(
         /**
          * Active MLS groups this account successfully left.
-         */groupsLeft: UInt32,
+         */groupsLeft: UInt32, 
         /**
          * Per-group leave failures. Best-effort: the wipe does not abort on these.
-         */groupLeaveFailures: [GroupLeaveFailureFfi],
+         */groupLeaveFailures: [GroupLeaveFailureFfi], 
         /**
          * Relay-published KeyPackage events successfully deleted.
-         */keyPackagesDeleted: UInt32,
+         */keyPackagesDeleted: UInt32, 
         /**
          * Per-relay KeyPackage deletion (or discovery) failures.
-         */keyPackageFailures: [RelayFailureFfi],
+         */keyPackageFailures: [RelayFailureFfi], 
         /**
          * Local cleanup (MLS DB, media cache, SQL row, secret-store nsec) result.
          */localCleanup: LocalCleanupReportFfi) {
@@ -12273,10 +12816,10 @@ public struct FfiConverterTypeWipeOutcomeFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WipeOutcomeFfi {
         return
             try WipeOutcomeFfi(
-                groupsLeft: FfiConverterUInt32.read(from: &buf),
-                groupLeaveFailures: FfiConverterSequenceTypeGroupLeaveFailureFfi.read(from: &buf),
-                keyPackagesDeleted: FfiConverterUInt32.read(from: &buf),
-                keyPackageFailures: FfiConverterSequenceTypeRelayFailureFfi.read(from: &buf),
+                groupsLeft: FfiConverterUInt32.read(from: &buf), 
+                groupLeaveFailures: FfiConverterSequenceTypeGroupLeaveFailureFfi.read(from: &buf), 
+                keyPackagesDeleted: FfiConverterUInt32.read(from: &buf), 
+                keyPackageFailures: FfiConverterSequenceTypeRelayFailureFfi.read(from: &buf), 
                 localCleanup: FfiConverterTypeLocalCleanupReportFfi.read(from: &buf)
         )
     }
@@ -12313,7 +12856,7 @@ public func FfiConverterTypeWipeOutcomeFfi_lower(_ value: WipeOutcomeFfi) -> Rus
  */
 
 public enum AgentStreamUpdateFfi {
-
+    
     case chunk(seq: UInt64, text: String
     )
     case status(seq: UInt64, status: String
@@ -12338,69 +12881,69 @@ public struct FfiConverterTypeAgentStreamUpdateFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AgentStreamUpdateFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .chunk(seq: try FfiConverterUInt64.read(from: &buf), text: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 2: return .status(seq: try FfiConverterUInt64.read(from: &buf), status: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 3: return .progress(seq: try FfiConverterUInt64.read(from: &buf), text: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 4: return .record(seq: try FfiConverterUInt64.read(from: &buf), recordType: try FfiConverterUInt8.read(from: &buf), text: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 5: return .finished(text: try FfiConverterString.read(from: &buf), transcriptHashHex: try FfiConverterString.read(from: &buf), chunkCount: try FfiConverterUInt64.read(from: &buf)
         )
-
+        
         case 6: return .failed(message: try FfiConverterString.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: AgentStreamUpdateFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .chunk(seq,text):
             writeInt(&buf, Int32(1))
             FfiConverterUInt64.write(seq, into: &buf)
             FfiConverterString.write(text, into: &buf)
-
-
+            
+        
         case let .status(seq,status):
             writeInt(&buf, Int32(2))
             FfiConverterUInt64.write(seq, into: &buf)
             FfiConverterString.write(status, into: &buf)
-
-
+            
+        
         case let .progress(seq,text):
             writeInt(&buf, Int32(3))
             FfiConverterUInt64.write(seq, into: &buf)
             FfiConverterString.write(text, into: &buf)
-
-
+            
+        
         case let .record(seq,recordType,text):
             writeInt(&buf, Int32(4))
             FfiConverterUInt64.write(seq, into: &buf)
             FfiConverterUInt8.write(recordType, into: &buf)
             FfiConverterString.write(text, into: &buf)
-
-
+            
+        
         case let .finished(text,transcriptHashHex,chunkCount):
             writeInt(&buf, Int32(5))
             FfiConverterString.write(text, into: &buf)
             FfiConverterString.write(transcriptHashHex, into: &buf)
             FfiConverterUInt64.write(chunkCount, into: &buf)
-
-
+            
+        
         case let .failed(message):
             writeInt(&buf, Int32(6))
             FfiConverterString.write(message, into: &buf)
-
+            
         }
     }
 }
@@ -12436,7 +12979,7 @@ extension AgentStreamUpdateFfi: Equatable, Hashable {}
  */
 
 public enum AppGroupHydrationQuarantineReasonFfi {
-
+    
     /**
      * OpenMLS returned an error while loading the stored group state.
      */
@@ -12470,44 +13013,44 @@ public struct FfiConverterTypeAppGroupHydrationQuarantineReasonFfi: FfiConverter
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppGroupHydrationQuarantineReasonFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .openMlsLoadFailed
-
+        
         case 2: return .openMlsGroupMissing
-
+        
         case 3: return .memberValidationFailed
-
+        
         case 4: return .groupRecordLoadFailed
-
+        
         case 5: return .pendingCommitRecoveryFailed
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: AppGroupHydrationQuarantineReasonFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .openMlsLoadFailed:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .openMlsGroupMissing:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .memberValidationFailed:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case .groupRecordLoadFailed:
             writeInt(&buf, Int32(4))
-
-
+        
+        
         case .pendingCommitRecoveryFailed:
             writeInt(&buf, Int32(5))
-
+        
         }
     }
 }
@@ -12540,7 +13083,7 @@ extension AppGroupHydrationQuarantineReasonFfi: Equatable, Hashable {}
  */
 
 public enum AuditDataModeFfi {
-
+    
     /**
      * Default safety posture: obfuscated/hashed identifiers, no plaintext.
      */
@@ -12561,26 +13104,26 @@ public struct FfiConverterTypeAuditDataModeFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AuditDataModeFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .obfuscatedSensitiveData
-
+        
         case 2: return .fullData
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: AuditDataModeFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .obfuscatedSensitiveData:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .fullData:
             writeInt(&buf, Int32(2))
-
+        
         }
     }
 }
@@ -12610,7 +13153,7 @@ extension AuditDataModeFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum ChatListSubscriptionUpdateFfi {
-
+    
     case row(trigger: ChatListUpdateTriggerFfi, row: ChatListRowFfi
     )
     case removeRow(trigger: ChatListUpdateTriggerFfi, groupIdHex: String
@@ -12627,32 +13170,32 @@ public struct FfiConverterTypeChatListSubscriptionUpdateFfi: FfiConverterRustBuf
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ChatListSubscriptionUpdateFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .row(trigger: try FfiConverterTypeChatListUpdateTriggerFfi.read(from: &buf), row: try FfiConverterTypeChatListRowFfi.read(from: &buf)
         )
-
+        
         case 2: return .removeRow(trigger: try FfiConverterTypeChatListUpdateTriggerFfi.read(from: &buf), groupIdHex: try FfiConverterString.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ChatListSubscriptionUpdateFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .row(trigger,row):
             writeInt(&buf, Int32(1))
             FfiConverterTypeChatListUpdateTriggerFfi.write(trigger, into: &buf)
             FfiConverterTypeChatListRowFfi.write(row, into: &buf)
-
-
+            
+        
         case let .removeRow(trigger,groupIdHex):
             writeInt(&buf, Int32(2))
             FfiConverterTypeChatListUpdateTriggerFfi.write(trigger, into: &buf)
             FfiConverterString.write(groupIdHex, into: &buf)
-
+            
         }
     }
 }
@@ -12682,7 +13225,7 @@ extension ChatListSubscriptionUpdateFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum ChatListUpdateTriggerFfi {
-
+    
     case newGroup
     case newLastMessage
     case lastMessageDeleted
@@ -12704,68 +13247,68 @@ public struct FfiConverterTypeChatListUpdateTriggerFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ChatListUpdateTriggerFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .newGroup
-
+        
         case 2: return .newLastMessage
-
+        
         case 3: return .lastMessageDeleted
-
+        
         case 4: return .archiveChanged
-
+        
         case 5: return .pendingConfirmationChanged
-
+        
         case 6: return .membershipChanged
-
+        
         case 7: return .unreadChanged
-
+        
         case 8: return .snapshotRefresh
-
+        
         case 9: return .removed
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: ChatListUpdateTriggerFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .newGroup:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .newLastMessage:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .lastMessageDeleted:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case .archiveChanged:
             writeInt(&buf, Int32(4))
-
-
+        
+        
         case .pendingConfirmationChanged:
             writeInt(&buf, Int32(5))
-
-
+        
+        
         case .membershipChanged:
             writeInt(&buf, Int32(6))
-
-
+        
+        
         case .unreadChanged:
             writeInt(&buf, Int32(7))
-
-
+        
+        
         case .snapshotRefresh:
             writeInt(&buf, Int32(8))
-
-
+        
+        
         case .removed:
             writeInt(&buf, Int32(9))
-
+        
         }
     }
 }
@@ -12794,6 +13337,84 @@ extension ChatListUpdateTriggerFfi: Equatable, Hashable {}
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 /**
+ * Durable transport-cursor persistence policy, chosen at [`crate::Marmot`]
+ * construction (`Marmot::new_with_cursor_persistence`).
+ *
+ * `Frozen` is the wake-collection posture for runtimes with a sub-second
+ * drain budget on cold sockets — the iOS NSE (one runtime per push around
+ * `collect_notifications_after_wake`) and the notification reply/mark-read
+ * action paths. A `Frozen` pass still ingests, decrypts, and projects
+ * everything; it only cannot move the durable `since` floor, so a wake that
+ * drained for a fraction of a second can never make events permanently
+ * unfetchable. Worst case is bounded redelivery on the next `Advance`
+ * catch-up, absorbed by seen-id dedup. Foreground app runtimes must keep the
+ * default `Advance`. Full semantics: `marmot_app::CursorPersistence`.
+ */
+
+public enum CursorPersistenceFfi {
+    
+    case advance
+    case frozen
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeCursorPersistenceFfi: FfiConverterRustBuffer {
+    typealias SwiftType = CursorPersistenceFfi
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> CursorPersistenceFfi {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+        
+        case 1: return .advance
+        
+        case 2: return .frozen
+        
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: CursorPersistenceFfi, into buf: inout [UInt8]) {
+        switch value {
+        
+        
+        case .advance:
+            writeInt(&buf, Int32(1))
+        
+        
+        case .frozen:
+            writeInt(&buf, Int32(2))
+        
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeCursorPersistenceFfi_lift(_ buf: RustBuffer) throws -> CursorPersistenceFfi {
+    return try FfiConverterTypeCursorPersistenceFfi.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeCursorPersistenceFfi_lower(_ value: CursorPersistenceFfi) -> RustBuffer {
+    return FfiConverterTypeCursorPersistenceFfi.lower(value)
+}
+
+
+
+extension CursorPersistenceFfi: Equatable, Hashable {}
+
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
  * FFI projection of [`cgka_traits::engine::GroupEvent`]. The previous FFI
  * firehose collapsed every group event to bare `account_id_hex` /
  * `account_label`, discarding the group id, event kind, and the typed
@@ -12808,7 +13429,7 @@ extension ChatListUpdateTriggerFfi: Equatable, Hashable {}
  */
 
 public enum GroupEventKindFfi {
-
+    
     case groupCreated
     case groupJoined(viaWelcomeHex: String, welcomerIdHex: String?
     )
@@ -12852,127 +13473,127 @@ public struct FfiConverterTypeGroupEventKindFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> GroupEventKindFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .groupCreated
-
+        
         case 2: return .groupJoined(viaWelcomeHex: try FfiConverterString.read(from: &buf), welcomerIdHex: try FfiConverterOptionString.read(from: &buf)
         )
-
+        
         case 3: return .messageReceived(senderIdHex: try FfiConverterString.read(from: &buf), epoch: try FfiConverterUInt64.read(from: &buf)
         )
-
+        
         case 4: return .appMessageInvalidated(messageIdHex: try FfiConverterString.read(from: &buf), epoch: try FfiConverterUInt64.read(from: &buf), reason: try FfiConverterString.read(from: &buf), decryptedPayloadRef: try FfiConverterOptionString.read(from: &buf)
         )
-
+        
         case 5: return .groupStateChanged(epoch: try FfiConverterUInt64.read(from: &buf), actorIdHex: try FfiConverterOptionString.read(from: &buf), change: try FfiConverterString.read(from: &buf), originCommitIdHex: try FfiConverterOptionString.read(from: &buf)
         )
-
+        
         case 6: return .groupHydrationQuarantined(reason: try FfiConverterTypeAppGroupHydrationQuarantineReasonFfi.read(from: &buf)
         )
-
+        
         case 7: return .epochChanged(from: try FfiConverterUInt64.read(from: &buf), to: try FfiConverterUInt64.read(from: &buf)
         )
-
+        
         case 8: return .forkRecovered(sourceEpoch: try FfiConverterUInt64.read(from: &buf), recoveredEpoch: try FfiConverterUInt64.read(from: &buf), invalidatedCommitIdHex: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 9: return .commitRolledBack(invalidatedCommitIdHex: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 10: return .groupStateInvalidated(epoch: try FfiConverterUInt64.read(from: &buf), invalidatedCommitIdHex: try FfiConverterString.read(from: &buf), reason: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 11: return .groupUnrecoverable
-
+        
         case 12: return .pendingCommitRecovered(recoveredEpoch: try FfiConverterUInt64.read(from: &buf)
         )
-
+        
         case 13: return .groupHydrationRecovered(recoveredEpoch: try FfiConverterUInt64.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: GroupEventKindFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .groupCreated:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case let .groupJoined(viaWelcomeHex,welcomerIdHex):
             writeInt(&buf, Int32(2))
             FfiConverterString.write(viaWelcomeHex, into: &buf)
             FfiConverterOptionString.write(welcomerIdHex, into: &buf)
-
-
+            
+        
         case let .messageReceived(senderIdHex,epoch):
             writeInt(&buf, Int32(3))
             FfiConverterString.write(senderIdHex, into: &buf)
             FfiConverterUInt64.write(epoch, into: &buf)
-
-
+            
+        
         case let .appMessageInvalidated(messageIdHex,epoch,reason,decryptedPayloadRef):
             writeInt(&buf, Int32(4))
             FfiConverterString.write(messageIdHex, into: &buf)
             FfiConverterUInt64.write(epoch, into: &buf)
             FfiConverterString.write(reason, into: &buf)
             FfiConverterOptionString.write(decryptedPayloadRef, into: &buf)
-
-
+            
+        
         case let .groupStateChanged(epoch,actorIdHex,change,originCommitIdHex):
             writeInt(&buf, Int32(5))
             FfiConverterUInt64.write(epoch, into: &buf)
             FfiConverterOptionString.write(actorIdHex, into: &buf)
             FfiConverterString.write(change, into: &buf)
             FfiConverterOptionString.write(originCommitIdHex, into: &buf)
-
-
+            
+        
         case let .groupHydrationQuarantined(reason):
             writeInt(&buf, Int32(6))
             FfiConverterTypeAppGroupHydrationQuarantineReasonFfi.write(reason, into: &buf)
-
-
+            
+        
         case let .epochChanged(from,to):
             writeInt(&buf, Int32(7))
             FfiConverterUInt64.write(from, into: &buf)
             FfiConverterUInt64.write(to, into: &buf)
-
-
+            
+        
         case let .forkRecovered(sourceEpoch,recoveredEpoch,invalidatedCommitIdHex):
             writeInt(&buf, Int32(8))
             FfiConverterUInt64.write(sourceEpoch, into: &buf)
             FfiConverterUInt64.write(recoveredEpoch, into: &buf)
             FfiConverterString.write(invalidatedCommitIdHex, into: &buf)
-
-
+            
+        
         case let .commitRolledBack(invalidatedCommitIdHex):
             writeInt(&buf, Int32(9))
             FfiConverterString.write(invalidatedCommitIdHex, into: &buf)
-
-
+            
+        
         case let .groupStateInvalidated(epoch,invalidatedCommitIdHex,reason):
             writeInt(&buf, Int32(10))
             FfiConverterUInt64.write(epoch, into: &buf)
             FfiConverterString.write(invalidatedCommitIdHex, into: &buf)
             FfiConverterString.write(reason, into: &buf)
-
-
+            
+        
         case .groupUnrecoverable:
             writeInt(&buf, Int32(11))
-
-
+        
+        
         case let .pendingCommitRecovered(recoveredEpoch):
             writeInt(&buf, Int32(12))
             FfiConverterUInt64.write(recoveredEpoch, into: &buf)
-
-
+            
+        
         case let .groupHydrationRecovered(recoveredEpoch):
             writeInt(&buf, Int32(13))
             FfiConverterUInt64.write(recoveredEpoch, into: &buf)
-
+            
         }
     }
 }
@@ -13002,7 +13623,7 @@ extension GroupEventKindFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum MarkdownAlignmentFfi {
-
+    
     case none
     case left
     case center
@@ -13019,38 +13640,38 @@ public struct FfiConverterTypeMarkdownAlignmentFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownAlignmentFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .none
-
+        
         case 2: return .left
-
+        
         case 3: return .center
-
+        
         case 4: return .right
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MarkdownAlignmentFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .none:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .left:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .center:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case .right:
             writeInt(&buf, Int32(4))
-
+        
         }
     }
 }
@@ -13080,7 +13701,7 @@ extension MarkdownAlignmentFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum MarkdownAutolinkKindFfi {
-
+    
     case uri
     case email
 }
@@ -13095,26 +13716,26 @@ public struct FfiConverterTypeMarkdownAutolinkKindFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownAutolinkKindFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .uri
-
+        
         case 2: return .email
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MarkdownAutolinkKindFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .uri:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .email:
             writeInt(&buf, Int32(2))
-
+        
         }
     }
 }
@@ -13144,7 +13765,7 @@ extension MarkdownAutolinkKindFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum MarkdownBlockFfi {
-
+    
     case paragraph(inlines: [MarkdownInlineFfi]
     )
     case heading(level: UInt8, inlines: [MarkdownInlineFfi]
@@ -13176,83 +13797,83 @@ public struct FfiConverterTypeMarkdownBlockFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownBlockFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .paragraph(inlines: try FfiConverterSequenceTypeMarkdownInlineFfi.read(from: &buf)
         )
-
+        
         case 2: return .heading(level: try FfiConverterUInt8.read(from: &buf), inlines: try FfiConverterSequenceTypeMarkdownInlineFfi.read(from: &buf)
         )
-
+        
         case 3: return .thematicBreak
-
+        
         case 4: return .codeBlock(kind: try FfiConverterTypeMarkdownCodeBlockKindFfi.read(from: &buf), info: try FfiConverterString.read(from: &buf), content: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 5: return .blockQuote(blocks: try FfiConverterSequenceTypeMarkdownBlockFfi.read(from: &buf)
         )
-
+        
         case 6: return .listBlock(kind: try FfiConverterTypeMarkdownListKindFfi.read(from: &buf), tight: try FfiConverterBool.read(from: &buf), items: try FfiConverterSequenceTypeMarkdownListItemFfi.read(from: &buf)
         )
-
+        
         case 7: return .table(alignments: try FfiConverterSequenceTypeMarkdownAlignmentFfi.read(from: &buf), header: try FfiConverterSequenceTypeMarkdownTableCellFfi.read(from: &buf), rows: try FfiConverterSequenceSequenceTypeMarkdownTableCellFfi.read(from: &buf)
         )
-
+        
         case 8: return .mathBlock(content: try FfiConverterString.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MarkdownBlockFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .paragraph(inlines):
             writeInt(&buf, Int32(1))
             FfiConverterSequenceTypeMarkdownInlineFfi.write(inlines, into: &buf)
-
-
+            
+        
         case let .heading(level,inlines):
             writeInt(&buf, Int32(2))
             FfiConverterUInt8.write(level, into: &buf)
             FfiConverterSequenceTypeMarkdownInlineFfi.write(inlines, into: &buf)
-
-
+            
+        
         case .thematicBreak:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case let .codeBlock(kind,info,content):
             writeInt(&buf, Int32(4))
             FfiConverterTypeMarkdownCodeBlockKindFfi.write(kind, into: &buf)
             FfiConverterString.write(info, into: &buf)
             FfiConverterString.write(content, into: &buf)
-
-
+            
+        
         case let .blockQuote(blocks):
             writeInt(&buf, Int32(5))
             FfiConverterSequenceTypeMarkdownBlockFfi.write(blocks, into: &buf)
-
-
+            
+        
         case let .listBlock(kind,tight,items):
             writeInt(&buf, Int32(6))
             FfiConverterTypeMarkdownListKindFfi.write(kind, into: &buf)
             FfiConverterBool.write(tight, into: &buf)
             FfiConverterSequenceTypeMarkdownListItemFfi.write(items, into: &buf)
-
-
+            
+        
         case let .table(alignments,header,rows):
             writeInt(&buf, Int32(7))
             FfiConverterSequenceTypeMarkdownAlignmentFfi.write(alignments, into: &buf)
             FfiConverterSequenceTypeMarkdownTableCellFfi.write(header, into: &buf)
             FfiConverterSequenceSequenceTypeMarkdownTableCellFfi.write(rows, into: &buf)
-
-
+            
+        
         case let .mathBlock(content):
             writeInt(&buf, Int32(8))
             FfiConverterString.write(content, into: &buf)
-
+            
         }
     }
 }
@@ -13282,7 +13903,7 @@ extension MarkdownBlockFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum MarkdownCodeBlockKindFfi {
-
+    
     case indented
     case fenced
 }
@@ -13297,26 +13918,26 @@ public struct FfiConverterTypeMarkdownCodeBlockKindFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownCodeBlockKindFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .indented
-
+        
         case 2: return .fenced
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MarkdownCodeBlockKindFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .indented:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .fenced:
             writeInt(&buf, Int32(2))
-
+        
         }
     }
 }
@@ -13346,7 +13967,7 @@ extension MarkdownCodeBlockKindFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum MarkdownInlineFfi {
-
+    
     case text(content: String
     )
     case softBreak
@@ -13383,119 +14004,119 @@ public struct FfiConverterTypeMarkdownInlineFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownInlineFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .text(content: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 2: return .softBreak
-
+        
         case 3: return .hardBreak
-
+        
         case 4: return .code(content: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 5: return .emph(children: try FfiConverterSequenceTypeMarkdownInlineFfi.read(from: &buf)
         )
-
+        
         case 6: return .strong(children: try FfiConverterSequenceTypeMarkdownInlineFfi.read(from: &buf)
         )
-
+        
         case 7: return .strikethrough(children: try FfiConverterSequenceTypeMarkdownInlineFfi.read(from: &buf)
         )
-
+        
         case 8: return .link(dest: try FfiConverterString.read(from: &buf), title: try FfiConverterOptionString.read(from: &buf), children: try FfiConverterSequenceTypeMarkdownInlineFfi.read(from: &buf)
         )
-
+        
         case 9: return .image(dest: try FfiConverterString.read(from: &buf), title: try FfiConverterOptionString.read(from: &buf), alt: try FfiConverterSequenceTypeMarkdownInlineFfi.read(from: &buf)
         )
-
+        
         case 10: return .autolink(url: try FfiConverterString.read(from: &buf), kind: try FfiConverterTypeMarkdownAutolinkKindFfi.read(from: &buf)
         )
-
+        
         case 11: return .math(content: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 12: return .nostrMention(entity: try FfiConverterTypeMarkdownNostrEntityFfi.read(from: &buf)
         )
-
+        
         case 13: return .nostrUri(entity: try FfiConverterTypeMarkdownNostrEntityFfi.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MarkdownInlineFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .text(content):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(content, into: &buf)
-
-
+            
+        
         case .softBreak:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .hardBreak:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case let .code(content):
             writeInt(&buf, Int32(4))
             FfiConverterString.write(content, into: &buf)
-
-
+            
+        
         case let .emph(children):
             writeInt(&buf, Int32(5))
             FfiConverterSequenceTypeMarkdownInlineFfi.write(children, into: &buf)
-
-
+            
+        
         case let .strong(children):
             writeInt(&buf, Int32(6))
             FfiConverterSequenceTypeMarkdownInlineFfi.write(children, into: &buf)
-
-
+            
+        
         case let .strikethrough(children):
             writeInt(&buf, Int32(7))
             FfiConverterSequenceTypeMarkdownInlineFfi.write(children, into: &buf)
-
-
+            
+        
         case let .link(dest,title,children):
             writeInt(&buf, Int32(8))
             FfiConverterString.write(dest, into: &buf)
             FfiConverterOptionString.write(title, into: &buf)
             FfiConverterSequenceTypeMarkdownInlineFfi.write(children, into: &buf)
-
-
+            
+        
         case let .image(dest,title,alt):
             writeInt(&buf, Int32(9))
             FfiConverterString.write(dest, into: &buf)
             FfiConverterOptionString.write(title, into: &buf)
             FfiConverterSequenceTypeMarkdownInlineFfi.write(alt, into: &buf)
-
-
+            
+        
         case let .autolink(url,kind):
             writeInt(&buf, Int32(10))
             FfiConverterString.write(url, into: &buf)
             FfiConverterTypeMarkdownAutolinkKindFfi.write(kind, into: &buf)
-
-
+            
+        
         case let .math(content):
             writeInt(&buf, Int32(11))
             FfiConverterString.write(content, into: &buf)
-
-
+            
+        
         case let .nostrMention(entity):
             writeInt(&buf, Int32(12))
             FfiConverterTypeMarkdownNostrEntityFfi.write(entity, into: &buf)
-
-
+            
+        
         case let .nostrUri(entity):
             writeInt(&buf, Int32(13))
             FfiConverterTypeMarkdownNostrEntityFfi.write(entity, into: &buf)
-
+            
         }
     }
 }
@@ -13525,7 +14146,7 @@ extension MarkdownInlineFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum MarkdownListKindFfi {
-
+    
     /**
      * `marker` is a single-character string: "-", "*", or "+".
      */
@@ -13548,31 +14169,31 @@ public struct FfiConverterTypeMarkdownListKindFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownListKindFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .bullet(marker: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 2: return .ordered(start: try FfiConverterUInt32.read(from: &buf), delimiter: try FfiConverterString.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MarkdownListKindFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .bullet(marker):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(marker, into: &buf)
-
-
+            
+        
         case let .ordered(start,delimiter):
             writeInt(&buf, Int32(2))
             FfiConverterUInt32.write(start, into: &buf)
             FfiConverterString.write(delimiter, into: &buf)
-
+            
         }
     }
 }
@@ -13602,7 +14223,7 @@ extension MarkdownListKindFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum MarkdownNostrHrpFfi {
-
+    
     case npub
     case note
     case nevent
@@ -13621,50 +14242,50 @@ public struct FfiConverterTypeMarkdownNostrHrpFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarkdownNostrHrpFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .npub
-
+        
         case 2: return .note
-
+        
         case 3: return .nevent
-
+        
         case 4: return .nprofile
-
+        
         case 5: return .naddr
-
+        
         case 6: return .nrelay
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MarkdownNostrHrpFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .npub:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .note:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .nevent:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case .nprofile:
             writeInt(&buf, Int32(4))
-
-
+        
+        
         case .naddr:
             writeInt(&buf, Int32(5))
-
-
+        
+        
         case .nrelay:
             writeInt(&buf, Int32(6))
-
+        
         }
     }
 }
@@ -13699,7 +14320,7 @@ extension MarkdownNostrHrpFfi: Equatable, Hashable {}
  */
 
 public enum MarmotEventFfi {
-
+    
     case groupJoined(accountIdHex: String, accountLabel: String, groupIdHex: String
     )
     case groupStateUpdated(accountIdHex: String, accountLabel: String, groupIdHex: String
@@ -13733,84 +14354,84 @@ public struct FfiConverterTypeMarmotEventFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MarmotEventFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .groupJoined(accountIdHex: try FfiConverterString.read(from: &buf), accountLabel: try FfiConverterString.read(from: &buf), groupIdHex: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 2: return .groupStateUpdated(accountIdHex: try FfiConverterString.read(from: &buf), accountLabel: try FfiConverterString.read(from: &buf), groupIdHex: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 3: return .messageReceived(received: try FfiConverterTypeRuntimeMessageReceivedFfi.read(from: &buf)
         )
-
+        
         case 4: return .projectionUpdated(update: try FfiConverterTypeRuntimeProjectionUpdateFfi.read(from: &buf)
         )
-
+        
         case 5: return .groupEvent(accountIdHex: try FfiConverterString.read(from: &buf), accountLabel: try FfiConverterString.read(from: &buf), groupIdHex: try FfiConverterString.read(from: &buf), event: try FfiConverterTypeGroupEventKindFfi.read(from: &buf)
         )
-
+        
         case 6: return .accountError(accountIdHex: try FfiConverterString.read(from: &buf), accountLabel: try FfiConverterString.read(from: &buf), message: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 7: return .agentStreamActivity(accountIdHex: try FfiConverterString.read(from: &buf), accountLabel: try FfiConverterString.read(from: &buf)
         )
-
+        
         case 8: return .welcomeDeliveryPending(accountIdHex: try FfiConverterString.read(from: &buf), accountLabel: try FfiConverterString.read(from: &buf), groupIdHex: try FfiConverterString.read(from: &buf), messageIdHex: try FfiConverterString.read(from: &buf), recipientHex: try FfiConverterString.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MarmotEventFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .groupJoined(accountIdHex,accountLabel,groupIdHex):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(accountIdHex, into: &buf)
             FfiConverterString.write(accountLabel, into: &buf)
             FfiConverterString.write(groupIdHex, into: &buf)
-
-
+            
+        
         case let .groupStateUpdated(accountIdHex,accountLabel,groupIdHex):
             writeInt(&buf, Int32(2))
             FfiConverterString.write(accountIdHex, into: &buf)
             FfiConverterString.write(accountLabel, into: &buf)
             FfiConverterString.write(groupIdHex, into: &buf)
-
-
+            
+        
         case let .messageReceived(received):
             writeInt(&buf, Int32(3))
             FfiConverterTypeRuntimeMessageReceivedFfi.write(received, into: &buf)
-
-
+            
+        
         case let .projectionUpdated(update):
             writeInt(&buf, Int32(4))
             FfiConverterTypeRuntimeProjectionUpdateFfi.write(update, into: &buf)
-
-
+            
+        
         case let .groupEvent(accountIdHex,accountLabel,groupIdHex,event):
             writeInt(&buf, Int32(5))
             FfiConverterString.write(accountIdHex, into: &buf)
             FfiConverterString.write(accountLabel, into: &buf)
             FfiConverterString.write(groupIdHex, into: &buf)
             FfiConverterTypeGroupEventKindFfi.write(event, into: &buf)
-
-
+            
+        
         case let .accountError(accountIdHex,accountLabel,message):
             writeInt(&buf, Int32(6))
             FfiConverterString.write(accountIdHex, into: &buf)
             FfiConverterString.write(accountLabel, into: &buf)
             FfiConverterString.write(message, into: &buf)
-
-
+            
+        
         case let .agentStreamActivity(accountIdHex,accountLabel):
             writeInt(&buf, Int32(7))
             FfiConverterString.write(accountIdHex, into: &buf)
             FfiConverterString.write(accountLabel, into: &buf)
-
-
+            
+        
         case let .welcomeDeliveryPending(accountIdHex,accountLabel,groupIdHex,messageIdHex,recipientHex):
             writeInt(&buf, Int32(8))
             FfiConverterString.write(accountIdHex, into: &buf)
@@ -13818,7 +14439,7 @@ public struct FfiConverterTypeMarmotEventFfi: FfiConverterRustBuffer {
             FfiConverterString.write(groupIdHex, into: &buf)
             FfiConverterString.write(messageIdHex, into: &buf)
             FfiConverterString.write(recipientHex, into: &buf)
-
+            
         }
     }
 }
@@ -13847,17 +14468,29 @@ extension MarmotEventFfi: Equatable, Hashable {}
 
 public enum MarmotKitError {
 
-
-
+    
+    
     case DuplicateIdentity(account: String
     )
     case UnknownAccount(accountRef: String
     )
     case UnknownGroup(groupIdHex: String
     )
+    /**
+     * Host-supplied draft attachment metadata is malformed.
+     */
+    case InvalidMessageDraft(details: String
+    )
     case InvalidHex(details: String
     )
     case InvalidIdentity(details: String
+    )
+    /**
+     * A fetched Nostr event exists for the recipient but cannot be used as a
+     * valid Marmot KeyPackage. Kept distinct from malformed recipient input so
+     * host apps can present a setup/invite state without string matching.
+     */
+    case InvalidKeyPackageEvent(details: String
     )
     case MissingKeyPackage(account: String
     )
@@ -13865,6 +14498,15 @@ public enum MarmotKitError {
     )
     case TransportClosed
     case RuntimeStopping
+    /**
+     * An account worker's transport catch-up failed (sync error or timeout).
+     * Distinct, typed variant — separate from [`MarmotKitError::Runtime`] —
+     * so hosts (notably the NSE wake path) can tell a catch-up failure from
+     * a generic runtime error; the untyped bucket is what sent an earlier
+     * investigation chasing the wrong subsystem.
+     */
+    case AccountCatchUp(details: String
+    )
     case NotGroupAdmin(groupIdHex: String
     )
     case AdminCannotSelfRemove(groupIdHex: String
@@ -13958,9 +14600,9 @@ public struct FfiConverterTypeMarmotKitError: FfiConverterRustBuffer {
         let variant: Int32 = try readInt(&buf)
         switch variant {
 
+        
 
-
-
+        
         case 1: return .DuplicateIdentity(
             account: try FfiConverterString.read(from: &buf)
             )
@@ -13970,63 +14612,72 @@ public struct FfiConverterTypeMarmotKitError: FfiConverterRustBuffer {
         case 3: return .UnknownGroup(
             groupIdHex: try FfiConverterString.read(from: &buf)
             )
-        case 4: return .InvalidHex(
+        case 4: return .InvalidMessageDraft(
             details: try FfiConverterString.read(from: &buf)
             )
-        case 5: return .InvalidIdentity(
+        case 5: return .InvalidHex(
             details: try FfiConverterString.read(from: &buf)
             )
-        case 6: return .MissingKeyPackage(
+        case 6: return .InvalidIdentity(
+            details: try FfiConverterString.read(from: &buf)
+            )
+        case 7: return .InvalidKeyPackageEvent(
+            details: try FfiConverterString.read(from: &buf)
+            )
+        case 8: return .MissingKeyPackage(
             account: try FfiConverterString.read(from: &buf)
             )
-        case 7: return .Publish(
+        case 9: return .Publish(
             details: try FfiConverterString.read(from: &buf)
             )
-        case 8: return .TransportClosed
-        case 9: return .RuntimeStopping
-        case 10: return .NotGroupAdmin(
+        case 10: return .TransportClosed
+        case 11: return .RuntimeStopping
+        case 12: return .AccountCatchUp(
+            details: try FfiConverterString.read(from: &buf)
+            )
+        case 13: return .NotGroupAdmin(
             groupIdHex: try FfiConverterString.read(from: &buf)
             )
-        case 11: return .AdminCannotSelfRemove(
+        case 14: return .AdminCannotSelfRemove(
             groupIdHex: try FfiConverterString.read(from: &buf)
             )
-        case 12: return .WouldRemoveLastAdmin(
+        case 15: return .WouldRemoveLastAdmin(
             groupIdHex: try FfiConverterString.read(from: &buf)
             )
-        case 13: return .MemberNotInGroup(
-            groupIdHex: try FfiConverterString.read(from: &buf),
+        case 16: return .MemberNotInGroup(
+            groupIdHex: try FfiConverterString.read(from: &buf), 
             memberIdHex: try FfiConverterString.read(from: &buf)
             )
-        case 14: return .AlreadyAdmin(
-            groupIdHex: try FfiConverterString.read(from: &buf),
+        case 17: return .AlreadyAdmin(
+            groupIdHex: try FfiConverterString.read(from: &buf), 
             memberIdHex: try FfiConverterString.read(from: &buf)
             )
-        case 15: return .NotAdmin(
-            groupIdHex: try FfiConverterString.read(from: &buf),
+        case 18: return .NotAdmin(
+            groupIdHex: try FfiConverterString.read(from: &buf), 
             memberIdHex: try FfiConverterString.read(from: &buf)
             )
-        case 16: return .StorageBusy(
+        case 19: return .StorageBusy(
             details: try FfiConverterString.read(from: &buf)
             )
-        case 17: return .SecretNotFound(
+        case 20: return .SecretNotFound(
             details: try FfiConverterString.read(from: &buf)
             )
-        case 18: return .KeystoreUnavailable(
+        case 21: return .KeystoreUnavailable(
             details: try FfiConverterString.read(from: &buf)
             )
-        case 19: return .EmptyPassphrase
-        case 20: return .EncryptionFailed(
+        case 22: return .EmptyPassphrase
+        case 23: return .EncryptionFailed(
             details: try FfiConverterString.read(from: &buf)
             )
-        case 21: return .Io(
+        case 24: return .Io(
             details: try FfiConverterString.read(from: &buf)
             )
-        case 22: return .ExternalSignerUnavailable(
+        case 25: return .ExternalSignerUnavailable(
             account: try FfiConverterString.read(from: &buf)
             )
-        case 23: return .ExternalSignerMismatch
-        case 24: return .ExternalSignerRejected
-        case 25: return .Runtime(
+        case 26: return .ExternalSignerMismatch
+        case 27: return .ExternalSignerRejected
+        case 28: return .Runtime(
             details: try FfiConverterString.read(from: &buf)
             )
 
@@ -14037,132 +14688,147 @@ public struct FfiConverterTypeMarmotKitError: FfiConverterRustBuffer {
     public static func write(_ value: MarmotKitError, into buf: inout [UInt8]) {
         switch value {
 
+        
 
-
-
-
+        
+        
         case let .DuplicateIdentity(account):
             writeInt(&buf, Int32(1))
             FfiConverterString.write(account, into: &buf)
-
-
+            
+        
         case let .UnknownAccount(accountRef):
             writeInt(&buf, Int32(2))
             FfiConverterString.write(accountRef, into: &buf)
-
-
+            
+        
         case let .UnknownGroup(groupIdHex):
             writeInt(&buf, Int32(3))
             FfiConverterString.write(groupIdHex, into: &buf)
-
-
-        case let .InvalidHex(details):
+            
+        
+        case let .InvalidMessageDraft(details):
             writeInt(&buf, Int32(4))
             FfiConverterString.write(details, into: &buf)
-
-
-        case let .InvalidIdentity(details):
+            
+        
+        case let .InvalidHex(details):
             writeInt(&buf, Int32(5))
             FfiConverterString.write(details, into: &buf)
-
-
-        case let .MissingKeyPackage(account):
+            
+        
+        case let .InvalidIdentity(details):
             writeInt(&buf, Int32(6))
-            FfiConverterString.write(account, into: &buf)
-
-
-        case let .Publish(details):
+            FfiConverterString.write(details, into: &buf)
+            
+        
+        case let .InvalidKeyPackageEvent(details):
             writeInt(&buf, Int32(7))
             FfiConverterString.write(details, into: &buf)
-
-
-        case .TransportClosed:
+            
+        
+        case let .MissingKeyPackage(account):
             writeInt(&buf, Int32(8))
-
-
-        case .RuntimeStopping:
+            FfiConverterString.write(account, into: &buf)
+            
+        
+        case let .Publish(details):
             writeInt(&buf, Int32(9))
-
-
-        case let .NotGroupAdmin(groupIdHex):
+            FfiConverterString.write(details, into: &buf)
+            
+        
+        case .TransportClosed:
             writeInt(&buf, Int32(10))
-            FfiConverterString.write(groupIdHex, into: &buf)
-
-
-        case let .AdminCannotSelfRemove(groupIdHex):
+        
+        
+        case .RuntimeStopping:
             writeInt(&buf, Int32(11))
-            FfiConverterString.write(groupIdHex, into: &buf)
-
-
-        case let .WouldRemoveLastAdmin(groupIdHex):
+        
+        
+        case let .AccountCatchUp(details):
             writeInt(&buf, Int32(12))
-            FfiConverterString.write(groupIdHex, into: &buf)
-
-
-        case let .MemberNotInGroup(groupIdHex,memberIdHex):
+            FfiConverterString.write(details, into: &buf)
+            
+        
+        case let .NotGroupAdmin(groupIdHex):
             writeInt(&buf, Int32(13))
             FfiConverterString.write(groupIdHex, into: &buf)
-            FfiConverterString.write(memberIdHex, into: &buf)
-
-
-        case let .AlreadyAdmin(groupIdHex,memberIdHex):
+            
+        
+        case let .AdminCannotSelfRemove(groupIdHex):
             writeInt(&buf, Int32(14))
             FfiConverterString.write(groupIdHex, into: &buf)
-            FfiConverterString.write(memberIdHex, into: &buf)
-
-
-        case let .NotAdmin(groupIdHex,memberIdHex):
+            
+        
+        case let .WouldRemoveLastAdmin(groupIdHex):
             writeInt(&buf, Int32(15))
             FfiConverterString.write(groupIdHex, into: &buf)
-            FfiConverterString.write(memberIdHex, into: &buf)
-
-
-        case let .StorageBusy(details):
+            
+        
+        case let .MemberNotInGroup(groupIdHex,memberIdHex):
             writeInt(&buf, Int32(16))
-            FfiConverterString.write(details, into: &buf)
-
-
-        case let .SecretNotFound(details):
+            FfiConverterString.write(groupIdHex, into: &buf)
+            FfiConverterString.write(memberIdHex, into: &buf)
+            
+        
+        case let .AlreadyAdmin(groupIdHex,memberIdHex):
             writeInt(&buf, Int32(17))
-            FfiConverterString.write(details, into: &buf)
-
-
-        case let .KeystoreUnavailable(details):
+            FfiConverterString.write(groupIdHex, into: &buf)
+            FfiConverterString.write(memberIdHex, into: &buf)
+            
+        
+        case let .NotAdmin(groupIdHex,memberIdHex):
             writeInt(&buf, Int32(18))
-            FfiConverterString.write(details, into: &buf)
-
-
-        case .EmptyPassphrase:
+            FfiConverterString.write(groupIdHex, into: &buf)
+            FfiConverterString.write(memberIdHex, into: &buf)
+            
+        
+        case let .StorageBusy(details):
             writeInt(&buf, Int32(19))
-
-
-        case let .EncryptionFailed(details):
+            FfiConverterString.write(details, into: &buf)
+            
+        
+        case let .SecretNotFound(details):
             writeInt(&buf, Int32(20))
             FfiConverterString.write(details, into: &buf)
-
-
-        case let .Io(details):
+            
+        
+        case let .KeystoreUnavailable(details):
             writeInt(&buf, Int32(21))
             FfiConverterString.write(details, into: &buf)
-
-
-        case let .ExternalSignerUnavailable(account):
+            
+        
+        case .EmptyPassphrase:
             writeInt(&buf, Int32(22))
-            FfiConverterString.write(account, into: &buf)
-
-
-        case .ExternalSignerMismatch:
+        
+        
+        case let .EncryptionFailed(details):
             writeInt(&buf, Int32(23))
-
-
-        case .ExternalSignerRejected:
-            writeInt(&buf, Int32(24))
-
-
-        case let .Runtime(details):
-            writeInt(&buf, Int32(25))
             FfiConverterString.write(details, into: &buf)
-
+            
+        
+        case let .Io(details):
+            writeInt(&buf, Int32(24))
+            FfiConverterString.write(details, into: &buf)
+            
+        
+        case let .ExternalSignerUnavailable(account):
+            writeInt(&buf, Int32(25))
+            FfiConverterString.write(account, into: &buf)
+            
+        
+        case .ExternalSignerMismatch:
+            writeInt(&buf, Int32(26))
+        
+        
+        case .ExternalSignerRejected:
+            writeInt(&buf, Int32(27))
+        
+        
+        case let .Runtime(details):
+            writeInt(&buf, Int32(28))
+            FfiConverterString.write(details, into: &buf)
+            
         }
     }
 }
@@ -14185,7 +14851,7 @@ extension MarmotKitError: Foundation.LocalizedError {
  */
 
 public enum MessageUpdateFfi {
-
+    
     /**
      * A raw message update: chat, reply, media, reaction, delete, or the kind-9
      * stream-final. Materialized timeline pages also include kind-1200 stream
@@ -14212,30 +14878,30 @@ public struct FfiConverterTypeMessageUpdateFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MessageUpdateFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .message(received: try FfiConverterTypeRuntimeMessageReceivedFfi.read(from: &buf)
         )
-
+        
         case 2: return .agentStreamStarted(received: try FfiConverterTypeRuntimeMessageReceivedFfi.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MessageUpdateFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .message(received):
             writeInt(&buf, Int32(1))
             FfiConverterTypeRuntimeMessageReceivedFfi.write(received, into: &buf)
-
-
+            
+        
         case let .agentStreamStarted(received):
             writeInt(&buf, Int32(2))
             FfiConverterTypeRuntimeMessageReceivedFfi.write(received, into: &buf)
-
+            
         }
     }
 }
@@ -14269,7 +14935,7 @@ extension MessageUpdateFfi: Equatable, Hashable {}
  */
 
 public enum MissingRelayListKindFfi {
-
+    
     /**
      * NIP-65 relay list — where this account publishes (outbox/write-side).
      */
@@ -14290,26 +14956,26 @@ public struct FfiConverterTypeMissingRelayListKindFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> MissingRelayListKindFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .nip65
-
+        
         case 2: return .inbox
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: MissingRelayListKindFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .nip65:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .inbox:
             writeInt(&buf, Int32(2))
-
+        
         }
     }
 }
@@ -14339,7 +15005,7 @@ extension MissingRelayListKindFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum NotificationCollectionStatusFfi {
-
+    
     case newData
     case noData
     case failed
@@ -14355,32 +15021,32 @@ public struct FfiConverterTypeNotificationCollectionStatusFfi: FfiConverterRustB
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NotificationCollectionStatusFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .newData
-
+        
         case 2: return .noData
-
+        
         case 3: return .failed
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: NotificationCollectionStatusFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .newData:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .noData:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .failed:
             writeInt(&buf, Int32(3))
-
+        
         }
     }
 }
@@ -14410,7 +15076,7 @@ extension NotificationCollectionStatusFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum NotificationTriggerFfi {
-
+    
     case newMessage
     case groupInvite
 }
@@ -14425,26 +15091,26 @@ public struct FfiConverterTypeNotificationTriggerFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NotificationTriggerFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .newMessage
-
+        
         case 2: return .groupInvite
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: NotificationTriggerFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .newMessage:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .groupInvite:
             writeInt(&buf, Int32(2))
-
+        
         }
     }
 }
@@ -14474,7 +15140,7 @@ extension NotificationTriggerFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum NotificationWakeSourceFfi {
-
+    
     case apnsNse
     case fcmDataMessage
     case androidForegroundService
@@ -14491,38 +15157,38 @@ public struct FfiConverterTypeNotificationWakeSourceFfi: FfiConverterRustBuffer 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> NotificationWakeSourceFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .apnsNse
-
+        
         case 2: return .fcmDataMessage
-
+        
         case 3: return .androidForegroundService
-
+        
         case 4: return .manualCatchUp
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: NotificationWakeSourceFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .apnsNse:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .fcmDataMessage:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .androidForegroundService:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case .manualCatchUp:
             writeInt(&buf, Int32(4))
-
+        
         }
     }
 }
@@ -14552,7 +15218,7 @@ extension NotificationWakeSourceFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum PushPlatformFfi {
-
+    
     case apns
     case fcm
 }
@@ -14567,26 +15233,26 @@ public struct FfiConverterTypePushPlatformFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PushPlatformFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .apns
-
+        
         case 2: return .fcm
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: PushPlatformFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .apns:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .fcm:
             writeInt(&buf, Int32(2))
-
+        
         }
     }
 }
@@ -14622,7 +15288,7 @@ extension PushPlatformFfi: Equatable, Hashable {}
  */
 
 public enum SelfMembershipFfi {
-
+    
     case member
     case left
     case removed
@@ -14638,32 +15304,32 @@ public struct FfiConverterTypeSelfMembershipFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SelfMembershipFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .member
-
+        
         case 2: return .left
-
+        
         case 3: return .removed
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: SelfMembershipFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .member:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .left:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .removed:
             writeInt(&buf, Int32(3))
-
+        
         }
     }
 }
@@ -14693,7 +15359,7 @@ extension SelfMembershipFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum TimelineMessageChangeFfi {
-
+    
     case upsert(trigger: TimelineUpdateTriggerFfi, message: TimelineMessageRecordFfi
     )
     case remove(messageIdHex: String, reason: TimelineRemoveReasonFfi
@@ -14710,32 +15376,32 @@ public struct FfiConverterTypeTimelineMessageChangeFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineMessageChangeFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .upsert(trigger: try FfiConverterTypeTimelineUpdateTriggerFfi.read(from: &buf), message: try FfiConverterTypeTimelineMessageRecordFfi.read(from: &buf)
         )
-
+        
         case 2: return .remove(messageIdHex: try FfiConverterString.read(from: &buf), reason: try FfiConverterTypeTimelineRemoveReasonFfi.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: TimelineMessageChangeFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .upsert(trigger,message):
             writeInt(&buf, Int32(1))
             FfiConverterTypeTimelineUpdateTriggerFfi.write(trigger, into: &buf)
             FfiConverterTypeTimelineMessageRecordFfi.write(message, into: &buf)
-
-
+            
+        
         case let .remove(messageIdHex,reason):
             writeInt(&buf, Int32(2))
             FfiConverterString.write(messageIdHex, into: &buf)
             FfiConverterTypeTimelineRemoveReasonFfi.write(reason, into: &buf)
-
+            
         }
     }
 }
@@ -14765,7 +15431,7 @@ extension TimelineMessageChangeFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum TimelineRemoveReasonFfi {
-
+    
     case invalidated
     case cleared
     case pruned
@@ -14782,38 +15448,38 @@ public struct FfiConverterTypeTimelineRemoveReasonFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineRemoveReasonFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .invalidated
-
+        
         case 2: return .cleared
-
+        
         case 3: return .pruned
-
+        
         case 4: return .noLongerMatchesQuery
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: TimelineRemoveReasonFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .invalidated:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .cleared:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .pruned:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case .noLongerMatchesQuery:
             writeInt(&buf, Int32(4))
-
+        
         }
     }
 }
@@ -14843,7 +15509,7 @@ extension TimelineRemoveReasonFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum TimelineSubscriptionUpdateFfi {
-
+    
     case page(page: TimelinePageFfi
     )
     case projection(update: RuntimeProjectionUpdateFfi
@@ -14860,30 +15526,30 @@ public struct FfiConverterTypeTimelineSubscriptionUpdateFfi: FfiConverterRustBuf
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineSubscriptionUpdateFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .page(page: try FfiConverterTypeTimelinePageFfi.read(from: &buf)
         )
-
+        
         case 2: return .projection(update: try FfiConverterTypeRuntimeProjectionUpdateFfi.read(from: &buf)
         )
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: TimelineSubscriptionUpdateFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case let .page(page):
             writeInt(&buf, Int32(1))
             FfiConverterTypeTimelinePageFfi.write(page, into: &buf)
-
-
+            
+        
         case let .projection(update):
             writeInt(&buf, Int32(2))
             FfiConverterTypeRuntimeProjectionUpdateFfi.write(update, into: &buf)
-
+            
         }
     }
 }
@@ -14913,7 +15579,7 @@ extension TimelineSubscriptionUpdateFfi: Equatable, Hashable {}
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum TimelineUpdateTriggerFfi {
-
+    
     case newMessage
     case messageEditedOrReprojected
     case reactionAdded
@@ -14940,98 +15606,98 @@ public struct FfiConverterTypeTimelineUpdateTriggerFfi: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> TimelineUpdateTriggerFfi {
         let variant: Int32 = try readInt(&buf)
         switch variant {
-
+        
         case 1: return .newMessage
-
+        
         case 2: return .messageEditedOrReprojected
-
+        
         case 3: return .reactionAdded
-
+        
         case 4: return .reactionRemoved
-
+        
         case 5: return .messageDeleted
-
+        
         case 6: return .replyPreviewChanged
-
+        
         case 7: return .agentStreamStarted
-
+        
         case 8: return .agentStreamFinished
-
+        
         case 9: return .agentActivity
-
+        
         case 10: return .agentOperation
-
+        
         case 11: return .groupSystem
-
+        
         case 12: return .deliveryOrSendStateChanged
-
+        
         case 13: return .receiptChanged
-
+        
         case 14: return .snapshotRefresh
-
+        
         default: throw UniffiInternalError.unexpectedEnumCase
         }
     }
 
     public static func write(_ value: TimelineUpdateTriggerFfi, into buf: inout [UInt8]) {
         switch value {
-
-
+        
+        
         case .newMessage:
             writeInt(&buf, Int32(1))
-
-
+        
+        
         case .messageEditedOrReprojected:
             writeInt(&buf, Int32(2))
-
-
+        
+        
         case .reactionAdded:
             writeInt(&buf, Int32(3))
-
-
+        
+        
         case .reactionRemoved:
             writeInt(&buf, Int32(4))
-
-
+        
+        
         case .messageDeleted:
             writeInt(&buf, Int32(5))
-
-
+        
+        
         case .replyPreviewChanged:
             writeInt(&buf, Int32(6))
-
-
+        
+        
         case .agentStreamStarted:
             writeInt(&buf, Int32(7))
-
-
+        
+        
         case .agentStreamFinished:
             writeInt(&buf, Int32(8))
-
-
+        
+        
         case .agentActivity:
             writeInt(&buf, Int32(9))
-
-
+        
+        
         case .agentOperation:
             writeInt(&buf, Int32(10))
-
-
+        
+        
         case .groupSystem:
             writeInt(&buf, Int32(11))
-
-
+        
+        
         case .deliveryOrSendStateChanged:
             writeInt(&buf, Int32(12))
-
-
+        
+        
         case .receiptChanged:
             writeInt(&buf, Int32(13))
-
-
+        
+        
         case .snapshotRefresh:
             writeInt(&buf, Int32(14))
-
+        
         }
     }
 }
@@ -15124,6 +15790,30 @@ fileprivate struct FfiConverterOptionInt64: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterInt64.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionDouble: FfiConverterRustBuffer {
+    typealias SwiftType = Double?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterDouble.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterDouble.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -15316,6 +16006,30 @@ fileprivate struct FfiConverterOptionTypeGroupSystemEventFfi: FfiConverterRustBu
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeGroupSystemEventFfi.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeMessageDraftFfi: FfiConverterRustBuffer {
+    typealias SwiftType = MessageDraftFfi?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeMessageDraftFfi.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeMessageDraftFfi.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -15629,6 +16343,31 @@ fileprivate struct FfiConverterSequenceUInt16: FfiConverterRustBuffer {
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterUInt16.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceDouble: FfiConverterRustBuffer {
+    typealias SwiftType = [Double]
+
+    public static func write(_ value: [Double], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterDouble.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [Double] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [Double]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterDouble.read(from: &buf))
         }
         return seq
     }
@@ -16212,6 +16951,81 @@ fileprivate struct FfiConverterSequenceTypeMediaUploadAttachmentResultFfi: FfiCo
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeMessageDraftAttachmentFfi: FfiConverterRustBuffer {
+    typealias SwiftType = [MessageDraftAttachmentFfi]
+
+    public static func write(_ value: [MessageDraftAttachmentFfi], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeMessageDraftAttachmentFfi.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [MessageDraftAttachmentFfi] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [MessageDraftAttachmentFfi]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeMessageDraftAttachmentFfi.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeMessageDraftAttachmentSummaryFfi: FfiConverterRustBuffer {
+    typealias SwiftType = [MessageDraftAttachmentSummaryFfi]
+
+    public static func write(_ value: [MessageDraftAttachmentSummaryFfi], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeMessageDraftAttachmentSummaryFfi.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [MessageDraftAttachmentSummaryFfi] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [MessageDraftAttachmentSummaryFfi]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeMessageDraftAttachmentSummaryFfi.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeMessageDraftSummaryFfi: FfiConverterRustBuffer {
+    typealias SwiftType = [MessageDraftSummaryFfi]
+
+    public static func write(_ value: [MessageDraftSummaryFfi], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeMessageDraftSummaryFfi.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [MessageDraftSummaryFfi] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [MessageDraftSummaryFfi]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeMessageDraftSummaryFfi.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeMessageTagFfi: FfiConverterRustBuffer {
     typealias SwiftType = [MessageTagFfi]
 
@@ -16678,6 +17492,9 @@ private var initializationResult: InitializationResult = {
     if (uniffi_marmot_uniffi_checksum_method_marmot_delete_message() != 13951) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_marmot_uniffi_checksum_method_marmot_delete_message_draft() != 15962) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_marmot_uniffi_checksum_method_marmot_demote_admin() != 42693) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -16742,6 +17559,12 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_marmot_uniffi_checksum_method_marmot_mark_timeline_message_read() != 32522) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_marmot_uniffi_checksum_method_marmot_message_draft() != 54000) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_marmot_uniffi_checksum_method_marmot_message_drafts() != 19334) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_marmot_uniffi_checksum_method_marmot_messages() != 45709) {
@@ -16826,6 +17649,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_marmot_uniffi_checksum_method_marmot_reveal_nsec() != 58041) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_marmot_uniffi_checksum_method_marmot_save_message_draft() != 6018) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_marmot_uniffi_checksum_method_marmot_secure_delete_expired() != 16091) {
@@ -16939,6 +17765,9 @@ private var initializationResult: InitializationResult = {
     if (uniffi_marmot_uniffi_checksum_method_marmot_user_profile() != 12217) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_marmot_uniffi_checksum_method_marmot_user_profile_website() != 23102) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_marmot_uniffi_checksum_method_marmot_watch_agent_text_stream() != 24253) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -16967,6 +17796,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_marmot_uniffi_checksum_constructor_marmot_new() != 56105) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_marmot_uniffi_checksum_constructor_marmot_new_with_cursor_persistence() != 18903) {
         return InitializationResult.apiChecksumMismatch
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -271,6 +271,7 @@ extension WorkspaceState {
             }
             try await client.removeAccount(accountRef: account.accountRef)
             clearComposerDrafts(forAccountId: removedAccountId)
+            purgeHiddenMessages(accountId: removedAccountId)
             await mediaDiskCache.purgeAccount(removedAccountId)
             clearMediaReferenceResolutionCache(forAccountId: removedAccountId)
             accounts = try await accountItemsFromRuntime(client: client)

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -642,6 +642,7 @@ extension WorkspaceState {
         searchText = ""
         isChatListVisible = true
         clearAllComposerDrafts()
+        clearAllHiddenMessages()
         isRefreshing = false
         isSending = false
         authenticationMode = .landing

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -397,6 +397,7 @@ extension WorkspaceState {
         }
         lastMarkedReadMarkers[groupIdHex] = nil
         lastConfirmedReadMarkers[groupIdHex] = nil
+        purgeHiddenMessages(accountId: accountId, groupIdHex: groupIdHex)
     }
 
     /// After the selected chat was removed, leave its live resources and select the most recent

--- a/whitenoise-mac/Core/WorkspaceState+HiddenMessages.swift
+++ b/whitenoise-mac/Core/WorkspaceState+HiddenMessages.swift
@@ -1,0 +1,102 @@
+//
+//  WorkspaceState+HiddenMessages.swift
+//  whitenoise-mac
+//
+//  "Delete for me" — a local, per-account/group set of hidden message ids. Hiding publishes
+//  nothing; the ids are filtered from the timeline projection so a hide survives reprojection
+//  and restart, and persisted in UserDefaults.
+//
+
+import Foundation
+
+@MainActor
+extension WorkspaceState {
+    static let hiddenMessagesDefaultsKey = "hiddenMessageIdsByChat"
+
+    private func hiddenMessagesKey(accountId: String, groupIdHex: String) -> String {
+        "\(accountId)\u{1F}\(groupIdHex)"
+    }
+
+    func loadHiddenMessages() {
+        guard
+            let raw = UserDefaults.standard.dictionary(forKey: Self.hiddenMessagesDefaultsKey)
+                as? [String: [String]]
+        else { return }
+        hiddenMessageIdsByChat = raw.mapValues(Set.init)
+    }
+
+    private func persistHiddenMessages() {
+        let encodable = hiddenMessageIdsByChat.mapValues(Array.init)
+        UserDefaults.standard.set(encodable, forKey: Self.hiddenMessagesDefaultsKey)
+    }
+
+    func hiddenMessageIds(accountId: String, groupIdHex: String) -> Set<String> {
+        hiddenMessageIdsByChat[hiddenMessagesKey(accountId: accountId, groupIdHex: groupIdHex)] ?? []
+    }
+
+    /// Hide `messageId` locally: record it, persist, and drop it from the live window immediately.
+    func hideMessageLocally(accountId: String, groupIdHex: String, messageId: String) {
+        let key = hiddenMessagesKey(accountId: accountId, groupIdHex: groupIdHex)
+        var ids = hiddenMessageIdsByChat[key] ?? []
+        guard ids.insert(messageId).inserted else { return }
+        hiddenMessageIdsByChat[key] = ids
+        persistHiddenMessages()
+
+        guard let store = messageTimelineStores[groupIdHex] else { return }
+        let paging = timelinePagingByChat[groupIdHex] ?? .empty
+        _ = store.applyProjection(
+            upserts: [],
+            removals: [messageId],
+            editMutations: [],
+            anchoredToNewest: !paging.hasMoreAfter,
+            windowLimit: Self.timelineWindowLimit
+        )
+        selectedChatRevision &+= 1
+    }
+
+    /// Drop locally-hidden messages from a full window replacement (initial load, pagination,
+    /// runtime re-window). Paired with `partitionHiddenMessages` on the incremental path so a hide
+    /// survives every projection route, chat switch, and cold start.
+    func filterHiddenMessages(_ messages: [MessageItem], groupIdHex: String) -> [MessageItem] {
+        guard let activeAccountId else { return messages }
+        let hidden = hiddenMessageIds(accountId: activeAccountId, groupIdHex: groupIdHex)
+        guard !hidden.isEmpty else { return messages }
+        return messages.filter { !hidden.contains($0.id) }
+    }
+
+    /// Forget the hidden set for a chat once it is removed, mirroring the per-chat caches.
+    func purgeHiddenMessages(accountId: String, groupIdHex: String) {
+        hiddenMessageIdsByChat[hiddenMessagesKey(accountId: accountId, groupIdHex: groupIdHex)] = nil
+        persistHiddenMessages()
+    }
+
+    /// Forget every hidden set for an account (account removal / full local wipe).
+    func purgeHiddenMessages(accountId: String) {
+        let prefix = "\(accountId)\u{1F}"
+        hiddenMessageIdsByChat = hiddenMessageIdsByChat.filter { !$0.key.hasPrefix(prefix) }
+        persistHiddenMessages()
+    }
+
+    /// Forget all hidden sets — part of the "Delete All Local Data" reset.
+    func clearAllHiddenMessages() {
+        guard !hiddenMessageIdsByChat.isEmpty else { return }
+        hiddenMessageIdsByChat = [:]
+        persistHiddenMessages()
+    }
+
+    /// Split a projection batch for `groupIdHex` against the hidden set: hidden ids are removed
+    /// from `upserts` and folded into `removals`, so a locally-hidden message stays gone across
+    /// reprojection and cold start without any network round-trip.
+    func partitionHiddenMessages(
+        upserts: [MessageItem],
+        removals: Set<String>,
+        groupIdHex: String
+    ) -> (upserts: [MessageItem], removals: Set<String>) {
+        guard let activeAccountId else { return (upserts, removals) }
+        let hidden = hiddenMessageIds(accountId: activeAccountId, groupIdHex: groupIdHex)
+        guard !hidden.isEmpty else { return (upserts, removals) }
+        let visibleUpserts = upserts.filter { !hidden.contains($0.id) }
+        let hiddenInBatch = upserts.filter { hidden.contains($0.id) }.map(\.id)
+        return (visibleUpserts, removals.union(hiddenInBatch))
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -784,8 +784,8 @@ extension WorkspaceState {
     /// another member's group message). Re-checks the capability so a mis-rendered option can't
     /// drive an unauthorized retraction — the engine is the final authority, this is the local guard.
     func deleteForEveryone(_ message: MessageItem) async {
-        guard messageDeletionCapability(message).canDeleteForEveryone else { return }
         guard let client, let activeAccount, let selectedChat else { return }
+        guard messageDeletionCapability(message).canDeleteForEveryone else { return }
         // Reentrancy guard: drop a repeated delete of the same in-flight message.
         guard !inFlightDeleteMessageIds.contains(message.id) else { return }
         inFlightDeleteMessageIds.insert(message.id)
@@ -796,9 +796,7 @@ extension WorkspaceState {
                 groupIdHex: selectedChat.id,
                 targetMessageId: message.id
             )
-            if replyDraftContext?.targetMessageId == message.id {
-                replyDraftContext = nil
-            }
+            clearComposerContextTargeting(message.id)
         } catch {
             lastError = error.localizedDescription
         }
@@ -806,11 +804,22 @@ extension WorkspaceState {
 
     /// Delete for me: hide the message locally and persist the hidden id. Publishes nothing.
     func deleteForMe(_ message: MessageItem) {
-        guard messageDeletionCapability(message).canDeleteForMe else { return }
         guard let activeAccountId, let selectedChat else { return }
+        guard messageDeletionCapability(message).canDeleteForMe else { return }
         hideMessageLocally(accountId: activeAccountId, groupIdHex: selectedChat.id, messageId: message.id)
-        if replyDraftContext?.targetMessageId == message.id {
+        clearComposerContextTargeting(message.id)
+    }
+
+    /// Drop any reply or in-progress edit in the selected conversation that targets `messageId`,
+    /// so a deleted message can't remain a live reply/edit target.
+    private func clearComposerContextTargeting(_ messageId: String) {
+        if replyDraftContext?.targetMessageId == messageId {
             replyDraftContext = nil
+        }
+        if let draftKey = selectedComposerDraftKey,
+            editingMessageContextByConversation[draftKey]?.targetMessageId == messageId
+        {
+            cancelEditingMessage()
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -360,9 +360,11 @@ extension WorkspaceState {
 
         let editMutations = MessageEditOverlay.mutations(from: page.messages)
         let currentPaging = timelinePagingByChat[groupIdHex]
-        TimelineSignpost.store.interval("replaceMessages", count: mappedMessages.count) {
+        // Keep "Delete for me" hides out of every full window replace, not just the incremental path.
+        let visibleMessages = filterHiddenMessages(mappedMessages, groupIdHex: groupIdHex)
+        TimelineSignpost.store.interval("replaceMessages", count: visibleMessages.count) {
             replaceMessages(
-                mappedMessages,
+                visibleMessages,
                 groupIdHex: groupIdHex,
                 paging: TimelinePagingState(
                     hasMoreBefore: page.hasMoreBefore,
@@ -528,12 +530,15 @@ extension WorkspaceState {
             clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: groupIdHex)
         }
 
+        // Keep "Delete for me" messages out of the window across every reprojection.
+        let (visibleUpserts, visibleRemovals) = partitionHiddenMessages(
+            upserts: mappedUpserts, removals: removalIds, groupIdHex: groupIdHex)
         let result = TimelineSignpost.store.interval(
-            "applyProjection", count: mappedUpserts.count + removalIds.count
+            "applyProjection", count: visibleUpserts.count + visibleRemovals.count
         ) {
             timelineStore.applyProjection(
-                upserts: mappedUpserts,
-                removals: removalIds,
+                upserts: visibleUpserts,
+                removals: visibleRemovals,
                 editMutations: editMutations,
                 anchoredToNewest: anchored,
                 windowLimit: Self.timelineWindowLimit
@@ -679,18 +684,45 @@ extension WorkspaceState {
         }
     }
 
+    /// The authoritative deletion-scope model for `message` in the selected conversation. Both the
+    /// action UI and the mutation paths derive from this — button visibility is not the security
+    /// boundary (the mutations re-check the same capability).
+    func messageDeletionCapability(_ message: MessageItem) -> MessageDeletionCapability {
+        guard message.supportsChatActions, let selectedChat else { return .none }
+        return MessageDeletionCapability.resolve(
+            isActionable: true,
+            isDirectConversation: selectedChat.isDirect,
+            isOwnMessage: message.isOutgoing,
+            isSelfGroupAdmin: conversationMetadataByChat[selectedChat.id]?.isSelfAdmin == true
+        )
+    }
+
     func canDeleteMessage(_ message: MessageItem) -> Bool {
-        guard message.supportsChatActions, let selectedChat else { return false }
-        if message.isOutgoing { return true }
-        guard !selectedChat.isDirect else { return false }
-        return conversationMetadataByChat[selectedChat.id]?.isSelfAdmin == true
+        messageDeletionCapability(message).canDelete
+    }
+
+    /// Adaptive supporting copy for the delete-confirmation surface. Explains the offered scopes
+    /// without admin-branding the action, per the unified model.
+    func messageDeletionScopeExplanation(_ message: MessageItem) -> String {
+        let capability = messageDeletionCapability(message)
+        guard capability.canDeleteForEveryone else {
+            return L10n.string("This message will be hidden on this device only.")
+        }
+        if message.isOutgoing {
+            return L10n.string("Remove this message for everyone, or hide it just for you.")
+        }
+        return L10n.string("Remove this message for everyone in the group, or hide it just for you.")
     }
 
     func deleteSelectedMessages() async {
-        let messages = selectedTimelineMessagesForAction.filter(canDeleteMessage)
+        // Multi-select acts only on messages the user may delete for everyone — it must not
+        // silently mix in local hides; single-message delete-for-me goes through the confirmation.
+        let messages = selectedTimelineMessagesForAction.filter {
+            messageDeletionCapability($0).canDeleteForEveryone
+        }
         guard !messages.isEmpty else { return }
         for message in messages {
-            await deleteMessage(message)
+            await deleteForEveryone(message)
         }
         cancelMessageSelection()
     }
@@ -748,8 +780,11 @@ extension WorkspaceState {
         }
     }
 
-    func deleteMessage(_ message: MessageItem) async {
-        guard canDeleteMessage(message) else { return }
+    /// Delete for everyone: publish a group-wide tombstone (self-retraction, or an admin moderating
+    /// another member's group message). Re-checks the capability so a mis-rendered option can't
+    /// drive an unauthorized retraction — the engine is the final authority, this is the local guard.
+    func deleteForEveryone(_ message: MessageItem) async {
+        guard messageDeletionCapability(message).canDeleteForEveryone else { return }
         guard let client, let activeAccount, let selectedChat else { return }
         // Reentrancy guard: drop a repeated delete of the same in-flight message.
         guard !inFlightDeleteMessageIds.contains(message.id) else { return }
@@ -766,6 +801,16 @@ extension WorkspaceState {
             }
         } catch {
             lastError = error.localizedDescription
+        }
+    }
+
+    /// Delete for me: hide the message locally and persist the hidden id. Publishes nothing.
+    func deleteForMe(_ message: MessageItem) {
+        guard messageDeletionCapability(message).canDeleteForMe else { return }
+        guard let activeAccountId, let selectedChat else { return }
+        hideMessageLocally(accountId: activeAccountId, groupIdHex: selectedChat.id, messageId: message.id)
+        if replyDraftContext?.targetMessageId == message.id {
+            replyDraftContext = nil
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -873,7 +873,14 @@ final class WorkspaceState {
     var groupDetailsSnapshot: GroupDetailsSnapshot?
     var conversationMetadataByChat: [String: ConversationMetadata] = [:]
     @ObservationIgnored var conversationMetadataGenerationByChat: [String: UInt64] = [:]
+    /// Message ids the local account hid via "Delete for me", keyed by `accountId\u{1F}groupId`.
+    /// Filtered from the timeline projection so a local hide survives reprojection and restart, and
+    /// never publishes anything. Persisted in `UserDefaults` under `Self.hiddenMessagesDefaultsKey`.
+    @ObservationIgnored var hiddenMessageIdsByChat: [String: Set<String>] = [:]
     var selectedTimelineMessageIds: Set<String> = []
+    /// Message whose unified delete-confirmation surface is open, or `nil`. Drives the adaptive
+    /// dialog that offers only the scopes `messageDeletionCapability` permits.
+    var messagePendingDeletion: MessageItem?
     var messageInfoTarget: MessageItem?
     var forwardingMessageIds: [String] = []
     var isForwardPickerPresented = false
@@ -1400,6 +1407,7 @@ final class WorkspaceState {
         self.localNotificationCenter.setResponseHandler { [weak self] userInfo in
             self?.handleNotificationResponse(userInfo)
         }
+        loadHiddenMessages()
         ensureSelectedMessageTimelineStore()
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -710,6 +710,11 @@ final class WorkspaceState {
     var activeAccountId: String?
     var selection: WorkspaceSelection? {
         didSet {
+            // A pending delete-confirmation belongs to the conversation it was opened in; drop it
+            // when the selection changes so a stale dialog can't act on a different chat.
+            if oldValue != selection {
+                messagePendingDeletion = nil
+            }
             dismissGroupImagePickerIfSelectedChatUnavailable()
             ensureSelectedMessageTimelineStore()
         }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1858,6 +1858,39 @@ nonisolated struct MessageItem: Identifiable, Hashable {
     }
 }
 
+/// Which delete scopes the local account may perform on one message. Derived from conversation
+/// type, message ownership, and the local account's admin role in *this* conversation.
+///
+/// Delete-for-me hides the message locally and never publishes. Delete-for-everyone publishes a
+/// group-wide tombstone (self-retraction, or an admin moderating another member's group message).
+/// A direct message is never removable for everyone by anyone but its author — an admin role from
+/// another group, or an admin flag on a DM's own two-member group, must never grant it, which the
+/// `isGroup` guard below enforces structurally.
+nonisolated struct MessageDeletionCapability: Equatable {
+    let canDeleteForMe: Bool
+    let canDeleteForEveryone: Bool
+
+    static let none = MessageDeletionCapability(canDeleteForMe: false, canDeleteForEveryone: false)
+
+    var canDelete: Bool { canDeleteForMe || canDeleteForEveryone }
+
+    /// - Parameters:
+    ///   - isActionable: a real, non-deleted message bubble the user can act on.
+    ///   - isDirectConversation: a two-member direct message rather than a group.
+    ///   - isOwnMessage: the local account authored the message.
+    ///   - isSelfGroupAdmin: the local account is admin/owner of THIS group. Ignored for DMs.
+    static func resolve(
+        isActionable: Bool,
+        isDirectConversation: Bool,
+        isOwnMessage: Bool,
+        isSelfGroupAdmin: Bool
+    ) -> MessageDeletionCapability {
+        guard isActionable else { return .none }
+        let forEveryone = isOwnMessage || (!isDirectConversation && isSelfGroupAdmin)
+        return MessageDeletionCapability(canDeleteForMe: true, canDeleteForEveryone: forEveryone)
+    }
+}
+
 extension MessageItem {
     // Hand-written `Equatable`/`Hashable` so equality and hashing stay O(1) instead of
     // recursively walking `contentMarkdown`'s pre-rendered Markdown tree.

--- a/whitenoise-mac/Views/MessageDeletionConfirmation.swift
+++ b/whitenoise-mac/Views/MessageDeletionConfirmation.swift
@@ -1,0 +1,51 @@
+//
+//  MessageDeletionConfirmation.swift
+//  whitenoise-mac
+//
+//  The unified delete-confirmation surface: one adaptive dialog offering only the scopes the
+//  local account may perform on the pending message. A native confirmationDialog carries the
+//  platform's semantic destructive styling, VoiceOver, keyboard, and RTL handling.
+//
+
+import SwiftUI
+
+private struct MessageDeletionConfirmationModifier: ViewModifier {
+    @Environment(WorkspaceState.self) private var workspace
+
+    func body(content: Content) -> some View {
+        @Bindable var workspace = workspace
+
+        content.confirmationDialog(
+            L10n.string("Delete message?"),
+            isPresented: Binding(
+                get: { workspace.messagePendingDeletion != nil },
+                set: { presented in
+                    if !presented { workspace.messagePendingDeletion = nil }
+                }
+            ),
+            titleVisibility: .visible,
+            presenting: workspace.messagePendingDeletion
+        ) { message in
+            let capability = workspace.messageDeletionCapability(message)
+            if capability.canDeleteForEveryone {
+                Button(L10n.string("Delete for everyone"), role: .destructive) {
+                    Task { await workspace.deleteForEveryone(message) }
+                }
+            }
+            if capability.canDeleteForMe {
+                Button(L10n.string("Delete for me"), role: .destructive) {
+                    workspace.deleteForMe(message)
+                }
+            }
+            Button(L10n.string("Cancel"), role: .cancel) {}
+        } message: { message in
+            Text(workspace.messageDeletionScopeExplanation(message))
+        }
+    }
+}
+
+extension View {
+    func messageDeletionConfirmation() -> some View {
+        modifier(MessageDeletionConfirmationModifier())
+    }
+}

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1836,7 +1836,7 @@ struct MessageRowAction: Identifiable {
             actions.append(
                 MessageRowAction(kind: .delete, title: "Delete", systemImage: "trash", role: .destructive) {
                     dismiss()
-                    Task { await workspace.deleteMessage(message) }
+                    workspace.messagePendingDeletion = message
                 })
         }
         return actions

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -391,6 +391,7 @@ private struct ConversationView: View {
         ZStack {
             VStack(spacing: 0) {
                 ConversationHeader(chat: chat)
+                    .messageDeletionConfirmation()
                 GlassSeparator(axis: .horizontal)
 
                 ScrollViewReader { proxy in

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -33,6 +33,60 @@ struct PureValueTests {
         #expect(DisappearingMessageOption.custom(oversizedSeconds).label == "9223372036854775808 seconds")
     }
 
+    @Test func messageDeletionCapabilityCoversEveryOwnershipAndRole() {
+        struct Case {
+            let name: String
+            let isDirect: Bool
+            let isOwn: Bool
+            let isAdmin: Bool
+            let forMe: Bool
+            let forEveryone: Bool
+        }
+        let cases = [
+            Case(name: "own DM", isDirect: true, isOwn: true, isAdmin: false, forMe: true, forEveryone: true),
+            Case(name: "other's DM", isDirect: true, isOwn: false, isAdmin: false, forMe: true, forEveryone: false),
+            // An admin flag on a DM's underlying two-member group must never grant for-everyone.
+            Case(
+                name: "other's DM, spurious admin", isDirect: true, isOwn: false, isAdmin: true,
+                forMe: true, forEveryone: false),
+            Case(name: "own group", isDirect: false, isOwn: true, isAdmin: false, forMe: true, forEveryone: true),
+            Case(
+                name: "other's group, admin", isDirect: false, isOwn: false, isAdmin: true,
+                forMe: true, forEveryone: true),
+            Case(
+                name: "other's group, member", isDirect: false, isOwn: false, isAdmin: false,
+                forMe: true, forEveryone: false),
+        ]
+        for testCase in cases {
+            let capability = MessageDeletionCapability.resolve(
+                isActionable: true,
+                isDirectConversation: testCase.isDirect,
+                isOwnMessage: testCase.isOwn,
+                isSelfGroupAdmin: testCase.isAdmin
+            )
+            #expect(capability.canDeleteForMe == testCase.forMe, "for-me mismatch: \(testCase.name)")
+            #expect(capability.canDeleteForEveryone == testCase.forEveryone, "for-everyone mismatch: \(testCase.name)")
+        }
+    }
+
+    @Test func messageDeletionCapabilityIsEmptyForNonActionableBubbles() {
+        // A deleted tombstone or system bubble offers no delete scope, regardless of role.
+        let capability = MessageDeletionCapability.resolve(
+            isActionable: false, isDirectConversation: false, isOwnMessage: true, isSelfGroupAdmin: true
+        )
+        #expect(capability == .none)
+        #expect(!capability.canDelete)
+    }
+
+    @Test func messageDeletionCapabilityForMeIsUniversalForActionableBubbles() {
+        // Any actionable message can be hidden locally, regardless of ownership or role.
+        let otherMemberMessage = MessageDeletionCapability.resolve(
+            isActionable: true, isDirectConversation: false, isOwnMessage: false, isSelfGroupAdmin: false
+        )
+        #expect(otherMemberMessage.canDeleteForMe)
+        #expect(!otherMemberMessage.canDeleteForEveryone)
+    }
+
     @Test func durationCountLabelsUseLocalePluralRules() {
         let russian = Locale(identifier: "ru")
         #expect(L10n.plural("%llu seconds", UInt64(1), locale: russian) == "1 секунда")

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11825,6 +11825,16 @@ struct whitenoise_macTests {
         runtime.installGroupDetails(
             groupDetailsFixture(selfAccountIdHex: account.accountIdHex, selfIsAdmin: false)
         )
+        // Snapshot the shared defaults so the test never wipes real hidden-message state.
+        let hiddenDefaultsKey = WorkspaceState.hiddenMessagesDefaultsKey
+        let priorHidden = UserDefaults.standard.dictionary(forKey: hiddenDefaultsKey)
+        defer {
+            if let priorHidden {
+                UserDefaults.standard.set(priorHidden, forKey: hiddenDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: hiddenDefaultsKey)
+            }
+        }
         let state = WorkspaceState(clientFactory: { runtime })
         state.clearAllHiddenMessages()
         let message = MessageItem(
@@ -11852,8 +11862,6 @@ struct whitenoise_macTests {
         #expect(runtime.deletedMessage == nil)
         #expect(state.hiddenMessageIds(accountId: accountId, groupIdHex: chat.id).contains(message.id))
         #expect(state.filterHiddenMessages([message], groupIdHex: chat.id).isEmpty)
-
-        state.clearAllHiddenMessages()
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10817,7 +10817,7 @@ struct whitenoise_macTests {
         let timelineSubscriptionCount = runtime.timelineSubscriptionCount
 
         await state.react(to: message, emoji: "👍")
-        await state.deleteMessage(message)
+        await state.deleteForEveryone(message)
 
         #expect(runtime.chatListSubscriptionCount == chatListSubscriptionCount)
         #expect(runtime.timelineSubscriptionCount == timelineSubscriptionCount)
@@ -11117,7 +11117,7 @@ struct whitenoise_macTests {
 
         await state.bootstrap()
         await state.react(to: message, emoji: "👍")
-        await state.deleteMessage(message)
+        await state.deleteForEveryone(message)
 
         #expect(
             runtime.reactedMessage
@@ -11763,13 +11763,13 @@ struct whitenoise_macTests {
         await state.bootstrap()
 
         runtime.messageActionGateEnabled = true
-        async let firstDelete: Void = state.deleteMessage(message)
+        async let firstDelete: Void = state.deleteForEveryone(message)
         while !runtime.didReachMessageActionGate {
             await Task.yield()
         }
 
         // Overlapping repeated delete of the same message is dropped by the per-target guard.
-        await state.deleteMessage(message)
+        await state.deleteForEveryone(message)
         #expect(runtime.deleteMessageCallCount == 1)
 
         runtime.releaseMessageActionGate()
@@ -11813,9 +11813,47 @@ struct whitenoise_macTests {
         )
 
         await state.bootstrap()
-        await state.deleteMessage(message)
+        await state.deleteForEveryone(message)
 
         #expect(runtime.deletedMessage == nil)
+    }
+
+    @MainActor
+    @Test func deleteForMeHidesLocallyAndPublishesNothing() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(
+            groupDetailsFixture(selfAccountIdHex: account.accountIdHex, selfIsAdmin: false)
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        state.clearAllHiddenMessages()
+        let message = MessageItem(
+            id: "hide-on-this-device",
+            senderName: "Alice",
+            body: "Hide this just for me",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: false
+        )
+
+        await state.bootstrap()
+        let chat = try #require(state.selectedChat)
+        await state.refreshConversationMetadata(for: chat)
+        let accountId = try #require(state.activeAccountId)
+
+        // A regular member may hide any message for themselves but not for everyone.
+        let capability = state.messageDeletionCapability(message)
+        #expect(capability.canDeleteForMe)
+        #expect(!capability.canDeleteForEveryone)
+
+        state.deleteForMe(message)
+
+        // Publishes nothing, records the hide, and filters it from a full window replace so it
+        // stays gone across reprojection and restart.
+        #expect(runtime.deletedMessage == nil)
+        #expect(state.hiddenMessageIds(accountId: accountId, groupIdHex: chat.id).contains(message.id))
+        #expect(state.filterHiddenMessages([message], groupIdHex: chat.id).isEmpty)
+
+        state.clearAllHiddenMessages()
     }
 
     @MainActor
@@ -11839,7 +11877,7 @@ struct whitenoise_macTests {
         await state.refreshConversationMetadata(for: chat)
 
         #expect(state.canDeleteMessage(message))
-        await state.deleteMessage(message)
+        await state.deleteForEveryone(message)
         #expect(
             runtime.deletedMessage
                 == DeletedMessage(


### PR DESCRIPTION
Consolidates message deletion into a single **Delete** action that opens one adaptive confirmation surface offering only the scopes the current user may perform, replacing the previous scope-blind item. Brings the desktop client to parity with the deletion redesign on the other clients.

## Capability model
- `MessageDeletionCapability.resolve(isActionable:isDirectConversation:isOwnMessage:isSelfGroupAdmin:)` is the single source of truth for `canDeleteForMe` / `canDeleteForEveryone`.
- Delete-for-everyone = your own message, **or** a group (structurally never a direct message) where you are admin of *this* group. An admin role from another group, or an admin flag on a DM's own two-member group, can never grant it — the `!isDirectConversation` guard enforces that.
- Both `deleteForMe` and `deleteForEveryone` re-check the capability in the mutation path; button visibility is not the security boundary. The engine remains the final authority on a moderation delete.

## Behavior
- **Delete for me** hides the message locally and publishes nothing. Hidden ids are persisted per account/group and filtered from every timeline route — incremental projection *and* full window replace — so a hide survives chat-switch, pagination, reprojection, and restart. Cleared on chat removal and full local wipe.
- **Delete for everyone** uses the existing group-tombstone path with the in-flight idempotency guard.
- Multi-select bulk delete acts only on messages deletable for everyone; it never silently mixes in local hides.

## Confirmation surface
- A native confirmation dialog: title, adaptive non-admin-branded scope explanation, destructive-styled options via the platform's semantic roles, Cancel; collapses to a single option when only one scope applies. Correct across appearance modes, large text, RTL, VoiceOver, and keyboard by construction.

## Engine bindings
- Bumps the vendored MarmotKit to mdk `f3ece0e3` so the timeline correctly **honors an incoming group-admin moderation delete**. The FFI surface change is additive only (new draft-persistence/profile-website methods the client does not consume); no protocol or fake-runtime reconciliation was required.

## Tests
- Table-driven capability coverage of all six ownership/role combinations, the spurious-DM-admin edge, non-actionable bubbles, and the universal delete-for-me scope.
- `deleteForMe` hides locally, publishes nothing, records the hide, and stays filtered from a window replace.
- Existing remote-delete regression tests repointed to `deleteForEveryone`.

## Verification
- Debug build and strict swift-format lint pass; full unit suite green (523 tests).
- Reviewed and had review findings applied (the window-replace filter gap, a bulk-delete regression, and a purge-on-removal leak were caught and fixed).

Closes #501.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/614">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deletion confirmation dialog with separate “Delete for me” and “Delete for everyone” options based on available permissions.
  * “Delete for me” now hides messages locally and keeps them hidden after restarting or refreshing chats.
  * Added support for message drafts, draft attachments, reactions, media messaging, and configurable message synchronization.
  * Expanded profile, relay, and account management capabilities.

* **Bug Fixes**
  * Hidden messages are now cleared when chats or local app data are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->