### PR TITLE
12-hour message timestamps and a leading multi-select control

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2449,6 +2449,14 @@ nonisolated enum DisplayText {
         return "\(value.prefix(head))...\(value.suffix(tail))"
     }
 
+    /// A 12-hour-clock variant of `locale` so clock times always carry an AM/PM marker, even when
+    /// the region's default is 24-hour. Casing/format still follow the locale (e.g. "PM" vs "pm").
+    private static func twelveHourLocale(_ locale: Locale) -> Locale {
+        var components = Locale.Components(locale: locale)
+        components.hourCycle = .oneToTwelve
+        return Locale(components: components)
+    }
+
     static func initials(for value: String, fallback: String) -> String {
         let source = value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? fallback : value
         let parts =
@@ -2464,7 +2472,7 @@ nonisolated enum DisplayText {
         -> String
     {
         if calendar.isDateInToday(date) {
-            return date.formatted(timeOnlyStyle.locale(locale))
+            return date.formatted(timeOnlyStyle.locale(twelveHourLocale(locale)))
         }
         if calendar.isDate(date, equalTo: now, toGranularity: .weekOfYear) {
             return date.formatted(weekdayStyle.locale(locale))
@@ -2473,7 +2481,7 @@ nonisolated enum DisplayText {
     }
 
     static func messageTimestamp(for date: Date, locale: Locale = AppLanguage.currentLocale) -> String {
-        date.formatted(timeOnlyStyle.locale(locale))
+        date.formatted(timeOnlyStyle.locale(twelveHourLocale(locale)))
     }
 
     static func dateTimeTimestamp(for date: Date, locale: Locale = AppLanguage.currentLocale) -> String {

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -81,7 +81,9 @@ struct ConversationMessageRow: View {
     // so SwiftUI diffs each row by value and only re-runs the rows that actually changed
     // instead of invalidating every visible row on each page load / streaming update.
     var body: some View {
-        if workspace.isTimelineSelectionMode {
+        // Only chat bubbles are selectable; `toggleMessageSelection` ignores system/notice rows,
+        // so they must not show a checkbox or carry button semantics in selection mode.
+        if workspace.isTimelineSelectionMode, message.presentation.isChatBubble {
             let isSelected = workspace.selectedTimelineMessageIds.contains(message.id)
             HStack(alignment: .center, spacing: 8) {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -71,6 +71,7 @@ extension EnvironmentValues {
 }
 
 struct ConversationMessageRow: View {
+    @Environment(WorkspaceState.self) private var workspace
     let message: MessageItem
     var showsDebugMetadata = false
     let onOpenImageGallery: (MessageImageGalleryPresentation) -> Void
@@ -80,6 +81,32 @@ struct ConversationMessageRow: View {
     // so SwiftUI diffs each row by value and only re-runs the rows that actually changed
     // instead of invalidating every visible row on each page load / streaming update.
     var body: some View {
+        if workspace.isTimelineSelectionMode {
+            let isSelected = workspace.selectedTimelineMessageIds.contains(message.id)
+            HStack(alignment: .center, spacing: 8) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .frame(width: 24)
+                    .padding(.leading, 14)
+                content
+            }
+            .padding(.vertical, 1)
+            .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+            .contentShape(Rectangle())
+            .onTapGesture { workspace.toggleMessageSelection(message) }
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+            .accessibilityLabel(
+                isSelected ? L10n.string("Deselect message") : L10n.string("Select message")
+            )
+        } else {
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
         if message.presentation.isChatBubble {
             MessageBubble(
                 message: message,
@@ -261,30 +288,6 @@ struct MessageBubble: View {
                 inlineActions
             }
         }
-        .overlay(alignment: .leading) {
-            if workspace.isTimelineSelectionMode {
-                Button {
-                    workspace.toggleMessageSelection(message)
-                } label: {
-                    Image(
-                        systemName: workspace.selectedTimelineMessageIds.contains(message.id)
-                            ? "checkmark.circle.fill" : "circle"
-                    )
-                    .font(.system(size: 20, weight: .medium))
-                    .foregroundStyle(
-                        workspace.selectedTimelineMessageIds.contains(message.id)
-                            ? Color.accentColor : Color.secondary
-                    )
-                    .frame(width: 40, height: 40)
-                    .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(
-                    workspace.selectedTimelineMessageIds.contains(message.id)
-                        ? L10n.string("Deselect message") : L10n.string("Select message")
-                )
-            }
-        }
         .animation(.smooth(duration: 0.12), value: showsInlineActions)
         .frame(maxWidth: 660, alignment: message.isOutgoing ? .trailing : .leading)
         .frame(maxWidth: .infinity, alignment: message.isOutgoing ? .trailing : .leading)
@@ -293,11 +296,6 @@ struct MessageBubble: View {
         .contextMenu {
             if !workspace.isTimelineSelectionMode {
                 MessageContextMenuItems(message: message)
-            }
-        }
-        .onTapGesture {
-            if workspace.isTimelineSelectionMode {
-                workspace.toggleMessageSelection(message)
             }
         }
         .onAppear {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -3698,9 +3698,12 @@ struct whitenoise_macTests {
         AppLanguage.refreshCachedLocale()
 
         let messageDate = Date(timeIntervalSince1970: 1_700_000_000)
+        // Message times force a 12-hour clock with a meridiem while still following the selected
+        // language, so the expected value forces the same hour cycle on the Spanish locale.
+        var components = Locale.Components(locale: Locale(identifier: AppLanguage.spanish.rawValue))
+        components.hourCycle = .oneToTwelve
         let expected = messageDate.formatted(
-            Date.FormatStyle(date: .omitted, time: .shortened)
-                .locale(Locale(identifier: AppLanguage.spanish.rawValue))
+            Date.FormatStyle(date: .omitted, time: .shortened).locale(Locale(components: components))
         )
 
         #expect(DisplayText.messageTimestamp(for: messageDate) == expected)


### PR DESCRIPTION
Two transcript-UI fixes.

## 12-hour clock with AM/PM
Message and chat-list times rendered without a meridiem on 24-hour regions (e.g. "2:07" instead of "2:07 AM"), making morning/evening ambiguous. Clock times now force a 12-hour cycle with an AM/PM marker across message bubbles, the chat-list, and the timestamp detail styles, while day/date wording still follows the locale.

## Multi-select selection control
Selection mode previously floated the selection circles in the middle of the transcript, detached from the bubbles. The control now sits in a fixed leading gutter on each row, bubbles keep their normal incoming/outgoing alignment, the whole row is tappable, and selected rows are highlighted — matching the reference pattern.

## Verification
Debug build and strict swift-format lint pass; full unit suite green. AM/PM confirmed on device.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/635">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/updated timeline message selection at the conversation-row level, with a leading selection indicator, improved tap handling, and enhanced accessibility/selection styling.
* **Bug Fixes**
  * Message timestamps now consistently display a 12-hour clock with AM/PM markers, regardless of the device’s regional hour-cycle setting.
  * Selection behavior is now applied consistently across the entire message row (instead of only the bubble area).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->