### PR TITLE
Add @-mentions with a member picker and transcript name rendering

### DIFF
--- a/whitenoise-mac/Core/ComposerMentionSupport.swift
+++ b/whitenoise-mac/Core/ComposerMentionSupport.swift
@@ -1,0 +1,169 @@
+//
+//  ComposerMentionSupport.swift
+//  whitenoise-mac
+//
+//  Pure @-mention logic ported from the iOS client: detecting the active mention query in a
+//  draft, filtering group-member candidates, rewriting the draft on selection, and
+//  canonicalizing "@DisplayName" to "@npub…" at send time. No UI or platform state here.
+//
+
+import Foundation
+import MarmotKit
+
+nonisolated struct ComposerMentionCandidate: Identifiable, Equatable, Sendable {
+    let id: String
+    let memberIdHex: String
+    /// Avatar/profile seed — the member's account id (falls back to the member id).
+    let accountIdHex: String
+    let displayName: String
+    let npub: String
+
+    // Lowercased match fields, precomputed once — `filter` runs on every keystroke.
+    let displayNameLowercased: String
+    let npubLowercased: String
+    let memberIdHexLowercased: String
+
+    init(details: GroupMemberDetailsFfi) {
+        memberIdHex = details.memberIdHex
+        accountIdHex = details.account ?? details.memberIdHex
+        npub = details.npub
+        let reference = details.npub.isEmpty ? memberIdHex : details.npub
+        displayName = PeerDisplayText.sanitize(details.displayName) ?? DisplayText.short(reference, head: 10, tail: 6)
+        id = memberIdHex
+        displayNameLowercased = displayName.lowercased()
+        npubLowercased = npub.lowercased()
+        memberIdHexLowercased = memberIdHex.lowercased()
+    }
+}
+
+nonisolated enum ComposerMentionQuery {
+    struct Session: Equatable {
+        let atIndex: String.Index
+        let caretIndex: String.Index
+        let query: String
+
+        var range: Range<String.Index> { atIndex..<caretIndex }
+    }
+
+    static let maxVisibleCandidates = 8
+    private static let completeNpubBodyLength = 58
+
+    /// The active mention query anchored at the end of `draft`.
+    static func active(in draft: String) -> Session? {
+        active(in: draft, upTo: draft.endIndex)
+    }
+
+    /// The active mention query immediately left of `caret`: the last `@` before the caret whose
+    /// left neighbour is a word boundary, with no whitespace between it and the caret. `nil` when
+    /// no query is open. Scoping to the caret lets the user complete a mention mid-message, not
+    /// only at the end of the draft.
+    static func active(in draft: String, upTo caret: String.Index) -> Session? {
+        guard caret <= draft.endIndex else { return nil }
+        guard let atIndex = draft[..<caret].lastIndex(of: "@") else { return nil }
+        if atIndex > draft.startIndex {
+            let before = draft[draft.index(before: atIndex)]
+            guard before.isWhitespace || before.isNewline else { return nil }
+        }
+        let queryStart = draft.index(after: atIndex)
+        let query = String(draft[queryStart..<caret])
+        guard !query.contains(where: { $0.isWhitespace || $0.isNewline }) else { return nil }
+        return Session(atIndex: atIndex, caretIndex: caret, query: query)
+    }
+
+    /// A pasted full npub suppresses autocomplete.
+    static func looksLikeCompleteNpub(_ query: String) -> Bool {
+        query.hasPrefix("npub1") && query.count >= 5 + completeNpubBodyLength
+    }
+
+    static func filter(_ candidates: [ComposerMentionCandidate], matching query: String)
+        -> [ComposerMentionCandidate]
+    {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered: [ComposerMentionCandidate]
+        if trimmed.isEmpty {
+            filtered = candidates
+        } else {
+            let needle = trimmed.lowercased()
+            filtered = candidates.filter { candidate in
+                candidate.displayNameLowercased.contains(needle)
+                    || candidate.npubLowercased.contains(needle)
+                    || candidate.memberIdHexLowercased.contains(needle)
+            }
+        }
+        return Array(filtered.prefix(maxVisibleCandidates))
+    }
+
+    static func replacing(session: Session, in draft: String, with displayName: String) -> String {
+        var updated = draft
+        updated.replaceSubrange(session.range, with: "@\(displayName) ")
+        return updated
+    }
+}
+
+nonisolated enum ComposerMentionCanonicalizer {
+    private static let underscoreScalar = UnicodeScalar("_")
+    private static let slashScalar = UnicodeScalar("/")
+
+    /// Rewrite every "@DisplayName" in `text` that matches a candidate to "@npub…", so the wire
+    /// format carries stable public keys rather than display names.
+    static func canonicalize(_ text: String, candidates: [ComposerMentionCandidate]) -> String {
+        guard text.contains("@") else { return text }
+        let replacements =
+            candidates
+            .filter { candidate in
+                !candidate.npub.isEmpty
+                    && !candidate.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }
+            .sorted { $0.displayName.count > $1.displayName.count }
+        guard !replacements.isEmpty else { return text }
+
+        var canonical = ""
+        var index = text.startIndex
+        while index < text.endIndex {
+            if text[index] == "@",
+                leftBoundaryAllowsMention(at: index, in: text),
+                let match = matchCandidate(in: text, at: index, candidates: replacements)
+            {
+                canonical += "@\(match.candidate.npub)"
+                index = match.endIndex
+                continue
+            }
+            canonical.append(text[index])
+            index = text.index(after: index)
+        }
+        return canonical
+    }
+
+    private static func matchCandidate(
+        in text: String,
+        at atIndex: String.Index,
+        candidates: [ComposerMentionCandidate]
+    ) -> (candidate: ComposerMentionCandidate, endIndex: String.Index)? {
+        let nameStart = text.index(after: atIndex)
+        for candidate in candidates {
+            guard text[nameStart...].hasPrefix(candidate.displayName) else { continue }
+            let nameEnd = text.index(nameStart, offsetBy: candidate.displayName.count)
+            guard rightBoundaryAllowsMention(at: nameEnd, in: text) else { continue }
+            return (candidate, nameEnd)
+        }
+        return nil
+    }
+
+    private static func leftBoundaryAllowsMention(at atIndex: String.Index, in text: String) -> Bool {
+        if atIndex == text.startIndex { return true }
+        return isNostrMentionBoundary(text[text.index(before: atIndex)])
+    }
+
+    private static func rightBoundaryAllowsMention(at index: String.Index, in text: String) -> Bool {
+        guard index < text.endIndex else { return true }
+        return isNostrMentionBoundary(text[index])
+    }
+
+    private static func isNostrMentionBoundary(_ character: Character) -> Bool {
+        !character.unicodeScalars.contains { scalar in
+            CharacterSet.alphanumerics.contains(scalar)
+                || scalar == underscoreScalar
+                || scalar == slashScalar
+        }
+    }
+}

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -36,7 +36,8 @@ extension ChatItem {
         row: ChatListRowFfi,
         activeAccountIdHex: String?,
         directPeer: ChatPeerProfile? = nil,
-        groupAvatarURL: String? = nil
+        groupAvatarURL: String? = nil,
+        mentionNames: MarkdownMentionNames = [:]
     ) {
         let groupName = PeerDisplayText.sanitize(row.groupName) ?? ""
         let peerName = PeerDisplayText.sanitize(directPeer?.displayName)
@@ -51,7 +52,9 @@ extension ChatItem {
         } else {
             title = DisplayText.short(directPeer?.accountIdHex ?? row.groupIdHex)
         }
-        let preview = row.lastMessage.map { ChatItem.previewText(for: $0, activeAccountIdHex: activeAccountIdHex) }
+        let preview = row.lastMessage.map {
+            ChatItem.previewText(for: $0, activeAccountIdHex: activeAccountIdHex, mentionNames: mentionNames)
+        }
         let previewTimestamp = row.lastMessage?.timelineAt ?? 0
         let timestamp = previewTimestamp > 0 ? previewTimestamp : row.updatedAt
         let updatedAt = timestamp > 0 ? Date(timeIntervalSince1970: TimeInterval(timestamp)) : nil
@@ -82,7 +85,11 @@ extension ChatItem {
         )
     }
 
