### PR TITLE
fix: reject userinfo in remote image URLs

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -39,7 +39,8 @@ nonisolated enum RemoteImageURLPolicy {
     /// bytes under the response-size cap and never trips the per-request stall timeout.
     static let downloadResourceTimeout: TimeInterval = 60
 
-    /// Returns true if `url` is safe to fetch: `https` scheme with a non-empty, public host.
+    /// Returns true if `url` is safe to fetch: `https`, no embedded userinfo, and a non-empty,
+    /// public host.
     ///
     /// "Public host" means the host is not a literal private/loopback/link-local/unspecified
     /// IP address and not an obvious local hostname (`localhost`, `*.local`). This is the SSRF
@@ -54,6 +55,10 @@ nonisolated enum RemoteImageURLPolicy {
     /// local-hostname vectors (which is what the attacker can set without controlling DNS).
     static func isAllowed(_ url: URL) -> Bool {
         guard let scheme = url.scheme?.lowercased(), scheme == "https" else { return false }
+        // Reject embedded userinfo before host-based checks. A peer-controlled
+        // avatar URL like `https://trusted.example@evil.example` connects to
+        // `evil.example` but reads as the trusted host to a human.
+        guard url.user == nil, url.password == nil else { return false }
         guard let host = url.host, !host.isEmpty else { return false }
         guard !isDisallowedHost(host) else { return false }
         return true

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1459,6 +1459,23 @@ struct PureValueTests {
                 == "https://cdn.example/p.png")
     }
 
+    @Test func remoteImagePolicyRejectsEmbeddedUserinfoHostConfusion() async throws {
+        // Profile picture URLs are attacker-controlled Nostr metadata. Embedded userinfo can make
+        // the URL read like a trusted host while URL parsing fetches from the attacker's host;
+        // match MarkdownLinkPolicy and reject any user/password component before allowing a fetch.
+        for raw in [
+            "https://trusted.example@evil.example/x.png",
+            "https://cdn.example@evil.example/avatar.png",
+            "https://user:pass@evil.example/x.png",
+            "https://:pass@evil.example/x.png",
+            "https://user@evil.example/x.png",
+        ] {
+            let url = try #require(URL(string: raw))
+            #expect(!RemoteImageURLPolicy.isAllowed(url), "expected rejection for \(raw)")
+            #expect(RemoteImageURLPolicy.sanitizedURL(from: raw) == nil, "expected nil for \(raw)")
+        }
+    }
+
     @Test func remoteImageCollectorReturnsAllBytesUnderCap() async throws {
         // Several chunks spanning typical OS delivery sizes should round-trip byte-for-byte.
         let chunkSize = 64 * 1024


### PR DESCRIPTION
Fixes #585

## Summary
- reject remote-image URLs containing embedded username or password userinfo before host validation
- cover both `RemoteImageURLPolicy.isAllowed` and `sanitizedURL(from:)` with a focused host-confusion regression test
- keep the policy documentation aligned with the hardened behavior

## Verification
- `git diff --check` — passed
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed (portable shell syntax only)
- macOS `swift-format`, `xcodebuild test`, build, and analyzer checks are unavailable on this Linux worker; the draft PR CI will run the exact repository gates on macOS

## Sensitive paths
- `whitenoise-mac/Core/RemoteImageLoader.swift` — URL trust policy used by remote-image and redirect fetch validation (security/privacy defense-in-depth)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/655">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->