### PR TITLE
fix: cache media after in-memory store pruning

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -284,6 +284,21 @@ extension WorkspaceState {
                     reference: reference
                 )
             }
+            let mediaDownload = MessageMediaDownload(
+                payload: DownloadedMediaPayload(
+                    id: "\(key)|\(UUID().uuidString)",
+                    data: download.plaintext
+                ),
+                fileName: download.fileName,
+                mediaType: download.mediaType,
+                sizeBytes: download.sizeBytes
+            )
+            scheduleMediaDiskCacheStore(
+                mediaDownload,
+                for: cacheKey,
+                accountId: accountId,
+                storeGuard: storeGuard
+            )
             guard
                 canPublishMediaDownloadState(
                     forKey: key,
@@ -295,22 +310,7 @@ extension WorkspaceState {
                 stateStore.update(.idle)
                 return
             }
-            let mediaDownload = MessageMediaDownload(
-                payload: DownloadedMediaPayload(
-                    id: "\(key)|\(UUID().uuidString)",
-                    data: download.plaintext
-                ),
-                fileName: download.fileName,
-                mediaType: download.mediaType,
-                sizeBytes: download.sizeBytes
-            )
             stateStore.update(.loaded(mediaDownload))
-            scheduleMediaDiskCacheStore(
-                mediaDownload,
-                for: cacheKey,
-                accountId: accountId,
-                storeGuard: storeGuard
-            )
         } catch is CancellationError {
             guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
                 stateStore.update(.idle)

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -666,15 +666,22 @@ extension WorkspaceState {
             return
         }
 
-        let prefix = [activeAccountId, groupIdHex, ""].joined(separator: "\u{1F}")
+        let accountPrefix = [activeAccountId, ""].joined(separator: "\u{1F}")
+        let groupPrefix = [activeAccountId, groupIdHex, ""].joined(separator: "\u{1F}")
         let retainedKeys = retainedMediaDownloadKeys(groupIdHex: groupIdHex, accountId: activeAccountId)
         let removedKeys = mediaDownloads.keys.filter { key in
-            guard key.hasPrefix(prefix) else { return true }
+            guard key.hasPrefix(groupPrefix) else { return true }
             return !retainedKeys.contains(key)
         }
         for key in removedKeys {
+            guard let store = mediaDownloads[key] else { continue }
+            if case .loading = store.state, key.hasPrefix(accountPrefix) {
+                // Keep this account's in-flight downloads across chat pruning so a reappearing
+                // tile reuses the same store instead of starting a second runtime call.
+                continue
+            }
             // Notify any lingering per-attachment observers before dropping the store.
-            mediaDownloads[key]?.update(.idle)
+            store.update(.idle)
             mediaDownloads[key] = nil
         }
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6790,7 +6790,7 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func mediaDownloadFinishingAfterTimelinePruneDoesNotPublishPlaintext() async throws {
+    @Test func mediaDownloadFinishingAfterTimelinePruneCachesWithoutPublishingPlaintext() async throws {
         let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
         defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
         UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
@@ -6879,16 +6879,34 @@ struct whitenoise_macTests {
         #expect(state.mediaDownloads[key] == nil)
         #expect(stateStore.state == .idle)
 
+        state.replaceMessages([message], groupIdHex: "group")
+        let recreatedStateStore = state.mediaDownloadStateStore(for: message, attachment: attachment)
+        #expect(recreatedStateStore !== stateStore)
+        #expect(recreatedStateStore.state == .idle)
+
         runtime.releaseMediaDownloadGate()
         await load
         for _ in 0..<20 where !state.mediaDiskStoreTasks.isEmpty {
             await Task.yield()
         }
 
-        #expect(state.mediaDownloads[key] == nil)
         #expect(stateStore.state == .idle)
+        #expect(recreatedStateStore.state == .idle)
         #expect(state.mediaDiskStoreTasks.isEmpty)
-        #expect(await mediaDiskCache.cachedDownload(for: cacheKey) == nil)
+        guard let cachedDownload = await mediaDiskCache.cachedDownload(for: cacheKey) else {
+            Issue.record("Expected pruned late download to persist to encrypted disk cache")
+            return
+        }
+        #expect(cachedDownload.data == plaintext)
+        #expect(runtime.downloadMediaCallCount == 1)
+
+        await state.loadMediaAttachment(attachment, for: message)
+        guard case .loaded(let loaded) = recreatedStateStore.state else {
+            Issue.record("Expected recreated store to load from disk cache without re-downloading")
+            return
+        }
+        #expect(loaded.data == plaintext)
+        #expect(runtime.downloadMediaCallCount == 1)
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6870,9 +6870,14 @@ struct whitenoise_macTests {
         )
 
         runtime.mediaDownloadGateEnabled = true
+        defer {
+            runtime.releaseMediaDownloadGate()
+            runtime.mediaDownloadGateEnabled = false
+        }
         async let load: Void = state.loadMediaAttachment(attachment, for: message)
-        while !runtime.didReachMediaDownloadGate {
-            await Task.yield()
+        guard await waitFor { runtime.didReachMediaDownloadGate } else {
+            Issue.record("Expected first media download to reach the fake runtime gate")
+            return
         }
 
         state.replaceMessages([], groupIdHex: "group")
@@ -6884,14 +6889,35 @@ struct whitenoise_macTests {
         #expect(recreatedStateStore !== stateStore)
         #expect(recreatedStateStore.state == .idle)
 
+        // Model AutomaticMediaDownloadModifier: replacement load starts while the first
+        // runtime download is still gated, before the prune-era fetch can finish.
+        async let replacementLoad: Void = state.loadMediaAttachment(attachment, for: message)
+        let replacementEngaged = await waitFor {
+            if case .loading = recreatedStateStore.state {
+                return true
+            }
+            return runtime.downloadMediaCallCount > 1
+        }
+        guard replacementEngaged else {
+            Issue.record("Expected replacement media load to engage while the first runtime download is gated")
+            return
+        }
+        #expect(runtime.downloadMediaCallCount == 1)
+
         runtime.releaseMediaDownloadGate()
         await load
-        for _ in 0..<20 where !state.mediaDiskStoreTasks.isEmpty {
-            await Task.yield()
+        await replacementLoad
+        guard await waitFor { state.mediaDiskStoreTasks.isEmpty } else {
+            Issue.record("Expected media disk-cache store tasks to finish")
+            return
         }
 
         #expect(stateStore.state == .idle)
-        #expect(recreatedStateStore.state == .idle)
+        guard case .loaded(let loadedFromCoalescedFetch) = recreatedStateStore.state else {
+            Issue.record("Expected recreated store to load from the coalesced runtime download")
+            return
+        }
+        #expect(loadedFromCoalescedFetch.data == plaintext)
         #expect(state.mediaDiskStoreTasks.isEmpty)
         guard let cachedDownload = await mediaDiskCache.cachedDownload(for: cacheKey) else {
             Issue.record("Expected pruned late download to persist to encrypted disk cache")

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6790,7 +6790,7 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func mediaDownloadFinishingAfterTimelinePruneCachesWithoutPublishingPlaintext() async throws {
+    @Test func mediaDownloadCoalescesAcrossChatSwitchBeforeFirstFetchCompletes() async throws {
         let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
         defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
         UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
@@ -6880,14 +6880,18 @@ struct whitenoise_macTests {
             return
         }
 
+        state.selection = .chat("other-group")
         state.replaceMessages([], groupIdHex: "group")
-        #expect(state.mediaDownloads[key] == nil)
-        #expect(stateStore.state == .idle)
+        state.pruneMediaDownloadCache(keeping: "other-group")
+        let preservedLoadingStore = try #require(state.mediaDownloads[key])
+        #expect(preservedLoadingStore === stateStore)
+        #expect(stateStore.state == .loading)
 
+        state.selection = .chat("group")
         state.replaceMessages([message], groupIdHex: "group")
         let recreatedStateStore = state.mediaDownloadStateStore(for: message, attachment: attachment)
-        #expect(recreatedStateStore !== stateStore)
-        #expect(recreatedStateStore.state == .idle)
+        #expect(recreatedStateStore === stateStore)
+        #expect(recreatedStateStore.state == .loading)
 
         // Model AutomaticMediaDownloadModifier: replacement load starts while the first
         // runtime download is still gated, before the prune-era fetch can finish.
@@ -6912,11 +6916,11 @@ struct whitenoise_macTests {
             return
         }
 
-        #expect(stateStore.state == .idle)
-        guard case .loaded(let loadedFromCoalescedFetch) = recreatedStateStore.state else {
-            Issue.record("Expected recreated store to load from the coalesced runtime download")
+        guard case .loaded(let loadedFromCoalescedFetch) = stateStore.state else {
+            Issue.record("Expected preserved store to load from the coalesced runtime download")
             return
         }
+        #expect(recreatedStateStore.state == stateStore.state)
         #expect(loadedFromCoalescedFetch.data == plaintext)
         #expect(state.mediaDiskStoreTasks.isEmpty)
         guard let cachedDownload = await mediaDiskCache.cachedDownload(for: cacheKey) else {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6875,7 +6875,7 @@ struct whitenoise_macTests {
             runtime.mediaDownloadGateEnabled = false
         }
         async let load: Void = state.loadMediaAttachment(attachment, for: message)
-        guard await waitFor { runtime.didReachMediaDownloadGate } else {
+        guard await waitFor({ runtime.didReachMediaDownloadGate }) else {
             Issue.record("Expected first media download to reach the fake runtime gate")
             return
         }
@@ -6907,7 +6907,7 @@ struct whitenoise_macTests {
         runtime.releaseMediaDownloadGate()
         await load
         await replacementLoad
-        guard await waitFor { state.mediaDiskStoreTasks.isEmpty } else {
+        guard await waitFor({ state.mediaDiskStoreTasks.isEmpty }) else {
             Issue.record("Expected media disk-cache store tasks to finish")
             return
         }


### PR DESCRIPTION
Fixes #503

## Summary
- persist a completed media download through the independently generation-guarded encrypted disk cache before checking whether its captured in-memory state store is still publishable
- preserve stale-store behavior: an in-flight task does not publish plaintext into either the pruned store or its replacement
- extend the gated regression test to recreate the store mid-fetch and prove the next load hits disk without a second runtime download

## Verification
- `git diff --check`
- portable source assertions verify disk scheduling precedes the stale-store publish guard and the regression covers cache reuse
- `bash -n scripts/ci/macos-sanity-checks.sh`
- `scripts/ci/macos-sanity-checks.sh` attempted, but this Linux host has no `xcodebuild`; macOS build/unit/static-analysis coverage is delegated to PR CI

## Sensitive paths
None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/654">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->