### PR TITLE
fix: defer composer mention synchronization

### DIFF
--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -271,10 +271,12 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         if textView.string != text {
             textView.string = text
         }
-        context.coordinator.synchronizeMentionMarkers(in: textView)
-        context.coordinator.synchronizeMentionContextScope(mentionContextScope, in: textView)
+        context.coordinator.scheduleMentionSynchronization(
+            scope: mentionContextScope,
+            insertion: mentionInsertion,
+            in: textView
+        )
         context.coordinator.scheduleEmojiInsertion(emojiInsertion, into: textView)
-        context.coordinator.insertMentionIfNeeded(mentionInsertion, into: textView)
         DispatchQueue.main.async {
             context.coordinator.updateMeasuredHeight(for: textView)
         }
@@ -303,6 +305,7 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         private var lastEmojiInsertionID: UUID?
         private var lastMentionInsertionID: UUID?
         private var lastMentionContext: ComposerMentionContext?
+        private var mentionSynchronizationGeneration: UInt64 = 0
 
         init(
             text: Binding<String>,
@@ -336,6 +339,21 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
                 updateMeasuredHeight(for: textView)
                 textView.window?.makeFirstResponder(textView)
                 onEmojiInsertionConsumed(insertion.id)
+            }
+        }
+
+        func scheduleMentionSynchronization(
+            scope: WorkspaceState.ComposerDraftKey?,
+            insertion: ComposerMentionInsertion?,
+            in textView: NSTextView
+        ) {
+            mentionSynchronizationGeneration &+= 1
+            let generation = mentionSynchronizationGeneration
+            DispatchQueue.main.async { [self] in
+                guard generation == mentionSynchronizationGeneration else { return }
+                synchronizeMentionMarkers(in: textView)
+                synchronizeMentionContextScope(scope, in: textView)
+                insertMentionIfNeeded(insertion, into: textView)
             }
         }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -124,6 +124,112 @@ struct PureValueTests {
     }
 
     @MainActor
+    @Test func mentionSynchronizationDefersObservableWritesUntilAfterTheViewUpdate() async {
+        let firstScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "first")
+        let secondScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "second")
+        var boundText = "@Al"
+        var measuredHeight: CGFloat = 20
+        var boundSelections: [ComposerMentionSelection] = []
+        var publishedContexts: [ComposerMentionContext?] = []
+        var consumedInsertions: [UUID] = []
+        let coordinator = ComposerMessageTextViewRepresentable.Coordinator(
+            text: Binding(get: { boundText }, set: { boundText = $0 }),
+            measuredHeight: Binding(get: { measuredHeight }, set: { measuredHeight = $0 }),
+            mentionSelections: Binding(get: { boundSelections }, set: { boundSelections = $0 }),
+            mentionContextScope: firstScope,
+            onPasteMedia: { _ in },
+            onSend: {},
+            onMentionInsertionConsumed: { consumedInsertions.append($0) },
+            onMentionContextChange: { publishedContexts.append($0) }
+        )
+        let textView = NSTextView()
+        textView.string = boundText
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+        let insertion = ComposerMentionInsertion(
+            scope: secondScope,
+            context: ComposerMentionContext(query: "Al", tokenRange: NSRange(location: 0, length: 3)),
+            candidate: mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
+        )
+
+        coordinator.scheduleMentionSynchronization(
+            scope: secondScope,
+            insertion: insertion,
+            in: textView
+        )
+
+        #expect(boundText == "@Al")
+        #expect(boundSelections.isEmpty)
+        #expect(publishedContexts.isEmpty)
+        #expect(consumedInsertions.isEmpty)
+
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+
+        #expect(boundText == "@Alex ")
+        #expect(boundSelections.map(\.npub) == ["npub1qqqq"])
+        #expect(publishedContexts.compactMap { $0 }.first?.query == "Al")
+        #expect(consumedInsertions == [insertion.id])
+    }
+
+    @MainActor
+    @Test func newerMentionSynchronizationSupersedesQueuedWorkFromPreviousScope() async {
+        let firstScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "first")
+        let secondScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "second")
+        let thirdScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "third")
+        var boundText = "@Al"
+        var measuredHeight: CGFloat = 20
+        var boundSelections: [ComposerMentionSelection] = []
+        var consumedInsertions: [UUID] = []
+        let coordinator = ComposerMessageTextViewRepresentable.Coordinator(
+            text: Binding(get: { boundText }, set: { boundText = $0 }),
+            measuredHeight: Binding(get: { measuredHeight }, set: { measuredHeight = $0 }),
+            mentionSelections: Binding(get: { boundSelections }, set: { boundSelections = $0 }),
+            mentionContextScope: firstScope,
+            onPasteMedia: { _ in },
+            onSend: {},
+            onMentionInsertionConsumed: { consumedInsertions.append($0) }
+        )
+        let textView = NSTextView()
+        textView.string = boundText
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+        let context = ComposerMentionContext(query: "Al", tokenRange: NSRange(location: 0, length: 3))
+        let staleInsertion = ComposerMentionInsertion(
+            scope: secondScope,
+            context: context,
+            candidate: mentionCandidate(id: "stale", displayName: "Alex", npub: "npub1stale")
+        )
+        let latestInsertion = ComposerMentionInsertion(
+            scope: thirdScope,
+            context: context,
+            candidate: mentionCandidate(id: "latest", displayName: "Alicia", npub: "npub1latest")
+        )
+
+        coordinator.scheduleMentionSynchronization(
+            scope: secondScope,
+            insertion: staleInsertion,
+            in: textView
+        )
+        coordinator.scheduleMentionSynchronization(
+            scope: thirdScope,
+            insertion: latestInsertion,
+            in: textView
+        )
+
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+
+        #expect(boundText == "@Alicia ")
+        #expect(boundSelections.map(\.npub) == ["npub1latest"])
+        #expect(consumedInsertions == [latestInsertion.id])
+    }
+
+    @MainActor
     @Test func mentionCoordinatorRepublishesContextAndRejectsStaleInsertionAcrossChats() throws {
         let firstScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "first")
         let secondScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "second")


### PR DESCRIPTION
## Summary

- defer mention marker, context-scope, and insertion synchronization until after `updateNSView` returns
- coalesce queued synchronization snapshots so a superseded chat scope cannot mutate the latest draft
- cover both immediate-write deferral and back-to-back scope updates with regression tests

## Test plan

- [x] Structural update-path invariant check (all mention publishes leave `updateNSView` through the deferred scheduler)
- [x] `git diff --check`
- [x] Mac CI `PR Checks` (Swift format, sanity checks, unit tests, release build)
- [x] Mac CI `Static Analysis`

Fixes #644
