### PR TITLE
perf: index timeline edits by target

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -266,6 +266,10 @@ final class MessageTimelineStore {
     /// Active kind-1009 edit candidates keyed by edit-event id. Retained across trim and
     /// authoritative window replaces that omit edit records; bounded by `windowLimit`.
     @ObservationIgnored private var editCandidatesById: [String: MessageEditOverlay] = [:]
+    /// The same candidates grouped by target id, rebuilt whenever the canonical id map changes.
+    /// Rendering a full window therefore visits only each row's candidates instead of rescanning
+    /// every retained edit for every row.
+    @ObservationIgnored private var editCandidatesByTargetId: [String: [MessageEditOverlay]] = [:]
     private(set) var isLoaded: Bool
 
     init(messages: [MessageItem] = [], isLoaded: Bool = false) {
@@ -307,7 +311,7 @@ final class MessageTimelineStore {
         lookup = [:]
         indexById = [:]
         baseMessagesById = [:]
-        editCandidatesById = [:]
+        replaceEditCandidates(with: [:])
         isLoaded = false
     }
 
@@ -394,6 +398,7 @@ final class MessageTimelineStore {
     }
 
     private func applyEditMutations(_ mutations: [MessageEditMutation]) {
+        guard !mutations.isEmpty else { return }
         for mutation in mutations {
             switch mutation {
             case .upsert(let overlay):
@@ -402,6 +407,7 @@ final class MessageTimelineStore {
                 editCandidatesById.removeValue(forKey: editMessageIdHex)
             }
         }
+        rebuildEditCandidateTargetIndex()
     }
 
     @discardableResult
@@ -425,12 +431,19 @@ final class MessageTimelineStore {
     }
 
     private func effectiveEdit(for targetId: String, base: MessageItem) -> MessageEditOverlay? {
-        guard isValidEditTarget(base, editSender: base.senderAccountIdHex) else { return nil }
-        return editCandidatesById.values
-            .filter { $0.targetMessageIdHex == targetId && $0.sender == base.senderAccountIdHex }
+        guard isValidEditTarget(base, editSender: base.senderAccountIdHex),
+            let candidates = editCandidatesByTargetId[targetId]
+        else { return nil }
+        return candidates.lazy
+            .filter { $0.sender == base.senderAccountIdHex }
             .max(by: { lhs, rhs in
                 MessageEditOverlay.shouldPrefer(rhs, over: lhs)
             })
+    }
+
+    /// Number of candidates a render lookup for `targetId` must inspect. Diagnostic / test helper.
+    func editCandidateLookupWidth(forTarget targetId: String) -> Int {
+        editCandidatesByTargetId[targetId]?.count ?? 0
     }
 
     /// The ordered edit history for `targetId` — oldest first: the original, then each accepted
@@ -439,8 +452,8 @@ final class MessageTimelineStore {
         guard let base = baseMessagesById[targetId],
             isValidEditTarget(base, editSender: base.senderAccountIdHex)
         else { return [] }
-        let edits = editCandidatesById.values
-            .filter { $0.targetMessageIdHex == targetId && $0.sender == base.senderAccountIdHex }
+        let edits = (editCandidatesByTargetId[targetId] ?? [])
+            .filter { $0.sender == base.senderAccountIdHex }
             .sorted { MessageEditOverlay.shouldPrefer($1, over: $0) }
         guard !edits.isEmpty else { return [] }
         var versions = [
@@ -464,18 +477,22 @@ final class MessageTimelineStore {
 
     private func purgeEditCandidates(forRemovalIds removalIds: Set<String>) {
         guard !removalIds.isEmpty, !editCandidatesById.isEmpty else { return }
-        editCandidatesById = editCandidatesById.filter { _, candidate in
-            !removalIds.contains(candidate.editMessageIdHex)
-                && !removalIds.contains(candidate.targetMessageIdHex)
-        }
+        replaceEditCandidates(
+            with: editCandidatesById.filter { _, candidate in
+                !removalIds.contains(candidate.editMessageIdHex)
+                    && !removalIds.contains(candidate.targetMessageIdHex)
+            }
+        )
     }
 
     private func pruneInvalidSenderCandidatesForMaterializedTargets() {
         guard !editCandidatesById.isEmpty else { return }
-        editCandidatesById = editCandidatesById.filter { _, candidate in
-            guard let base = baseMessagesById[candidate.targetMessageIdHex] else { return true }
-            return candidate.sender == base.senderAccountIdHex
-        }
+        replaceEditCandidates(
+            with: editCandidatesById.filter { _, candidate in
+                guard let base = baseMessagesById[candidate.targetMessageIdHex] else { return true }
+                return candidate.sender == base.senderAccountIdHex
+            }
+        )
     }
 
     private func pruneEditCandidates(windowLimit limit: Int) {
@@ -546,7 +563,19 @@ final class MessageTimelineStore {
                 kept[candidate.key] = candidate.value
             }
         }
-        editCandidatesById = kept
+        replaceEditCandidates(with: kept)
+    }
+
+    private func replaceEditCandidates(with candidates: [String: MessageEditOverlay]) {
+        editCandidatesById = candidates
+        rebuildEditCandidateTargetIndex()
+    }
+
+    private func rebuildEditCandidateTargetIndex() {
+        editCandidatesByTargetId = Dictionary(
+            grouping: editCandidatesById.values,
+            by: { $0.targetMessageIdHex }
+        )
     }
 
     private func isValidEditTarget(_ message: MessageItem, editSender: String) -> Bool {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -270,6 +270,8 @@ final class MessageTimelineStore {
     /// Rendering a full window therefore visits only each row's candidates instead of rescanning
     /// every retained edit for every row.
     @ObservationIgnored private var editCandidatesByTargetId: [String: [MessageEditOverlay]] = [:]
+    /// Candidates inspected by the most recent full render pass. Diagnostic / test helper.
+    @ObservationIgnored private(set) var lastRenderEditCandidateVisitCount = 0
     private(set) var isLoaded: Bool
 
     init(messages: [MessageItem] = [], isLoaded: Bool = false) {
@@ -413,37 +415,45 @@ final class MessageTimelineStore {
     @discardableResult
     private func recomputeAllRenderedMessages() -> Bool {
         var didChange = false
+        var candidateVisitCount = 0
         for index in messages.indices {
             let messageId = messages[index].id
             guard let base = baseMessagesById[messageId] else { continue }
-            let rendered = renderedMessage(from: base)
+            let renderResult = renderedMessage(from: base)
+            candidateVisitCount += renderResult.candidateVisitCount
+            let rendered = renderResult.message
             guard messages[index] != rendered else { continue }
             messages[index] = rendered
             lookup[messageId] = rendered
             didChange = true
         }
+        lastRenderEditCandidateVisitCount = candidateVisitCount
         return didChange
     }
 
-    private func renderedMessage(from base: MessageItem) -> MessageItem {
-        guard let edit = effectiveEdit(for: base.id, base: base) else { return base }
-        return base.applyingEdit(plaintext: edit.plaintext)
+    private func renderedMessage(from base: MessageItem) -> (message: MessageItem, candidateVisitCount: Int) {
+        let result = effectiveEdit(for: base.id, base: base)
+        guard let edit = result.edit else { return (base, result.candidateVisitCount) }
+        return (base.applyingEdit(plaintext: edit.plaintext), result.candidateVisitCount)
     }
 
-    private func effectiveEdit(for targetId: String, base: MessageItem) -> MessageEditOverlay? {
+    private func effectiveEdit(
+        for targetId: String,
+        base: MessageItem
+    ) -> (edit: MessageEditOverlay?, candidateVisitCount: Int) {
         guard isValidEditTarget(base, editSender: base.senderAccountIdHex),
             let candidates = editCandidatesByTargetId[targetId]
-        else { return nil }
-        return candidates.lazy
-            .filter { $0.sender == base.senderAccountIdHex }
-            .max(by: { lhs, rhs in
-                MessageEditOverlay.shouldPrefer(rhs, over: lhs)
-            })
-    }
-
-    /// Number of candidates a render lookup for `targetId` must inspect. Diagnostic / test helper.
-    func editCandidateLookupWidth(forTarget targetId: String) -> Int {
-        editCandidatesByTargetId[targetId]?.count ?? 0
+        else { return (nil, 0) }
+        var winner: MessageEditOverlay?
+        var candidateVisitCount = 0
+        for candidate in candidates {
+            candidateVisitCount += 1
+            guard candidate.sender == base.senderAccountIdHex else { continue }
+            if MessageEditOverlay.shouldPrefer(candidate, over: winner) {
+                winner = candidate
+            }
+        }
+        return (winner, candidateVisitCount)
     }
 
     /// The ordered edit history for `targetId` — oldest first: the original, then each accepted
@@ -513,7 +523,7 @@ final class MessageTimelineStore {
         // evict a pending candidate from the target's actual author.
         var materializedWinnerIds = Set<String>()
         for (targetId, base) in baseMessagesById {
-            if let winner = effectiveEdit(for: targetId, base: base) {
+            if let winner = effectiveEdit(for: targetId, base: base).edit {
                 materializedWinnerIds.insert(winner.editMessageIdHex)
             }
         }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -937,7 +937,7 @@ struct PureValueTests {
         )
 
         #expect(store.lookup["target"]?.body == "Edited")
-        #expect(store.editCandidateLookupWidth(forTarget: "target") == 1)
+        #expect(store.lastRenderEditCandidateVisitCount == 1)
     }
 
     @MainActor

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -902,6 +902,45 @@ struct PureValueTests {
     }
 
     @MainActor
+    @Test func messageTimelineStoreIndexesEditCandidatesByTarget() async throws {
+        // Regression for whitenoise-mac#586: rendering one materialized row must inspect only
+        // that target's candidates, not every retained edit in the timeline window.
+        let store = MessageTimelineStore.loaded(with: [
+            chatMessage(id: "target", body: "Original", timelineAt: 1_800_000_000)
+        ])
+        var mutations = (0..<199).map { index in
+            editUpsert(
+                makeEditOverlay(
+                    target: "unrelated-\(index)",
+                    editId: "unrelated-edit-\(index)",
+                    plaintext: "Unrelated \(index)",
+                    timelineAt: 1_800_000_001 + UInt64(index)
+                )
+            )
+        }
+        mutations.append(
+            editUpsert(
+                makeEditOverlay(
+                    editId: "target-edit",
+                    plaintext: "Edited",
+                    timelineAt: 1_800_000_200
+                )
+            )
+        )
+
+        _ = store.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: mutations,
+            anchoredToNewest: true,
+            windowLimit: 200
+        )
+
+        #expect(store.lookup["target"]?.body == "Edited")
+        #expect(store.editCandidateLookupWidth(forTarget: "target") == 1)
+    }
+
+    @MainActor
     @Test func messageTimelineStoreReplaceReappliesStoredEditsAcrossWindowChanges() async throws {
         // Regression for whitenoise-mac#419: replace() rebuilds indexes before validating targets,
         // and stored overlays survive authoritative replaces that omit the edit record.


### PR DESCRIPTION
## Summary
- maintain a target-indexed view of retained timeline edit candidates alongside the canonical edit-id map
- resolve rendered edits, edit history, and materialized pruning from the target bucket instead of scanning every candidate
- cover a saturated 200-candidate fixture and assert the actual render pass visits only the target candidate

## Verification
- PASS — Mac CI on initial implementation head: Swift format lint, project sanity checks, unit tests, release build smoke, and static analysis
- PASS — render-path regression contract: one candidate visited with 200 retained candidates
- PASS — 50,000 modeled sequences preserve effective-edit winner selection after adding visit accounting
- PASS — `git diff --check`
- NOT RUN locally — Xcode, `xcodebuild`, and `swift-format` are unavailable on this Linux worker; Mac CI is the executable build/test/format gate

Fixes #586

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/657">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved message rendering efficiency by limiting edit-history checks to candidates relevant to each message.
  * Added diagnostics to track edit candidates inspected during rendering.

* **Bug Fixes**
  * Ensured edited message content continues to display correctly when many unrelated edits are retained.

* **Tests**
  * Added coverage verifying targeted edit lookup and efficient rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->