### PR TITLE
test: preserve notification replay dedup across account switches

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -111,13 +111,9 @@ extension WorkspaceState {
         clearGroupMemberCache()
         // Read markers are keyed by groupIdHex only; stale entries from the
         // previous account suppress the first legitimate advance for a shared
-        // group id under the new identity. Notification keys are likewise
-        // account-scoped and can suppress a genuine delivery after a collision.
-        // See #429/#646.
+        // group id under the new identity. See #429.
         lastMarkedReadMarkers.removeAll()
         lastConfirmedReadMarkers.removeAll()
-        deliveredNotificationKeys.removeAll()
-        deliveredNotificationKeyOrder.removeAll()
         refreshObservabilityRuntime()
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -111,9 +111,13 @@ extension WorkspaceState {
         clearGroupMemberCache()
         // Read markers are keyed by groupIdHex only; stale entries from the
         // previous account suppress the first legitimate advance for a shared
-        // group id under the new identity. See #429.
+        // group id under the new identity. Notification keys are likewise
+        // account-scoped and can suppress a genuine delivery after a collision.
+        // See #429/#646.
         lastMarkedReadMarkers.removeAll()
         lastConfirmedReadMarkers.removeAll()
+        deliveredNotificationKeys.removeAll()
+        deliveredNotificationKeyOrder.removeAll()
         refreshObservabilityRuntime()
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1542,7 +1542,7 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func prepareForActiveAccountSwitchClearsAccountScopedResidue() async throws {
+    @Test func prepareForActiveAccountSwitchClearsReadMarkers() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -1574,8 +1574,6 @@ struct whitenoise_macTests {
         )
         state.lastMarkedReadMarkers["shared-group"] = marker
         state.lastConfirmedReadMarkers["shared-group"] = marker
-        state.deliveredNotificationKeys.insert("notif-from-primary")
-        state.deliveredNotificationKeyOrder.append("notif-from-primary")
         state.composeContacts = [
             ComposeContact(
                 accountIdHex: String(repeating: "2", count: 64),
@@ -1590,12 +1588,10 @@ struct whitenoise_macTests {
 
         state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
 
-        // Live account switches must not inherit account-scoped residue from the
-        // previous identity. See #429/#588/#646.
+        // Live account switches must not inherit groupIdHex-keyed read markers or the
+        // previous identity's compose-flow contact directory. See #429/#588.
         #expect(state.lastMarkedReadMarkers.isEmpty)
         #expect(state.lastConfirmedReadMarkers.isEmpty)
-        #expect(state.deliveredNotificationKeys.isEmpty)
-        #expect(state.deliveredNotificationKeyOrder.isEmpty)
         #expect(state.composeContacts.isEmpty)
         #expect(!state.isLoadingComposeContacts)
         #expect(state.composeContactsGeneration == 42)
@@ -19413,6 +19409,75 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func accountSwitchPreservesClientWideNotificationReplayDeduplication() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+        let accountA = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.installNotificationSettings(
+            accountRef: accountA.label,
+            settings: notificationSettings(for: accountA, localEnabled: true)
+        )
+        runtime.installNotificationSettings(
+            accountRef: accountB.label,
+            settings: notificationSettings(for: accountB, localEnabled: true)
+        )
+        UserDefaults.standard.set(accountA.label, forKey: WorkspaceState.activeAccountKey)
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+        let messageIdHex = String(repeating: "f", count: 64)
+        let accountAKey = "message:\(accountA.accountIdHex):\(messageIdHex)"
+        let accountBKey = "message:\(accountB.accountIdHex):\(messageIdHex)"
+        let accountAUpdate = notificationUpdate(
+            account: accountA,
+            notificationKey: accountAKey,
+            senderName: "Alice",
+            previewText: "For account A.",
+            messageIdHex: messageIdHex
+        )
+
+        await state.bootstrap()
+        await state.handleNotificationUpdate(accountAUpdate)
+        state.prepareForActiveAccountSwitch(
+            to: AccountItem(summary: accountB),
+            preservingMessageCacheFor: nil
+        )
+        await state.handleNotificationUpdate(accountAUpdate)
+        await state.handleNotificationUpdate(
+            notificationUpdate(
+                account: accountB,
+                notificationKey: accountBKey,
+                senderName: "Alice",
+                previewText: "For account B.",
+                messageIdHex: messageIdHex
+            ))
+
+        // The listener is client-wide, so an account-A replay can still arrive after
+        // switching to B. MDK account-namespaces keys, allowing B's distinct update
+        // through while the replay remains suppressed. See #646.
+        #expect(notificationCenter.postedRequests.map(\.identifier) == [accountAKey, accountBKey])
+    }
+
+    @MainActor
     @Test func activeSelectedChatNotificationPostsLocalAlertWhenConversationWindowIsHidden() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -22637,7 +22702,8 @@ private func notificationUpdate(
     previewText: String,
     isDm: Bool = true,
     groupName: String? = nil,
-    isFromSelf: Bool = false
+    isFromSelf: Bool = false,
+    messageIdHex: String? = nil
 ) -> NotificationUpdateFfi {
     NotificationUpdateFfi(
         notificationKey: notificationKey,
@@ -22649,7 +22715,7 @@ private func notificationUpdate(
         groupName: groupName,
         isDm: isDm,
         isMention: false,
-        messageIdHex: "\(notificationKey)-message",
+        messageIdHex: messageIdHex ?? "\(notificationKey)-message",
         sender: NotificationUserFfi(
             accountIdHex: isFromSelf
                 ? account.accountIdHex : "alice1234567890alice1234567890alice1234567890alice1234567890",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1542,7 +1542,7 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func prepareForActiveAccountSwitchClearsReadMarkers() async throws {
+    @Test func prepareForActiveAccountSwitchClearsAccountScopedResidue() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -1574,6 +1574,8 @@ struct whitenoise_macTests {
         )
         state.lastMarkedReadMarkers["shared-group"] = marker
         state.lastConfirmedReadMarkers["shared-group"] = marker
+        state.deliveredNotificationKeys.insert("notif-from-primary")
+        state.deliveredNotificationKeyOrder.append("notif-from-primary")
         state.composeContacts = [
             ComposeContact(
                 accountIdHex: String(repeating: "2", count: 64),
@@ -1588,10 +1590,12 @@ struct whitenoise_macTests {
 
         state.prepareForActiveAccountSwitch(to: backupAccount, preservingMessageCacheFor: nil)
 
-        // Live account switches must not inherit groupIdHex-keyed read markers or the
-        // previous identity's compose-flow contact directory. See #429/#588.
+        // Live account switches must not inherit account-scoped residue from the
+        // previous identity. See #429/#588/#646.
         #expect(state.lastMarkedReadMarkers.isEmpty)
         #expect(state.lastConfirmedReadMarkers.isEmpty)
+        #expect(state.deliveredNotificationKeys.isEmpty)
+        #expect(state.deliveredNotificationKeyOrder.isEmpty)
         #expect(state.composeContacts.isEmpty)
         #expect(!state.isLoadingComposeContacts)
         #expect(state.composeContactsGeneration == 42)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -19472,8 +19472,8 @@ struct whitenoise_macTests {
             ))
 
         // The listener is client-wide, so an account-A replay can still arrive after
-        // switching to B. MDK account-namespaces keys, allowing B's distinct update
-        // through while the replay remains suppressed. See #646.
+        // switching to B. The vendored MDK account-namespaces keys, allowing B's
+        // distinct update through while the replay remains suppressed. See #646.
         #expect(notificationCenter.postedRequests.map(\.identifier) == [accountAKey, accountBKey])
     }
 


### PR DESCRIPTION
## Summary
- preserve the client-wide delivered-notification replay history across active-account switches
- verify the vendored MDK account-namespaced key contract with a behavior regression
- prove an account-A replay stays suppressed after A→B while account B receives its distinct key for the same message ID

## Review resolution
The original clear-on-switch change was removed. Vendored MDK `f3ece0e3` emits `message:<account_id_hex>:<message_id_hex>` and `invite:<account_id_hex>:<invite_ref>`, so the reported cross-account collision cannot occur. Clearing the shared history instead reopened a duplicate-alert window because the notification listener is client-wide.

## Test plan
- [x] Source invariant probe: original head RED, revised branch GREEN
- [x] `git diff --check origin/master...HEAD`
- [x] committed-tree conflict-marker and duplicate-test-name sweeps
- [x] Mac CI PR Checks and Static Analysis

Fixes #646

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->