-    private static func previewText(for preview: ChatListMessagePreviewFfi, activeAccountIdHex: String?) -> String {
+    private static func previewText(
+        for preview: ChatListMessagePreviewFfi,
+        activeAccountIdHex: String?,
+        mentionNames: MarkdownMentionNames = [:]
+    ) -> String {
         if preview.deleted {
             return L10n.string("Message deleted")
         }
@@ -111,7 +118,7 @@ extension ChatItem {
         if text.isEmpty || isMediaOnlyChat {
             body = presentation.isChatBubble ? L10n.string("Attachment") : L10n.string("Unsupported message")
         } else {
-            body = text
+            body = Self.resolvePreviewMentions(in: text, mentionNames: mentionNames)
         }
         guard presentation.isChatBubble,
             preview.sender != activeAccountIdHex,
@@ -122,6 +129,19 @@ extension ChatItem {
         }
 
         return "\(PeerDisplayText.templateFragment(senderName)): \(body)"
+    }
+
+    /// Rewrite canonical "@npub…" mentions in a chat-list preview to "@Display Name" for known
+    /// members. Only exact roster npubs are substituted, so there are no false positives; unknown
+    /// references keep their bech32 form. No-op when the roster isn't loaded for the row.
+    private static func resolvePreviewMentions(in text: String, mentionNames: MarkdownMentionNames) -> String {
+        guard !mentionNames.isEmpty, text.contains("npub1") else { return text }
+        var resolved = text
+        for (npub, rawName) in mentionNames {
+            guard let name = PeerDisplayText.sanitize(rawName) else { continue }
+            resolved = resolved.replacingOccurrences(of: "@\(npub)", with: "@\(name)")
+        }
+        return resolved
     }
 }
 
@@ -202,6 +222,7 @@ nonisolated extension MessageItem {
         record: TimelineMessageRecordFfi,
         activeAccountIdHex: String?,
         senderProfiles: [String: ChatPeerProfile],
+        mentionNames: MarkdownMentionNames = [:],
         editedPlaintext: String? = nil,
         isEdited: Bool = false,
         reactions: [MessageReaction],
@@ -253,6 +274,7 @@ nonisolated extension MessageItem {
                     invalidationStatus: record.invalidationStatus,
                     presentation: presentation
                 ),
+            mentionNames: mentionNames,
             sentAt: Date(timeIntervalSince1970: TimeInterval(record.timelineAt)),
             timelineAt: record.timelineAt,
             timelineKind: record.kind,
@@ -271,7 +293,8 @@ nonisolated extension MessageItem {
     static func timeline(
         from page: TimelinePageFfi,
         activeAccountIdHex: String?,
-        senderProfiles: [String: ChatPeerProfile] = [:]
+        senderProfiles: [String: ChatPeerProfile] = [:],
+        mentionNames: MarkdownMentionNames = [:]
     ) -> [MessageItem] {
         // MarmotKit returns an authoritative timeline window. Keep that order
         // intact: `timelineAt` is second-granular, and re-sorting in the client
@@ -282,6 +305,7 @@ nonisolated extension MessageItem {
                 record: record,
                 activeAccountIdHex: activeAccountIdHex,
                 senderProfiles: senderProfiles,
+                mentionNames: mentionNames,
                 reactions: MessageReaction.summarize(
                     record.reactions,
                     activeAccountIdHex: activeAccountIdHex

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -436,7 +436,11 @@ extension WorkspaceState {
         ChatItem(
             row: row,
             activeAccountIdHex: account.accountIdHex,
-            groupAvatarURL: firstNonBlank([row.avatarUrl])
+            groupAvatarURL: firstNonBlank([row.avatarUrl]),
+            // The no-enrich fast path (e.g. a live `newLastMessage`) can't fetch the roster, but a
+            // recently viewed group usually has it cached — resolve preview mentions when so, which
+            // covers the just-sent-message case; otherwise the reference keeps its bech32 form.
+            mentionNames: cachedMentionNames(groupIdHex: row.groupIdHex)
         )
     }
 
@@ -561,6 +565,7 @@ extension WorkspaceState {
         client: any MarmotRuntime
     ) async -> ChatItem {
         var directPeer: ChatPeerProfile?
+        var mentionNames: MarkdownMentionNames = [:]
         let groupAvatarURL = firstNonBlank([row.avatarUrl])
         if let members = await cachedGroupMembers(
             groupIdHex: row.groupIdHex,
@@ -573,6 +578,9 @@ extension WorkspaceState {
             guard !Task.isCancelled else {
                 return ChatItem(row: row, activeAccountIdHex: account.accountIdHex)
             }
+            // The roster is already in hand here, so resolving the preview's "@npub…" mentions to
+            // names costs only a dictionary build — no extra FFI on the chat-list path.
+            mentionNames = Self.mentionNames(from: members)
             directPeer = await directPeerProfile(
                 from: members,
                 activeAccount: account,
@@ -584,7 +592,8 @@ extension WorkspaceState {
             row: row,
             activeAccountIdHex: account.accountIdHex,
             directPeer: directPeer,
-            groupAvatarURL: groupAvatarURL
+            groupAvatarURL: groupAvatarURL,
+            mentionNames: mentionNames
         )
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Mentions.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Mentions.swift
@@ -1,0 +1,62 @@
+//
+//  WorkspaceState+Mentions.swift
+//  whitenoise-mac
+//
+//  Composer @-mention support: the group-member roster the picker draws from, the filtered
+//  candidate list for an active query, and the send-time rewrite of "@DisplayName" to the
+//  member's stable "@npub…" so mentions travel as public keys, not display names.
+//
+
+import Foundation
+import MarmotKit
+
+@MainActor
+extension WorkspaceState {
+    /// Mentionable members of the selected conversation, excluding the local account. Empty for
+    /// direct chats, where mentioning the sole peer carries no meaning.
+    func mentionRoster() -> [ComposerMentionCandidate] {
+        guard let selectedChat, !selectedChat.isDirect,
+            let members = groupMemberDetailsCache[selectedChat.id]
+        else { return [] }
+        return members.filter { !$0.isSelf }.map(ComposerMentionCandidate.init(details:))
+    }
+
+    /// The candidates the picker should show for an active `@query`, capped and boundary-filtered.
+    func mentionCandidates(matching query: String) -> [ComposerMentionCandidate] {
+        ComposerMentionQuery.filter(mentionRoster(), matching: query)
+    }
+
+    /// Pull the member roster into cache the first time a mention query opens in a group, so the
+    /// picker can populate. No-op for direct chats or once the cache is warm.
+    func ensureMentionRosterLoaded() {
+        guard let selectedChat, !selectedChat.isDirect,
+            groupMemberDetailsCache[selectedChat.id] == nil,
+            let client, let activeAccount
+        else { return }
+        Task { _ = await cachedGroupMembers(groupIdHex: selectedChat.id, account: activeAccount, client: client) }
+    }
+
+    /// Rewrite display-name mentions to canonical npubs before the text leaves the composer.
+    func canonicalizeMentions(in text: String) -> String {
+        let roster = mentionRoster()
+        guard !roster.isEmpty else { return text }
+        return ComposerMentionCanonicalizer.canonicalize(text, candidates: roster)
+    }
+
+    /// npub → sanitized display name from the roster already in cache (no FFI), used by the
+    /// transcript and chat-list previews to render "@npub…" mention tokens back as
+    /// "@Display Name". Reads only the cache — never triggers a `groupDetails` lookup — so it is
+    /// safe on the timeline hot path and cannot re-drive a failed/uncached group's lookup (#40).
+    /// Empty until some other path (chat-list enrichment, the mention picker, sender-name
+    /// fallback) has warmed the roster, in which case mentions keep the truncated-bech32 form.
+    func cachedMentionNames(groupIdHex: String) -> MarkdownMentionNames {
+        Self.mentionNames(from: groupMemberDetailsCache[groupIdHex] ?? [])
+    }
+
+    static func mentionNames(from members: [GroupMemberDetailsFfi]) -> MarkdownMentionNames {
+        members.reduce(into: MarkdownMentionNames()) { map, member in
+            guard !member.npub.isEmpty, let name = PeerDisplayText.sanitize(member.displayName) else { return }
+            map[member.npub] = name
+        }
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -315,6 +315,7 @@ extension WorkspaceState {
                 client: client
             )
         }
+        let mentionNames = cachedMentionNames(groupIdHex: groupIdHex)
         guard
             canApplyTimelineWindow(
                 groupIdHex: groupIdHex,
@@ -347,7 +348,8 @@ extension WorkspaceState {
             await Self.mapTimelineOffMain(
                 page: page,
                 activeAccountIdHex: activeAccountIdHex,
-                senderProfiles: senderProfiles
+                senderProfiles: senderProfiles,
+                mentionNames: mentionNames
             )
         }
         guard
@@ -485,6 +487,7 @@ extension WorkspaceState {
                 client: client
             )
         }
+        let mentionNames = cachedMentionNames(groupIdHex: groupIdHex)
         guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
         // Map only the changed records off the main actor (same pure transformation as the
         // window path), then re-check the selection guard after the await before mutating
@@ -498,7 +501,8 @@ extension WorkspaceState {
             await Self.mapTimelineOffMain(
                 page: upsertPage,
                 activeAccountIdHex: activeAccountIdHex,
-                senderProfiles: senderProfiles
+                senderProfiles: senderProfiles,
+                mentionNames: mentionNames
             )
         }
         guard activeAccountId == account.id, selectedChat?.id == groupIdHex else { return }
@@ -833,7 +837,7 @@ extension WorkspaceState {
     }
 
     func sendDraft() async {
-        let text = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = canonicalizeMentions(in: draftText.trimmingCharacters(in: .whitespacesAndNewlines))
         let mediaAttachments = pendingMediaAttachments
         // `!isSending` is the reentrancy guard: `isSending` flips synchronously here,
         // but the model only suspends (and `draftText` is only cleared) at the `await`

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1210,7 +1210,8 @@ final class WorkspaceState {
     nonisolated static func mapTimelineOffMain(
         page: TimelinePageFfi,
         activeAccountIdHex: String?,
-        senderProfiles: [String: ChatPeerProfile]
+        senderProfiles: [String: ChatPeerProfile],
+        mentionNames: MarkdownMentionNames
     ) async -> [MessageItem] {
         await withCheckedContinuation { (continuation: CheckedContinuation<[MessageItem], Never>) in
             Self.ffiQueue.async {
@@ -1218,7 +1219,8 @@ final class WorkspaceState {
                     returning: MessageItem.timeline(
                         from: page,
                         activeAccountIdHex: activeAccountIdHex,
-                        senderProfiles: senderProfiles
+                        senderProfiles: senderProfiles,
+                        mentionNames: mentionNames
                     )
                 )
             }

--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -2,6 +2,11 @@ import Foundation
 import MarmotKit
 import SwiftUI
 
+/// npub/nprofile bech32 → known display name, keyed as the entity carries it (`entity.bech32`).
+/// Empty when no roster is loaded, in which case mentions keep their truncated-bech32 fallback.
+/// Injected through the builder so the transformation stays pure and off-main.
+typealias MarkdownMentionNames = [String: String]
+
 // Pure FFI → display-model transformation (built off-main while mapping a timeline window,
 // read on the main actor by the views). Marked `nonisolated` so it does not inherit the
 // module's default main-actor isolation — otherwise constructing it from `MessageItem.init`
@@ -30,11 +35,12 @@ nonisolated struct MarkdownDisplayDocument {
     /// than preserving nested structure.
     fileprivate static let maxDepth = 32
 
-    init(document: MarkdownDocumentFfi) {
+    init(document: MarkdownDocumentFfi, mentionNames: MarkdownMentionNames = [:]) {
         var swiftTruncated = false
         self.blocks = Self.makeBlocks(
             from: document.blocks,
             remainingDepth: Self.maxDepth,
+            mentionNames: mentionNames,
             truncated: &swiftTruncated
         )
         self.truncated = document.truncated || swiftTruncated
@@ -43,6 +49,7 @@ nonisolated struct MarkdownDisplayDocument {
     fileprivate static func makeBlocks(
         from blocks: [MarkdownBlockFfi],
         remainingDepth: Int,
+        mentionNames: MarkdownMentionNames,
         truncated: inout Bool
     ) -> [MarkdownDisplayBlockNode] {
         guard remainingDepth > 0 else {
@@ -55,6 +62,7 @@ nonisolated struct MarkdownDisplayDocument {
                 block: MarkdownDisplayBlock(
                     block,
                     remainingDepth: remainingDepth,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -77,13 +85,14 @@ nonisolated enum MarkdownDisplayBlock {
     case table(header: [MarkdownDisplayTableCell], rows: [MarkdownDisplayTableRow])
     case mathBlock(String)
 
-    init(_ block: MarkdownBlockFfi, remainingDepth: Int, truncated: inout Bool) {
+    init(_ block: MarkdownBlockFfi, remainingDepth: Int, mentionNames: MarkdownMentionNames, truncated: inout Bool) {
         switch block {
         case .paragraph(let inlines):
             self = .paragraph(
                 MarkdownDisplayInlineBuilder.attributedString(
                     from: inlines,
                     remainingDepth: remainingDepth,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -93,6 +102,7 @@ nonisolated enum MarkdownDisplayBlock {
                 text: MarkdownDisplayInlineBuilder.attributedString(
                     from: inlines,
                     remainingDepth: remainingDepth,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -105,6 +115,7 @@ nonisolated enum MarkdownDisplayBlock {
                 MarkdownDisplayDocument.makeBlocks(
                     from: blocks,
                     remainingDepth: remainingDepth - 1,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -114,6 +125,7 @@ nonisolated enum MarkdownDisplayBlock {
                     kind: kind,
                     items: items,
                     remainingDepth: remainingDepth,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -122,6 +134,7 @@ nonisolated enum MarkdownDisplayBlock {
                 header: Self.tableCells(
                     from: header,
                     remainingDepth: remainingDepth,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 ),
                 rows: rows.enumerated().map { rowIndex, row in
@@ -130,6 +143,7 @@ nonisolated enum MarkdownDisplayBlock {
                         cells: Self.tableCells(
                             from: row,
                             remainingDepth: remainingDepth,
+                            mentionNames: mentionNames,
                             truncated: &truncated
                         )
                     )
@@ -146,6 +160,7 @@ nonisolated enum MarkdownDisplayBlock {
         kind: MarkdownListKindFfi,
         items: [MarkdownListItemFfi],
         remainingDepth: Int,
+        mentionNames: MarkdownMentionNames,
         truncated: inout Bool
     ) -> [MarkdownDisplayListItem] {
         items.enumerated().map { index, item in
@@ -155,6 +170,7 @@ nonisolated enum MarkdownDisplayBlock {
                 blocks: MarkdownDisplayDocument.makeBlocks(
                     from: item.blocks,
                     remainingDepth: remainingDepth - 1,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -182,6 +198,7 @@ nonisolated enum MarkdownDisplayBlock {
     private static func tableCells(
         from cells: [MarkdownTableCellFfi],
         remainingDepth: Int,
+        mentionNames: MarkdownMentionNames,
         truncated: inout Bool
     ) -> [MarkdownDisplayTableCell] {
         cells.enumerated().map { index, cell in
@@ -190,6 +207,7 @@ nonisolated enum MarkdownDisplayBlock {
                 text: MarkdownDisplayInlineBuilder.attributedString(
                     from: cell.inlines,
                     remainingDepth: remainingDepth,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -219,14 +237,24 @@ nonisolated struct MarkdownDisplayTableRow: Identifiable {
 }
 
 nonisolated enum MarkdownDisplayInlineBuilder {
-    static func attributedString(from inlines: [MarkdownInlineFfi], remainingDepth: Int) -> AttributedString {
+    static func attributedString(
+        from inlines: [MarkdownInlineFfi],
+        remainingDepth: Int,
+        mentionNames: MarkdownMentionNames = [:]
+    ) -> AttributedString {
         var truncated = false
-        return attributedString(from: inlines, remainingDepth: remainingDepth, truncated: &truncated)
+        return attributedString(
+            from: inlines,
+            remainingDepth: remainingDepth,
+            mentionNames: mentionNames,
+            truncated: &truncated
+        )
     }
 
     fileprivate static func attributedString(
         from inlines: [MarkdownInlineFfi],
         remainingDepth: Int,
+        mentionNames: MarkdownMentionNames,
         truncated: inout Bool
     ) -> AttributedString {
         guard remainingDepth > 0 else {
@@ -241,6 +269,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     intent: [],
                     link: nil,
                     remainingDepth: remainingDepth,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -253,6 +282,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         intent: InlinePresentationIntent,
         link: URL?,
         remainingDepth: Int,
+        mentionNames: MarkdownMentionNames,
         truncated: inout Bool
     ) -> AttributedString {
         switch inline {
@@ -270,6 +300,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 intent: intent.union(.emphasized),
                 link: link,
                 remainingDepth: remainingDepth - 1,
+                mentionNames: mentionNames,
                 truncated: &truncated
             )
         case .strong(let children):
@@ -278,6 +309,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 intent: intent.union(.stronglyEmphasized),
                 link: link,
                 remainingDepth: remainingDepth - 1,
+                mentionNames: mentionNames,
                 truncated: &truncated
             )
         case .strikethrough(let children):
@@ -286,12 +318,14 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 intent: intent.union(.strikethrough),
                 link: link,
                 remainingDepth: remainingDepth - 1,
+                mentionNames: mentionNames,
                 truncated: &truncated
             )
         case .link(let dest, _, let children):
             return concat(
                 children, intent: intent, link: MarkdownLinkPolicy.sanitizedURL(from: dest),
                 remainingDepth: remainingDepth - 1,
+                mentionNames: mentionNames,
                 truncated: &truncated
             )
         case .image(_, let title, let alt):
@@ -301,6 +335,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     intent: intent,
                     link: link,
                     remainingDepth: remainingDepth - 1,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             }
@@ -310,7 +345,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         case .math(let content):
             return styled(content, intent: intent.union(.code), link: link)
         case .nostrMention(let entity), .nostrUri(let entity):
-            return nostrEntity(entity, intent: intent)
+            return nostrEntity(entity, intent: intent, mentionNames: mentionNames)
         @unknown default:
             return AttributedString()
         }
@@ -321,6 +356,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         intent: InlinePresentationIntent,
         link: URL?,
         remainingDepth: Int,
+        mentionNames: MarkdownMentionNames,
         truncated: inout Bool
     ) -> AttributedString {
         guard remainingDepth > 0 else {
@@ -335,6 +371,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     intent: intent,
                     link: link,
                     remainingDepth: remainingDepth,
+                    mentionNames: mentionNames,
                     truncated: &truncated
                 )
             )
@@ -367,22 +404,37 @@ nonisolated enum MarkdownDisplayInlineBuilder {
 
     private static func nostrEntity(
         _ entity: MarkdownNostrEntityFfi,
-        intent: InlinePresentationIntent
+        intent: InlinePresentationIntent,
+        mentionNames: MarkdownMentionNames
     ) -> AttributedString {
         let shortReference = shortBech32(entity.bech32)
         let displayText: String
+        var isMention = false
         switch entity.hrp {
         case .npub, .nprofile:
-            displayText = "@\(shortReference)"
+            // A known group member renders as "@Display Name"; otherwise the truncated bech32
+            // keeps the reference legible and tappable.
+            if let name = PeerDisplayText.sanitize(mentionNames[entity.bech32]) {
+                displayText = "@\(name)"
+            } else {
+                displayText = "@\(shortReference)"
+            }
+            isMention = true
         case .note, .nevent, .naddr, .nrelay:
             displayText = shortReference
         @unknown default:
             displayText = shortReference
         }
+        // No baked foreground color: the bubble owns `.tint` so the linked reference stays visible
+        // on both sent and received. A mention is set off by a subtle background pill (Signal's
+        // treatment) rather than bold weight or a color — `.primary` adapts to light/dark and the
+        // low alpha reads as a soft highlight over either bubble fill.
         var attributed = AttributedString(displayText)
-        attributed.foregroundColor = .accentColor
         if !intent.isEmpty {
             attributed.inlinePresentationIntent = intent
+        }
+        if isMention {
+            attributed.backgroundColor = Color.primary.opacity(0.14)
         }
         if let link = MarkdownLinkPolicy.nostrURL(for: entity.bech32) {
             attributed.link = link

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1660,6 +1660,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         senderPictureURL: String? = nil,
         body: String,
         contentMarkdown: MarkdownDocumentFfi? = nil,
+        mentionNames: MarkdownMentionNames = [:],
         sentAt: Date,
         timelineAt: UInt64? = nil,
         timelineKind: UInt64 = 9,
@@ -1683,7 +1684,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         self.senderName = senderName
         self.senderPictureURL = senderPictureURL
         self.body = body
-        self.contentMarkdown = contentMarkdown.map(MarkdownDisplayDocument.init(document:))
+        self.contentMarkdown = contentMarkdown.map { MarkdownDisplayDocument(document: $0, mentionNames: mentionNames) }
         self.trimmedBody = trimmedBody
         self.sentAt = sentAt
         // `timelineAt` is normally supplied by the core mapping; the fallback derives it from

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -18,11 +18,29 @@ struct ComposerEmojiInsertion: Equatable {
     let emoji: String
 }
 
+/// An open "@query" left of the caret, published by the text view so the shell can show the
+/// mention picker. `tokenRange` is the "@…caret" span to replace when a candidate is chosen.
+struct ComposerMentionContext: Equatable {
+    let query: String
+    let tokenRange: NSRange
+}
+
+/// A caret-preserving mention insertion the text view applies on the next update, mirroring
+/// `ComposerEmojiInsertion` but replacing the "@query" token rather than the current selection.
+struct ComposerMentionInsertion: Equatable {
+    let id = UUID()
+    let range: NSRange
+    let replacement: String
+}
+
 struct ComposerMessageInputView: View {
     @Binding var text: String
     let placeholder: String
     let emojiInsertion: ComposerEmojiInsertion?
     let onEmojiInsertionConsumed: (UUID) -> Void
+    let mentionInsertion: ComposerMentionInsertion?
+    let onMentionInsertionConsumed: (UUID) -> Void
+    let onMentionContextChange: (ComposerMentionContext?) -> Void
     let onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
     let onSend: () -> Void
 
@@ -35,6 +53,9 @@ struct ComposerMessageInputView: View {
                 measuredHeight: $measuredHeight,
                 emojiInsertion: emojiInsertion,
                 onEmojiInsertionConsumed: onEmojiInsertionConsumed,
+                mentionInsertion: mentionInsertion,
+                onMentionInsertionConsumed: onMentionInsertionConsumed,
+                onMentionContextChange: onMentionContextChange,
                 onPasteMedia: onPasteMedia,
                 onSend: onSend
             )
@@ -55,6 +76,80 @@ struct ComposerMessageInputView: View {
 private enum ComposerMessageInputMetrics {
     static let minHeight: CGFloat = 20
     static let maxHeight: CGFloat = 96
+}
+
+/// Autocomplete list of mentionable group members, shown above the composer while an "@query"
+/// is open. Mouse-driven selection; the caret stays in the text field.
+struct ComposerMentionPicker: View {
+    let candidates: [ComposerMentionCandidate]
+    let onSelect: (ComposerMentionCandidate) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(candidates) { candidate in
+                ComposerMentionRow(candidate: candidate) {
+                    onSelect(candidate)
+                }
+                if candidate.id != candidates.last?.id {
+                    Divider().padding(.leading, 44)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.14), radius: 12, y: 4)
+        .accessibilityIdentifier("composer.mentionPicker")
+    }
+}
+
+private struct ComposerMentionRow: View {
+    let candidate: ComposerMentionCandidate
+    let onSelect: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 8) {
+                ProfileImageAvatarView(
+                    seed: candidate.accountIdHex,
+                    initials: candidate.displayName,
+                    sanitizedPictureURL: nil,
+                    size: 26,
+                    isSelected: false
+                )
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(candidate.displayName)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    if !candidate.npub.isEmpty {
+                        Text(DisplayText.short(candidate.npub))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+            .background {
+                if isHovered {
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.14))
+                        .padding(.horizontal, 4)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
 }
 
 nonisolated enum ComposerReturnKeyAction: Equatable {
@@ -84,11 +179,20 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
     @Binding var measuredHeight: CGFloat
     let emojiInsertion: ComposerEmojiInsertion?
     let onEmojiInsertionConsumed: (UUID) -> Void
+    let mentionInsertion: ComposerMentionInsertion?
+    let onMentionInsertionConsumed: (UUID) -> Void
+    let onMentionContextChange: (ComposerMentionContext?) -> Void
     let onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
     let onSend: () -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, measuredHeight: $measuredHeight, onPasteMedia: onPasteMedia, onSend: onSend)
+        Coordinator(
+            text: $text,
+            measuredHeight: $measuredHeight,
+            onPasteMedia: onPasteMedia,
+            onSend: onSend,
+            onMentionContextChange: onMentionContextChange
+        )
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -132,6 +236,8 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         context.coordinator.onPasteMedia = onPasteMedia
         context.coordinator.onSend = onSend
         context.coordinator.onEmojiInsertionConsumed = onEmojiInsertionConsumed
+        context.coordinator.onMentionInsertionConsumed = onMentionInsertionConsumed
+        context.coordinator.onMentionContextChange = onMentionContextChange
 
         guard let textView = scrollView.documentView as? ComposerPasteInterceptingTextView else { return }
         configureHandlers(for: textView, coordinator: context.coordinator)
@@ -140,6 +246,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             textView.string = text
         }
         context.coordinator.insertEmojiIfNeeded(emojiInsertion, into: textView)
+        context.coordinator.insertMentionIfNeeded(mentionInsertion, into: textView)
         DispatchQueue.main.async {
             context.coordinator.updateMeasuredHeight(for: textView)
         }
@@ -161,20 +268,28 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         var onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
         var onSend: () -> Void
         var onEmojiInsertionConsumed: (UUID) -> Void
+        var onMentionInsertionConsumed: (UUID) -> Void
+        var onMentionContextChange: (ComposerMentionContext?) -> Void
         private var lastEmojiInsertionID: UUID?
+        private var lastMentionInsertionID: UUID?
+        private var lastMentionContext: ComposerMentionContext?
 
         init(
             text: Binding<String>,
             measuredHeight: Binding<CGFloat>,
             onPasteMedia: @escaping ([OutgoingMediaPasteboardAttachment]) -> Void,
             onSend: @escaping () -> Void,
-            onEmojiInsertionConsumed: @escaping (UUID) -> Void = { _ in }
+            onEmojiInsertionConsumed: @escaping (UUID) -> Void = { _ in },
+            onMentionInsertionConsumed: @escaping (UUID) -> Void = { _ in },
+            onMentionContextChange: @escaping (ComposerMentionContext?) -> Void = { _ in }
         ) {
             self.text = text
             self.measuredHeight = measuredHeight
             self.onPasteMedia = onPasteMedia
             self.onSend = onSend
             self.onEmojiInsertionConsumed = onEmojiInsertionConsumed
+            self.onMentionInsertionConsumed = onMentionInsertionConsumed
+            self.onMentionContextChange = onMentionContextChange
         }
 
         func insertEmojiIfNeeded(_ insertion: ComposerEmojiInsertion?, into textView: NSTextView) {
@@ -188,10 +303,54 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             onEmojiInsertionConsumed(insertion.id)
         }
 
+        func insertMentionIfNeeded(_ insertion: ComposerMentionInsertion?, into textView: NSTextView) {
+            guard let insertion, insertion.id != lastMentionInsertionID else { return }
+            lastMentionInsertionID = insertion.id
+            let bounds = NSRange(location: 0, length: (textView.string as NSString).length)
+            // The token range was captured on an earlier text snapshot; drop it if the text has
+            // since shrunk past it rather than inserting at a stale offset.
+            guard NSMaxRange(insertion.range) <= bounds.length else {
+                onMentionInsertionConsumed(insertion.id)
+                return
+            }
+            textView.insertText(insertion.replacement, replacementRange: insertion.range)
+            text.wrappedValue = textView.string
+            updateMeasuredHeight(for: textView)
+            textView.window?.makeFirstResponder(textView)
+            publishMentionContext(for: textView)
+            onMentionInsertionConsumed(insertion.id)
+        }
+
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
             text.wrappedValue = textView.string
             updateMeasuredHeight(for: textView)
+            publishMentionContext(for: textView)
+        }
+
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            publishMentionContext(for: textView)
+        }
+
+        /// Recompute the open mention query left of the caret and forward it upward when it
+        /// changes, so the picker tracks both typing and caret moves.
+        private func publishMentionContext(for textView: NSTextView) {
+            let context = Self.mentionContext(in: textView)
+            guard context != lastMentionContext else { return }
+            lastMentionContext = context
+            onMentionContextChange(context)
+        }
+
+        private static func mentionContext(in textView: NSTextView) -> ComposerMentionContext? {
+            let selection = textView.selectedRange()
+            guard selection.length == 0 else { return nil }
+            let full = textView.string
+            guard let caret = Range(NSRange(location: selection.location, length: 0), in: full)?.lowerBound,
+                let session = ComposerMentionQuery.active(in: full, upTo: caret),
+                !ComposerMentionQuery.looksLikeCompleteNpub(session.query)
+            else { return nil }
+            return ComposerMentionContext(query: session.query, tokenRange: NSRange(session.range, in: full))
         }
 
         func handleMediaPaste() -> Bool {

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -434,6 +434,9 @@ struct MessageBubble: View {
                 )
                 .font(.system(size: 15.5))
                 .foregroundStyle(message.isOutgoing ? .white : .primary)
+                // Links and @-mentions (no baked color) render in the tint: white on the sent
+                // gradient so they stay visible, accent on received so they read as links.
+                .tint(message.isOutgoing ? .white : .accentColor)
                 .multilineTextAlignment(.leading)
             }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -368,6 +368,8 @@ private struct ConversationView: View {
     @State private var isFileDropTargeted = false
     @State private var isComposerEmojiPickerPresented = false
     @State private var composerEmojiInsertion: ComposerEmojiInsertion?
+    @State private var composerMentionContext: ComposerMentionContext?
+    @State private var composerMentionInsertion: ComposerMentionInsertion?
     @State private var imageGallery: MessageImageGalleryPresentation?
     /// Hover-scoped text-selection gate for chat bubbles. Not read by `body` — bubbles
     /// register local `isSelectable` state so hover only updates the previous and active row
@@ -705,6 +707,20 @@ private struct ConversationView: View {
             )
         }
 
+        if let context = composerMentionContext {
+            let candidates = workspace.mentionCandidates(matching: context.query)
+            if !candidates.isEmpty {
+                ComposerMentionPicker(candidates: candidates) { candidate in
+                    composerMentionInsertion = ComposerMentionInsertion(
+                        range: context.tokenRange,
+                        replacement: "@\(candidate.displayName) "
+                    )
+                    composerMentionContext = nil
+                }
+                .padding(.bottom, 6)
+            }
+        }
+
         if workspace.isRecordingVoiceMessage {
             VoiceRecordingComposerView(
                 samples: workspace.voiceRecordingSamples,
@@ -760,6 +776,17 @@ private struct ConversationView: View {
                     onEmojiInsertionConsumed: { insertionID in
                         guard composerEmojiInsertion?.id == insertionID else { return }
                         composerEmojiInsertion = nil
+                    },
+                    mentionInsertion: composerMentionInsertion,
+                    onMentionInsertionConsumed: { insertionID in
+                        guard composerMentionInsertion?.id == insertionID else { return }
+                        composerMentionInsertion = nil
+                    },
+                    onMentionContextChange: { context in
+                        composerMentionContext = context
+                        if context != nil {
+                            workspace.ensureMentionRosterLoaded()
+                        }
                     },
                     onPasteMedia: { attachments in
                         guard workspace.editingMessageContext == nil else { return }


### PR DESCRIPTION
Adds @-mentions to the group composer and renders them throughout the app.

## Composer
- Typing `@` opens a member picker above the input, filtered live (name, npub, or hex), capped at 8. Choosing a member inserts `@Display Name` at the caret, preserving the cursor and undo history.
- On send, each `@Display Name` is canonicalized to the member's `@npub…` at a single point, so mentions travel as stable public keys and interoperate with other clients. Covers plain sends, replies, edits, and media captions.

## Rendering
- The transcript resolves `@npub…` back to `@Display Name` for known members, falling back to the truncated bech32 when the name isn't known. A resolver map is threaded through the pure Markdown builder; the map is built from the group roster at the timeline map sites.
- Mentions are set off with a subtle background highlight — no bold, no recolor — and stay tappable. Links and mentions now inherit the bubble tint (white on sent, accent on received), fixing accent-on-accent invisibility on sent bubbles.
- Chat-list previews resolve member mentions to names too, reusing the roster already loaded during list enrichment (and the cached roster on the live new-message path) — no extra lookups.

## Notes
- Stacked on `transcript-bubble-parity` (#636) — review/merge that first.
- Follow-ups: mentions inside an edited message aren't resolved back yet; previews for groups not opened this session (cold roster) still show the short npub; the picker is mouse-driven (keyboard nav to come).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/637">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `@mention` autocomplete when composing messages in group chats.
  * Search group members by display name, npub, or member ID, then insert a selected mention.
  * Automatically converts selected mentions to their canonical format when sending.
  * Displays readable member names for mentions in chat lists, timelines, and message previews.
* **Style**
  * Improved mention and link visibility in outgoing and incoming message bubbles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->