### PR TITLE
Transcript-bubble parity: sender avatars, edit history, reaction polish

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -130,6 +130,15 @@ nonisolated enum MessageEditMutation: Equatable, Sendable {
     case retract(editMessageIdHex: String)
 }
 
+/// One revision of an edited message for the edit-history viewer: the original, then each
+/// accepted edit. `date` is derived from the record's second-granular `timelineAt`.
+nonisolated struct MessageEditVersion: Identifiable, Equatable, Sendable {
+    let id: String
+    let text: String
+    let date: Date
+    let isOriginal: Bool
+}
+
 nonisolated struct MessageEditOverlay: Equatable, Sendable {
     let targetMessageIdHex: String
     let editMessageIdHex: String

--- a/whitenoise-mac/Core/WorkspaceState+Links.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Links.swift
@@ -13,7 +13,19 @@ extension WorkspaceState {
     /// Gate every tappable link rendered from peer-controlled Markdown before SwiftUI can fall
     /// through to LaunchServices. Only browser-safe web links may use the system action; Nostr
     /// and marmot profile links are consumed in-app, and every other scheme is dropped.
+    /// Custom scheme for the tappable "Edited" label; routed to the edit-history sheet in-app.
+    static let editHistoryMessageURLScheme = "whitenoise-edit-history"
+
     func handleMessageLinkOpen(_ url: URL) -> OpenURLAction.Result {
+        if url.scheme == Self.editHistoryMessageURLScheme {
+            let messageId = String(url.absoluteString.dropFirst(Self.editHistoryMessageURLScheme.count + 1))
+            if case .chat(let groupIdHex) = selection,
+                let message = messageTimelineStores[groupIdHex]?.lookup[messageId]
+            {
+                messagePendingEditHistory = message
+            }
+            return .handled
+        }
         guard MarkdownLinkPolicy.isAllowed(url) else { return .discarded }
 
         if MarkdownLinkPolicy.isInternalNostrURL(url) {

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -739,6 +739,15 @@ extension WorkspaceState {
         copyTextHandler(text, concealed)
     }
 
+    /// Ordered edit history (oldest first) for `message` in the selected conversation, or empty
+    /// when it was never edited. Derived from the timeline store's retained edit overlays.
+    func editHistory(for message: MessageItem) -> [MessageEditVersion] {
+        guard case .chat(let groupIdHex) = selection,
+            let store = messageTimelineStores[groupIdHex]
+        else { return [] }
+        return store.editHistory(forTarget: message.id)
+    }
+
     func react(to message: MessageItem, emoji: String) async {
         guard message.supportsChatActions else { return }
         guard let client, let activeAccount, let selectedChat else { return }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -433,6 +433,35 @@ final class MessageTimelineStore {
             })
     }
 
+    /// The ordered edit history for `targetId` — oldest first: the original, then each accepted
+    /// edit by the target's own author. Empty when the message was never edited.
+    func editHistory(forTarget targetId: String) -> [MessageEditVersion] {
+        guard let base = baseMessagesById[targetId],
+            isValidEditTarget(base, editSender: base.senderAccountIdHex)
+        else { return [] }
+        let edits = editCandidatesById.values
+            .filter { $0.targetMessageIdHex == targetId && $0.sender == base.senderAccountIdHex }
+            .sorted { MessageEditOverlay.shouldPrefer($1, over: $0) }
+        guard !edits.isEmpty else { return [] }
+        var versions = [
+            MessageEditVersion(
+                id: base.id,
+                text: base.body,
+                date: Date(timeIntervalSince1970: TimeInterval(base.timelineAt)),
+                isOriginal: true
+            )
+        ]
+        versions += edits.map { edit in
+            MessageEditVersion(
+                id: edit.editMessageIdHex,
+                text: edit.plaintext,
+                date: Date(timeIntervalSince1970: TimeInterval(edit.timelineAt)),
+                isOriginal: false
+            )
+        }
+        return versions
+    }
+
     private func purgeEditCandidates(forRemovalIds removalIds: Set<String>) {
         guard !removalIds.isEmpty, !editCandidatesById.isEmpty else { return }
         editCandidatesById = editCandidatesById.filter { _, candidate in
@@ -710,10 +739,12 @@ final class WorkspaceState {
     var activeAccountId: String?
     var selection: WorkspaceSelection? {
         didSet {
-            // A pending delete-confirmation belongs to the conversation it was opened in; drop it
-            // when the selection changes so a stale dialog can't act on a different chat.
+            // A pending delete-confirmation or edit-history sheet belongs to the conversation it
+            // was opened in; drop both when the selection changes so a stale dialog can't act on a
+            // different chat.
             if oldValue != selection {
                 messagePendingDeletion = nil
+                messagePendingEditHistory = nil
             }
             dismissGroupImagePickerIfSelectedChatUnavailable()
             ensureSelectedMessageTimelineStore()
@@ -886,6 +917,8 @@ final class WorkspaceState {
     /// Message whose unified delete-confirmation surface is open, or `nil`. Drives the adaptive
     /// dialog that offers only the scopes `messageDeletionCapability` permits.
     var messagePendingDeletion: MessageItem?
+    /// Message whose edit-history sheet is open, or `nil`. Cleared when the selection changes.
+    var messagePendingEditHistory: MessageItem?
     var messageInfoTarget: MessageItem?
     var forwardingMessageIds: [String] = []
     var isForwardPickerPresented = false

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1637,6 +1637,9 @@ nonisolated struct MessageItem: Identifiable, Hashable {
     /// Whether the bubble should render the parsed Markdown AST instead of plain text.
     var rendersMarkdown: Bool { contentMarkdown != nil }
 
+    /// The sender's avatar URL, passed through the remote-image policy for incoming-bubble avatars.
+    var senderSanitizedPictureURL: URL? { RemoteImageURLPolicy.sanitizedURL(from: senderPictureURL) }
+
     /// Plain text and a single Markdown paragraph can place compact metadata at
     /// the end of the final text line. Structured Markdown keeps a separate
     /// metadata row so its block semantics remain intact.

--- a/whitenoise-mac/Views/MessageEditHistorySheet.swift
+++ b/whitenoise-mac/Views/MessageEditHistorySheet.swift
@@ -1,0 +1,96 @@
+//
+//  MessageEditHistorySheet.swift
+//  whitenoise-mac
+//
+//  The edit-history viewer: the current text on top, then each earlier revision newest-first
+//  down to the original, reconstructed client-side from the timeline's retained edit overlays.
+//
+
+import SwiftUI
+
+private struct MessageEditHistoryModifier: ViewModifier {
+    @Environment(WorkspaceState.self) private var workspace
+
+    func body(content: Content) -> some View {
+        @Bindable var workspace = workspace
+
+        content.sheet(item: $workspace.messagePendingEditHistory) { message in
+            MessageEditHistoryView(message: message)
+                .environment(workspace)
+        }
+    }
+}
+
+extension View {
+    func messageEditHistory() -> some View {
+        modifier(MessageEditHistoryModifier())
+    }
+}
+
+private struct MessageEditHistoryView: View {
+    @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.dismiss) private var dismiss
+    let message: MessageItem
+
+    var body: some View {
+        // Newest first: the current text, earlier revisions, then the original last.
+        let versions = workspace.editHistory(for: message).reversed().enumerated().map { index, version in
+            (version: version, isLatest: index == 0)
+        }
+
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(L10n.string("Edit history"))
+                    .font(.headline)
+                Spacer()
+                GlassCircleCloseButton { dismiss() }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    if versions.isEmpty {
+                        Text(L10n.string("No earlier versions."))
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 8)
+                    }
+                    ForEach(versions, id: \.version.id) { entry in
+                        versionRow(entry.version, isLatest: entry.isLatest)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+            }
+        }
+        .frame(minWidth: 360, minHeight: 320)
+    }
+
+    private func versionRow(_ version: MessageEditVersion, isLatest: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(
+                    version.isOriginal
+                        ? L10n.string("Original")
+                        : (isLatest ? L10n.string("Current") : L10n.string("Edited"))
+                )
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(isLatest ? Color.accentColor : Color.secondary)
+                Spacer()
+                Text(DisplayText.messageTimestamp(for: version.date))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Text(version.text)
+                .font(.body)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .glassCard()
+        }
+    }
+}

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -243,10 +243,18 @@ struct MessageBubble: View {
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 3)
                                 .background {
-                                    GlassCapsuleBackground(
-                                        borderColor: reaction.canRemoveOwnReaction
-                                            ? MessagesPalette.sentBubble.opacity(0.45) : Color.white.opacity(0.18)
-                                    )
+                                    // Own reactions get a gentle accent fill rather than a heavy
+                                    // ring, so a row of them reads as one cluster, not selected chips.
+                                    if reaction.canRemoveOwnReaction {
+                                        Capsule(style: .continuous)
+                                            .fill(Color.accentColor.opacity(0.16))
+                                            .overlay {
+                                                Capsule(style: .continuous)
+                                                    .strokeBorder(Color.accentColor.opacity(0.4), lineWidth: 1)
+                                            }
+                                    } else {
+                                        GlassCapsuleBackground()
+                                    }
                                 }
                         }
                         .buttonStyle(.plain)
@@ -294,6 +302,20 @@ struct MessageBubble: View {
         .frame(maxWidth: 660, alignment: message.isOutgoing ? .trailing : .leading)
         .frame(maxWidth: .infinity, alignment: message.isOutgoing ? .trailing : .leading)
         .padding(message.isOutgoing ? .leading : .trailing, 72)
+        // Sender avatar in a leading gutter for incoming group messages (never DMs or own).
+        .padding(.leading, showsSenderAvatar ? 36 : 0)
+        .overlay(alignment: .bottomLeading) {
+            if showsSenderAvatar {
+                ProfileImageAvatarView(
+                    seed: message.senderAccountIdHex,
+                    initials: message.senderName,
+                    sanitizedPictureURL: message.senderSanitizedPictureURL,
+                    size: 28,
+                    isSelected: false
+                )
+                .padding(.bottom, 2)
+            }
+        }
         .contentShape(Rectangle())
         .contextMenu {
             if !workspace.isTimelineSelectionMode {
@@ -355,6 +377,12 @@ struct MessageBubble: View {
 
     private var usesBubbleSurface: Bool {
         showsDebugMetadata || message.hasBubbleContent
+    }
+
+    /// Incoming messages in a group carry the sender's avatar in a leading gutter; DMs and the
+    /// local account's own messages do not (the peer/self is unambiguous there).
+    private var showsSenderAvatar: Bool {
+        !message.isOutgoing && !(workspace.selectedChat?.isDirect ?? true)
     }
 
     @ViewBuilder
@@ -441,11 +469,15 @@ struct MessageBubble: View {
         let color = metadataColor
         var result = Text("  ")
         if message.isEdited {
-            result =
-                result
-                + Text("Edited ")
-                .font(.system(size: 10.5, weight: .medium))
-                .foregroundColor(color)
+            // "Edited" is a tappable link (routed to the edit-history sheet via the message-link
+            // handler) while staying inline with the message's trailing metadata.
+            var edited = AttributedString("Edited ")
+            edited.foregroundColor = color
+            edited.font = .system(size: 10.5, weight: .medium)
+            if let url = URL(string: "\(WorkspaceState.editHistoryMessageURLScheme):\(message.id)") {
+                edited.link = url
+            }
+            result = result + Text(edited)
         }
         result =
             result
@@ -476,7 +508,9 @@ struct MessageBubble: View {
     private var compactMetadata: some View {
         HStack(spacing: 4) {
             if message.isEdited {
-                Text("Edited")
+                Button("Edited") { workspace.messagePendingEditHistory = message }
+                    .buttonStyle(.plain)
+                    .help(L10n.string("View edit history"))
             }
             Text(message.timeLabel)
                 .monospacedDigit()
@@ -1879,49 +1913,15 @@ struct MessageOverflowPopover: View {
     }
 }
 
-/// The right-click menu for a chat bubble. Unlike the inline hover bar this is always
-/// reachable (no hover), so it mirrors the same React/Reply/Copy/Delete actions — gated on
-/// the message's own capabilities — rather than only the Copy/Delete overflow subset. This
-/// keeps React/Reply available for media-only bubbles, where the hover bar can be easy to
-/// miss and text/copy actions don't apply. See whitenoise-mac#361.
+/// The right-click menu for a chat bubble. Shows the same action set as the hover bar's "…"
+/// overflow (`MessageRowAction.all`) so both entry points are identical — React/Reply stay on
+/// the inline hover bar, not here.
 struct MessageContextMenuItems: View {
     @Environment(WorkspaceState.self) private var workspace
     let message: MessageItem
 
-    /// A short list of common reactions offered inline in the context menu; the hover bar's
-    /// popover remains the path to the full emoji grid.
-    private static let quickReactionEmojis = ChatReactionDefaults.quick
-
     var body: some View {
-        let actions = MessageRowAction.all(for: message, workspace: workspace)
-
-        if message.canReact {
-            Menu {
-                ForEach(Self.quickReactionEmojis, id: \.self) { emoji in
-                    Button {
-                        Task { await workspace.react(to: message, emoji: emoji) }
-                    } label: {
-                        Text(emoji)
-                    }
-                }
-            } label: {
-                Label("React", systemImage: "face.smiling")
-            }
-        }
-
-        if message.canReply {
-            Button {
-                workspace.startReply(to: message)
-            } label: {
-                Label("Reply", systemImage: "arrowshape.turn.up.left")
-            }
-        }
-
-        if (message.canReact || message.canReply) && !actions.isEmpty {
-            Divider()
-        }
-        ForEach(Array(actions.enumerated()), id: \.element.id) { index, action in
-            if index > 0 { Divider() }
+        ForEach(MessageRowAction.all(for: message, workspace: workspace)) { action in
             Button(role: action.role, action: action.run) {
                 Label(action.title, systemImage: action.systemImage)
             }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -392,6 +392,7 @@ private struct ConversationView: View {
             VStack(spacing: 0) {
                 ConversationHeader(chat: chat)
                     .messageDeletionConfirmation()
+                    .messageEditHistory()
                 GlassSeparator(axis: .horizontal)
 
                 ScrollViewReader { proxy in


### PR DESCRIPTION
Transcript-bubble parity, matching the other clients. Stacked on the 12-hour-timestamps / multi-select branch (merge that first).

## Sender avatars
Incoming messages in a **group** now show the sender's avatar in a leading gutter (28pt). Direct messages and the local account's own messages show none, where the peer/self is unambiguous.

## Message edit-history
The "Edited" label is now a tappable affordance that opens a history sheet — the current text on top, then each earlier revision down to the original, with per-version timestamps. Versions are reconstructed client-side from the timeline's retained edit overlays (author-scoped); no new engine call. The inline "Edited" stays on the same line as the message's trailing metadata via a styled in-app link.

## Reaction pills
Own reactions now use a gentle accent fill instead of a heavy border on every chip, so a row of reactions reads as one cluster rather than a set of selected buttons. Tap-to-remove/add behavior is unchanged.

## Bubble right-click menu
The right-click menu now shows the same action set as the hover-bar "…" overflow (Message Info, Select, Forward, Edit, Copy, Delete) — React/Reply stay on the inline hover bar, so both entry points are consistent.

## Verification
Debug build and strict swift-format lint pass; full unit suite green; confirmed on device.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/636">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->