### PR TITLE
Group Shared Media browser and a members picker

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -1344,7 +1344,8 @@ private nonisolated extension MessageReaction {
                 emoji: reaction.emoji,
                 count: reaction.senders.count,
                 isOwn: activeAccountIdHex.map { reaction.senders.contains($0) } ?? false,
-                ownReactionMessageId: ownReactionIdsByEmoji[reaction.emoji]
+                ownReactionMessageId: ownReactionIdsByEmoji[reaction.emoji],
+                senders: reaction.senders
             )
         }
     }

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -291,6 +291,12 @@ extension WorkspaceState {
             if groupDetailsSnapshot?.groupIdHex == groupIdHex {
                 await loadGroupDetails(groupIdHex: groupIdHex)
             }
+            // Those two awaits suspended the actor (and `loadGroupDetails` bumps the mutation
+            // generation), so re-validate the captured account/group before touching state — an
+            // account switch mid-reconcile must not write this error into a different workspace.
+            guard activeAccountId == accountId, groupDetailsSnapshot?.groupIdHex == groupIdHex else {
+                return false
+            }
             let currentMemberIds = Set(groupDetailsSnapshot?.members.map(\.id) ?? [])
             if !currentMemberIds.isEmpty,
                 recipients.allSatisfy({ currentMemberIds.contains($0.accountIdHex) })
@@ -597,8 +603,11 @@ extension WorkspaceState {
                 disappearingMessageSecs: seconds
             )
             // Keep the mounted conversation header's timer in sync — it reads
-            // `conversationMetadataByChat`, which the details reload below does not touch.
+            // `conversationMetadataByChat`, which the details reload below does not touch. Bump the
+            // metadata generation so an older in-flight `refreshConversationMetadata` (which
+            // captured the pre-change value) can't complete afterward and overwrite this.
             if let existing = conversationMetadataByChat[groupIdHex] {
+                conversationMetadataGenerationByChat[groupIdHex, default: 0] &+= 1
                 conversationMetadataByChat[groupIdHex] = ConversationMetadata(
                     memberCount: existing.memberCount,
                     disappearingMessageSecs: seconds,

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -288,13 +288,15 @@ extension WorkspaceState {
             // a member, the invite succeeded despite the read error — report success so the sheet
             // dismisses and a retry doesn't hit "already a member".
             await reloadChats(forceFreshSnapshot: true)
-            if groupDetailsSnapshot?.groupIdHex == groupIdHex {
-                await loadGroupDetails(groupIdHex: groupIdHex)
+            // Every await here suspends the actor, so re-validate the full presentation context
+            // after each one — not just the snapshot: a switch to another chat leaves the old
+            // snapshot temporarily intact (`loadGroupDetails` early-returns for a deselected
+            // group), and this error must not land in whatever the user is looking at now.
+            guard isInviteReconciliationTargetCurrent(accountId: accountId, groupIdHex: groupIdHex) else {
+                return false
             }
-            // Those two awaits suspended the actor (and `loadGroupDetails` bumps the mutation
-            // generation), so re-validate the captured account/group before touching state — an
-            // account switch mid-reconcile must not write this error into a different workspace.
-            guard activeAccountId == accountId, groupDetailsSnapshot?.groupIdHex == groupIdHex else {
+            await loadGroupDetails(groupIdHex: groupIdHex)
+            guard isInviteReconciliationTargetCurrent(accountId: accountId, groupIdHex: groupIdHex) else {
                 return false
             }
             let currentMemberIds = Set(groupDetailsSnapshot?.members.map(\.id) ?? [])
@@ -590,6 +592,19 @@ extension WorkspaceState {
         }
     }
 
+    /// The invite-failure reconciliation may only touch workspace state while the user is still
+    /// on the same account, with the same group selected, and its details still presented.
+    private func isInviteReconciliationTargetCurrent(accountId: String?, groupIdHex: String) -> Bool {
+        guard
+            activeAccountId == accountId,
+            isGroupDetailsPresented,
+            groupDetailsSnapshot?.groupIdHex == groupIdHex,
+            case .chat(let selectedGroupId) = selection,
+            selectedGroupId == groupIdHex
+        else { return false }
+        return true
+    }
+
     func setDisappearingMessages(groupIdHex: String, seconds: UInt64) async {
         guard let client, let activeAccount, !hasInFlightGroupCommit else { return }
         lastError = nil
@@ -604,15 +619,20 @@ extension WorkspaceState {
             )
             // Keep the mounted conversation header's timer in sync — it reads
             // `conversationMetadataByChat`, which the details reload below does not touch. Bump the
-            // metadata generation so an older in-flight `refreshConversationMetadata` (which
-            // captured the pre-change value) can't complete afterward and overwrite this.
+            // metadata generation unconditionally so an older in-flight
+            // `refreshConversationMetadata` (which captured the pre-change value) can't complete
+            // afterward and overwrite this — the race exists even while the cache is still empty.
+            conversationMetadataGenerationByChat[groupIdHex, default: 0] &+= 1
             if let existing = conversationMetadataByChat[groupIdHex] {
-                conversationMetadataGenerationByChat[groupIdHex, default: 0] &+= 1
                 conversationMetadataByChat[groupIdHex] = ConversationMetadata(
                     memberCount: existing.memberCount,
                     disappearingMessageSecs: seconds,
                     isSelfAdmin: existing.isSelfAdmin
                 )
+            } else if let chat = activeChats.first(where: { $0.id == groupIdHex }) {
+                // Nothing cached to patch: publish a fresh post-commit read instead (it re-bumps
+                // the generation itself, so it stays newest).
+                await refreshConversationMetadata(for: chat)
             }
             if isGroupDetailsPresented, groupDetailsSnapshot?.groupIdHex == groupIdHex {
                 await loadGroupDetails(groupIdHex: groupIdHex)

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -249,14 +249,16 @@ extension WorkspaceState {
 
     /// Invite one or more already-resolved recipients in a single group commit. Recipients carry a
     /// normalized `npub` from the new-chat resolver, so no per-entry re-normalization is needed.
-    func inviteMembers(_ recipients: [NewChatRecipient]) async {
+    /// Returns `true` when the commit succeeded so the caller can dismiss only on success.
+    @discardableResult
+    func inviteMembers(_ recipients: [NewChatRecipient]) async -> Bool {
         guard let client,
             let activeAccount,
             let snapshot = groupDetailsSnapshot,
             !hasInFlightGroupCommit
-        else { return }
+        else { return false }
         let memberRefs = recipients.map(\.npub).filter { !$0.isEmpty }
-        guard !memberRefs.isEmpty else { return }
+        guard !memberRefs.isEmpty else { return false }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex
         let generation = beginGroupDetailsMutation()
@@ -273,14 +275,16 @@ extension WorkspaceState {
             )
             guard
                 isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
-            else { return }
+            else { return false }
             applyGroupMutationResult(result)
             await reloadChats(forceFreshSnapshot: true)
+            return true
         } catch {
             guard
                 isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
-            else { return }
+            else { return false }
             lastError = error.localizedDescription
+            return false
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -607,6 +607,7 @@ extension WorkspaceState {
 
     func setDisappearingMessages(groupIdHex: String, seconds: UInt64) async {
         guard let client, let activeAccount, !hasInFlightGroupCommit else { return }
+        let accountId = activeAccount.id
         lastError = nil
         isUpdatingDisappearingMessages = true
         defer { isUpdatingDisappearingMessages = false }
@@ -617,6 +618,9 @@ extension WorkspaceState {
                 groupIdHex: groupIdHex,
                 disappearingMessageSecs: seconds
             )
+            // The commit await may have suspended across an account switch — don't sync another
+            // account's header.
+            guard activeAccountId == accountId else { return }
             // Keep the mounted conversation header's timer in sync — it reads
             // `conversationMetadataByChat`, which the details reload below does not touch. Bump the
             // metadata generation unconditionally so an older in-flight
@@ -629,9 +633,10 @@ extension WorkspaceState {
                     disappearingMessageSecs: seconds,
                     isSelfAdmin: existing.isSelfAdmin
                 )
-            } else if let chat = activeChats.first(where: { $0.id == groupIdHex }) {
+            } else if let chat = chatItem(accountId: accountId, chatId: groupIdHex) {
                 // Nothing cached to patch: publish a fresh post-commit read instead (it re-bumps
-                // the generation itself, so it stays newest).
+                // the generation itself, so it stays newest). `chatItem` spans active *and*
+                // archived indexes, so an archived group that's open still gets its header updated.
                 await refreshConversationMetadata(for: chat)
             }
             if isGroupDetailsPresented, groupDetailsSnapshot?.groupIdHex == groupIdHex {

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -247,6 +247,43 @@ extension WorkspaceState {
         }
     }
 
+    /// Invite one or more already-resolved recipients in a single group commit. Recipients carry a
+    /// normalized `npub` from the new-chat resolver, so no per-entry re-normalization is needed.
+    func inviteMembers(_ recipients: [NewChatRecipient]) async {
+        guard let client,
+            let activeAccount,
+            let snapshot = groupDetailsSnapshot,
+            !hasInFlightGroupCommit
+        else { return }
+        let memberRefs = recipients.map(\.npub).filter { !$0.isEmpty }
+        guard !memberRefs.isEmpty else { return }
+        let accountId = activeAccount.id
+        let groupIdHex = snapshot.groupIdHex
+        let generation = beginGroupDetailsMutation()
+
+        lastError = nil
+        isInvitingGroupMember = true
+        defer { isInvitingGroupMember = false }
+
+        do {
+            let result = try await client.inviteMembersDetailed(
+                accountRef: activeAccount.accountRef,
+                groupIdHex: groupIdHex,
+                memberRefs: memberRefs
+            )
+            guard
+                isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
+            else { return }
+            applyGroupMutationResult(result)
+            await reloadChats(forceFreshSnapshot: true)
+        } catch {
+            guard
+                isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
+            else { return }
+            lastError = error.localizedDescription
+        }
+    }
+
     func acceptGroupInvite(for chat: ChatItem) async {
         // DMs are 2-person MLS groups, so their welcomes are accepted the same way.
         await acceptGroupInvite(groupIdHex: chat.id)

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -283,6 +283,20 @@ extension WorkspaceState {
             guard
                 isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
             else { return false }
+            // `inviteMembersDetailed` can throw while reading post-commit details *after* the MLS
+            // invite already published. Refresh the roster and reconcile: if every recipient is now
+            // a member, the invite succeeded despite the read error — report success so the sheet
+            // dismisses and a retry doesn't hit "already a member".
+            await reloadChats(forceFreshSnapshot: true)
+            if groupDetailsSnapshot?.groupIdHex == groupIdHex {
+                await loadGroupDetails(groupIdHex: groupIdHex)
+            }
+            let currentMemberIds = Set(groupDetailsSnapshot?.members.map(\.id) ?? [])
+            if !currentMemberIds.isEmpty,
+                recipients.allSatisfy({ currentMemberIds.contains($0.accountIdHex) })
+            {
+                return true
+            }
             lastError = error.localizedDescription
             return false
         }
@@ -582,6 +596,15 @@ extension WorkspaceState {
                 groupIdHex: groupIdHex,
                 disappearingMessageSecs: seconds
             )
+            // Keep the mounted conversation header's timer in sync — it reads
+            // `conversationMetadataByChat`, which the details reload below does not touch.
+            if let existing = conversationMetadataByChat[groupIdHex] {
+                conversationMetadataByChat[groupIdHex] = ConversationMetadata(
+                    memberCount: existing.memberCount,
+                    disappearingMessageSecs: seconds,
+                    isSelfAdmin: existing.isSelfAdmin
+                )
+            }
             if isGroupDetailsPresented, groupDetailsSnapshot?.groupIdHex == groupIdHex {
                 await loadGroupDetails(groupIdHex: groupIdHex)
             }

--- a/whitenoise-mac/Core/WorkspaceState+Reactions.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Reactions.swift
@@ -1,0 +1,51 @@
+//
+//  WorkspaceState+Reactions.swift
+//  whitenoise-mac
+//
+//  Reactor identity resolution for the reaction viewer — display name + avatar for an
+//  account-id-hex, drawn from already-cached data (active account, resolved peer-profile cache,
+//  and the group roster). No FFI, so the viewer stays cheap to render.
+//
+
+import Foundation
+import MarmotKit
+
+@MainActor
+extension WorkspaceState {
+    struct ReactionReactorDisplay: Identifiable, Hashable {
+        let accountIdHex: String
+        let name: String
+        let sanitizedPictureURL: URL?
+        let isSelf: Bool
+        var id: String { accountIdHex }
+    }
+
+    func reactionReactorDisplay(accountIdHex: String) -> ReactionReactorDisplay {
+        if let active = activeAccount, active.accountIdHex == accountIdHex {
+            return ReactionReactorDisplay(
+                accountIdHex: accountIdHex,
+                name: active.displayName,
+                sanitizedPictureURL: RemoteImageURLPolicy.sanitizedURL(from: active.pictureURL),
+                isSelf: true
+            )
+        }
+        let resolved = peerProfileFFICache[accountIdHex]?.resolved
+        let rosterMember = selectedChat.flatMap { chat in
+            groupMemberDetailsCache[chat.id]?.first { $0.memberIdHex == accountIdHex }
+        }
+        let rosterName = rosterMember.flatMap { PeerDisplayText.sanitize($0.displayName) }
+        let name =
+            firstNonBlank([
+                resolved?.profileDisplayName,
+                resolved?.profileName,
+                rosterName,
+                resolved?.directoryDisplayName,
+            ]) ?? DisplayText.short(accountIdHex)
+        return ReactionReactorDisplay(
+            accountIdHex: accountIdHex,
+            name: name,
+            sanitizedPictureURL: RemoteImageURLPolicy.sanitizedURL(from: resolved?.profilePicture),
+            isSelf: false
+        )
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+SharedMedia.swift
+++ b/whitenoise-mac/Core/WorkspaceState+SharedMedia.swift
@@ -22,6 +22,7 @@ extension WorkspaceState {
         if sharedMediaGroupId != groupIdHex {
             sharedMediaRecords = []
             sharedMediaThumbnailCache.removeAll()
+            sharedMediaThumbnailCacheOrder.removeAll()
         }
         sharedMediaGroupId = groupIdHex
         sharedMediaError = nil
@@ -49,6 +50,7 @@ extension WorkspaceState {
         sharedMediaError = nil
         isLoadingSharedMedia = false
         sharedMediaThumbnailCache.removeAll()
+        sharedMediaThumbnailCacheOrder.removeAll()
     }
 
     /// Decrypt one shared-media reference's bytes, honoring the media-display privacy gate and the

--- a/whitenoise-mac/Core/WorkspaceState+SharedMedia.swift
+++ b/whitenoise-mac/Core/WorkspaceState+SharedMedia.swift
@@ -12,22 +12,32 @@ import MarmotKit
 
 @MainActor
 extension WorkspaceState {
-    /// Cap for the decrypted-thumbnail cache; the grid only shows a bounded window, and this keeps
-    /// a scroll-through from pinning every image's plaintext in memory.
-    private static let sharedMediaCacheLimit = 80
+    /// Cache bounds for decrypted thumbnails: a hard entry count, a cumulative byte budget, and a
+    /// per-entry ceiling so a single large image can't dominate memory. File-save payloads bypass
+    /// the cache entirely (see `sharedMediaData(cache:)`).
+    private static let sharedMediaCacheEntryLimit = 80
+    private static let sharedMediaCacheByteBudget = 48 * 1024 * 1024
+    private static let sharedMediaCacheMaxEntryBytes = 8 * 1024 * 1024
 
     func loadSharedMedia(groupIdHex: String) async {
         guard let client, let activeAccount, !groupIdHex.isEmpty else { return }
         // A fresh open of another group clears the previous list so stale thumbnails never flash.
         if sharedMediaGroupId != groupIdHex {
             sharedMediaRecords = []
-            sharedMediaThumbnailCache.removeAll()
-            sharedMediaThumbnailCacheOrder.removeAll()
+            clearSharedMediaCache()
         }
         sharedMediaGroupId = groupIdHex
         sharedMediaError = nil
         isLoadingSharedMedia = true
-        defer { isLoadingSharedMedia = false }
+        sharedMediaLoadGeneration &+= 1
+        let generation = sharedMediaLoadGeneration
+        // Only the still-current load owns the spinner, so a superseded call can't clear it early
+        // and flash a false empty state for the newer one.
+        defer {
+            if generation == sharedMediaLoadGeneration {
+                isLoadingSharedMedia = false
+            }
+        }
 
         let accountId = activeAccount.id
         let accountRef = activeAccount.accountRef
@@ -35,11 +45,15 @@ extension WorkspaceState {
             let records = try await runOffMain {
                 try client.listMedia(accountRef: accountRef, groupIdHex: groupIdHex, limit: nil)
             }
-            // The list FFI suspends this actor; drop the result if the user moved on.
-            guard activeAccountId == accountId, sharedMediaGroupId == groupIdHex else { return }
+            // The list FFI suspends this actor; drop a superseded/stale result.
+            guard generation == sharedMediaLoadGeneration,
+                activeAccountId == accountId, sharedMediaGroupId == groupIdHex
+            else { return }
             sharedMediaRecords = records
         } catch {
-            guard activeAccountId == accountId, sharedMediaGroupId == groupIdHex else { return }
+            guard generation == sharedMediaLoadGeneration,
+                activeAccountId == accountId, sharedMediaGroupId == groupIdHex
+            else { return }
             sharedMediaError = error.localizedDescription
         }
     }
@@ -48,21 +62,34 @@ extension WorkspaceState {
         sharedMediaGroupId = nil
         sharedMediaRecords = []
         sharedMediaError = nil
+        // Supersede any in-flight load so its result/error can't land in the torn-down state.
+        sharedMediaLoadGeneration &+= 1
         isLoadingSharedMedia = false
-        sharedMediaThumbnailCache.removeAll()
-        sharedMediaThumbnailCacheOrder.removeAll()
+        clearSharedMediaCache()
     }
 
-    /// Decrypt one shared-media reference's bytes, honoring the media-display privacy gate and the
-    /// shared download limiter. Cached by plaintext hash so repeated grid passes don't re-decrypt.
-    func sharedMediaData(for reference: MediaAttachmentReferenceFfi, groupIdHex: String) async -> Data? {
-        let cacheKey = reference.plaintextSha256.lowercased()
-        if !cacheKey.isEmpty, let cached = sharedMediaThumbnailCache[cacheKey] {
+    private func clearSharedMediaCache() {
+        sharedMediaThumbnailCache.removeAll()
+        sharedMediaThumbnailCacheOrder.removeAll()
+        sharedMediaThumbnailCacheBytes = 0
+    }
+
+    /// Decrypt one shared-media reference's bytes. Honors the media-display privacy gate before a
+    /// cache hit and again after the download, and re-checks the captured account/group so a
+    /// download completing after an account/group switch cannot leak plaintext into the new state.
+    /// Pass `cache: false` for file saves so large documents never sit in the thumbnail cache.
+    func sharedMediaData(
+        for reference: MediaAttachmentReferenceFfi,
+        groupIdHex: String,
+        cache: Bool = true
+    ) async -> Data? {
+        guard let client, let activeAccount, !groupIdHex.isEmpty else { return nil }
+        let accountId = activeAccount.id
+        guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else { return nil }
+        let cacheKey = sharedMediaCacheKey(accountId: accountId, groupIdHex: groupIdHex, reference: reference)
+        if cache, let cacheKey, let cached = sharedMediaThumbnailCache[cacheKey] {
             return cached
         }
-        guard let client, let activeAccount, !groupIdHex.isEmpty,
-            isMediaDisplayAllowed(forAccountId: activeAccount.id, groupIdHex: groupIdHex)
-        else { return nil }
         let accountRef = activeAccount.accountRef
         do {
             try await MediaAttachmentDownloadLimiter.shared.acquire()
@@ -72,24 +99,49 @@ extension WorkspaceState {
                 groupIdHex: groupIdHex,
                 reference: reference
             )
-            cacheSharedMediaData(download.plaintext, key: cacheKey)
+            // The download suspended this actor; a switch/teardown may have occurred. Re-check the
+            // captured account/group and the privacy gate before returning or caching plaintext.
+            guard activeAccountId == accountId, sharedMediaGroupId == groupIdHex,
+                isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex)
+            else { return nil }
+            if cache, let cacheKey {
+                cacheSharedMediaData(download.plaintext, key: cacheKey)
+            }
             return download.plaintext
         } catch {
             return nil
         }
     }
 
+    private func sharedMediaCacheKey(
+        accountId: String,
+        groupIdHex: String,
+        reference: MediaAttachmentReferenceFfi
+    ) -> String? {
+        let hash = reference.plaintextSha256.lowercased()
+        guard !hash.isEmpty else { return nil }
+        return "\(accountId)\u{1F}\(groupIdHex)\u{1F}\(hash)"
+    }
+
     private func cacheSharedMediaData(_ data: Data, key: String) {
-        guard !key.isEmpty else { return }
-        if sharedMediaThumbnailCache.count >= Self.sharedMediaCacheLimit,
-            let oldest = sharedMediaThumbnailCacheOrder.first
+        guard data.count <= Self.sharedMediaCacheMaxEntryBytes else { return }
+        // Evict oldest until under both the entry-count and byte budgets.
+        while sharedMediaThumbnailCache[key] == nil,
+            !sharedMediaThumbnailCacheOrder.isEmpty,
+            sharedMediaThumbnailCache.count >= Self.sharedMediaCacheEntryLimit
+                || sharedMediaThumbnailCacheBytes + data.count > Self.sharedMediaCacheByteBudget
         {
-            sharedMediaThumbnailCache[oldest] = nil
-            sharedMediaThumbnailCacheOrder.removeFirst()
+            let oldest = sharedMediaThumbnailCacheOrder.removeFirst()
+            if let removed = sharedMediaThumbnailCache.removeValue(forKey: oldest) {
+                sharedMediaThumbnailCacheBytes -= removed.count
+            }
         }
-        if sharedMediaThumbnailCache[key] == nil {
+        if let existing = sharedMediaThumbnailCache[key] {
+            sharedMediaThumbnailCacheBytes -= existing.count
+        } else {
             sharedMediaThumbnailCacheOrder.append(key)
         }
         sharedMediaThumbnailCache[key] = data
+        sharedMediaThumbnailCacheBytes += data.count
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState+SharedMedia.swift
+++ b/whitenoise-mac/Core/WorkspaceState+SharedMedia.swift
@@ -1,0 +1,93 @@
+//
+//  WorkspaceState+SharedMedia.swift
+//  whitenoise-mac
+//
+//  Group "Shared Media" browser: the media records for a conversation (via the `listMedia` FFI)
+//  and a self-contained decrypt loader for its thumbnails/files, kept separate from the message
+//  timeline's per-message download-state machine so the two never contend on keys or caches.
+//
+
+import Foundation
+import MarmotKit
+
+@MainActor
+extension WorkspaceState {
+    /// Cap for the decrypted-thumbnail cache; the grid only shows a bounded window, and this keeps
+    /// a scroll-through from pinning every image's plaintext in memory.
+    private static let sharedMediaCacheLimit = 80
+
+    func loadSharedMedia(groupIdHex: String) async {
+        guard let client, let activeAccount, !groupIdHex.isEmpty else { return }
+        // A fresh open of another group clears the previous list so stale thumbnails never flash.
+        if sharedMediaGroupId != groupIdHex {
+            sharedMediaRecords = []
+            sharedMediaThumbnailCache.removeAll()
+        }
+        sharedMediaGroupId = groupIdHex
+        sharedMediaError = nil
+        isLoadingSharedMedia = true
+        defer { isLoadingSharedMedia = false }
+
+        let accountId = activeAccount.id
+        let accountRef = activeAccount.accountRef
+        do {
+            let records = try await runOffMain {
+                try client.listMedia(accountRef: accountRef, groupIdHex: groupIdHex, limit: nil)
+            }
+            // The list FFI suspends this actor; drop the result if the user moved on.
+            guard activeAccountId == accountId, sharedMediaGroupId == groupIdHex else { return }
+            sharedMediaRecords = records
+        } catch {
+            guard activeAccountId == accountId, sharedMediaGroupId == groupIdHex else { return }
+            sharedMediaError = error.localizedDescription
+        }
+    }
+
+    func clearSharedMedia() {
+        sharedMediaGroupId = nil
+        sharedMediaRecords = []
+        sharedMediaError = nil
+        isLoadingSharedMedia = false
+        sharedMediaThumbnailCache.removeAll()
+    }
+
+    /// Decrypt one shared-media reference's bytes, honoring the media-display privacy gate and the
+    /// shared download limiter. Cached by plaintext hash so repeated grid passes don't re-decrypt.
+    func sharedMediaData(for reference: MediaAttachmentReferenceFfi, groupIdHex: String) async -> Data? {
+        let cacheKey = reference.plaintextSha256.lowercased()
+        if !cacheKey.isEmpty, let cached = sharedMediaThumbnailCache[cacheKey] {
+            return cached
+        }
+        guard let client, let activeAccount, !groupIdHex.isEmpty,
+            isMediaDisplayAllowed(forAccountId: activeAccount.id, groupIdHex: groupIdHex)
+        else { return nil }
+        let accountRef = activeAccount.accountRef
+        do {
+            try await MediaAttachmentDownloadLimiter.shared.acquire()
+            defer { Task { await MediaAttachmentDownloadLimiter.shared.release() } }
+            let download = try await client.downloadMedia(
+                accountRef: accountRef,
+                groupIdHex: groupIdHex,
+                reference: reference
+            )
+            cacheSharedMediaData(download.plaintext, key: cacheKey)
+            return download.plaintext
+        } catch {
+            return nil
+        }
+    }
+
+    private func cacheSharedMediaData(_ data: Data, key: String) {
+        guard !key.isEmpty else { return }
+        if sharedMediaThumbnailCache.count >= Self.sharedMediaCacheLimit,
+            let oldest = sharedMediaThumbnailCacheOrder.first
+        {
+            sharedMediaThumbnailCache[oldest] = nil
+            sharedMediaThumbnailCacheOrder.removeFirst()
+        }
+        if sharedMediaThumbnailCache[key] == nil {
+            sharedMediaThumbnailCacheOrder.append(key)
+        }
+        sharedMediaThumbnailCache[key] = data
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -918,6 +918,15 @@ final class WorkspaceState {
     var isSavingGroupImage = false
     var isGroupDetailsPresented = false
     var groupDetailsSnapshot: GroupDetailsSnapshot?
+    /// Shared-media browser state for the group-details sheet.
+    var sharedMediaRecords: [MediaRecordFfi] = []
+    var sharedMediaGroupId: String?
+    var sharedMediaError: String?
+    var isLoadingSharedMedia = false
+    /// Decrypted shared-media bytes keyed by plaintext hash, with an insertion-order list bounding
+    /// eviction. `@ObservationIgnored` — views read via the async loader, not by observing this.
+    @ObservationIgnored var sharedMediaThumbnailCache: [String: Data] = [:]
+    @ObservationIgnored var sharedMediaThumbnailCacheOrder: [String] = []
     var conversationMetadataByChat: [String: ConversationMetadata] = [:]
     @ObservationIgnored var conversationMetadataGenerationByChat: [String: UInt64] = [:]
     /// Message ids the local account hid via "Delete for me", keyed by `accountId\u{1F}groupId`.

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -923,10 +923,15 @@ final class WorkspaceState {
     var sharedMediaGroupId: String?
     var sharedMediaError: String?
     var isLoadingSharedMedia = false
-    /// Decrypted shared-media bytes keyed by plaintext hash, with an insertion-order list bounding
-    /// eviction. `@ObservationIgnored` — views read via the async loader, not by observing this.
+    /// Monotonic generation so a superseded `loadSharedMedia` can't clear the spinner or publish a
+    /// stale result/error into a newer load's state.
+    @ObservationIgnored var sharedMediaLoadGeneration: UInt64 = 0
+    /// Decrypted shared-media bytes keyed by account+group+plaintext-hash, with an insertion-order
+    /// list and running byte total bounding eviction. `@ObservationIgnored` — views read via the
+    /// async loader, not by observing this.
     @ObservationIgnored var sharedMediaThumbnailCache: [String: Data] = [:]
     @ObservationIgnored var sharedMediaThumbnailCacheOrder: [String] = []
+    @ObservationIgnored var sharedMediaThumbnailCacheBytes = 0
     var conversationMetadataByChat: [String: ConversationMetadata] = [:]
     @ObservationIgnored var conversationMetadataGenerationByChat: [String: UInt64] = [:]
     /// Message ids the local account hid via "Delete for me", keyed by `accountId\u{1F}groupId`.

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -267,12 +267,15 @@ nonisolated struct MessageReaction: Identifiable, Hashable {
     let count: Int
     let isOwn: Bool
     let ownReactionMessageId: String?
+    /// Account-id-hex of everyone who reacted with this emoji, so the reaction viewer can list them.
+    let senders: [String]
 
-    init(emoji: String, count: Int, isOwn: Bool, ownReactionMessageId: String? = nil) {
+    init(emoji: String, count: Int, isOwn: Bool, ownReactionMessageId: String? = nil, senders: [String] = []) {
         self.emoji = emoji
         self.count = count
         self.isOwn = isOwn
         self.ownReactionMessageId = ownReactionMessageId
+        self.senders = senders
     }
 
     var id: String { emoji }

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -1266,6 +1266,27 @@ struct ConversationHeader: View {
     @Environment(WorkspaceState.self) private var workspace
     let chat: ChatItem
 
+    /// Under the chat title: the disappearing-message timer as a bare clock icon + duration (no
+    /// "Disappearing messages:" label) when it's on, otherwise the usual member/DM subtitle.
+    @ViewBuilder
+    private var headerSubtitle: some View {
+        let metadata = workspace.conversationMetadataByChat[chat.id]
+        if let metadata, metadata.disappearingMessageSecs > 0 {
+            HStack(spacing: 4) {
+                Image(systemName: "timer")
+                Text(DisappearingMessageOption.option(for: metadata.disappearingMessageSecs).label)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        } else {
+            Text(metadata?.subtitle ?? chat.subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
     var body: some View {
         @Bindable var workspace = workspace
 
@@ -1312,10 +1333,7 @@ struct ConversationHeader: View {
                                 .lineLimit(1)
                                 .foregroundStyle(.primary)
 
-                            Text(workspace.conversationMetadataByChat[chat.id]?.subtitle ?? chat.subtitle)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
+                            headerSubtitle
                         }
                     }
                     .contentShape(Rectangle())

--- a/whitenoise-mac/Views/GroupAddMembersSheet.swift
+++ b/whitenoise-mac/Views/GroupAddMembersSheet.swift
@@ -1,0 +1,181 @@
+//
+//  GroupAddMembersSheet.swift
+//  whitenoise-mac
+//
+//  A staging picker for inviting people to a group: resolve a NIP-05 / npub / profile link / hex
+//  key to a recipient, stage several, then invite them all in one commit.
+//
+
+import SwiftUI
+
+struct GroupAddMembersSheet: View {
+    @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.dismiss) private var dismiss
+
+    let existingMemberIds: Set<String>
+
+    @State private var query = ""
+    @State private var staged: [NewChatRecipient] = []
+    @State private var isResolving = false
+    @State private var resolveError: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            entryField
+            if let resolveError {
+                Text(resolveError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 6)
+            }
+            Divider()
+            stagedList
+            Divider()
+            footer
+        }
+        .frame(width: 420, height: 460)
+    }
+
+    private var header: some View {
+        HStack {
+            Text(L10n.string("Add members"))
+                .font(.headline)
+            Spacer()
+            Button(L10n.string("Cancel")) { dismiss() }
+                .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var entryField: some View {
+        HStack(spacing: 10) {
+            TextField(L10n.string("NIP-05, npub, profile link, or hex public key"), text: $query)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { Task { await resolveAndStage() } }
+            Button {
+                Task { await resolveAndStage() }
+            } label: {
+                if isResolving {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "plus")
+                }
+            }
+            .disabled(isResolving || query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private var stagedList: some View {
+        if staged.isEmpty {
+            VStack(spacing: 6) {
+                Image(systemName: "person.2")
+                    .font(.title)
+                    .foregroundStyle(.tertiary)
+                Text(L10n.string("No one added yet"))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(staged, id: \.accountIdHex) { recipient in
+                        recipientRow(recipient)
+                        if recipient.accountIdHex != staged.last?.accountIdHex {
+                            Divider().padding(.leading, 54)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private func recipientRow(_ recipient: NewChatRecipient) -> some View {
+        HStack(spacing: 10) {
+            ProfileImageAvatarView(
+                seed: recipient.accountIdHex,
+                initials: recipient.title,
+                sanitizedPictureURL: recipient.sanitizedPictureURL,
+                size: 32,
+                isSelected: false
+            )
+            VStack(alignment: .leading, spacing: 1) {
+                Text(recipient.title)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+                Text(DisplayText.short(recipient.npub))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            Button {
+                staged.removeAll { $0.accountIdHex == recipient.accountIdHex }
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button {
+                let toInvite = staged
+                Task {
+                    await workspace.inviteMembers(toInvite)
+                    dismiss()
+                }
+            } label: {
+                Text(
+                    staged.isEmpty
+                        ? L10n.string("Invite")
+                        : String(format: L10n.string("Invite %lld"), staged.count)
+                )
+                .frame(minWidth: 96)
+            }
+            .keyboardShortcut(.defaultAction)
+            .nativeGlassProminentButtonStyle()
+            .disabled(staged.isEmpty || workspace.hasInFlightGroupCommit)
+        }
+        .padding(16)
+    }
+
+    private func resolveAndStage() async {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isResolving else { return }
+        isResolving = true
+        resolveError = nil
+        defer { isResolving = false }
+        do {
+            guard let recipient = try await workspace.resolveNewChatRecipient(for: trimmed) else {
+                resolveError = L10n.string("Enter a valid npub, profile link, or hex public key.")
+                return
+            }
+            if existingMemberIds.contains(recipient.accountIdHex) {
+                resolveError = L10n.string("That person is already in this group.")
+                return
+            }
+            if staged.contains(where: { $0.accountIdHex == recipient.accountIdHex }) {
+                query = ""
+                return
+            }
+            staged.append(recipient)
+            query = ""
+        } catch {
+            resolveError = L10n.string("Enter a valid npub, profile link, or hex public key.")
+        }
+    }
+}

--- a/whitenoise-mac/Views/GroupAddMembersSheet.swift
+++ b/whitenoise-mac/Views/GroupAddMembersSheet.swift
@@ -180,7 +180,7 @@ struct GroupAddMembersSheet: View {
         defer { isResolving = false }
         do {
             guard let recipient = try await workspace.resolveNewChatRecipient(for: trimmed) else {
-                resolveError = L10n.string("Enter a valid npub, profile link, or hex public key.")
+                resolveError = L10n.string("Enter a valid NIP-05, npub, profile link, or hex public key.")
                 return
             }
             if existingMemberIds.contains(recipient.accountIdHex) {
@@ -194,7 +194,7 @@ struct GroupAddMembersSheet: View {
             staged.append(recipient)
             query = ""
         } catch {
-            resolveError = L10n.string("Enter a valid npub, profile link, or hex public key.")
+            resolveError = L10n.string("Enter a valid NIP-05, npub, profile link, or hex public key.")
         }
     }
 }

--- a/whitenoise-mac/Views/GroupAddMembersSheet.swift
+++ b/whitenoise-mac/Views/GroupAddMembersSheet.swift
@@ -133,24 +133,43 @@ struct GroupAddMembersSheet: View {
         HStack {
             Spacer()
             Button {
-                let toInvite = staged
-                Task {
-                    await workspace.inviteMembers(toInvite)
-                    dismiss()
-                }
+                Task { await inviteStaged() }
             } label: {
-                Text(
-                    staged.isEmpty
-                        ? L10n.string("Invite")
-                        : String(format: L10n.string("Invite %lld"), staged.count)
-                )
-                .frame(minWidth: 96)
+                Text(inviteLabel).frame(minWidth: 96)
             }
             .keyboardShortcut(.defaultAction)
             .nativeGlassProminentButtonStyle()
-            .disabled(staged.isEmpty || workspace.hasInFlightGroupCommit)
+            .disabled(!canInvite || isResolving || workspace.hasInFlightGroupCommit)
         }
         .padding(16)
+    }
+
+    private var pendingQuery: Bool {
+        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var canInvite: Bool {
+        !staged.isEmpty || pendingQuery
+    }
+
+    private var inviteLabel: String {
+        let count = staged.count + (pendingQuery && !staged.isEmpty ? 1 : 0)
+        return count <= 1 ? L10n.string("Invite") : String(format: L10n.string("Invite %lld"), count)
+    }
+
+    /// Fold in any recipient still typed in the field so a single "Invite" (or Return) works even
+    /// when the user didn't press "+" first, then commit. Dismiss only on success.
+    private func inviteStaged() async {
+        if pendingQuery {
+            await resolveAndStage()
+            guard resolveError == nil else { return }
+        }
+        guard !staged.isEmpty else { return }
+        if await workspace.inviteMembers(staged) {
+            dismiss()
+        } else {
+            resolveError = workspace.lastError ?? L10n.string("Couldn't add members.")
+        }
     }
 
     private func resolveAndStage() async {

--- a/whitenoise-mac/Views/GroupSharedMediaViews.swift
+++ b/whitenoise-mac/Views/GroupSharedMediaViews.swift
@@ -170,6 +170,7 @@ private struct SharedMediaThumbnail: View {
     @State private var image: NSImage?
     @State private var imageData: Data?
     @State private var didFail = false
+    @State private var actionError: String?
 
     private var isVideo: Bool { item.attachment.kind == .video }
 
@@ -184,9 +185,11 @@ private struct SharedMediaThumbnail: View {
         .disabled(!canOpen)
         .accessibilityLabel(item.attachment.fileName)
         .task(id: item.id) { await load() }
+        .sharedMediaErrorAlert($actionError)
     }
 
-    private var canOpen: Bool { isVideo || image != nil }
+    // A failed image stays activatable so tapping it retries the download.
+    private var canOpen: Bool { isVideo || image != nil || didFail }
 
     private var tileContent: some View {
         ZStack {
@@ -223,6 +226,9 @@ private struct SharedMediaThumbnail: View {
             await openVideo()
         } else if let imageData {
             onOpen(imageData)
+        } else if didFail {
+            didFail = false
+            await load()
         }
     }
 
@@ -243,7 +249,10 @@ private struct SharedMediaThumbnail: View {
         guard
             let data = await workspace.sharedMediaData(
                 for: item.reference, groupIdHex: item.groupIdHex, cache: false)
-        else { return }
+        else {
+            actionError = L10n.string("Couldn't download this video.")
+            return
+        }
         let download = MessageMediaDownload(
             payload: DownloadedMediaPayload(data: data),
             fileName: item.attachment.fileName,
@@ -253,7 +262,10 @@ private struct SharedMediaThumbnail: View {
         guard
             let url = await MessageMediaPlaybackFileStore.fileURL(
                 attachment: item.attachment, download: download)
-        else { return }
+        else {
+            actionError = L10n.string("Couldn't open this video.")
+            return
+        }
         let didOpen = NSWorkspace.shared.open(url)
         let delay: TimeInterval = didOpen ? 30 : 0
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
@@ -298,6 +310,7 @@ private struct SharedMediaFileRow: View {
     let item: GroupSharedMediaItem
 
     @State private var isSaving = false
+    @State private var saveError: String?
 
     var body: some View {
         HStack(spacing: 10) {
@@ -327,6 +340,7 @@ private struct SharedMediaFileRow: View {
             }
         }
         .padding(.vertical, 2)
+        .sharedMediaErrorAlert($saveError)
     }
 
     private func save() async {
@@ -336,11 +350,38 @@ private struct SharedMediaFileRow: View {
         guard
             let data = await workspace.sharedMediaData(
                 for: item.reference, groupIdHex: item.groupIdHex, cache: false)
-        else { return }
+        else {
+            saveError = L10n.string("Couldn't download this file.")
+            return
+        }
         let panel = NSSavePanel()
         panel.nameFieldStringValue = item.attachment.fileName
         panel.canCreateDirectories = true
+        // A cancelled panel is not an error.
         guard panel.runModal() == .OK, let url = panel.url else { return }
-        try? data.write(to: url, options: .atomic)
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            saveError = error.localizedDescription
+        }
+    }
+}
+
+extension View {
+    /// A cancelable alert bound to an optional message, used for shared-media file/video failures.
+    fileprivate func sharedMediaErrorAlert(_ message: Binding<String?>) -> some View {
+        alert(
+            L10n.string("Something went wrong"),
+            isPresented: Binding(
+                get: { message.wrappedValue != nil },
+                set: { presented in
+                    if !presented { message.wrappedValue = nil }
+                }
+            )
+        ) {
+            Button(L10n.string("OK"), role: .cancel) { message.wrappedValue = nil }
+        } message: {
+            Text(message.wrappedValue ?? "")
+        }
     }
 }

--- a/whitenoise-mac/Views/GroupSharedMediaViews.swift
+++ b/whitenoise-mac/Views/GroupSharedMediaViews.swift
@@ -174,6 +174,21 @@ private struct SharedMediaThumbnail: View {
     private var isVideo: Bool { item.attachment.kind == .video }
 
     var body: some View {
+        // A `Button` (not a tap gesture) so tiles are keyboard/VoiceOver reachable.
+        Button {
+            Task { await open() }
+        } label: {
+            tileContent
+        }
+        .buttonStyle(.plain)
+        .disabled(!canOpen)
+        .accessibilityLabel(item.attachment.fileName)
+        .task(id: item.id) { await load() }
+    }
+
+    private var canOpen: Bool { isVideo || image != nil }
+
+    private var tileContent: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 6, style: .continuous)
                 .fill(Color.secondary.opacity(0.12))
@@ -181,6 +196,10 @@ private struct SharedMediaThumbnail: View {
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFill()
+            } else if isVideo {
+                // Static placeholder — videos aren't frame-extracted here, so never spin.
+                Image(systemName: "film")
+                    .foregroundStyle(.tertiary)
             } else if didFail {
                 Image(systemName: "photo")
                     .foregroundStyle(.tertiary)
@@ -197,11 +216,14 @@ private struct SharedMediaThumbnail: View {
         .aspectRatio(1, contentMode: .fit)
         .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
         .contentShape(Rectangle())
-        .onTapGesture {
-            guard !isVideo, let imageData else { return }
+    }
+
+    private func open() async {
+        if isVideo {
+            await openVideo()
+        } else if let imageData {
             onOpen(imageData)
         }
-        .task(id: item.id) { await load() }
     }
 
     private func load() async {
@@ -213,6 +235,30 @@ private struct SharedMediaThumbnail: View {
         }
         imageData = data
         image = decoded
+    }
+
+    /// Open a video in the default player: decrypt (uncached), stage a temp file via the shared
+    /// playback store, hand off to LaunchServices, then clean up shortly after.
+    private func openVideo() async {
+        guard
+            let data = await workspace.sharedMediaData(
+                for: item.reference, groupIdHex: item.groupIdHex, cache: false)
+        else { return }
+        let download = MessageMediaDownload(
+            payload: DownloadedMediaPayload(data: data),
+            fileName: item.attachment.fileName,
+            mediaType: item.attachment.mediaType,
+            sizeBytes: UInt64(data.count)
+        )
+        guard
+            let url = await MessageMediaPlaybackFileStore.fileURL(
+                attachment: item.attachment, download: download)
+        else { return }
+        let didOpen = NSWorkspace.shared.open(url)
+        let delay: TimeInterval = didOpen ? 30 : 0
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
+            MediaPlaybackTempStore.remove(at: url)
+        }
     }
 }
 
@@ -286,7 +332,10 @@ private struct SharedMediaFileRow: View {
     private func save() async {
         isSaving = true
         defer { isSaving = false }
-        guard let data = await workspace.sharedMediaData(for: item.reference, groupIdHex: item.groupIdHex)
+        // `cache: false` — a saved file may be large and shouldn't sit in the thumbnail cache.
+        guard
+            let data = await workspace.sharedMediaData(
+                for: item.reference, groupIdHex: item.groupIdHex, cache: false)
         else { return }
         let panel = NSSavePanel()
         panel.nameFieldStringValue = item.attachment.fileName

--- a/whitenoise-mac/Views/GroupSharedMediaViews.swift
+++ b/whitenoise-mac/Views/GroupSharedMediaViews.swift
@@ -1,0 +1,297 @@
+//
+//  GroupSharedMediaViews.swift
+//  whitenoise-mac
+//
+//  The group-details "Shared Media" section: a segmented Media/Files browser over the
+//  conversation's media records, with self-loading thumbnails and a file saver.
+//
+
+import AppKit
+import MarmotKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+enum GroupSharedMediaCategory: String, CaseIterable, Identifiable {
+    case media = "Media"
+    case files = "Files"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .media: return L10n.string("Media")
+        case .files: return L10n.string("Files")
+        }
+    }
+}
+
+nonisolated struct GroupSharedMediaItem: Identifiable, Hashable {
+    let id: String
+    let reference: MediaAttachmentReferenceFfi
+    let groupIdHex: String
+    let timestamp: UInt64
+
+    var attachment: MessageMediaAttachment { MessageMediaAttachment(id: id, reference: reference) }
+    var isVisual: Bool { attachment.kind == .image || attachment.kind == .video }
+
+    static func items(from records: [MediaRecordFfi]) -> [GroupSharedMediaItem] {
+        records
+            .enumerated()
+            .map { index, record in
+                let stableRecordID =
+                    record.messageIdHex.isEmpty
+                    ? record.reference.plaintextSha256.lowercased() : record.messageIdHex
+                return GroupSharedMediaItem(
+                    id: "shared-media:\(stableRecordID):\(record.attachmentIndex):\(index)",
+                    reference: record.reference,
+                    groupIdHex: record.groupIdHex,
+                    timestamp: max(record.recordedAt, record.receivedAt)
+                )
+            }
+            .sorted { lhs, rhs in
+                lhs.timestamp != rhs.timestamp ? lhs.timestamp > rhs.timestamp : lhs.id > rhs.id
+            }
+    }
+}
+
+struct GroupSharedMediaSection: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let groupIdHex: String
+
+    @State private var selectedCategory = GroupSharedMediaCategory.media
+    @State private var preview: SharedMediaImagePreview?
+
+    private let columns = Array(repeating: GridItem(.flexible(minimum: 72), spacing: 3), count: 3)
+
+    var body: some View {
+        Section("Shared Media") {
+            Picker("Shared media type", selection: $selectedCategory) {
+                ForEach(GroupSharedMediaCategory.allCases) { category in
+                    Text(category.label).tag(category)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            let items = GroupSharedMediaItem.items(from: workspace.sharedMediaRecords)
+            if workspace.isLoadingSharedMedia && items.isEmpty {
+                loadingRow
+            } else if let error = workspace.sharedMediaError, items.isEmpty {
+                errorRow(error)
+            } else {
+                switch selectedCategory {
+                case .media:
+                    mediaGrid(items.filter(\.isVisual))
+                case .files:
+                    filesList(items.filter { !$0.isVisual })
+                }
+            }
+        }
+        .sheet(item: $preview) { SharedMediaImagePreviewView(data: $0.data) }
+    }
+
+    @ViewBuilder
+    private func mediaGrid(_ items: [GroupSharedMediaItem]) -> some View {
+        if items.isEmpty {
+            emptyRow(L10n.string("No photos or videos"), systemImage: "photo.on.rectangle.angled")
+        } else {
+            LazyVGrid(columns: columns, spacing: 3) {
+                ForEach(items) { item in
+                    SharedMediaThumbnail(item: item) { data in
+                        preview = SharedMediaImagePreview(data: data)
+                    }
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    @ViewBuilder
+    private func filesList(_ items: [GroupSharedMediaItem]) -> some View {
+        if items.isEmpty {
+            emptyRow(L10n.string("No files"), systemImage: "doc")
+        } else {
+            ForEach(items) { item in
+                SharedMediaFileRow(item: item)
+            }
+        }
+    }
+
+    private var loadingRow: some View {
+        HStack {
+            Spacer()
+            ProgressView()
+            Spacer()
+        }
+        .padding(.vertical, 16)
+    }
+
+    private func errorRow(_ error: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(L10n.string("Shared media unavailable"), systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.secondary)
+            Text(error)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Button(L10n.string("Retry")) {
+                Task { await workspace.loadSharedMedia(groupIdHex: groupIdHex) }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func emptyRow(_ title: String, systemImage: String) -> some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.title2)
+                    .foregroundStyle(.tertiary)
+                Text(title)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 18)
+    }
+}
+
+private struct SharedMediaImagePreview: Identifiable {
+    let id = UUID()
+    let data: Data
+}
+
+private struct SharedMediaThumbnail: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let item: GroupSharedMediaItem
+    let onOpen: (Data) -> Void
+
+    @State private var image: NSImage?
+    @State private var imageData: Data?
+    @State private var didFail = false
+
+    private var isVideo: Bool { item.attachment.kind == .video }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.secondary.opacity(0.12))
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else if didFail {
+                Image(systemName: "photo")
+                    .foregroundStyle(.tertiary)
+            } else {
+                ProgressView().controlSize(.small)
+            }
+            if isVideo {
+                Image(systemName: "play.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(.white.opacity(0.9))
+                    .shadow(radius: 2)
+            }
+        }
+        .aspectRatio(1, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard !isVideo, let imageData else { return }
+            onOpen(imageData)
+        }
+        .task(id: item.id) { await load() }
+    }
+
+    private func load() async {
+        guard image == nil, !isVideo else { return }
+        let data = await workspace.sharedMediaData(for: item.reference, groupIdHex: item.groupIdHex)
+        guard let data, let decoded = NSImage(data: data) else {
+            didFail = true
+            return
+        }
+        imageData = data
+        image = decoded
+    }
+}
+
+private struct SharedMediaImagePreviewView: View {
+    let data: Data
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let image = NSImage(data: data) {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ContentUnavailableView(L10n.string("Couldn't open image"), systemImage: "photo")
+            }
+        }
+        .frame(minWidth: 480, minHeight: 360)
+        .background(Color.black.opacity(0.85))
+        .overlay(alignment: .topTrailing) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+            .buttonStyle(.plain)
+            .padding(12)
+        }
+    }
+}
+
+private struct SharedMediaFileRow: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let item: GroupSharedMediaItem
+
+    @State private var isSaving = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: item.attachment.kind.systemImageName)
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(item.attachment.fileName)
+                    .lineLimit(1)
+                Text(item.attachment.mediaType)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            if isSaving {
+                ProgressView().controlSize(.small)
+            } else {
+                Button {
+                    Task { await save() }
+                } label: {
+                    Image(systemName: "square.and.arrow.down")
+                }
+                .buttonStyle(.borderless)
+                .help(L10n.string("Save file"))
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+        guard let data = await workspace.sharedMediaData(for: item.reference, groupIdHex: item.groupIdHex)
+        else { return }
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = item.attachment.fileName
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+}

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -169,6 +169,8 @@ struct GroupDetailsSheet: View {
                     // non-member the same way it rejects sends (`invalid_transition`).
                     .disabled(snapshot.selfMembership != .member)
 
+                    GroupSharedMediaSection(groupIdHex: snapshot.groupIdHex)
+
                     Section {
                         if snapshot.members.isEmpty {
                             ContentUnavailableView("No members", systemImage: "person.2.slash")
@@ -189,8 +191,6 @@ struct GroupDetailsSheet: View {
                     } header: {
                         Text(snapshot.memberCountLabel)
                     }
-
-                    GroupSharedMediaSection(groupIdHex: snapshot.groupIdHex)
 
                     Section("Disappearing Messages") {
                         Picker(

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -123,6 +123,7 @@ struct GroupDetailsSheet: View {
                     TextField("", text: $customDurationText)
                         .textFieldStyle(.roundedBorder)
                         .frame(width: 64)
+                        .accessibilityLabel(L10n.string("Duration value"))
                 } onIncrement: {
                     guard let value = customDurationValue, value < UInt64.max else { return }
                     customDurationText = String(value + 1)
@@ -130,7 +131,8 @@ struct GroupDetailsSheet: View {
                     guard let value = customDurationValue, value > 1 else { return }
                     customDurationText = String(value - 1)
                 }
-                Picker("", selection: $customDurationUnit) {
+                // Real label for VoiceOver, hidden from the visual layout.
+                Picker(L10n.string("Duration unit"), selection: $customDurationUnit) {
                     ForEach(CustomDurationUnit.allCases) { unit in
                         Text(unit.label).tag(unit)
                     }

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -146,7 +146,8 @@ struct GroupDetailsSheet: View {
     /// Bounds the *total* (value × unit), not a raw per-unit cap, so large-but-valid values commit.
     private var customDurationSeconds: UInt64? {
         guard customDurationValue >= 1 else { return nil }
-        let (seconds, overflow) = customDurationValue
+        let (seconds, overflow) =
+            customDurationValue
             .multipliedReportingOverflow(by: customDurationUnit.seconds)
         return overflow ? nil : seconds
     }

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -17,8 +17,10 @@ private enum DisappearingChoice: Hashable {
     case customEntry
 }
 
-/// Units offered by the custom disappearing-timer picker.
+/// Units offered by the custom disappearing-timer picker. `seconds` is included so any exact core
+/// value round-trips (e.g. a 90-second timer opens as "90 Seconds", not a truncated minute).
 private enum CustomDurationUnit: String, CaseIterable, Identifiable {
+    case seconds
     case minutes
     case hours
     case days
@@ -28,6 +30,7 @@ private enum CustomDurationUnit: String, CaseIterable, Identifiable {
 
     var seconds: UInt64 {
         switch self {
+        case .seconds: return 1
         case .minutes: return 60
         case .hours: return 3600
         case .days: return 86_400
@@ -37,6 +40,7 @@ private enum CustomDurationUnit: String, CaseIterable, Identifiable {
 
     var label: String {
         switch self {
+        case .seconds: return L10n.string("Seconds")
         case .minutes: return L10n.string("Minutes")
         case .hours: return L10n.string("Hours")
         case .days: return L10n.string("Days")
@@ -55,6 +59,8 @@ struct GroupDetailsSheet: View {
     @State private var isCustomDisappearingPresented = false
     @State private var customDurationValue = 1
     @State private var customDurationUnit = CustomDurationUnit.days
+    /// Upper bound for a custom timer entry; 100k weeks stays well within `UInt64` seconds.
+    private static let maxCustomDurationValue = 100_000
     let chat: ChatItem
 
     private var hasProfileChanges: Bool {
@@ -95,12 +101,13 @@ struct GroupDetailsSheet: View {
             return
         }
         for unit in CustomDurationUnit.allCases.reversed() where seconds % unit.seconds == 0 {
-            customDurationValue = Int(seconds / unit.seconds)
+            customDurationValue = Int(clamping: seconds / unit.seconds)
             customDurationUnit = unit
             return
         }
-        customDurationValue = Int(seconds / CustomDurationUnit.minutes.seconds)
-        customDurationUnit = .minutes
+        // Unreachable — the `.seconds` unit divides any value — but keeps the compiler happy.
+        customDurationValue = Int(clamping: seconds)
+        customDurationUnit = .seconds
     }
 
     private func customDurationPopover(groupIdHex: String) -> some View {
@@ -108,10 +115,10 @@ struct GroupDetailsSheet: View {
             Text(L10n.string("Custom duration"))
                 .font(.headline)
             HStack(spacing: 8) {
-                Stepper(value: $customDurationValue, in: 1...999) {
+                Stepper(value: $customDurationValue, in: 1...Self.maxCustomDurationValue) {
                     TextField("", value: $customDurationValue, format: .number)
                         .textFieldStyle(.roundedBorder)
-                        .frame(width: 56)
+                        .frame(width: 64)
                 }
                 Picker("", selection: $customDurationUnit) {
                     ForEach(CustomDurationUnit.allCases) { unit in
@@ -123,17 +130,23 @@ struct GroupDetailsSheet: View {
             }
             HStack {
                 Spacer()
-                Button(L10n.string("Set")) {
-                    let seconds = UInt64(max(1, customDurationValue)) * customDurationUnit.seconds
-                    isCustomDisappearingPresented = false
-                    Task { await workspace.setDisappearingMessages(groupIdHex: groupIdHex, seconds: seconds) }
-                }
-                .keyboardShortcut(.defaultAction)
-                .nativeGlassProminentButtonStyle()
+                Button(L10n.string("Set")) { commitCustomDuration(groupIdHex: groupIdHex) }
+                    .keyboardShortcut(.defaultAction)
+                    .nativeGlassProminentButtonStyle()
             }
         }
         .padding(16)
         .frame(width: 300)
+    }
+
+    /// Clamp the (freely typed) value into range and multiply overflow-safely before committing, so
+    /// a huge entry can't trap on the `value * unit.seconds` conversion.
+    private func commitCustomDuration(groupIdHex: String) {
+        let clamped = UInt64(min(max(customDurationValue, 1), Self.maxCustomDurationValue))
+        let (seconds, overflow) = clamped.multipliedReportingOverflow(by: customDurationUnit.seconds)
+        guard !overflow else { return }
+        isCustomDisappearingPresented = false
+        Task { await workspace.setDisappearingMessages(groupIdHex: groupIdHex, seconds: seconds) }
     }
 
     var body: some View {

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -10,6 +10,13 @@
 import AppKit
 import SwiftUI
 
+/// Disappearing-timer picker selection: a concrete preset/current value, or the "Custom…" entry
+/// that opens the value+unit editor rather than committing immediately.
+private enum DisappearingChoice: Hashable {
+    case preset(DisappearingMessageOption)
+    case customEntry
+}
+
 /// Units offered by the custom disappearing-timer picker.
 private enum CustomDurationUnit: String, CaseIterable, Identifiable {
     case minutes
@@ -307,22 +314,31 @@ struct GroupDetailsSheet: View {
 
                     Section("Disappearing Messages") {
                         Picker(
-                            selection: Binding(
-                                get: { DisappearingMessageOption.option(for: snapshot.disappearingMessageSecs) },
-                                set: { option in
-                                    Task {
-                                        await workspace.setDisappearingMessages(
-                                            groupIdHex: snapshot.groupIdHex,
-                                            seconds: option.seconds
-                                        )
+                            selection: Binding<DisappearingChoice>(
+                                get: {
+                                    .preset(DisappearingMessageOption.option(for: snapshot.disappearingMessageSecs))
+                                },
+                                set: { choice in
+                                    switch choice {
+                                    case .preset(let option):
+                                        Task {
+                                            await workspace.setDisappearingMessages(
+                                                groupIdHex: snapshot.groupIdHex,
+                                                seconds: option.seconds
+                                            )
+                                        }
+                                    case .customEntry:
+                                        seedCustomDuration(from: snapshot.disappearingMessageSecs)
+                                        isCustomDisappearingPresented = true
                                     }
                                 }
                             )
                         ) {
                             ForEach(DisappearingMessageOption.options(for: snapshot.disappearingMessageSecs)) {
                                 option in
-                                Text(option.label).tag(option)
+                                Text(option.label).tag(DisappearingChoice.preset(option))
                             }
+                            Text(L10n.string("Custom…")).tag(DisappearingChoice.customEntry)
                         } label: {
                             Label("Auto-delete after", systemImage: "timer")
                         }
@@ -331,14 +347,6 @@ struct GroupDetailsSheet: View {
                         .disabled(
                             workspace.hasInFlightGroupCommit || snapshot.selfMembership != .member
                         )
-
-                        Button {
-                            seedCustomDuration(from: snapshot.disappearingMessageSecs)
-                            isCustomDisappearingPresented = true
-                        } label: {
-                            Label(L10n.string("Custom…"), systemImage: "slider.horizontal.3")
-                        }
-                        .disabled(workspace.hasInFlightGroupCommit || snapshot.selfMembership != .member)
                         .popover(isPresented: $isCustomDisappearingPresented, arrowEdge: .bottom) {
                             customDurationPopover(groupIdHex: snapshot.groupIdHex)
                         }

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -59,8 +59,6 @@ struct GroupDetailsSheet: View {
     @State private var isCustomDisappearingPresented = false
     @State private var customDurationValue = 1
     @State private var customDurationUnit = CustomDurationUnit.days
-    /// Upper bound for a custom timer entry; 100k weeks stays well within `UInt64` seconds.
-    private static let maxCustomDurationValue = 100_000
     let chat: ChatItem
 
     private var hasProfileChanges: Bool {
@@ -115,7 +113,7 @@ struct GroupDetailsSheet: View {
             Text(L10n.string("Custom duration"))
                 .font(.headline)
             HStack(spacing: 8) {
-                Stepper(value: $customDurationValue, in: 1...Self.maxCustomDurationValue) {
+                Stepper(value: $customDurationValue, in: 1...Int.max) {
                     TextField("", value: $customDurationValue, format: .number)
                         .textFieldStyle(.roundedBorder)
                         .frame(width: 64)
@@ -133,18 +131,27 @@ struct GroupDetailsSheet: View {
                 Button(L10n.string("Set")) { commitCustomDuration(groupIdHex: groupIdHex) }
                     .keyboardShortcut(.defaultAction)
                     .nativeGlassProminentButtonStyle()
+                    // Validate rather than clamp: disable Set for a non-positive or overflowing
+                    // total so a valid core value round-trips unchanged and nothing is silently
+                    // truncated.
+                    .disabled(customDurationSeconds == nil)
             }
         }
         .padding(16)
         .frame(width: 300)
     }
 
-    /// Clamp the (freely typed) value into range and multiply overflow-safely before committing, so
-    /// a huge entry can't trap on the `value * unit.seconds` conversion.
+    /// The entered duration in seconds, or `nil` when it isn't a positive value that fits `UInt64`.
+    /// Bounds the *total* (value × unit), not a raw per-unit cap, so large-but-valid values commit.
+    private var customDurationSeconds: UInt64? {
+        guard customDurationValue >= 1 else { return nil }
+        let (seconds, overflow) = UInt64(customDurationValue)
+            .multipliedReportingOverflow(by: customDurationUnit.seconds)
+        return overflow ? nil : seconds
+    }
+
     private func commitCustomDuration(groupIdHex: String) {
-        let clamped = UInt64(min(max(customDurationValue, 1), Self.maxCustomDurationValue))
-        let (seconds, overflow) = clamped.multipliedReportingOverflow(by: customDurationUnit.seconds)
-        guard !overflow else { return }
+        guard let seconds = customDurationSeconds else { return }
         isCustomDisappearingPresented = false
         Task { await workspace.setDisappearingMessages(groupIdHex: groupIdHex, seconds: seconds) }
     }

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -57,7 +57,10 @@ struct GroupDetailsSheet: View {
     @State private var showRemoveLocallyConfirmation = false
     @State private var isAddMembersPresented = false
     @State private var isCustomDisappearingPresented = false
-    @State private var customDurationValue: UInt64 = 1
+    // Kept as an exactly parsed decimal string: `UInt64.Stride` is `Int`, so any
+    // range-based numeric control spanning past `Int.max` traps in stride math,
+    // and narrowing to `Int` silently clamps large core values.
+    @State private var customDurationText = "1"
     @State private var customDurationUnit = CustomDurationUnit.days
     let chat: ChatItem
 
@@ -94,18 +97,18 @@ struct GroupDetailsSheet: View {
     /// unit that divides it evenly so a 4-week timer opens as "4 weeks".
     private func seedCustomDuration(from seconds: UInt64) {
         guard seconds > 0 else {
-            customDurationValue = 1
+            customDurationText = "1"
             customDurationUnit = .days
             return
         }
         for unit in CustomDurationUnit.allCases.reversed() where seconds % unit.seconds == 0 {
-            // Stays UInt64 end-to-end so any core value round-trips through Set unchanged.
-            customDurationValue = seconds / unit.seconds
+            // Stays UInt64-exact so any core value round-trips through Set unchanged.
+            customDurationText = String(seconds / unit.seconds)
             customDurationUnit = unit
             return
         }
         // Unreachable — the `.seconds` unit divides any value — but keeps the compiler happy.
-        customDurationValue = seconds
+        customDurationText = String(seconds)
         customDurationUnit = .seconds
     }
 
@@ -114,10 +117,18 @@ struct GroupDetailsSheet: View {
             Text(L10n.string("Custom duration"))
                 .font(.headline)
             HStack(spacing: 8) {
-                Stepper(value: $customDurationValue, in: 1...UInt64.max) {
-                    TextField("", value: $customDurationValue, format: .number)
+                // Closure-based stepper: no range, so no stride arithmetic to
+                // trap on; the parsed value saturates at the UInt64 bounds.
+                Stepper {
+                    TextField("", text: $customDurationText)
                         .textFieldStyle(.roundedBorder)
                         .frame(width: 64)
+                } onIncrement: {
+                    guard let value = customDurationValue, value < UInt64.max else { return }
+                    customDurationText = String(value + 1)
+                } onDecrement: {
+                    guard let value = customDurationValue, value > 1 else { return }
+                    customDurationText = String(value - 1)
                 }
                 Picker("", selection: $customDurationUnit) {
                     ForEach(CustomDurationUnit.allCases) { unit in
@@ -142,12 +153,17 @@ struct GroupDetailsSheet: View {
         .frame(width: 300)
     }
 
+    /// The entered count, exactly parsed; `nil` for anything that isn't a decimal `UInt64`.
+    private var customDurationValue: UInt64? {
+        UInt64(customDurationText.trimmingCharacters(in: .whitespaces))
+    }
+
     /// The entered duration in seconds, or `nil` when it isn't a positive value that fits `UInt64`.
     /// Bounds the *total* (value × unit), not a raw per-unit cap, so large-but-valid values commit.
     private var customDurationSeconds: UInt64? {
-        guard customDurationValue >= 1 else { return nil }
+        guard let value = customDurationValue, value >= 1 else { return nil }
         let (seconds, overflow) =
-            customDurationValue
+            value
             .multipliedReportingOverflow(by: customDurationUnit.seconds)
         return overflow ? nil : seconds
     }

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -57,7 +57,7 @@ struct GroupDetailsSheet: View {
     @State private var showRemoveLocallyConfirmation = false
     @State private var isAddMembersPresented = false
     @State private var isCustomDisappearingPresented = false
-    @State private var customDurationValue = 1
+    @State private var customDurationValue: UInt64 = 1
     @State private var customDurationUnit = CustomDurationUnit.days
     let chat: ChatItem
 
@@ -99,12 +99,13 @@ struct GroupDetailsSheet: View {
             return
         }
         for unit in CustomDurationUnit.allCases.reversed() where seconds % unit.seconds == 0 {
-            customDurationValue = Int(clamping: seconds / unit.seconds)
+            // Stays UInt64 end-to-end so any core value round-trips through Set unchanged.
+            customDurationValue = seconds / unit.seconds
             customDurationUnit = unit
             return
         }
         // Unreachable — the `.seconds` unit divides any value — but keeps the compiler happy.
-        customDurationValue = Int(clamping: seconds)
+        customDurationValue = seconds
         customDurationUnit = .seconds
     }
 
@@ -113,7 +114,7 @@ struct GroupDetailsSheet: View {
             Text(L10n.string("Custom duration"))
                 .font(.headline)
             HStack(spacing: 8) {
-                Stepper(value: $customDurationValue, in: 1...Int.max) {
+                Stepper(value: $customDurationValue, in: 1...UInt64.max) {
                     TextField("", value: $customDurationValue, format: .number)
                         .textFieldStyle(.roundedBorder)
                         .frame(width: 64)
@@ -145,7 +146,7 @@ struct GroupDetailsSheet: View {
     /// Bounds the *total* (value × unit), not a raw per-unit cap, so large-but-valid values commit.
     private var customDurationSeconds: UInt64? {
         guard customDurationValue >= 1 else { return nil }
-        let (seconds, overflow) = UInt64(customDurationValue)
+        let (seconds, overflow) = customDurationValue
             .multipliedReportingOverflow(by: customDurationUnit.seconds)
         return overflow ? nil : seconds
     }

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -928,6 +928,7 @@ enum DisappearingMessageOption: Hashable, Identifiable {
         if seconds % 604_800 == 0 { return L10n.plural("%llu weeks", seconds / 604_800) }
         if seconds % 86_400 == 0 { return L10n.plural("%llu days", seconds / 86_400) }
         if seconds % 3_600 == 0 { return L10n.plural("%llu hours", seconds / 3_600) }
+        if seconds % 60 == 0 { return L10n.plural("%llu minutes", seconds / 60) }
         return L10n.plural("%llu seconds", seconds)
     }
 

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -10,6 +10,34 @@
 import AppKit
 import SwiftUI
 
+/// Units offered by the custom disappearing-timer picker.
+private enum CustomDurationUnit: String, CaseIterable, Identifiable {
+    case minutes
+    case hours
+    case days
+    case weeks
+
+    var id: String { rawValue }
+
+    var seconds: UInt64 {
+        switch self {
+        case .minutes: return 60
+        case .hours: return 3600
+        case .days: return 86_400
+        case .weeks: return 604_800
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .minutes: return L10n.string("Minutes")
+        case .hours: return L10n.string("Hours")
+        case .days: return L10n.string("Days")
+        case .weeks: return L10n.string("Weeks")
+        }
+    }
+}
+
 struct GroupDetailsSheet: View {
     @Environment(WorkspaceState.self) private var workspace
     @State private var showArchiveConfirmation = false
@@ -17,6 +45,9 @@ struct GroupDetailsSheet: View {
     @State private var showSelfDemoteConfirmation = false
     @State private var showRemoveLocallyConfirmation = false
     @State private var isAddMembersPresented = false
+    @State private var isCustomDisappearingPresented = false
+    @State private var customDurationValue = 1
+    @State private var customDurationUnit = CustomDurationUnit.days
     let chat: ChatItem
 
     private var hasProfileChanges: Bool {
@@ -46,6 +77,56 @@ struct GroupDetailsSheet: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
         }
+    }
+
+    /// Prefill the custom-duration fields from the group's current timer, choosing the largest
+    /// unit that divides it evenly so a 4-week timer opens as "4 weeks".
+    private func seedCustomDuration(from seconds: UInt64) {
+        guard seconds > 0 else {
+            customDurationValue = 1
+            customDurationUnit = .days
+            return
+        }
+        for unit in CustomDurationUnit.allCases.reversed() where seconds % unit.seconds == 0 {
+            customDurationValue = Int(seconds / unit.seconds)
+            customDurationUnit = unit
+            return
+        }
+        customDurationValue = Int(seconds / CustomDurationUnit.minutes.seconds)
+        customDurationUnit = .minutes
+    }
+
+    private func customDurationPopover(groupIdHex: String) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(L10n.string("Custom duration"))
+                .font(.headline)
+            HStack(spacing: 8) {
+                Stepper(value: $customDurationValue, in: 1...999) {
+                    TextField("", value: $customDurationValue, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 56)
+                }
+                Picker("", selection: $customDurationUnit) {
+                    ForEach(CustomDurationUnit.allCases) { unit in
+                        Text(unit.label).tag(unit)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 120)
+            }
+            HStack {
+                Spacer()
+                Button(L10n.string("Set")) {
+                    let seconds = UInt64(max(1, customDurationValue)) * customDurationUnit.seconds
+                    isCustomDisappearingPresented = false
+                    Task { await workspace.setDisappearingMessages(groupIdHex: groupIdHex, seconds: seconds) }
+                }
+                .keyboardShortcut(.defaultAction)
+                .nativeGlassProminentButtonStyle()
+            }
+        }
+        .padding(16)
+        .frame(width: 300)
     }
 
     var body: some View {
@@ -250,6 +331,17 @@ struct GroupDetailsSheet: View {
                         .disabled(
                             workspace.hasInFlightGroupCommit || snapshot.selfMembership != .member
                         )
+
+                        Button {
+                            seedCustomDuration(from: snapshot.disappearingMessageSecs)
+                            isCustomDisappearingPresented = true
+                        } label: {
+                            Label(L10n.string("Custom…"), systemImage: "slider.horizontal.3")
+                        }
+                        .disabled(workspace.hasInFlightGroupCommit || snapshot.selfMembership != .member)
+                        .popover(isPresented: $isCustomDisappearingPresented, arrowEdge: .bottom) {
+                            customDurationPopover(groupIdHex: snapshot.groupIdHex)
+                        }
 
                         if snapshot.disappearingMessagesEnabled {
                             Button {

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -30,6 +30,24 @@ struct GroupDetailsSheet: View {
         GroupDetailsHeaderAvatar.sanitizedURL(snapshot: workspace.groupDetailsSnapshot, fallback: chat)
     }
 
+    /// Under the group name: the disappearing-message timer as a bare icon + duration (no label)
+    /// when it's on, otherwise the member count.
+    @ViewBuilder
+    private var headerSubtitle: some View {
+        if let snapshot = workspace.groupDetailsSnapshot, snapshot.disappearingMessagesEnabled {
+            HStack(spacing: 4) {
+                Image(systemName: "timer")
+                Text(DisappearingMessageOption.option(for: snapshot.disappearingMessageSecs).label)
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        } else {
+            Text(workspace.groupDetailsSnapshot?.memberCountLabel ?? "Group details")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
     var body: some View {
         @Bindable var workspace = workspace
 
@@ -47,9 +65,7 @@ struct GroupDetailsSheet: View {
                     Text(workspace.groupDetailsSnapshot?.name ?? chat.title)
                         .font(.title3.weight(.semibold))
                         .lineLimit(1)
-                    Text(workspace.groupDetailsSnapshot?.memberCountLabel ?? "Group details")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
+                    headerSubtitle
                 }
 
                 Spacer()
@@ -57,6 +73,22 @@ struct GroupDetailsSheet: View {
                 if workspace.isLoadingGroupDetails {
                     ProgressView()
                         .controlSize(.small)
+                }
+
+                if let snapshot = workspace.groupDetailsSnapshot,
+                    snapshot.canInvite, snapshot.selfMembership == .member
+                {
+                    Button {
+                        isAddMembersPresented = true
+                    } label: {
+                        Image(systemName: "person.badge.plus")
+                            .font(.system(size: 16, weight: .semibold))
+                            .frame(width: 30, height: 30)
+                            .background { MessagesCircleControlBackground() }
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(workspace.hasInFlightGroupCommit)
+                    .help(L10n.string("Add members"))
                 }
 
                 GlassCircleCloseButton(symbol: "chevron.backward", help: "Back to chat") {
@@ -785,8 +817,18 @@ enum DisappearingMessageOption: Hashable, Identifiable {
         case .oneDay: return L10n.plural("%llu days", UInt64(1))
         case .oneWeek: return L10n.plural("%llu weeks", UInt64(1))
         case .oneMonth: return L10n.plural("%llu months", UInt64(1))
-        case .custom(let value): return L10n.plural("%llu seconds", value)
+        case .custom(let value): return Self.humanDuration(value)
         }
+    }
+
+    /// A whole-unit human duration for non-preset values (e.g. a 4-week timer reads "4 weeks"
+    /// rather than a raw seconds count). Uses the largest unit that divides evenly.
+    static func humanDuration(_ seconds: UInt64) -> String {
+        if seconds == 0 { return L10n.string("Off") }
+        if seconds % 604_800 == 0 { return L10n.plural("%llu weeks", seconds / 604_800) }
+        if seconds % 86_400 == 0 { return L10n.plural("%llu days", seconds / 86_400) }
+        if seconds % 3_600 == 0 { return L10n.plural("%llu hours", seconds / 3_600) }
+        return L10n.plural("%llu seconds", seconds)
     }
 
     /// The matching preset for `seconds`, or a `.custom` wrapper when none match.

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -16,6 +16,7 @@ struct GroupDetailsSheet: View {
     @State private var showLeaveConfirmation = false
     @State private var showSelfDemoteConfirmation = false
     @State private var showRemoveLocallyConfirmation = false
+    @State private var isAddMembersPresented = false
     let chat: ChatItem
 
     private var hasProfileChanges: Bool {
@@ -168,7 +169,7 @@ struct GroupDetailsSheet: View {
                     // non-member the same way it rejects sends (`invalid_transition`).
                     .disabled(snapshot.selfMembership != .member)
 
-                    Section("Members") {
+                    Section {
                         if snapshot.members.isEmpty {
                             ContentUnavailableView("No members", systemImage: "person.2.slash")
                                 .frame(minHeight: 120)
@@ -177,7 +178,19 @@ struct GroupDetailsSheet: View {
                                 GroupMemberRow(member: member)
                             }
                         }
+                        if snapshot.canInvite && snapshot.selfMembership == .member {
+                            Button {
+                                isAddMembersPresented = true
+                            } label: {
+                                Label(L10n.string("Add members"), systemImage: "person.badge.plus")
+                            }
+                            .disabled(workspace.hasInFlightGroupCommit)
+                        }
+                    } header: {
+                        Text(snapshot.memberCountLabel)
                     }
+
+                    GroupSharedMediaSection(groupIdHex: snapshot.groupIdHex)
 
                     Section("Disappearing Messages") {
                         Picker(
@@ -214,33 +227,6 @@ struct GroupDetailsSheet: View {
                             }
                             .disabled(workspace.isSecureDeletingExpired)
                             .help(L10n.string("Securely prune already-expired messages on this device"))
-                        }
-                    }
-
-                    if snapshot.canInvite && snapshot.selfMembership == .member {
-                        Section("Invite") {
-                            HStack(spacing: 10) {
-                                TextField(
-                                    "NIP-05, npub, profile link, or hex public key",
-                                    text: $workspace.groupInviteMemberQuery
-                                )
-                                .textFieldStyle(.roundedBorder)
-
-                                Button {
-                                    Task { await workspace.inviteMemberToSelectedGroup() }
-                                } label: {
-                                    Label(
-                                        workspace.isInvitingGroupMember
-                                            ? L10n.string("Inviting...") : L10n.string("Invite"),
-                                        systemImage: "person.badge.plus")
-                                }
-                                .disabled(
-                                    workspace.hasInFlightGroupCommit
-                                        || workspace.groupInviteMemberQuery.trimmingCharacters(
-                                            in: .whitespacesAndNewlines
-                                        ).isEmpty
-                                )
-                            }
                         }
                     }
 
@@ -377,6 +363,17 @@ struct GroupDetailsSheet: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background {
             MessagesTranscriptBackground()
+        }
+        .task(id: chat.id) {
+            await workspace.loadSharedMedia(groupIdHex: chat.id)
+        }
+        .onDisappear {
+            workspace.clearSharedMedia()
+        }
+        .sheet(isPresented: $isAddMembersPresented) {
+            GroupAddMembersSheet(
+                existingMemberIds: Set(workspace.groupDetailsSnapshot?.members.map(\.id) ?? [])
+            )
         }
         .confirmationDialog(
             archiveConfirmationTitle,

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -177,7 +177,8 @@ struct MessageBubble: View {
     @State private var isHovering = false
     @State private var isInlineActionPresentationActive = false
     @State private var isSelectable = false
-    @State private var isReactionSummaryPresented = false
+    @State private var isReactionViewerPresented = false
+    @State private var reactionViewerEmoji: String?
     let message: MessageItem
     let showsDebugMetadata: Bool
     let onOpenImageGallery: (MessageImageGalleryPresentation) -> Void
@@ -227,70 +228,17 @@ struct MessageBubble: View {
             }
 
             if message.supportsChatActions && !message.reactions.isEmpty {
-                HStack(spacing: 5) {
-                    ForEach(Array(message.reactions.prefix(5))) { reaction in
-                        Button {
-                            Task {
-                                if reaction.canRemoveOwnReaction {
-                                    await workspace.removeReaction(reaction, from: message)
-                                } else {
-                                    await workspace.react(to: message, emoji: reaction.emoji)
-                                }
-                            }
-                        } label: {
-                            Text(reaction.label)
-                                .font(.caption.weight(.semibold))
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 3)
-                                .background {
-                                    // Own reactions get a gentle accent fill rather than a heavy
-                                    // ring, so a row of them reads as one cluster, not selected chips.
-                                    if reaction.canRemoveOwnReaction {
-                                        Capsule(style: .continuous)
-                                            .fill(Color.accentColor.opacity(0.16))
-                                            .overlay {
-                                                Capsule(style: .continuous)
-                                                    .strokeBorder(Color.accentColor.opacity(0.4), lineWidth: 1)
-                                            }
-                                    } else {
-                                        GlassCapsuleBackground()
-                                    }
-                                }
-                        }
-                        .buttonStyle(.plain)
-                        .contentShape(Capsule())
-                        .help(
-                            reaction.canRemoveOwnReaction
-                                ? "Remove \(reaction.emoji) reaction" : "React with \(reaction.emoji)")
-                    }
-                    if message.reactions.count > 5 {
-                        Button("+\(message.reactions.count - 5)") {
-                            isReactionSummaryPresented = true
-                        }
-                        .font(.caption.weight(.semibold))
-                        .buttonStyle(.plain)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background { GlassCapsuleBackground() }
-                        .popover(isPresented: $isReactionSummaryPresented, arrowEdge: .bottom) {
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text(L10n.string("Reactions"))
-                                    .font(.headline)
-                                ScrollView {
-                                    LazyVStack(spacing: 8) {
-                                        ForEach(message.reactions) { reaction in
-                                            reactionSummaryRow(reaction)
-                                        }
-                                    }
-                                }
-                                .frame(maxHeight: 260)
-                            }
-                            .padding(14)
-                            .frame(width: 220)
-                        }
-                    }
+                MessageReactionChips(reactions: message.reactions) { emoji in
+                    reactionViewerEmoji = emoji
+                    isReactionViewerPresented = true
                 }
-                .padding(.horizontal, 4)
+                // Hang the chips on the bubble's bottom edge (a slight upward overlap) instead of
+                // floating as a detached row, matching the sibling clients' bubble-bound reactions.
+                .padding(.horizontal, 10)
+                .padding(.top, -10)
+                .popover(isPresented: $isReactionViewerPresented, arrowEdge: .bottom) {
+                    MessageReactionDetailsView(message: message, selectedEmoji: $reactionViewerEmoji)
+                }
             }
         }
         .overlay(alignment: message.isOutgoing ? .leading : .trailing) {
@@ -340,39 +288,6 @@ struct MessageBubble: View {
 
     private var showsInlineActions: Bool {
         message.supportsChatActions && (isHovering || isInlineActionPresentationActive)
-    }
-
-    @ViewBuilder
-    private func reactionSummaryRow(_ reaction: MessageReaction) -> some View {
-        if reaction.canRemoveOwnReaction {
-            Button {
-                Task {
-                    await workspace.removeReaction(reaction, from: message)
-                    isReactionSummaryPresented = false
-                }
-            } label: {
-                reactionSummaryLabel(reaction)
-            }
-            .buttonStyle(.plain)
-            .help(String(format: L10n.string("Remove %@ reaction"), reaction.emoji))
-        } else {
-            reactionSummaryLabel(reaction)
-        }
-    }
-
-    private func reactionSummaryLabel(_ reaction: MessageReaction) -> some View {
-        HStack {
-            Text(reaction.emoji)
-            Text("\(reaction.count)")
-                .foregroundStyle(.secondary)
-            Spacer()
-            if reaction.canRemoveOwnReaction {
-                Text(L10n.string("You"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .contentShape(Rectangle())
     }
 
     private var usesBubbleSurface: Bool {

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -891,15 +891,19 @@ struct MessageDocumentAttachmentRow: View {
 
     var body: some View {
         // A finished document opens on click of the whole row — no trailing retry/download glyph
-        // (the file is already in hand, especially for our own sends).
-        MessageAttachmentStatusRow(
-            systemImage: "doc",
-            title: download.fileName.nilIfBlank ?? attachment.fileName,
-            detail: mediaDetail,
-            isOutgoing: isOutgoing
-        )
-        .contentShape(Rectangle())
-        .onTapGesture { Task { await openAttachment() } }
+        // (the file is already in hand, especially for our own sends). A `Button` (not a tap
+        // gesture) keeps it reachable by keyboard/VoiceOver.
+        Button {
+            Task { await openAttachment() }
+        } label: {
+            MessageAttachmentStatusRow(
+                systemImage: "doc",
+                title: download.fileName.nilIfBlank ?? attachment.fileName,
+                detail: mediaDetail,
+                isOutgoing: isOutgoing
+            )
+        }
+        .buttonStyle(.plain)
         .help(L10n.string("Open"))
     }
 

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -890,14 +890,17 @@ struct MessageDocumentAttachmentRow: View {
     let isOutgoing: Bool
 
     var body: some View {
+        // A finished document opens on click of the whole row — no trailing retry/download glyph
+        // (the file is already in hand, especially for our own sends).
         MessageAttachmentStatusRow(
             systemImage: "doc",
             title: download.fileName.nilIfBlank ?? attachment.fileName,
             detail: mediaDetail,
             isOutgoing: isOutgoing
-        ) {
-            Task { await openAttachment() }
-        }
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { Task { await openAttachment() } }
+        .help(L10n.string("Open"))
     }
 
     private var mediaDetail: String {

--- a/whitenoise-mac/Views/MessageReactionViews.swift
+++ b/whitenoise-mac/Views/MessageReactionViews.swift
@@ -175,9 +175,25 @@ struct MessageReactionDetailsView: View {
         }
     }
 
+    @ViewBuilder
     private func reactorRow(_ row: ReactorRow) -> some View {
         let canRemove = row.reactor.isSelf && row.reaction.canRemoveOwnReaction
-        return HStack(spacing: 10) {
+        if canRemove {
+            // A `Button` (not a tap gesture) so removing your reaction is keyboard/VoiceOver
+            // reachable.
+            Button {
+                Task { await workspace.removeReaction(row.reaction, from: message) }
+            } label: {
+                reactorRowContent(row, canRemove: true)
+            }
+            .buttonStyle(.plain)
+        } else {
+            reactorRowContent(row, canRemove: false)
+        }
+    }
+
+    private func reactorRowContent(_ row: ReactorRow, canRemove: Bool) -> some View {
+        HStack(spacing: 10) {
             ProfileImageAvatarView(
                 seed: row.reactor.accountIdHex,
                 initials: row.reactor.name,
@@ -202,9 +218,5 @@ struct MessageReactionDetailsView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
         .contentShape(Rectangle())
-        .onTapGesture {
-            guard canRemove else { return }
-            Task { await workspace.removeReaction(row.reaction, from: message) }
-        }
     }
 }

--- a/whitenoise-mac/Views/MessageReactionViews.swift
+++ b/whitenoise-mac/Views/MessageReactionViews.swift
@@ -1,0 +1,196 @@
+//
+//  MessageReactionViews.swift
+//  whitenoise-mac
+//
+//  Compact reaction chips shown under a bubble, and the reaction viewer popover that lists who
+//  reacted (grouped by emoji), matching the sibling clients' reaction detail panel.
+//
+
+import SwiftUI
+
+/// A tight, clustered row of reaction chips (emoji + count). Own reactions get a gentle accent
+/// fill. Tapping a chip opens the viewer filtered to that emoji; the overflow chip opens it on
+/// "All". Chips are view-only — adding/removing is done from the hover React control.
+struct MessageReactionChips: View {
+    let reactions: [MessageReaction]
+    /// emoji to focus the viewer on, or nil for the "All" tab.
+    let onOpenViewer: (String?) -> Void
+
+    private let maxVisible = 5
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(reactions.prefix(maxVisible)) { reaction in
+                chip(label: reaction.label, isOwn: reaction.isOwn) { onOpenViewer(reaction.emoji) }
+            }
+            if reactions.count > maxVisible {
+                chip(label: "+\(reactions.count - maxVisible)", isOwn: false) { onOpenViewer(nil) }
+            }
+        }
+    }
+
+    private func chip(label: String, isOwn: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(isOwn ? Color.accentColor.opacity(0.20) : Color(nsColor: .controlBackgroundColor))
+                )
+                .overlay(
+                    Capsule(style: .continuous)
+                        .strokeBorder(
+                            isOwn ? Color.accentColor.opacity(0.45) : Color.primary.opacity(0.12),
+                            lineWidth: 1
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .contentShape(Capsule(style: .continuous))
+    }
+}
+
+/// Reaction viewer: a horizontal "All / per-emoji" filter row over a list of reactors (avatar +
+/// name + their emoji). Your own row can be tapped to remove your reaction.
+struct MessageReactionDetailsView: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let message: MessageItem
+    @Binding var selectedEmoji: String?
+
+    private struct ReactorRow: Identifiable {
+        let reactor: WorkspaceState.ReactionReactorDisplay
+        let emoji: String
+        let reaction: MessageReaction
+        var id: String { "\(reactor.accountIdHex)|\(emoji)" }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            filters
+            Divider()
+            reactorList
+        }
+        .frame(width: 300)
+        .frame(maxHeight: 380)
+    }
+
+    private var totalCount: Int {
+        message.reactions.reduce(0) { $0 + $1.count }
+    }
+
+    private var filters: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                filterButton(emoji: nil, label: L10n.string("All"), count: totalCount)
+                ForEach(message.reactions) { reaction in
+                    filterButton(emoji: reaction.emoji, label: reaction.emoji, count: reaction.count)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+        }
+    }
+
+    /// The active filter, but only while its emoji still has reactions — so removing your last
+    /// reaction of an emoji falls the viewer back to "All" instead of showing an empty list with
+    /// no pill highlighted.
+    private var effectiveEmoji: String? {
+        guard let selectedEmoji, message.reactions.contains(where: { $0.emoji == selectedEmoji }) else {
+            return nil
+        }
+        return selectedEmoji
+    }
+
+    private func filterButton(emoji: String?, label: String, count: Int) -> some View {
+        let isSelected = effectiveEmoji == emoji
+        return Button {
+            selectedEmoji = emoji
+        } label: {
+            HStack(spacing: 5) {
+                Text(label)
+                Text("\(count)")
+                    .font(.caption.weight(.semibold))
+            }
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(isSelected ? Color.white : Color.primary)
+            .padding(.horizontal, 12)
+            .frame(minHeight: 30)
+            .background(isSelected ? Color.accentColor : Color.secondary.opacity(0.16), in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var rows: [ReactorRow] {
+        let filtered =
+            effectiveEmoji.map { emoji in message.reactions.filter { $0.emoji == emoji } }
+            ?? message.reactions
+        let unsorted = filtered.flatMap { reaction in
+            reaction.senders.map { sender in
+                ReactorRow(
+                    reactor: workspace.reactionReactorDisplay(accountIdHex: sender),
+                    emoji: reaction.emoji,
+                    reaction: reaction
+                )
+            }
+        }
+        // Local account first, then by display name.
+        return unsorted.sorted { lhs, rhs in
+            if lhs.reactor.isSelf != rhs.reactor.isSelf { return lhs.reactor.isSelf }
+            let comparison = lhs.reactor.name.localizedCaseInsensitiveCompare(rhs.reactor.name)
+            return comparison == .orderedSame
+                ? lhs.reactor.accountIdHex < rhs.reactor.accountIdHex
+                : comparison == .orderedAscending
+        }
+    }
+
+    private var reactorList: some View {
+        let reactorRows = rows
+        return ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(reactorRows) { row in
+                    reactorRow(row)
+                    if row.id != reactorRows.last?.id {
+                        Divider().padding(.leading, 54)
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func reactorRow(_ row: ReactorRow) -> some View {
+        let canRemove = row.reactor.isSelf && row.reaction.canRemoveOwnReaction
+        return HStack(spacing: 10) {
+            ProfileImageAvatarView(
+                seed: row.reactor.accountIdHex,
+                initials: row.reactor.name,
+                sanitizedPictureURL: row.reactor.sanitizedPictureURL,
+                size: 32,
+                isSelected: false
+            )
+            VStack(alignment: .leading, spacing: 1) {
+                Text(row.reactor.isSelf ? L10n.string("You") : row.reactor.name)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+                if canRemove {
+                    Text(L10n.string("Tap to remove"))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 8)
+            Text(row.emoji)
+                .font(.title3)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard canRemove else { return }
+            Task { await workspace.removeReaction(row.reaction, from: message) }
+        }
+    }
+}

--- a/whitenoise-mac/Views/MessageReactionViews.swift
+++ b/whitenoise-mac/Views/MessageReactionViews.swift
@@ -16,36 +16,48 @@ struct MessageReactionChips: View {
     /// emoji to focus the viewer on, or nil for the "All" tab.
     let onOpenViewer: (String?) -> Void
 
-    private let maxVisible = 5
+    private let maxVisibleEmojis = 6
 
-    var body: some View {
-        HStack(spacing: 4) {
-            ForEach(reactions.prefix(maxVisible)) { reaction in
-                chip(label: reaction.label, isOwn: reaction.isOwn) { onOpenViewer(reaction.emoji) }
-            }
-            if reactions.count > maxVisible {
-                chip(label: "+\(reactions.count - maxVisible)", isOwn: false) { onOpenViewer(nil) }
-            }
-        }
+    /// All reacted emojis run together in one pill (deduped by emoji), matching the sibling
+    /// clients' single grouped chip rather than a spread of separate capsules.
+    private var emojis: String {
+        reactions.prefix(maxVisibleEmojis).map(\.emoji).joined()
     }
 
-    private func chip(label: String, isOwn: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(label)
-                .font(.caption.weight(.semibold))
-                .padding(.horizontal, 7)
-                .padding(.vertical, 3)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(isOwn ? Color.accentColor.opacity(0.20) : Color(nsColor: .controlBackgroundColor))
-                )
-                .overlay(
-                    Capsule(style: .continuous)
-                        .strokeBorder(
-                            isOwn ? Color.accentColor.opacity(0.45) : Color.primary.opacity(0.12),
-                            lineWidth: 1
-                        )
-                )
+    private var totalCount: Int {
+        reactions.reduce(0) { $0 + $1.count }
+    }
+
+    private var isOwn: Bool {
+        reactions.contains { $0.isOwn }
+    }
+
+    var body: some View {
+        Button {
+            onOpenViewer(nil)
+        } label: {
+            HStack(spacing: 3) {
+                Text(emojis)
+                if totalCount > 1 {
+                    Text("\(totalCount)")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .font(.footnote)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(isOwn ? Color.accentColor.opacity(0.20) : Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .strokeBorder(
+                        isOwn ? Color.accentColor.opacity(0.45) : Color.primary.opacity(0.12),
+                        lineWidth: 1
+                    )
+            )
         }
         .buttonStyle(.plain)
         .contentShape(Capsule(style: .continuous))
@@ -71,9 +83,11 @@ struct MessageReactionDetailsView: View {
             filters
             Divider()
             reactorList
+                .frame(maxHeight: .infinity)
         }
-        .frame(width: 300)
-        .frame(maxHeight: 380)
+        // A definite height so the reactor list fills the popover and shows several rows at once,
+        // rather than collapsing to a single intrinsic row.
+        .frame(width: 320, height: 420)
     }
 
     private var totalCount: Int {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7957,7 +7957,13 @@ struct whitenoise_macTests {
         #expect(state.messagesByChat["group"]?.first?.body == "The launch plan is ready.")
         #expect(
             state.messagesByChat["group"]?.first?.reactions == [
-                MessageReaction(emoji: "👍", count: 1, isOwn: true, ownReactionMessageId: "reaction")
+                MessageReaction(
+                    emoji: "👍",
+                    count: 1,
+                    isOwn: true,
+                    ownReactionMessageId: "reaction",
+                    senders: ["abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"]
+                )
             ])
     }
 


### PR DESCRIPTION
Adds two group-details features, matching the sibling clients.

## Shared Media
A new "Shared Media" section in the group-details sheet, sourced from the `listMedia` FFI, with a segmented **Media / Files** browser:
- **Media** — a 3-column thumbnail grid of images (and videos, marked with a play glyph). Thumbnails decrypt lazily through the shared download limiter and are cached by plaintext hash; tapping a photo opens a full-size preview.
- **Files** — a list of non-visual attachments (icon, name, type) with a per-file save (`NSSavePanel`).
- Loading / error (with Retry) / empty states.

The loader is self-contained (`WorkspaceState+SharedMedia.swift`) and never touches the timeline's per-message download-state machine, so the two can't contend on keys or caches. Records load on sheet open and clear on dismiss.

## Members picker
Replaces the single-field invite box with an **Add members** action in the Members section that opens a staging picker:
- Resolve a NIP-05 / npub / profile link / hex key to a recipient, stage several, then invite them all in one commit (`inviteMembersDetailed`).
- Already-in-group and duplicate entries are rejected with inline feedback.
- The Members section header now shows the member count.

## Notes
- Media/file bytes are decrypted on demand and honor the existing media-display privacy gate.
- Video thumbnails show a placeholder + play glyph (no frame extraction yet) — follow-up.
- Awaiting an on-device pass (the media grid needs a group with real attachments to exercise fully).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/638">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group “Shared Media” browsing with images/videos thumbnails, video playback, image preview, and file download.
  * Added an “Add members” invite flow with identifier resolution, staging, and one-step inviting.
  * Added reaction viewer with per-reactor details, emoji filtering, and “remove reaction” support.
  * Added custom disappearing-message durations with improved time labeling and header display.
* **Improvements**
  * Document attachments are now openable by clicking anywhere on the row.
  * Reaction details and disappearing-message header information stay consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->