### PR TITLE
fix: mark invalid telemetry environments unknown

### DIFF
--- a/whitenoise-mac/Core/TelemetryBuildConfig.swift
+++ b/whitenoise-mac/Core/TelemetryBuildConfig.swift
@@ -148,7 +148,7 @@ struct TelemetryBuildConfig: Equatable {
         case "production", "staging", "development", "test":
             return environment
         default:
-            return "development"
+            return "unknown"
         }
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -18136,6 +18136,41 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func telemetryBuildConfigDefaultsUnsetDeploymentEnvironmentToDevelopment() async throws {
+        let config = TelemetryBuildConfig.current(
+            infoDictionary: [
+                "CFBundleShortVersionString": "2026.6",
+                "CFBundleVersion": "12",
+            ],
+            environment: [:]
+        )
+
+        #expect(config.deploymentEnvironment == "development")
+
+        let runtimeResource = config.runtimeConfig(installId: "install-id").resource
+        #expect(runtimeResource?.deploymentEnvironment == "development")
+    }
+
+    @MainActor
+    @Test func telemetryBuildConfigMapsUnrecognizedDeploymentEnvironmentToUnknown() async throws {
+        let config = TelemetryBuildConfig.current(
+            infoDictionary: [
+                "WhiteNoiseTelemetryBearerToken": "release-otlp-token",
+                "WhiteNoiseTelemetryEnvironment": "prod",
+                "CFBundleShortVersionString": "2026.6",
+                "CFBundleVersion": "12",
+            ],
+            environment: [:]
+        )
+
+        #expect(config.bearerToken == "release-otlp-token")
+        #expect(config.deploymentEnvironment == "unknown")
+
+        let runtimeResource = config.runtimeConfig(installId: "install-id").resource
+        #expect(runtimeResource?.deploymentEnvironment == "unknown")
+    }
+
+    @MainActor
     @Test func privacySecuritySettingsLoadAndPersistTelemetryAndAuditToggles() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
Fixes #647

## Summary
- Preserve `development` as the fallback only when the telemetry environment is absent, blank, or unresolved.
- Map an explicitly supplied unrecognized environment such as `prod` to `unknown`, preventing token-enabled release telemetry from masquerading as development.
- Add regression coverage for both the unset default and the token-enabled misconfiguration through the exported runtime resource.

## Verification
- `git diff --check` — passed
- Source contract check — passed; confirms unset → `development`, recognized values preserved, and explicit unrecognized → `unknown`
- Regression RED inspection against `origin/master` — confirmed the new `prod` → `unknown` expectation fails under the old `default: return "development"` branch
- `scripts/ci/macos-sanity-checks.sh` — unavailable on this Linux worker (`xcodebuild: command not found`)
- `xcodebuild test` / `xcrun swift-format lint` — unavailable on this Linux worker; Mac CI will run them

## Sensitive paths
None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->