### PR TITLE
Fix scoped deletion and @-mention follow-ups

### DIFF
--- a/whitenoise-mac/Core/ComposerMentionSupport.swift
+++ b/whitenoise-mac/Core/ComposerMentionSupport.swift
@@ -36,6 +36,24 @@ nonisolated struct ComposerMentionCandidate: Identifiable, Equatable, Sendable {
     }
 }
 
+/// A picker-selected mention tied to the exact visible range in the composer. Keeping the
+/// canonical npub here avoids re-identifying a selected member by a non-unique display name.
+nonisolated struct ComposerMentionSelection: Hashable, Sendable {
+    let location: Int
+    let length: Int
+    let displayText: String
+    let npub: String
+
+    init(range: NSRange, displayText: String, npub: String) {
+        location = range.location
+        length = range.length
+        self.displayText = displayText
+        self.npub = npub
+    }
+
+    var range: NSRange { NSRange(location: location, length: length) }
+}
+
 nonisolated enum ComposerMentionQuery {
     struct Session: Equatable {
         let atIndex: String.Index
@@ -106,30 +124,63 @@ nonisolated enum ComposerMentionCanonicalizer {
 
     /// Rewrite every "@DisplayName" in `text` that matches a candidate to "@npub…", so the wire
     /// format carries stable public keys rather than display names.
-    static func canonicalize(_ text: String, candidates: [ComposerMentionCandidate]) -> String {
+    static func canonicalize(
+        _ text: String,
+        selections: [ComposerMentionSelection] = [],
+        candidates: [ComposerMentionCandidate]
+    ) -> String {
         guard text.contains("@") else { return text }
+        let canonical = canonicalizeSelections(in: text, selections: selections)
         let replacements =
-            candidates
+            Dictionary(grouping: candidates, by: \.displayName)
+            .values
+            // A typed name is safe to infer only when every matching roster entry identifies the
+            // same npub. Picker selections above remain unambiguous even for duplicate names.
+            .compactMap { matches -> ComposerMentionCandidate? in
+                let npubs = Set(matches.map(\.npub).filter { !$0.isEmpty })
+                guard npubs.count == 1, let onlyNpub = npubs.first else { return nil }
+                return matches.first { $0.npub == onlyNpub }
+            }
             .filter { candidate in
                 !candidate.npub.isEmpty
                     && !candidate.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             }
             .sorted { $0.displayName.count > $1.displayName.count }
-        guard !replacements.isEmpty else { return text }
+        guard !replacements.isEmpty else { return canonical }
 
-        var canonical = ""
-        var index = text.startIndex
-        while index < text.endIndex {
-            if text[index] == "@",
-                leftBoundaryAllowsMention(at: index, in: text),
-                let match = matchCandidate(in: text, at: index, candidates: replacements)
+        var inferred = ""
+        var index = canonical.startIndex
+        while index < canonical.endIndex {
+            if canonical[index] == "@",
+                leftBoundaryAllowsMention(at: index, in: canonical),
+                let match = matchCandidate(in: canonical, at: index, candidates: replacements)
             {
-                canonical += "@\(match.candidate.npub)"
+                inferred += "@\(match.candidate.npub)"
                 index = match.endIndex
                 continue
             }
-            canonical.append(text[index])
-            index = text.index(after: index)
+            inferred.append(canonical[index])
+            index = canonical.index(after: index)
+        }
+        return inferred
+    }
+
+    private static func canonicalizeSelections(
+        in text: String,
+        selections: [ComposerMentionSelection]
+    ) -> String {
+        var canonical = text
+        for selection in selections.sorted(by: { $0.location > $1.location }) {
+            guard !selection.npub.isEmpty,
+                selection.location >= 0,
+                selection.length >= 0,
+                NSMaxRange(selection.range) <= (canonical as NSString).length,
+                (canonical as NSString).substring(with: selection.range) == selection.displayText
+            else { continue }
+            canonical = (canonical as NSString).replacingCharacters(
+                in: selection.range,
+                with: "@\(selection.npub)"
+            )
         }
         return canonical
     }
@@ -165,5 +216,48 @@ nonisolated enum ComposerMentionCanonicalizer {
                 || scalar == underscoreScalar
                 || scalar == slashScalar
         }
+    }
+}
+
+/// Converts canonical mention tokens back to roster display names for plain-text surfaces such as
+/// chat previews, edited-message bubbles, and edit history.
+nonisolated enum MentionDisplayResolver {
+    private static let bech32Characters = CharacterSet(charactersIn: "023456789acdefghjklmnpqrstuvwxyz")
+
+    static func resolve(in text: String, mentionNames: MarkdownMentionNames) -> String {
+        guard !mentionNames.isEmpty, text.contains("@npub1") else { return text }
+        let replacements = mentionNames.compactMap { npub, rawName -> (npub: String, name: String)? in
+            guard let name = PeerDisplayText.sanitize(rawName), !npub.isEmpty else { return nil }
+            return (npub, name)
+        }
+        guard !replacements.isEmpty else { return text }
+
+        var resolved = ""
+        var index = text.startIndex
+        while index < text.endIndex {
+            var match: (npub: String, name: String, end: String.Index)?
+            if text[index] == "@" {
+                let tokenStart = text.index(after: index)
+                for replacement in replacements where text[tokenStart...].hasPrefix(replacement.npub) {
+                    let end = text.index(tokenStart, offsetBy: replacement.npub.count)
+                    guard end == text.endIndex || !isBech32Character(text[end]) else { continue }
+                    match = (replacement.npub, replacement.name, end)
+                    break
+                }
+            }
+            if let match {
+                resolved += "@\(match.name)"
+                index = match.end
+            } else {
+                resolved.append(text[index])
+                index = text.index(after: index)
+            }
+        }
+        return resolved
+    }
+
+    private static func isBech32Character(_ character: Character) -> Bool {
+        !character.unicodeScalars.isEmpty
+            && character.unicodeScalars.allSatisfy { bech32Characters.contains($0) }
     }
 }

--- a/whitenoise-mac/Core/ComposerMentionSupport.swift
+++ b/whitenoise-mac/Core/ComposerMentionSupport.swift
@@ -175,7 +175,8 @@ nonisolated enum ComposerMentionCanonicalizer {
                 selection.location >= 0,
                 selection.length >= 0,
                 NSMaxRange(selection.range) <= (canonical as NSString).length,
-                (canonical as NSString).substring(with: selection.range) == selection.displayText
+                (canonical as NSString).substring(with: selection.range) == selection.displayText,
+                isValidVisibleMention(selection.range, in: canonical)
             else { continue }
             canonical = (canonical as NSString).replacingCharacters(
                 in: selection.range,
@@ -183,6 +184,24 @@ nonisolated enum ComposerMentionCanonicalizer {
             )
         }
         return canonical
+    }
+
+    static func isValidVisibleMention(_ range: NSRange, in text: String) -> Bool {
+        guard range.location >= 0,
+            range.length > 1,
+            NSMaxRange(range) <= (text as NSString).length,
+            let stringRange = Range(range, in: text),
+            text[stringRange].first == "@"
+        else { return false }
+        if stringRange.lowerBound > text.startIndex {
+            guard isNostrMentionBoundary(text[text.index(before: stringRange.lowerBound)]) else {
+                return false
+            }
+        }
+        if stringRange.upperBound < text.endIndex {
+            guard isNostrMentionBoundary(text[stringRange.upperBound]) else { return false }
+        }
+        return true
     }
 
     private static func matchCandidate(

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -118,7 +118,7 @@ extension ChatItem {
         if text.isEmpty || isMediaOnlyChat {
             body = presentation.isChatBubble ? L10n.string("Attachment") : L10n.string("Unsupported message")
         } else {
-            body = Self.resolvePreviewMentions(in: text, mentionNames: mentionNames)
+            body = MentionDisplayResolver.resolve(in: text, mentionNames: mentionNames)
         }
         guard presentation.isChatBubble,
             preview.sender != activeAccountIdHex,
@@ -131,18 +131,6 @@ extension ChatItem {
         return "\(PeerDisplayText.templateFragment(senderName)): \(body)"
     }
 
-    /// Rewrite canonical "@npub…" mentions in a chat-list preview to "@Display Name" for known
-    /// members. Only exact roster npubs are substituted, so there are no false positives; unknown
-    /// references keep their bech32 form. No-op when the roster isn't loaded for the row.
-    private static func resolvePreviewMentions(in text: String, mentionNames: MarkdownMentionNames) -> String {
-        guard !mentionNames.isEmpty, text.contains("npub1") else { return text }
-        var resolved = text
-        for (npub, rawName) in mentionNames {
-            guard let name = PeerDisplayText.sanitize(rawName) else { continue }
-            resolved = resolved.replacingOccurrences(of: "@\(npub)", with: "@\(name)")
-        }
-        return resolved
-    }
 }
 
 nonisolated enum MessageEditMutation: Equatable, Sendable {

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -22,6 +22,7 @@ private nonisolated struct MediaReferenceIndexTaskFailure: Error {
 extension WorkspaceState {
     func clearAllComposerDrafts() {
         draftTextByConversation.removeAll()
+        composerMentionSelectionsByConversation.removeAll()
         replyDraftContextByConversation.removeAll()
         editingMessageContextByConversation.removeAll()
         pendingMediaAttachmentsByConversation.removeAll()
@@ -32,6 +33,7 @@ extension WorkspaceState {
         for chatId in chatIds {
             let key = ComposerDraftKey(accountId: accountId, chatId: chatId)
             draftTextByConversation[key] = nil
+            composerMentionSelectionsByConversation[key] = nil
             replyDraftContextByConversation[key] = nil
             editingMessageContextByConversation[key] = nil
             pendingMediaAttachmentsByConversation[key] = nil
@@ -42,6 +44,9 @@ extension WorkspaceState {
     func clearComposerDrafts(forAccountId accountId: String) {
         for key in draftTextByConversation.keys.filter({ $0.accountId == accountId }) {
             draftTextByConversation[key] = nil
+        }
+        for key in composerMentionSelectionsByConversation.keys.filter({ $0.accountId == accountId }) {
+            composerMentionSelectionsByConversation[key] = nil
         }
         for key in replyDraftContextByConversation.keys.filter({ $0.accountId == accountId }) {
             replyDraftContextByConversation[key] = nil
@@ -573,6 +578,7 @@ extension WorkspaceState {
         replyDraftContextByConversation[draftKey] = nil
         if attachment.kind == .audio {
             draftTextByConversation[draftKey] = nil
+            composerMentionSelectionsByConversation[draftKey] = nil
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Mentions.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Mentions.swift
@@ -37,10 +37,10 @@ extension WorkspaceState {
     }
 
     /// Rewrite display-name mentions to canonical npubs before the text leaves the composer.
-    func canonicalizeMentions(in text: String) -> String {
+    func canonicalizeMentions(in text: String, selections: [ComposerMentionSelection] = []) -> String {
         let roster = mentionRoster()
         guard !roster.isEmpty else { return text }
-        return ComposerMentionCanonicalizer.canonicalize(text, candidates: roster)
+        return ComposerMentionCanonicalizer.canonicalize(text, selections: selections, candidates: roster)
     }
 
     /// npub → sanitized display name from the roster already in cache (no FFI), used by the

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -593,6 +593,7 @@ extension WorkspaceState {
             senderName: message.senderName,
             originalBody: message.body,
             preservedDraft: preservedDraft,
+            preservedMentionSelections: composerMentionSelectionsByConversation[draftKey] ?? [],
             preservedReplyContext: replyDraftContextByConversation[draftKey],
             preservedMediaAttachments: pendingMediaAttachmentsByConversation[draftKey] ?? [],
             preservedMediaUploadStates: pendingMediaUploadStatesByConversation[draftKey] ?? [:]
@@ -600,7 +601,8 @@ extension WorkspaceState {
         replyDraftContextByConversation[draftKey] = nil
         pendingMediaAttachmentsByConversation[draftKey] = nil
         pendingMediaUploadStatesByConversation[draftKey] = nil
-        draftTextByConversation[draftKey] = message.body
+        draftTextByConversation[draftKey] = message.wireBody
+        composerMentionSelectionsByConversation[draftKey] = nil
     }
 
     func cancelEditingMessage() {
@@ -608,6 +610,8 @@ extension WorkspaceState {
             let edit = editingMessageContextByConversation.removeValue(forKey: draftKey)
         else { return }
         draftTextByConversation[draftKey] = edit.preservedDraft.isEmpty ? nil : edit.preservedDraft
+        composerMentionSelectionsByConversation[draftKey] =
+            edit.preservedMentionSelections.isEmpty ? nil : edit.preservedMentionSelections
         replyDraftContextByConversation[draftKey] = edit.preservedReplyContext
         pendingMediaAttachmentsByConversation[draftKey] =
             edit.preservedMediaAttachments.isEmpty ? nil : edit.preservedMediaAttachments
@@ -678,7 +682,7 @@ extension WorkspaceState {
                 _ = try await client.sendText(
                     accountRef: activeAccount.accountRef,
                     groupIdHex: chat.id,
-                    text: message.body
+                    text: message.wireBody
                 )
             }
             cancelForwarding()
@@ -688,17 +692,36 @@ extension WorkspaceState {
         }
     }
 
-    /// The authoritative deletion-scope model for `message` in the selected conversation. Both the
-    /// action UI and the mutation paths derive from this — button visibility is not the security
-    /// boundary (the mutations re-check the same capability).
-    func messageDeletionCapability(_ message: MessageItem) -> MessageDeletionCapability {
-        guard message.supportsChatActions, let selectedChat else { return .none }
-        return MessageDeletionCapability.resolve(
-            isActionable: true,
+    func messageDeletionTarget(for message: MessageItem) -> MessageDeletionTarget? {
+        guard message.supportsChatActions, let selectedChat, let activeAccount, let activeAccountId else {
+            return nil
+        }
+        return MessageDeletionTarget(
+            message: message,
+            accountId: activeAccountId,
+            accountRef: activeAccount.accountRef,
+            groupIdHex: selectedChat.id,
             isDirectConversation: selectedChat.isDirect,
-            isOwnMessage: message.isOutgoing,
             isSelfGroupAdmin: conversationMetadataByChat[selectedChat.id]?.isSelfAdmin == true
         )
+    }
+
+    /// The authoritative deletion-scope model captured when the action was opened. Both the action
+    /// UI and mutation path use this immutable target; the engine remains the final authority.
+    func messageDeletionCapability(_ target: MessageDeletionTarget) -> MessageDeletionCapability {
+        let message = target.message
+        guard message.supportsChatActions else { return .none }
+        return MessageDeletionCapability.resolve(
+            isActionable: true,
+            isDirectConversation: target.isDirectConversation,
+            isOwnMessage: message.isOutgoing,
+            isSelfGroupAdmin: target.isSelfGroupAdmin
+        )
+    }
+
+    func messageDeletionCapability(_ message: MessageItem) -> MessageDeletionCapability {
+        guard let target = messageDeletionTarget(for: message) else { return .none }
+        return messageDeletionCapability(target)
     }
 
     func canDeleteMessage(_ message: MessageItem) -> Bool {
@@ -707,8 +730,9 @@ extension WorkspaceState {
 
     /// Adaptive supporting copy for the delete-confirmation surface. Explains the offered scopes
     /// without admin-branding the action, per the unified model.
-    func messageDeletionScopeExplanation(_ message: MessageItem) -> String {
-        let capability = messageDeletionCapability(message)
+    func messageDeletionScopeExplanation(_ target: MessageDeletionTarget) -> String {
+        let message = target.message
+        let capability = messageDeletionCapability(target)
         guard capability.canDeleteForEveryone else {
             return L10n.string("This message will be hidden on this device only.")
         }
@@ -721,12 +745,15 @@ extension WorkspaceState {
     func deleteSelectedMessages() async {
         // Multi-select acts only on messages the user may delete for everyone — it must not
         // silently mix in local hides; single-message delete-for-me goes through the confirmation.
-        let messages = selectedTimelineMessagesForAction.filter {
-            messageDeletionCapability($0).canDeleteForEveryone
+        let targets = selectedTimelineMessagesForAction.compactMap { message -> MessageDeletionTarget? in
+            guard let target = messageDeletionTarget(for: message),
+                messageDeletionCapability(target).canDeleteForEveryone
+            else { return nil }
+            return target
         }
-        guard !messages.isEmpty else { return }
-        for message in messages {
-            await deleteForEveryone(message)
+        guard !targets.isEmpty else { return }
+        for target in targets {
+            await deleteForEveryone(target)
         }
         cancelMessageSelection()
     }
@@ -776,12 +803,17 @@ extension WorkspaceState {
     func removeReaction(_ reaction: MessageReaction, from message: MessageItem) async {
         guard message.supportsChatActions else { return }
         guard reaction.canRemoveOwnReaction, let reactionMessageId = reaction.ownReactionMessageId else { return }
-        guard let client, let activeAccount, let selectedChat else { return }
+        guard let client, let activeAccount, let activeAccountId, let selectedChat else { return }
         // Reentrancy guard: the removal deletes the reaction event, so key on its id
         // (shared namespace with `deleteMessage`) to drop a repeated in-flight removal.
-        guard !inFlightDeleteMessageIds.contains(reactionMessageId) else { return }
-        inFlightDeleteMessageIds.insert(reactionMessageId)
-        defer { inFlightDeleteMessageIds.remove(reactionMessageId) }
+        let inFlightKey = deleteInFlightKey(
+            accountId: activeAccountId,
+            groupIdHex: selectedChat.id,
+            messageId: reactionMessageId
+        )
+        guard !inFlightDeleteMessageIds.contains(inFlightKey) else { return }
+        inFlightDeleteMessageIds.insert(inFlightKey)
+        defer { inFlightDeleteMessageIds.remove(inFlightKey) }
         do {
             _ = try await client.deleteMessage(
                 accountRef: activeAccount.accountRef,
@@ -797,19 +829,29 @@ extension WorkspaceState {
     /// another member's group message). Re-checks the capability so a mis-rendered option can't
     /// drive an unauthorized retraction — the engine is the final authority, this is the local guard.
     func deleteForEveryone(_ message: MessageItem) async {
-        guard let client, let activeAccount, let selectedChat else { return }
-        guard messageDeletionCapability(message).canDeleteForEveryone else { return }
+        guard let target = messageDeletionTarget(for: message) else { return }
+        await deleteForEveryone(target)
+    }
+
+    func deleteForEveryone(_ target: MessageDeletionTarget) async {
+        let message = target.message
+        guard let client, messageDeletionCapability(target).canDeleteForEveryone else { return }
         // Reentrancy guard: drop a repeated delete of the same in-flight message.
-        guard !inFlightDeleteMessageIds.contains(message.id) else { return }
-        inFlightDeleteMessageIds.insert(message.id)
-        defer { inFlightDeleteMessageIds.remove(message.id) }
+        let inFlightKey = deleteInFlightKey(
+            accountId: target.accountId,
+            groupIdHex: target.groupIdHex,
+            messageId: message.id
+        )
+        guard !inFlightDeleteMessageIds.contains(inFlightKey) else { return }
+        inFlightDeleteMessageIds.insert(inFlightKey)
+        defer { inFlightDeleteMessageIds.remove(inFlightKey) }
         do {
             _ = try await client.deleteMessage(
-                accountRef: activeAccount.accountRef,
-                groupIdHex: selectedChat.id,
+                accountRef: target.accountRef,
+                groupIdHex: target.groupIdHex,
                 targetMessageId: message.id
             )
-            clearComposerContextTargeting(message.id)
+            clearComposerContextTargeting(message.id, target: target)
         } catch {
             lastError = error.localizedDescription
         }
@@ -817,27 +859,46 @@ extension WorkspaceState {
 
     /// Delete for me: hide the message locally and persist the hidden id. Publishes nothing.
     func deleteForMe(_ message: MessageItem) {
-        guard let activeAccountId, let selectedChat else { return }
-        guard messageDeletionCapability(message).canDeleteForMe else { return }
-        hideMessageLocally(accountId: activeAccountId, groupIdHex: selectedChat.id, messageId: message.id)
-        clearComposerContextTargeting(message.id)
+        guard let target = messageDeletionTarget(for: message) else { return }
+        deleteForMe(target)
+    }
+
+    func deleteForMe(_ target: MessageDeletionTarget) {
+        let message = target.message
+        guard messageDeletionCapability(target).canDeleteForMe else { return }
+        hideMessageLocally(accountId: target.accountId, groupIdHex: target.groupIdHex, messageId: message.id)
+        clearComposerContextTargeting(message.id, target: target)
+    }
+
+    private func deleteInFlightKey(accountId: String, groupIdHex: String, messageId: String) -> String {
+        "\(accountId)\u{1F}\(groupIdHex)\u{1F}\(messageId)"
     }
 
     /// Drop any reply or in-progress edit in the selected conversation that targets `messageId`,
     /// so a deleted message can't remain a live reply/edit target.
-    private func clearComposerContextTargeting(_ messageId: String) {
-        if replyDraftContext?.targetMessageId == messageId {
-            replyDraftContext = nil
+    private func clearComposerContextTargeting(_ messageId: String, target: MessageDeletionTarget) {
+        let draftKey = ComposerDraftKey(accountId: target.accountId, chatId: target.groupIdHex)
+        if replyDraftContextByConversation[draftKey]?.targetMessageId == messageId {
+            replyDraftContextByConversation[draftKey] = nil
         }
-        if let draftKey = selectedComposerDraftKey,
-            editingMessageContextByConversation[draftKey]?.targetMessageId == messageId
+        if let edit = editingMessageContextByConversation[draftKey],
+            edit.targetMessageId == messageId
         {
-            cancelEditingMessage()
+            editingMessageContextByConversation[draftKey] = nil
+            draftTextByConversation[draftKey] = edit.preservedDraft.isEmpty ? nil : edit.preservedDraft
+            composerMentionSelectionsByConversation[draftKey] =
+                edit.preservedMentionSelections.isEmpty ? nil : edit.preservedMentionSelections
+            replyDraftContextByConversation[draftKey] = edit.preservedReplyContext
+            pendingMediaAttachmentsByConversation[draftKey] =
+                edit.preservedMediaAttachments.isEmpty ? nil : edit.preservedMediaAttachments
+            pendingMediaUploadStatesByConversation[draftKey] =
+                edit.preservedMediaUploadStates.isEmpty ? nil : edit.preservedMediaUploadStates
         }
     }
 
     func sendDraft() async {
-        let text = canonicalizeMentions(in: draftText.trimmingCharacters(in: .whitespacesAndNewlines))
+        let text = canonicalizeMentions(in: draftText, selections: composerMentionSelections)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         let mediaAttachments = pendingMediaAttachments
         // `!isSending` is the reentrancy guard: `isSending` flips synchronously here,
         // but the model only suspends (and `draftText` is only cleared) at the `await`
@@ -870,6 +931,8 @@ extension WorkspaceState {
             )
             editingMessageContextByConversation[draftKey] = nil
             draftTextByConversation[draftKey] = editContext.preservedDraft.isEmpty ? nil : editContext.preservedDraft
+            composerMentionSelectionsByConversation[draftKey] =
+                editContext.preservedMentionSelections.isEmpty ? nil : editContext.preservedMentionSelections
             replyDraftContextByConversation[draftKey] = editContext.preservedReplyContext
             pendingMediaAttachmentsByConversation[draftKey] =
                 editContext.preservedMediaAttachments.isEmpty ? nil : editContext.preservedMediaAttachments
@@ -933,6 +996,7 @@ extension WorkspaceState {
             // switched chats during the `await` above they would wipe the newly selected
             // conversation's composer state instead of the one we just sent from.
             draftTextByConversation[draftKey] = nil
+            composerMentionSelectionsByConversation[draftKey] = nil
             replyDraftContextByConversation[draftKey] = nil
             pendingMediaAttachmentsByConversation[draftKey] = nil
             pendingMediaUploadStatesByConversation[draftKey] = nil

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -446,7 +446,7 @@ final class MessageTimelineStore {
         var versions = [
             MessageEditVersion(
                 id: base.id,
-                text: base.body,
+                text: MentionDisplayResolver.resolve(in: base.wireBody, mentionNames: base.mentionNames),
                 date: Date(timeIntervalSince1970: TimeInterval(base.timelineAt)),
                 isOriginal: true
             )
@@ -454,7 +454,7 @@ final class MessageTimelineStore {
         versions += edits.map { edit in
             MessageEditVersion(
                 id: edit.editMessageIdHex,
-                text: edit.plaintext,
+                text: MentionDisplayResolver.resolve(in: edit.plaintext, mentionNames: base.mentionNames),
                 date: Date(timeIntervalSince1970: TimeInterval(edit.timelineAt)),
                 isOriginal: false
             )
@@ -763,9 +763,20 @@ final class WorkspaceState {
             guard let selectedComposerDraftKey else { return }
             if newValue.isEmpty {
                 draftTextByConversation[selectedComposerDraftKey] = nil
+                composerMentionSelectionsByConversation[selectedComposerDraftKey] = nil
             } else {
                 draftTextByConversation[selectedComposerDraftKey] = newValue
             }
+        }
+    }
+    var composerMentionSelections: [ComposerMentionSelection] {
+        get {
+            guard let selectedComposerDraftKey else { return [] }
+            return composerMentionSelectionsByConversation[selectedComposerDraftKey] ?? []
+        }
+        set {
+            guard let selectedComposerDraftKey else { return }
+            composerMentionSelectionsByConversation[selectedComposerDraftKey] = newValue.isEmpty ? nil : newValue
         }
     }
     var pendingMediaAttachments: [PendingMediaAttachment] {
@@ -914,9 +925,9 @@ final class WorkspaceState {
     /// never publishes anything. Persisted in `UserDefaults` under `Self.hiddenMessagesDefaultsKey`.
     @ObservationIgnored var hiddenMessageIdsByChat: [String: Set<String>] = [:]
     var selectedTimelineMessageIds: Set<String> = []
-    /// Message whose unified delete-confirmation surface is open, or `nil`. Drives the adaptive
+    /// Scoped message target whose unified delete-confirmation surface is open, or `nil`. Drives the adaptive
     /// dialog that offers only the scopes `messageDeletionCapability` permits.
-    var messagePendingDeletion: MessageItem?
+    var messagePendingDeletion: MessageDeletionTarget?
     /// Message whose edit-history sheet is open, or `nil`. Cleared when the selection changes.
     var messagePendingEditHistory: MessageItem?
     var messageInfoTarget: MessageItem?
@@ -944,6 +955,7 @@ final class WorkspaceState {
     var timelinePagingByChat: [String: TimelinePagingState] = [:]
     var timelineInitialLoadGroupId: String?
     var draftTextByConversation: [ComposerDraftKey: String] = [:]
+    var composerMentionSelectionsByConversation: [ComposerDraftKey: [ComposerMentionSelection]] = [:]
     var replyDraftContextByConversation: [ComposerDraftKey: MessageReplyContext] = [:]
     var editingMessageContextByConversation: [ComposerDraftKey: MessageEditContext] = [:]
     var pendingMediaAttachmentsByConversation: [ComposerDraftKey: [PendingMediaAttachment]] = [:]

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -297,6 +297,7 @@ nonisolated struct MessageEditContext: Hashable {
     let senderName: String
     let originalBody: String
     let preservedDraft: String
+    let preservedMentionSelections: [ComposerMentionSelection]
     let preservedReplyContext: MessageReplyContext?
     let preservedMediaAttachments: [PendingMediaAttachment]
     let preservedMediaUploadStates: [PendingMediaAttachment.ID: PendingMediaUploadState]
@@ -1611,10 +1612,14 @@ nonisolated struct MessageItem: Identifiable, Hashable {
     let senderName: String
     let senderPictureURL: String?
     let body: String
+    /// Canonical plaintext used when editing or forwarding. For edited messages, `body` is the
+    /// roster-resolved display text while this retains stable npub mention tokens.
+    let wireBody: String
     /// Pre-rendered Markdown display model for the message body. The Marmot core supplies
     /// parsed tokens; `MessageItem` converts them once so SwiftUI body/layout passes do not
     /// rebuild attributed strings or enumerated block arrays while scrolling.
     let contentMarkdown: MarkdownDisplayDocument?
+    let mentionNames: MarkdownMentionNames
     let trimmedBody: String
     let sentAt: Date
     let timelineAt: UInt64
@@ -1659,6 +1664,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         senderName: String,
         senderPictureURL: String? = nil,
         body: String,
+        wireBody: String? = nil,
         contentMarkdown: MarkdownDocumentFfi? = nil,
         mentionNames: MarkdownMentionNames = [:],
         sentAt: Date,
@@ -1684,7 +1690,9 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         self.senderName = senderName
         self.senderPictureURL = senderPictureURL
         self.body = body
+        self.wireBody = wireBody ?? body
         self.contentMarkdown = contentMarkdown.map { MarkdownDisplayDocument(document: $0, mentionNames: mentionNames) }
+        self.mentionNames = mentionNames
         self.trimmedBody = trimmedBody
         self.sentAt = sentAt
         // `timelineAt` is normally supplied by the core mapping; the fallback derives it from
@@ -1743,7 +1751,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
     }
 
     func applyingEdit(plaintext editedPlaintext: String) -> MessageItem {
-        let body = MessageItem.displayText(
+        let wireBody = MessageItem.displayText(
             presentation: presentation,
             plaintext: editedPlaintext,
             tags: [],
@@ -1751,6 +1759,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
             invalidationStatus: invalidationStatus,
             hasMediaAttachments: !mediaAttachments.isEmpty
         )
+        let body = MentionDisplayResolver.resolve(in: wireBody, mentionNames: mentionNames)
         return MessageItem(
             id: id,
             groupIdHex: groupIdHex,
@@ -1760,7 +1769,9 @@ nonisolated struct MessageItem: Identifiable, Hashable {
             senderName: senderName,
             senderPictureURL: senderPictureURL,
             body: body,
+            wireBody: wireBody,
             contentMarkdown: nil,
+            mentionNames: mentionNames,
             sentAt: sentAt,
             timelineAt: timelineAt,
             timelineKind: timelineKind,
@@ -1895,13 +1906,24 @@ nonisolated struct MessageDeletionCapability: Equatable {
     }
 }
 
+/// Immutable account/conversation scope captured when a deletion action is opened. Confirmation
+/// and async mutation paths use this instead of consulting the workspace's mutable selection.
+nonisolated struct MessageDeletionTarget: Hashable {
+    let message: MessageItem
+    let accountId: String
+    let accountRef: String
+    let groupIdHex: String
+    let isDirectConversation: Bool
+    let isSelfGroupAdmin: Bool
+}
+
 extension MessageItem {
     // Hand-written `Equatable`/`Hashable` so equality and hashing stay O(1) instead of
     // recursively walking `contentMarkdown`'s pre-rendered Markdown tree.
     //
     // `contentMarkdown` is a deterministic display projection of the message content
     // (the core's `contentTokens`), fully determined by the content-bearing fields
-    // compared below — chiefly `body`, `isDeleted`, and `presentation`. Two items that
+    // compared below — chiefly `body`, `mentionNames`, `isDeleted`, and `presentation`. Two items that
     // agree on those always carry the same AST, so excluding it from equality is sound
     // while avoiding an O(AST) traversal on every comparison. That traversal otherwise
     // ran for each row whenever SwiftUI diffed the transcript (and on any Set/Dictionary
@@ -1919,6 +1941,8 @@ extension MessageItem {
             && lhs.senderName == rhs.senderName
             && lhs.senderPictureURL == rhs.senderPictureURL
             && lhs.body == rhs.body
+            && lhs.wireBody == rhs.wireBody
+            && lhs.mentionNames == rhs.mentionNames
             && lhs.sentAt == rhs.sentAt
             && lhs.timelineAt == rhs.timelineAt
             && lhs.timelineKind == rhs.timelineKind

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -30,7 +30,16 @@ struct ComposerMentionContext: Equatable {
 struct ComposerMentionInsertion: Equatable {
     let id = UUID()
     let range: NSRange
-    let replacement: String
+    let displayText: String
+    let npub: String
+
+    init(range: NSRange, candidate: ComposerMentionCandidate) {
+        self.range = range
+        displayText = "@\(candidate.displayName)"
+        npub = candidate.npub
+    }
+
+    var replacement: String { "\(displayText) " }
 }
 
 struct ComposerMessageInputView: View {
@@ -40,6 +49,7 @@ struct ComposerMessageInputView: View {
     let onEmojiInsertionConsumed: (UUID) -> Void
     let mentionInsertion: ComposerMentionInsertion?
     let onMentionInsertionConsumed: (UUID) -> Void
+    @Binding var mentionSelections: [ComposerMentionSelection]
     let onMentionContextChange: (ComposerMentionContext?) -> Void
     let onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
     let onSend: () -> Void
@@ -55,6 +65,7 @@ struct ComposerMessageInputView: View {
                 onEmojiInsertionConsumed: onEmojiInsertionConsumed,
                 mentionInsertion: mentionInsertion,
                 onMentionInsertionConsumed: onMentionInsertionConsumed,
+                mentionSelections: $mentionSelections,
                 onMentionContextChange: onMentionContextChange,
                 onPasteMedia: onPasteMedia,
                 onSend: onSend
@@ -181,6 +192,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
     let onEmojiInsertionConsumed: (UUID) -> Void
     let mentionInsertion: ComposerMentionInsertion?
     let onMentionInsertionConsumed: (UUID) -> Void
+    @Binding var mentionSelections: [ComposerMentionSelection]
     let onMentionContextChange: (ComposerMentionContext?) -> Void
     let onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
     let onSend: () -> Void
@@ -189,6 +201,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         Coordinator(
             text: $text,
             measuredHeight: $measuredHeight,
+            mentionSelections: $mentionSelections,
             onPasteMedia: onPasteMedia,
             onSend: onSend,
             onMentionContextChange: onMentionContextChange
@@ -237,6 +250,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         context.coordinator.onSend = onSend
         context.coordinator.onEmojiInsertionConsumed = onEmojiInsertionConsumed
         context.coordinator.onMentionInsertionConsumed = onMentionInsertionConsumed
+        context.coordinator.mentionSelections = $mentionSelections
         context.coordinator.onMentionContextChange = onMentionContextChange
 
         guard let textView = scrollView.documentView as? ComposerPasteInterceptingTextView else { return }
@@ -245,6 +259,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         if textView.string != text {
             textView.string = text
         }
+        context.coordinator.synchronizeMentionMarkers(in: textView)
         context.coordinator.insertEmojiIfNeeded(emojiInsertion, into: textView)
         context.coordinator.insertMentionIfNeeded(mentionInsertion, into: textView)
         DispatchQueue.main.async {
@@ -265,6 +280,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         var text: Binding<String>
         var measuredHeight: Binding<CGFloat>
+        var mentionSelections: Binding<[ComposerMentionSelection]>
         var onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
         var onSend: () -> Void
         var onEmojiInsertionConsumed: (UUID) -> Void
@@ -277,6 +293,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         init(
             text: Binding<String>,
             measuredHeight: Binding<CGFloat>,
+            mentionSelections: Binding<[ComposerMentionSelection]>,
             onPasteMedia: @escaping ([OutgoingMediaPasteboardAttachment]) -> Void,
             onSend: @escaping () -> Void,
             onEmojiInsertionConsumed: @escaping (UUID) -> Void = { _ in },
@@ -285,6 +302,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         ) {
             self.text = text
             self.measuredHeight = measuredHeight
+            self.mentionSelections = mentionSelections
             self.onPasteMedia = onPasteMedia
             self.onSend = onSend
             self.onEmojiInsertionConsumed = onEmojiInsertionConsumed
@@ -314,7 +332,22 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
                 return
             }
             textView.insertText(insertion.replacement, replacementRange: insertion.range)
+            let mentionRange = NSRange(
+                location: insertion.range.location,
+                length: (insertion.displayText as NSString).length
+            )
+            textView.textStorage?.addAttribute(
+                .composerMentionNpub,
+                value: insertion.npub,
+                range: mentionRange
+            )
+            textView.textStorage?.addAttribute(
+                .composerMentionDisplayText,
+                value: insertion.displayText,
+                range: mentionRange
+            )
             text.wrappedValue = textView.string
+            publishMentionSelections(for: textView)
             updateMeasuredHeight(for: textView)
             textView.window?.makeFirstResponder(textView)
             publishMentionContext(for: textView)
@@ -324,6 +357,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
             text.wrappedValue = textView.string
+            publishMentionSelections(for: textView)
             updateMeasuredHeight(for: textView)
             publishMentionContext(for: textView)
         }
@@ -353,6 +387,73 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             return ComposerMentionContext(query: session.query, tokenRange: NSRange(session.range, in: full))
         }
 
+        func synchronizeMentionMarkers(in textView: NSTextView) {
+            let desired = mentionSelections.wrappedValue
+            guard validMentionSelections(in: textView, removingInvalid: false) != desired else { return }
+            let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+            textView.textStorage?.removeAttribute(.composerMentionNpub, range: fullRange)
+            textView.textStorage?.removeAttribute(.composerMentionDisplayText, range: fullRange)
+            for selection in desired where Self.isValid(selection, in: textView.string) {
+                textView.textStorage?.addAttribute(
+                    .composerMentionNpub,
+                    value: selection.npub,
+                    range: selection.range
+                )
+                textView.textStorage?.addAttribute(
+                    .composerMentionDisplayText,
+                    value: selection.displayText,
+                    range: selection.range
+                )
+            }
+            publishMentionSelections(for: textView)
+        }
+
+        private func publishMentionSelections(for textView: NSTextView) {
+            let selections = validMentionSelections(in: textView, removingInvalid: true)
+            if mentionSelections.wrappedValue != selections {
+                mentionSelections.wrappedValue = selections
+            }
+        }
+
+        private func validMentionSelections(
+            in textView: NSTextView,
+            removingInvalid: Bool
+        ) -> [ComposerMentionSelection] {
+            guard let storage = textView.textStorage else { return [] }
+            let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+            var selections: [ComposerMentionSelection] = []
+            var invalidRanges: [NSRange] = []
+            storage.enumerateAttribute(.composerMentionNpub, in: fullRange) { value, range, _ in
+                guard let npub = value as? String,
+                    let displayText = storage.attribute(
+                        .composerMentionDisplayText,
+                        at: range.location,
+                        effectiveRange: nil
+                    ) as? String
+                else { return }
+                let selection = ComposerMentionSelection(range: range, displayText: displayText, npub: npub)
+                if Self.isValid(selection, in: textView.string) {
+                    selections.append(selection)
+                } else {
+                    invalidRanges.append(range)
+                }
+            }
+            if removingInvalid {
+                for range in invalidRanges {
+                    storage.removeAttribute(.composerMentionNpub, range: range)
+                    storage.removeAttribute(.composerMentionDisplayText, range: range)
+                }
+            }
+            return selections.sorted { $0.location < $1.location }
+        }
+
+        private static func isValid(_ selection: ComposerMentionSelection, in text: String) -> Bool {
+            selection.location >= 0
+                && selection.length > 0
+                && NSMaxRange(selection.range) <= (text as NSString).length
+                && (text as NSString).substring(with: selection.range) == selection.displayText
+        }
+
         func handleMediaPaste() -> Bool {
             let attachments = OutgoingMediaPasteboardReader.attachments(from: .general)
             guard !attachments.isEmpty else { return false }
@@ -377,6 +478,11 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             }
         }
     }
+}
+
+private extension NSAttributedString.Key {
+    static let composerMentionNpub = NSAttributedString.Key("whitenoise.composerMentionNpub")
+    static let composerMentionDisplayText = NSAttributedString.Key("whitenoise.composerMentionDisplayText")
 }
 
 @MainActor

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -29,12 +29,20 @@ struct ComposerMentionContext: Equatable {
 /// `ComposerEmojiInsertion` but replacing the "@query" token rather than the current selection.
 struct ComposerMentionInsertion: Equatable {
     let id = UUID()
+    let scope: WorkspaceState.ComposerDraftKey
     let range: NSRange
+    let expectedText: String
     let displayText: String
     let npub: String
 
-    init(range: NSRange, candidate: ComposerMentionCandidate) {
-        self.range = range
+    init(
+        scope: WorkspaceState.ComposerDraftKey,
+        context: ComposerMentionContext,
+        candidate: ComposerMentionCandidate
+    ) {
+        self.scope = scope
+        range = context.tokenRange
+        expectedText = "@\(context.query)"
         displayText = "@\(candidate.displayName)"
         npub = candidate.npub
     }
@@ -50,6 +58,7 @@ struct ComposerMessageInputView: View {
     let mentionInsertion: ComposerMentionInsertion?
     let onMentionInsertionConsumed: (UUID) -> Void
     @Binding var mentionSelections: [ComposerMentionSelection]
+    let mentionContextScope: WorkspaceState.ComposerDraftKey?
     let onMentionContextChange: (ComposerMentionContext?) -> Void
     let onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
     let onSend: () -> Void
@@ -66,6 +75,7 @@ struct ComposerMessageInputView: View {
                 mentionInsertion: mentionInsertion,
                 onMentionInsertionConsumed: onMentionInsertionConsumed,
                 mentionSelections: $mentionSelections,
+                mentionContextScope: mentionContextScope,
                 onMentionContextChange: onMentionContextChange,
                 onPasteMedia: onPasteMedia,
                 onSend: onSend
@@ -185,7 +195,7 @@ nonisolated enum ComposerKeyboardShortcutPolicy {
     }
 }
 
-private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
+struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
     @Binding var text: String
     @Binding var measuredHeight: CGFloat
     let emojiInsertion: ComposerEmojiInsertion?
@@ -193,6 +203,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
     let mentionInsertion: ComposerMentionInsertion?
     let onMentionInsertionConsumed: (UUID) -> Void
     @Binding var mentionSelections: [ComposerMentionSelection]
+    let mentionContextScope: WorkspaceState.ComposerDraftKey?
     let onMentionContextChange: (ComposerMentionContext?) -> Void
     let onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
     let onSend: () -> Void
@@ -202,6 +213,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             text: $text,
             measuredHeight: $measuredHeight,
             mentionSelections: $mentionSelections,
+            mentionContextScope: mentionContextScope,
             onPasteMedia: onPasteMedia,
             onSend: onSend,
             onMentionContextChange: onMentionContextChange
@@ -260,6 +272,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             textView.string = text
         }
         context.coordinator.synchronizeMentionMarkers(in: textView)
+        context.coordinator.synchronizeMentionContextScope(mentionContextScope, in: textView)
         context.coordinator.insertEmojiIfNeeded(emojiInsertion, into: textView)
         context.coordinator.insertMentionIfNeeded(mentionInsertion, into: textView)
         DispatchQueue.main.async {
@@ -281,6 +294,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         var text: Binding<String>
         var measuredHeight: Binding<CGFloat>
         var mentionSelections: Binding<[ComposerMentionSelection]>
+        private var mentionContextScope: WorkspaceState.ComposerDraftKey?
         var onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
         var onSend: () -> Void
         var onEmojiInsertionConsumed: (UUID) -> Void
@@ -294,6 +308,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             text: Binding<String>,
             measuredHeight: Binding<CGFloat>,
             mentionSelections: Binding<[ComposerMentionSelection]>,
+            mentionContextScope: WorkspaceState.ComposerDraftKey?,
             onPasteMedia: @escaping ([OutgoingMediaPasteboardAttachment]) -> Void,
             onSend: @escaping () -> Void,
             onEmojiInsertionConsumed: @escaping (UUID) -> Void = { _ in },
@@ -303,6 +318,7 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             self.text = text
             self.measuredHeight = measuredHeight
             self.mentionSelections = mentionSelections
+            self.mentionContextScope = mentionContextScope
             self.onPasteMedia = onPasteMedia
             self.onSend = onSend
             self.onEmojiInsertionConsumed = onEmojiInsertionConsumed
@@ -324,10 +340,18 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         func insertMentionIfNeeded(_ insertion: ComposerMentionInsertion?, into textView: NSTextView) {
             guard let insertion, insertion.id != lastMentionInsertionID else { return }
             lastMentionInsertionID = insertion.id
+            guard insertion.scope == mentionContextScope else {
+                onMentionInsertionConsumed(insertion.id)
+                return
+            }
             let bounds = NSRange(location: 0, length: (textView.string as NSString).length)
             // The token range was captured on an earlier text snapshot; drop it if the text has
             // since shrunk past it rather than inserting at a stale offset.
             guard NSMaxRange(insertion.range) <= bounds.length else {
+                onMentionInsertionConsumed(insertion.id)
+                return
+            }
+            guard (textView.string as NSString).substring(with: insertion.range) == insertion.expectedText else {
                 onMentionInsertionConsumed(insertion.id)
                 return
             }
@@ -336,15 +360,13 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
                 location: insertion.range.location,
                 length: (insertion.displayText as NSString).length
             )
-            textView.textStorage?.addAttribute(
-                .composerMentionNpub,
-                value: insertion.npub,
-                range: mentionRange
-            )
-            textView.textStorage?.addAttribute(
-                .composerMentionDisplayText,
-                value: insertion.displayText,
-                range: mentionRange
+            ComposerMentionMarkerStore.add(
+                ComposerMentionSelection(
+                    range: mentionRange,
+                    displayText: insertion.displayText,
+                    npub: insertion.npub
+                ),
+                to: textView
             )
             text.wrappedValue = textView.string
             publishMentionSelections(for: textView)
@@ -376,6 +398,16 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             onMentionContextChange(context)
         }
 
+        func synchronizeMentionContextScope(
+            _ scope: WorkspaceState.ComposerDraftKey?,
+            in textView: NSTextView
+        ) {
+            guard mentionContextScope != scope else { return }
+            mentionContextScope = scope
+            lastMentionContext = nil
+            publishMentionContext(for: textView)
+        }
+
         private static func mentionContext(in textView: NSTextView) -> ComposerMentionContext? {
             let selection = textView.selectedRange()
             guard selection.length == 0 else { return nil }
@@ -389,69 +421,16 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
 
         func synchronizeMentionMarkers(in textView: NSTextView) {
             let desired = mentionSelections.wrappedValue
-            guard validMentionSelections(in: textView, removingInvalid: false) != desired else { return }
-            let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
-            textView.textStorage?.removeAttribute(.composerMentionNpub, range: fullRange)
-            textView.textStorage?.removeAttribute(.composerMentionDisplayText, range: fullRange)
-            for selection in desired where Self.isValid(selection, in: textView.string) {
-                textView.textStorage?.addAttribute(
-                    .composerMentionNpub,
-                    value: selection.npub,
-                    range: selection.range
-                )
-                textView.textStorage?.addAttribute(
-                    .composerMentionDisplayText,
-                    value: selection.displayText,
-                    range: selection.range
-                )
-            }
+            guard ComposerMentionMarkerStore.selections(in: textView) != desired else { return }
+            ComposerMentionMarkerStore.replaceAll(with: desired, in: textView)
             publishMentionSelections(for: textView)
         }
 
         private func publishMentionSelections(for textView: NSTextView) {
-            let selections = validMentionSelections(in: textView, removingInvalid: true)
+            let selections = ComposerMentionMarkerStore.selections(in: textView)
             if mentionSelections.wrappedValue != selections {
                 mentionSelections.wrappedValue = selections
             }
-        }
-
-        private func validMentionSelections(
-            in textView: NSTextView,
-            removingInvalid: Bool
-        ) -> [ComposerMentionSelection] {
-            guard let storage = textView.textStorage else { return [] }
-            let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
-            var selections: [ComposerMentionSelection] = []
-            var invalidRanges: [NSRange] = []
-            storage.enumerateAttribute(.composerMentionNpub, in: fullRange) { value, range, _ in
-                guard let npub = value as? String,
-                    let displayText = storage.attribute(
-                        .composerMentionDisplayText,
-                        at: range.location,
-                        effectiveRange: nil
-                    ) as? String
-                else { return }
-                let selection = ComposerMentionSelection(range: range, displayText: displayText, npub: npub)
-                if Self.isValid(selection, in: textView.string) {
-                    selections.append(selection)
-                } else {
-                    invalidRanges.append(range)
-                }
-            }
-            if removingInvalid {
-                for range in invalidRanges {
-                    storage.removeAttribute(.composerMentionNpub, range: range)
-                    storage.removeAttribute(.composerMentionDisplayText, range: range)
-                }
-            }
-            return selections.sorted { $0.location < $1.location }
-        }
-
-        private static func isValid(_ selection: ComposerMentionSelection, in text: String) -> Bool {
-            selection.location >= 0
-                && selection.length > 0
-                && NSMaxRange(selection.range) <= (text as NSString).length
-                && (text as NSString).substring(with: selection.range) == selection.displayText
         }
 
         func handleMediaPaste() -> Bool {
@@ -477,6 +456,119 @@ private struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
                 measuredHeight.wrappedValue = height
             }
         }
+    }
+}
+
+@MainActor
+enum ComposerMentionMarkerStore {
+    private struct Repair {
+        let oldRange: NSRange
+        let selection: ComposerMentionSelection
+    }
+
+    static func add(_ selection: ComposerMentionSelection, to textView: NSTextView) {
+        guard isExact(selection, in: textView.string), let storage = textView.textStorage else { return }
+        storage.addAttribute(.composerMentionNpub, value: selection.npub, range: selection.range)
+        storage.addAttribute(.composerMentionDisplayText, value: selection.displayText, range: selection.range)
+    }
+
+    static func replaceAll(with selections: [ComposerMentionSelection], in textView: NSTextView) {
+        guard let storage = textView.textStorage else { return }
+        let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
+        storage.removeAttribute(.composerMentionNpub, range: fullRange)
+        storage.removeAttribute(.composerMentionDisplayText, range: fullRange)
+        for selection in selections {
+            add(selection, to: textView)
+        }
+    }
+
+    static func selections(in textView: NSTextView) -> [ComposerMentionSelection] {
+        guard let storage = textView.textStorage else { return [] }
+        let text = textView.string
+        let fullRange = NSRange(location: 0, length: (text as NSString).length)
+        guard fullRange.length > 0 else { return [] }
+        var selections: [ComposerMentionSelection] = []
+        var invalidRanges: [NSRange] = []
+        var repairs: [Repair] = []
+        storage.enumerateAttribute(.composerMentionNpub, in: fullRange) { value, range, _ in
+            guard let npub = value as? String,
+                let displayText = storage.attribute(
+                    .composerMentionDisplayText,
+                    at: range.location,
+                    effectiveRange: nil
+                ) as? String,
+                let normalizedRange = normalizedRange(
+                    for: displayText,
+                    within: range,
+                    in: text
+                )
+            else {
+                invalidRanges.append(range)
+                return
+            }
+            let selection = ComposerMentionSelection(
+                range: normalizedRange,
+                displayText: displayText,
+                npub: npub
+            )
+            selections.append(selection)
+            if normalizedRange != range {
+                repairs.append(Repair(oldRange: range, selection: selection))
+            }
+        }
+        guard !invalidRanges.isEmpty || !repairs.isEmpty else {
+            return selections.sorted { $0.location < $1.location }
+        }
+        storage.beginEditing()
+        for range in invalidRanges + repairs.map(\.oldRange) {
+            storage.removeAttribute(.composerMentionNpub, range: range)
+            storage.removeAttribute(.composerMentionDisplayText, range: range)
+        }
+        for repair in repairs {
+            add(repair.selection, to: textView)
+        }
+        storage.endEditing()
+        return selections.sorted { $0.location < $1.location }
+    }
+
+    private static func normalizedRange(
+        for displayText: String,
+        within attributedRange: NSRange,
+        in text: String
+    ) -> NSRange? {
+        let nsText = text as NSString
+        guard attributedRange.location >= 0,
+            attributedRange.length > 0,
+            NSMaxRange(attributedRange) <= nsText.length
+        else { return nil }
+        if nsText.substring(with: attributedRange) == displayText,
+            ComposerMentionCanonicalizer.isValidVisibleMention(attributedRange, in: text)
+        {
+            return attributedRange
+        }
+        let first = nsText.range(of: displayText, options: [], range: attributedRange)
+        guard first.location != NSNotFound,
+            ComposerMentionCanonicalizer.isValidVisibleMention(first, in: text)
+        else { return nil }
+        let remainingLocation = NSMaxRange(first)
+        if remainingLocation < NSMaxRange(attributedRange) {
+            let remaining = NSRange(
+                location: remainingLocation,
+                length: NSMaxRange(attributedRange) - remainingLocation
+            )
+            guard nsText.range(of: displayText, options: [], range: remaining).location == NSNotFound else {
+                return nil
+            }
+        }
+        return first
+    }
+
+    private static func isExact(_ selection: ComposerMentionSelection, in text: String) -> Bool {
+        selection.location >= 0
+            && selection.length > 0
+            && NSMaxRange(selection.range) <= (text as NSString).length
+            && (text as NSString).substring(with: selection.range) == selection.displayText
+            && ComposerMentionCanonicalizer.isValidVisibleMention(selection.range, in: text)
     }
 }
 

--- a/whitenoise-mac/Views/MessageDeletionConfirmation.swift
+++ b/whitenoise-mac/Views/MessageDeletionConfirmation.swift
@@ -25,21 +25,21 @@ private struct MessageDeletionConfirmationModifier: ViewModifier {
             ),
             titleVisibility: .visible,
             presenting: workspace.messagePendingDeletion
-        ) { message in
-            let capability = workspace.messageDeletionCapability(message)
+        ) { target in
+            let capability = workspace.messageDeletionCapability(target)
             if capability.canDeleteForEveryone {
                 Button(L10n.string("Delete for everyone"), role: .destructive) {
-                    Task { await workspace.deleteForEveryone(message) }
+                    Task { await workspace.deleteForEveryone(target) }
                 }
             }
             if capability.canDeleteForMe {
                 Button(L10n.string("Delete for me"), role: .destructive) {
-                    workspace.deleteForMe(message)
+                    workspace.deleteForMe(target)
                 }
             }
             Button(L10n.string("Cancel"), role: .cancel) {}
-        } message: { message in
-            Text(workspace.messageDeletionScopeExplanation(message))
+        } message: { target in
+            Text(workspace.messageDeletionScopeExplanation(target))
         }
     }
 }

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1873,7 +1873,7 @@ struct MessageRowAction: Identifiable {
             actions.append(
                 MessageRowAction(kind: .delete, title: "Delete", systemImage: "trash", role: .destructive) {
                     dismiss()
-                    workspace.messagePendingDeletion = message
+                    workspace.messagePendingDeletion = workspace.messageDeletionTarget(for: message)
                 })
         }
         return actions

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -715,8 +715,10 @@ private struct ConversationView: View {
             let candidates = workspace.mentionCandidates(matching: context.query)
             if !candidates.isEmpty {
                 ComposerMentionPicker(candidates: candidates) { candidate in
+                    guard let draftKey = workspace.selectedComposerDraftKey else { return }
                     composerMentionInsertion = ComposerMentionInsertion(
-                        range: context.tokenRange,
+                        scope: draftKey,
+                        context: context,
                         candidate: candidate
                     )
                     composerMentionContext = nil
@@ -787,6 +789,7 @@ private struct ConversationView: View {
                         composerMentionInsertion = nil
                     },
                     mentionSelections: $workspace.composerMentionSelections,
+                    mentionContextScope: workspace.selectedComposerDraftKey,
                     onMentionContextChange: { context in
                         composerMentionContext = context
                         if context != nil {

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -487,6 +487,8 @@ private struct ConversationView: View {
                         // clear the gate here or the new transcript stays non-interactive until a scroll.
                         isActivelyScrolling = false
                         hoverSelectionCoordinator.reset()
+                        composerMentionContext = nil
+                        composerMentionInsertion = nil
                     }
                     .onChange(of: messageIDs.last) { _, newMessageId in
                         switch timelineNewestMessageScrollAction(
@@ -677,6 +679,8 @@ private struct ConversationView: View {
         // overlays open over a different transcript.
         .onChange(of: chat.id) { _, _ in
             imageGallery = nil
+            composerMentionContext = nil
+            composerMentionInsertion = nil
             workspace.cancelMessageSelection()
             workspace.cancelForwarding()
             workspace.messageInfoTarget = nil
@@ -713,7 +717,7 @@ private struct ConversationView: View {
                 ComposerMentionPicker(candidates: candidates) { candidate in
                     composerMentionInsertion = ComposerMentionInsertion(
                         range: context.tokenRange,
-                        replacement: "@\(candidate.displayName) "
+                        candidate: candidate
                     )
                     composerMentionContext = nil
                 }
@@ -782,6 +786,7 @@ private struct ConversationView: View {
                         guard composerMentionInsertion?.id == insertionID else { return }
                         composerMentionInsertion = nil
                     },
+                    mentionSelections: $workspace.composerMentionSelections,
                     onMentionContextChange: { context in
                         composerMentionContext = context
                         if context != nil {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -71,6 +71,97 @@ struct PureValueTests {
         )
     }
 
+    @MainActor
+    @Test func selectedMentionMarkersSurviveBoundaryEditsAndRejectInternalEdits() throws {
+        let candidate = mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
+        let textView = NSTextView()
+        textView.isRichText = false
+        textView.string = "@Alex "
+        ComposerMentionMarkerStore.replaceAll(
+            with: [
+                ComposerMentionSelection(
+                    range: NSRange(location: 0, length: 5),
+                    displayText: "@Alex",
+                    npub: candidate.npub
+                )
+            ],
+            in: textView
+        )
+
+        textView.insertText("Hi ", replacementRange: NSRange(location: 0, length: 0))
+        var selections = ComposerMentionMarkerStore.selections(in: textView)
+        #expect(selections.map(\.range) == [NSRange(location: 3, length: 5)])
+
+        textView.insertText(",", replacementRange: NSRange(location: 8, length: 0))
+        selections = ComposerMentionMarkerStore.selections(in: textView)
+        #expect(selections.map(\.range) == [NSRange(location: 3, length: 5)])
+        #expect(
+            ComposerMentionCanonicalizer.canonicalize(
+                textView.string,
+                selections: selections,
+                candidates: [
+                    candidate,
+                    mentionCandidate(id: "second", displayName: "Alex", npub: "npub1pppp"),
+                ]
+            ) == "Hi @npub1qqqq, "
+        )
+
+        let editedMentionView = NSTextView()
+        editedMentionView.isRichText = false
+        editedMentionView.string = "@Alex "
+        ComposerMentionMarkerStore.replaceAll(
+            with: [
+                ComposerMentionSelection(
+                    range: NSRange(location: 0, length: 5),
+                    displayText: "@Alex",
+                    npub: candidate.npub
+                )
+            ],
+            in: editedMentionView
+        )
+        editedMentionView.insertText("x", replacementRange: NSRange(location: 3, length: 0))
+        #expect(ComposerMentionMarkerStore.selections(in: editedMentionView).isEmpty)
+    }
+
+    @MainActor
+    @Test func mentionCoordinatorRepublishesContextAndRejectsStaleInsertionAcrossChats() throws {
+        let firstScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "first")
+        let secondScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "second")
+        var boundText = "@Al"
+        var measuredHeight: CGFloat = 20
+        var boundSelections: [ComposerMentionSelection] = []
+        var publishedContexts: [ComposerMentionContext?] = []
+        var consumedInsertions: [UUID] = []
+        let coordinator = ComposerMessageTextViewRepresentable.Coordinator(
+            text: Binding(get: { boundText }, set: { boundText = $0 }),
+            measuredHeight: Binding(get: { measuredHeight }, set: { measuredHeight = $0 }),
+            mentionSelections: Binding(get: { boundSelections }, set: { boundSelections = $0 }),
+            mentionContextScope: firstScope,
+            onPasteMedia: { _ in },
+            onSend: {},
+            onMentionInsertionConsumed: { consumedInsertions.append($0) },
+            onMentionContextChange: { publishedContexts.append($0) }
+        )
+        let textView = NSTextView()
+        textView.string = boundText
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        let firstContext = try #require(publishedContexts.last ?? nil)
+
+        coordinator.synchronizeMentionContextScope(secondScope, in: textView)
+        #expect(publishedContexts.compactMap { $0 }.count == 2)
+        #expect(publishedContexts.last ?? nil == firstContext)
+
+        let staleInsertion = ComposerMentionInsertion(
+            scope: firstScope,
+            context: firstContext,
+            candidate: mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
+        )
+        coordinator.insertMentionIfNeeded(staleInsertion, into: textView)
+        #expect(textView.string == "@Al")
+        #expect(consumedInsertions == [staleInsertion.id])
+    }
+
     @Test func mentionDisplayResolverRequiresACompleteBech32TokenBoundary() {
         let npub = "npub1qqqq"
         let names = [npub: "Alex"]

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -21,6 +21,123 @@ import UserNotifications
 @testable import whitenoise_mac
 
 struct PureValueTests {
+    @Test func selectedMentionsCanonicalizeByPickedNpubDespiteDisplayNameCollision() {
+        let first = mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
+        let second = mentionCandidate(id: "second", displayName: "Alex", npub: "npub1pppp")
+        let draft = "Hi @Alex and @Alex"
+        let nsDraft = draft as NSString
+        let firstRange = nsDraft.range(of: "@Alex")
+        let secondRange = nsDraft.range(of: "@Alex", options: [], range: NSRange(location: 8, length: 10))
+        let selections = [
+            ComposerMentionSelection(range: firstRange, displayText: "@Alex", npub: first.npub),
+            ComposerMentionSelection(range: secondRange, displayText: "@Alex", npub: second.npub),
+        ]
+
+        #expect(
+            ComposerMentionCanonicalizer.canonicalize(
+                draft,
+                selections: selections,
+                candidates: [first, second]
+            ) == "Hi @npub1qqqq and @npub1pppp"
+        )
+    }
+
+    @Test func ambiguousTypedMentionIsNotGuessedWithoutPickerSelection() {
+        let candidates = [
+            mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq"),
+            mentionCandidate(id: "second", displayName: "Alex", npub: "npub1pppp"),
+        ]
+
+        #expect(
+            ComposerMentionCanonicalizer.canonicalize("Hi @Alex", candidates: candidates)
+                == "Hi @Alex"
+        )
+    }
+
+    @Test func selectedMentionIsIgnoredAfterItsVisibleTextIsEdited() {
+        let candidate = mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
+        let staleSelection = ComposerMentionSelection(
+            range: NSRange(location: 3, length: 5),
+            displayText: "@Alex",
+            npub: candidate.npub
+        )
+
+        #expect(
+            ComposerMentionCanonicalizer.canonicalize(
+                "Hi @Alec",
+                selections: [staleSelection],
+                candidates: []
+            ) == "Hi @Alec"
+        )
+    }
+
+    @Test func mentionDisplayResolverRequiresACompleteBech32TokenBoundary() {
+        let npub = "npub1qqqq"
+        let names = [npub: "Alex"]
+
+        #expect(MentionDisplayResolver.resolve(in: "Hi @\(npub)!", mentionNames: names) == "Hi @Alex!")
+        #expect(MentionDisplayResolver.resolve(in: "Hi @\(npub)x", mentionNames: names) == "Hi @\(npub)x")
+    }
+
+    @Test func mentionQueryTracksMidDraftCaretAndSuppressesCompleteNpub() throws {
+        let draft = "Before @Ale after"
+        let caret = try #require(draft.range(of: "@Ale")?.upperBound)
+        let session = try #require(ComposerMentionQuery.active(in: draft, upTo: caret))
+        #expect(session.query == "Ale")
+        #expect(String(draft[session.range]) == "@Ale")
+        #expect(ComposerMentionQuery.active(in: "email@example.com") == nil)
+        #expect(ComposerMentionQuery.looksLikeCompleteNpub("npub1" + String(repeating: "q", count: 58)))
+    }
+
+    @Test func mentionCandidateFilterMatchesAllIdentityFieldsAndCapsResults() {
+        let candidates = (0..<12).map { index in
+            mentionCandidate(
+                id: "member-\(index)",
+                displayName: index == 11 ? "Special Person" : "Member \(index)",
+                npub: "npub1qqq\(index)"
+            )
+        }
+        #expect(ComposerMentionQuery.filter(candidates, matching: "").count == 8)
+        #expect(ComposerMentionQuery.filter(candidates, matching: "special").map(\.id) == ["member-11"])
+        #expect(ComposerMentionQuery.filter(candidates, matching: "member-9").map(\.id) == ["member-9"])
+        #expect(ComposerMentionQuery.filter(candidates, matching: "npub1qqq10").map(\.id) == ["member-10"])
+    }
+
+    @Test func editedMessageAndHistoryResolveCanonicalMentionsButRetainWireText() async throws {
+        let npub = "npub1qqqq"
+        let base = MessageItem(
+            id: "message",
+            senderAccountIdHex: "sender",
+            senderName: "Sender",
+            body: "Original @\(npub)",
+            mentionNames: [npub: "Alex"],
+            sentAt: Date(timeIntervalSince1970: 1),
+            timelineAt: 1,
+            isOutgoing: false
+        )
+        let edited = base.applyingEdit(plaintext: "Edited @\(npub)")
+        #expect(edited.body == "Edited @Alex")
+        #expect(edited.wireBody == "Edited @\(npub)")
+
+        let store = await MessageTimelineStore.loaded(with: [base])
+        await store.replace(
+            with: [base],
+            editMutations: [
+                .upsert(
+                    MessageEditOverlay(
+                        targetMessageIdHex: base.id,
+                        editMessageIdHex: "edit",
+                        sender: "sender",
+                        plaintext: "Edited @\(npub)",
+                        timelineAt: 2
+                    )
+                )
+            ]
+        )
+        let history = await store.editHistory(forTarget: base.id)
+        #expect(history.map(\.text) == ["Original @Alex", "Edited @Alex"])
+    }
+
     @MainActor
     @Test func disappearingMessageCustomLabelFormatsCoreUInt64Value() async throws {
         // Regression for whitenoise-mac#212: values can originate from the core as
@@ -2227,6 +2344,20 @@ struct PureValueTests {
         #expect(firstSelectable)
         #expect(!secondSelectable)
     }
+}
+
+private func mentionCandidate(id: String, displayName: String, npub: String) -> ComposerMentionCandidate {
+    ComposerMentionCandidate(
+        details: GroupMemberDetailsFfi(
+            memberIdHex: id,
+            account: id,
+            local: false,
+            isAdmin: false,
+            isSelf: false,
+            npub: npub,
+            displayName: displayName
+        )
+    )
 }
 
 @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11923,6 +11923,35 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func scopedDeletionTargetKeepsOriginatingConversationAfterChatSwitch() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let groupChat = try #require(state.activeChats.first { $0.id == "group" })
+        let directChat = try #require(state.activeChats.first { $0.id == "direct-group" })
+        state.selectChat(groupChat)
+        let message = MessageItem(
+            id: "scoped-delete",
+            senderName: "Desktop Account",
+            body: "Delete from the original group",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isOutgoing: true
+        )
+        let target = try #require(state.messageDeletionTarget(for: message))
+
+        state.selectChat(directChat)
+        await state.deleteForEveryone(target)
+
+        #expect(
+            runtime.deletedMessage
+                == DeletedMessage(groupIdHex: groupChat.id, targetMessageId: message.id)
+        )
+    }
+
+    @MainActor
     @Test func deleteForMeHidesLocallyAndPublishesNothing() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])


### PR DESCRIPTION
## Summary

- capture message-deletion account and conversation scope before showing confirmation, preventing chat switches from redirecting the mutation (follow-up to #614)
- preserve picker-selected mention identity and text ranges so duplicate display names canonicalize to the chosen member npub
- clear transient mention UI when switching chats and reject stale visible mention selections
- resolve complete `@npub` tokens back to display names in edited bubbles and edit history while retaining canonical wire text for edits and forwards
- require a complete bech32 token boundary when resolving mention previews (follow-up to unresolved review feedback on #637)

## Verification

- `xcrun swift-format lint --strict` on all changed Swift files
- `git diff --check`
- `xcodebuild -scheme whitenoise-mac -configuration Debug build-for-testing CODE_SIGNING_ALLOWED=NO` — **TEST BUILD SUCCEEDED** (app, unit-test, and UI-test targets compile)
- added focused Swift Testing coverage for duplicate display names, stale selection invalidation, token boundaries, edited-message/history rendering, and deletion scope after chat switching

The compiled macOS tests could not execute on this Codex host: the host is x86_64 while White Noise and its test bundle are arm64-only. `xcodebuild test-without-building` therefore reports the local Mac destination as architecture-ineligible.

Follow-up to #614, #636, and #637.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->