### PR TITLE
perf: cache composer mention rosters

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -911,11 +911,13 @@ extension WorkspaceState {
     func storeGroupMembers(_ members: [GroupMemberDetailsFfi], for groupIdHex: String) {
         groupMemberDetailsLookups[groupIdHex]?.task.cancel()
         groupMemberDetailsLookups[groupIdHex] = nil
+        mentionRosterCache[groupIdHex] = nil
         groupMemberDetailsCache[groupIdHex] = members
     }
 
     func invalidateGroupMembers(for groupIdHex: String) {
         groupMemberDetailsCache[groupIdHex] = nil
+        mentionRosterCache[groupIdHex] = nil
         groupMemberDetailsLookups[groupIdHex]?.task.cancel()
         groupMemberDetailsLookups[groupIdHex] = nil
         readStateMetadataEnrichmentAttempts.remove(groupIdHex)
@@ -923,6 +925,7 @@ extension WorkspaceState {
 
     func clearGroupMemberCache() {
         groupMemberDetailsCache.removeAll()
+        mentionRosterCache.removeAll()
         for lookup in groupMemberDetailsLookups.values {
             lookup.task.cancel()
         }
@@ -962,7 +965,7 @@ extension WorkspaceState {
         if groupMemberDetailsLookups[groupIdHex]?.token == token {
             groupMemberDetailsLookups[groupIdHex] = nil
             if activeAccountId == account.id, let members {
-                groupMemberDetailsCache[groupIdHex] = members
+                storeGroupMembers(members, for: groupIdHex)
             }
         }
         return members

--- a/whitenoise-mac/Core/WorkspaceState+Mentions.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Mentions.swift
@@ -18,7 +18,14 @@ extension WorkspaceState {
         guard let selectedChat, !selectedChat.isDirect,
             let members = groupMemberDetailsCache[selectedChat.id]
         else { return [] }
-        return members.filter { !$0.isSelf }.map(ComposerMentionCandidate.init(details:))
+        if let cached = mentionRosterCache[selectedChat.id] { return cached }
+
+        let roster = members.filter { !$0.isSelf }.map(ComposerMentionCandidate.init(details:))
+        mentionRosterCache[selectedChat.id] = roster
+        #if DEBUG
+            mentionRosterBuildCount += 1
+        #endif
+        return roster
     }
 
     /// The candidates the picker should show for an active `@query`, capped and boundary-filtered.

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1120,11 +1120,17 @@ final class WorkspaceState {
     /// need members to identify direct chats and provide member-name fallbacks, so cache just
     /// that membership slice and invalidate it on membership-changing subscription events.
     var groupMemberDetailsCache: [String: [GroupMemberDetailsFfi]] = [:]
+    /// Mention-picker projections derived from `groupMemberDetailsCache`. Kept outside Observation
+    /// so reading or populating the cache from a view body does not schedule another render.
+    @ObservationIgnored var mentionRosterCache: [String: [ComposerMentionCandidate]] = [:]
     var groupMemberDetailsLookups: [String: GroupMemberDetailsLookup] = [:]
     var readStateMetadataEnrichmentAttempts = Set<String>()
     var nextGroupMemberDetailsLookupToken: UInt64 = 0
 
     #if DEBUG
+        /// Test-only instrumentation for verifying mention roster projections are reused.
+        @ObservationIgnored var mentionRosterBuildCount = 0
+
         /// Test-only instrumentation: the number of times `messageSenderProfiles` had to fetch the
         /// group member list to build the sender-name fallback map. In the all-resolved steady
         /// state this must stay flat across timeline windows (whitenoise-mac#171). Not read by

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -194,6 +194,35 @@ struct PureValueTests {
         #expect(ComposerMentionQuery.filter(candidates, matching: "npub1qqq10").map(\.id) == ["member-10"])
     }
 
+    @MainActor
+    @Test func mentionRosterReusesCandidatesUntilGroupMembersChange() {
+        let account = AccountItem.samples[0]
+        let group = ChatItem.samples[0]
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [group]],
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(group.id)
+
+        let local = mentionMember(id: "self", displayName: "Local", npub: "npub1self", isSelf: true)
+        let alice = mentionMember(id: "alice", displayName: "Alice", npub: "npub1alice")
+        state.storeGroupMembers([local, alice], for: group.id)
+
+        #expect(state.mentionRoster().map(\.id) == ["alice"])
+        #expect(state.mentionRoster().map(\.id) == ["alice"])
+        #expect(state.mentionRosterBuildCount == 1)
+
+        let bob = mentionMember(id: "bob", displayName: "Bob", npub: "npub1bob")
+        state.storeGroupMembers([local, bob], for: group.id)
+
+        #expect(state.mentionRoster().map(\.id) == ["bob"])
+        #expect(state.mentionRosterBuildCount == 2)
+    }
+
     @Test func editedMessageAndHistoryResolveCanonicalMentionsButRetainWireText() async throws {
         let npub = "npub1qqqq"
         let base = MessageItem(
@@ -2438,16 +2467,23 @@ struct PureValueTests {
 }
 
 private func mentionCandidate(id: String, displayName: String, npub: String) -> ComposerMentionCandidate {
-    ComposerMentionCandidate(
-        details: GroupMemberDetailsFfi(
-            memberIdHex: id,
-            account: id,
-            local: false,
-            isAdmin: false,
-            isSelf: false,
-            npub: npub,
-            displayName: displayName
-        )
+    ComposerMentionCandidate(details: mentionMember(id: id, displayName: displayName, npub: npub))
+}
+
+private func mentionMember(
+    id: String,
+    displayName: String,
+    npub: String,
+    isSelf: Bool = false
+) -> GroupMemberDetailsFfi {
+    GroupMemberDetailsFfi(
+        memberIdHex: id,
+        account: id,
+        local: isSelf,
+        isAdmin: false,
+        isSelf: isSelf,
+        npub: npub,
+        displayName: displayName
     )
 }
 


### PR DESCRIPTION
## Summary
- cache per-group composer mention candidates across SwiftUI renders
- invalidate the derived roster whenever the group-member cache changes or clears
- cover cache reuse and membership-update invalidation with a regression test

## Test plan
- [x] git diff --check
- [x] source invariant check for cache reuse and invalidation hooks
- [x] GitHub Mac CI (Swift format, unit tests, release build, static analysis)

Local Xcode execution is unavailable on this Linux worker; GitHub Mac CI passed all native checks.

Fixes #642