### PR TITLE
fix: validate transition IPv6 embedded addresses

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -122,7 +122,8 @@ nonisolated enum RemoteImageURLPolicy {
     /// ULA `fc00::/7`, link-local `fe80::/10`, multicast `ff00::/8`, documentation
     /// `2001:db8::/32`, RFC 8215 local-use translation `64:ff9b:1::/48`, and the IPv4-embedding
     /// forms (mapped `::ffff:a.b.c.d`, translated `::ffff:0:a.b.c.d`, NAT64 `64:ff9b::a.b.c.d`,
-    /// and IPv4-compatible `::a.b.c.d`) whose embedded IPv4 is itself private.
+    /// and IPv4-compatible `::a.b.c.d`, 6to4 `2002::/16`, and Teredo `2001:0000::/32`) whose embedded
+    /// IPv4 is itself private.
     private static func isPrivateIPv6(_ groups: [UInt16]) -> Bool {
         guard groups.count == 8 else { return true }  // be conservative on anything unparseable
 
@@ -162,12 +163,27 @@ nonisolated enum RemoteImageURLPolicy {
         if groups[0...5].allSatisfy({ $0 == 0 }), groups[6] != 0 || groups[7] != 0 {
             return isPrivateIPv4(embeddedIPv4(groups))
         }
+        // 6to4 `2002:WWXX:YYZZ::/16` — the next two groups are the gateway IPv4 literal.
+        if first == 0x2002 {
+            return isPrivateIPv4(ipv4FromGroups(groups[1], groups[2]))
+        }
+        // Teredo `2001:0000::/32` — server IPv4 in groups 2–3 (literal), client IPv4 in
+        // groups 6–7 XOR'd with `0xFFFF` per 16-bit group (RFC 4380).
+        if first == 0x2001, groups[1] == 0x0000 {
+            if isPrivateIPv4(ipv4FromGroups(groups[2], groups[3])) { return true }
+            if isPrivateIPv4(ipv4FromGroups(groups[6] ^ 0xFFFF, groups[7] ^ 0xFFFF)) { return true }
+            return false
+        }
 
         return false
     }
 
+    private static func ipv4FromGroups(_ high: UInt16, _ low: UInt16) -> (UInt8, UInt8, UInt8, UInt8) {
+        (UInt8(high >> 8), UInt8(high & 0xFF), UInt8(low >> 8), UInt8(low & 0xFF))
+    }
+
     private static func embeddedIPv4(_ groups: [UInt16]) -> (UInt8, UInt8, UInt8, UInt8) {
-        (UInt8(groups[6] >> 8), UInt8(groups[6] & 0xFF), UInt8(groups[7] >> 8), UInt8(groups[7] & 0xFF))
+        ipv4FromGroups(groups[6], groups[7])
     }
 
     /// Parses a raw profile string into a fetchable URL, applying the same trimming the UI uses

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -2093,6 +2093,10 @@ struct PureValueTests {
             "https://[::2]/x.png",  // IPv4-compatible 0.0.0.2, inside 0.0.0.0/8
             "https://[::ffff]/x.png",  // IPv4-compatible 0.0.255.255
             "https://[2001:db8::5]/x.png",  // documentation range 2001:db8::/32, non-routable
+            "https://[2002:c0a8:0101::1]/x.png",  // 6to4 gateway 192.168.1.1
+            "https://[2002:7f00:0001::]/x.png",  // 6to4 gateway 127.0.0.1
+            "https://[2001:0:0808:0808:0:0:3f57:fefe]/x.png",  // Teredo client 192.168.1.1 (XOR obfuscated)
+            "https://[2001:0:c0a8:0101:0:0:f7f7:f7f7]/x.png",  // Teredo server 192.168.1.1 (direct)
         ] {
             #expect(
                 RemoteImageURLPolicy.sanitizedURL(from: raw) == nil,
@@ -2105,6 +2109,10 @@ struct PureValueTests {
         // Adjacent to the RFC 8215 /48.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[64:ff9b:2::1]/x.png") != nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[2606:4700:4700::1111]/x.png") != nil)
+        // 6to4 and Teredo with embedded-public IPv4 are not blanket-rejected.
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[2002:0808:0808::1]/x.png") != nil)
+        #expect(
+            RemoteImageURLPolicy.sanitizedURL(from: "https://[2001:0:0808:0808:0:0:f7f7:f7f7]/x.png") != nil)
     }
 
     @Test func markdownInlineBuilderDropsUnsafeMarkdownLinks() async throws {


### PR DESCRIPTION
Fixes #645

## Summary
- Decode 6to4 gateway IPv4 fields and apply the existing non-public IPv4 policy.
- Decode Teredo server/client IPv4 fields according to RFC 4380 and reject private/loopback embeddings.
- Add focused regressions for private and public 6to4/Teredo literals.

## Verification
- `git diff --check` — passed
- Transition-vector sanity harness — 6/6 cases passed
- `scripts/ci/macos-sanity-checks.sh` — unavailable on Linux (`xcodebuild` missing)
- Xcode/Swift tests — not run locally; GitHub macOS CI will execute them

## Sensitive paths
None. The change is limited to the remote-image SSRF URL policy and its unit tests; no crypto, MLS, key, trust-anchor, auth, or group-state code changed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/656">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->