### PR TITLE
fix: accept hinted edit target tags

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -184,17 +184,10 @@ nonisolated struct MessageEditOverlay: Equatable, Sendable {
     }
 
     fileprivate static func editTargetMessageId(in tags: [MessageTagFfi]) -> String? {
-        var target: String?
-        for tag in tags where tag.values.first == "e" {
-            guard tag.values.count == 2,
-                let candidate = tag.values.dropFirst().first?.nilIfBlank,
-                target == nil
-            else {
-                return nil
-            }
-            target = candidate
-        }
-        return target
+        tags.lazy
+            .filter { $0.values.first == "e" }
+            .compactMap { $0.values.dropFirst().first?.nilIfBlank }
+            .first
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4493,6 +4493,59 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func messageEditAcceptsNip10RelayHintedTargetTag() async throws {
+        let editRecord = timelineMessage(
+            id: "edit",
+            groupIdHex: "group",
+            sender: "alice",
+            plaintext: "Edited",
+            kind: 1_009,
+            tags: [MessageTagFfi(values: ["e", "target", "wss://relay.example", "reply"])],
+            recordedAt: 1_800_000_030
+        )
+
+        #expect(
+            MessageEditOverlay.mutations(from: [editRecord]) == [
+                .upsert(
+                    MessageEditOverlay(
+                        targetMessageIdHex: "target",
+                        editMessageIdHex: "edit",
+                        sender: "alice",
+                        plaintext: "Edited",
+                        timelineAt: 1_800_000_030
+                    ))
+            ])
+    }
+
+    @MainActor
+    @Test func messageEditUsesFirstValidTargetWhenAdditionalETagsArePresent() async throws {
+        let editRecord = timelineMessage(
+            id: "edit",
+            groupIdHex: "group",
+            sender: "alice",
+            plaintext: "Edited",
+            kind: 1_009,
+            tags: [
+                MessageTagFfi(values: ["e", "target"]),
+                MessageTagFfi(values: ["e", "reply-target", "wss://relay.example", "reply"]),
+            ],
+            recordedAt: 1_800_000_030
+        )
+
+        #expect(
+            MessageEditOverlay.mutations(from: [editRecord]) == [
+                .upsert(
+                    MessageEditOverlay(
+                        targetMessageIdHex: "target",
+                        editMessageIdHex: "edit",
+                        sender: "alice",
+                        plaintext: "Edited",
+                        timelineAt: 1_800_000_030
+                    ))
+            ])
+    }
+
+    @MainActor
     @Test func timelineStoreIgnoresKind1009EditsFromDifferentAuthors() async throws {
         let page = TimelinePageFfi(
             messages: [

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -4546,6 +4546,33 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func messageEditWithoutValidTargetRetractsCandidate() async throws {
+        let missingTarget = timelineMessage(
+            id: "missing-target",
+            groupIdHex: "group",
+            sender: "alice",
+            plaintext: "Edited",
+            kind: 1_009,
+            recordedAt: 1_800_000_030
+        )
+        let blankTarget = timelineMessage(
+            id: "blank-target",
+            groupIdHex: "group",
+            sender: "alice",
+            plaintext: "Edited",
+            kind: 1_009,
+            tags: [MessageTagFfi(values: ["e", "   ", "wss://relay.example"])],
+            recordedAt: 1_800_000_031
+        )
+
+        #expect(
+            MessageEditOverlay.mutations(from: [missingTarget, blankTarget]) == [
+                .retract(editMessageIdHex: "missing-target"),
+                .retract(editMessageIdHex: "blank-target"),
+            ])
+    }
+
+    @MainActor
     @Test func timelineStoreIgnoresKind1009EditsFromDifferentAuthors() async throws {
         let page = TimelinePageFfi(
             messages: [


### PR DESCRIPTION
## Summary
- accept the first valid `e` edit-target tag even when it carries a NIP-10 relay hint or marker
- preserve the first valid edit target when additional `e` tags are present
- cover relay-hinted and multi-`e` edit records with regression tests

## Test plan
- [x] `git diff --check`
- [x] static parser regression check
- [ ] GitHub Mac CI (Xcode is unavailable on this Linux worker)

Fixes #648

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/649">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->