### PR TITLE
perf: cap transcript export history

### DIFF
--- a/whitenoise-mac/Core/ConversationTranscriptExport.swift
+++ b/whitenoise-mac/Core/ConversationTranscriptExport.swift
@@ -6,6 +6,13 @@ import MarmotKit
 /// thread under the project's default `@MainActor` isolation.
 nonisolated enum ConversationTranscriptExport {
     static let pageLimit: UInt32 = 200
+    /// Bounds the records and encoded copies retained by the clipboard-only export path.
+    static let maximumEventCount = 1_000
+
+    struct FetchResult {
+        var messages: [TimelineMessageRecordFfi]
+        var truncated: Bool
+    }
 
     enum ExportError: LocalizedError {
         /// The FFI reported more history exists (`hasMoreBefore == true`) but the `before`
@@ -30,6 +37,7 @@ nonisolated enum ConversationTranscriptExport {
         var groupIdHex: String
         var groupName: String
         var eventCount: Int
+        var truncated: Bool
         var events: [Event]
 
         enum CodingKeys: String, CodingKey {
@@ -38,6 +46,7 @@ nonisolated enum ConversationTranscriptExport {
             case groupIdHex = "group_id_hex"
             case groupName = "group_name"
             case eventCount = "event_count"
+            case truncated
             case events
         }
     }
@@ -80,12 +89,14 @@ nonisolated enum ConversationTranscriptExport {
         }
     }
 
-    static func fetchAllMessages(
+    static func fetchMessages(
         client: any MarmotRuntime,
         accountRef: String,
         groupIdHex: String,
+        messageLimit: Int = maximumEventCount,
         checkCancellation: @Sendable () throws -> Void = { try Task.checkCancellation() }
-    ) throws -> [TimelineMessageRecordFfi] {
+    ) throws -> FetchResult {
+        precondition(messageLimit > 0)
         var collectedById: [String: TimelineMessageRecordFfi] = [:]
         var before: UInt64?
         var beforeMessageId: String?
@@ -107,6 +118,13 @@ nonisolated enum ConversationTranscriptExport {
             try checkCancellation()
             for message in page.messages {
                 collectedById[message.messageIdHex] = message
+            }
+
+            if collectedById.count > messageLimit
+                || (collectedById.count == messageLimit && page.hasMoreBefore)
+            {
+                let messages = Array(sortChronologically(Array(collectedById.values)).suffix(messageLimit))
+                return FetchResult(messages: messages, truncated: true)
             }
 
             guard page.hasMoreBefore else { break }
@@ -133,13 +151,17 @@ nonisolated enum ConversationTranscriptExport {
             beforeMessageId = nextBeforeMessageId
         }
 
-        return sortChronologically(Array(collectedById.values))
+        return FetchResult(
+            messages: sortChronologically(Array(collectedById.values)),
+            truncated: false
+        )
     }
 
     static func makeDocument(
         groupIdHex: String,
         groupName: String,
         chronologicallySortedMessages messages: [TimelineMessageRecordFfi],
+        truncated: Bool = false,
         exportedAt: Date = Date()
     ) -> Document {
         let events = messages.enumerated().map { index, record in
@@ -167,6 +189,7 @@ nonisolated enum ConversationTranscriptExport {
             groupIdHex: groupIdHex,
             groupName: groupName,
             eventCount: events.count,
+            truncated: truncated,
             events: events
         )
     }

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -114,10 +114,10 @@ extension WorkspaceState {
             let groupIdHex = snapshot.groupIdHex
             let groupName = snapshot.name
             let detailsGeneration = groupDetailsLoadGeneration
-            // Paginates the whole transcript via blocking FFI and JSON-encodes it; keep it
-            // off the main thread so a large export does not freeze the UI.
+            // Paginates a bounded suffix of the transcript via blocking FFI and JSON-encodes it;
+            // keep it off the main thread so a large export does not freeze the UI.
             let export = try await runOffMainCancellable { checkCancellation -> (json: String, eventCount: Int) in
-                let messages = try ConversationTranscriptExport.fetchAllMessages(
+                let result = try ConversationTranscriptExport.fetchMessages(
                     client: client,
                     accountRef: accountRef,
                     groupIdHex: groupIdHex,
@@ -126,7 +126,8 @@ extension WorkspaceState {
                 let document = ConversationTranscriptExport.makeDocument(
                     groupIdHex: groupIdHex,
                     groupName: groupName,
-                    chronologicallySortedMessages: messages
+                    chronologicallySortedMessages: result.messages,
+                    truncated: result.truncated
                 )
                 return (try ConversationTranscriptExport.encodeJSONString(document), document.eventCount)
             }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -12568,7 +12568,80 @@ struct whitenoise_macTests {
         let data = try ConversationTranscriptExport.encodeJSON(document)
         let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         #expect(json["group_name"] as? String == "Hermes 2")
+        #expect(json["truncated"] as? Bool == false)
         #expect((json["events"] as? [[String: Any]])?.count == 2)
+    }
+
+    @Test func conversationTranscriptExportStopsAtLimitAndMarksOlderEventsTruncated() throws {
+        let runtime = FakeMarmotRuntime(accounts: [desktopAccount()])
+        let records = (1...3).map { index in
+            timelineMessage(
+                id: String(repeating: String(index), count: 64),
+                groupIdHex: "group",
+                sender: String(repeating: "a", count: 64),
+                plaintext: "message \(index)",
+                recordedAt: UInt64(index)
+            )
+        }
+        runtime.timelineMessagesHandler = { query in
+            switch query.before {
+            case nil:
+                return TimelinePageFfi(messages: [records[2]], hasMoreBefore: true, hasMoreAfter: false)
+            case 3:
+                return TimelinePageFfi(messages: [records[0], records[1]], hasMoreBefore: true, hasMoreAfter: true)
+            default:
+                return TimelinePageFfi(messages: [], hasMoreBefore: false, hasMoreAfter: true)
+            }
+        }
+
+        let result = try ConversationTranscriptExport.fetchMessages(
+            client: runtime,
+            accountRef: "Desktop Account",
+            groupIdHex: "group",
+            messageLimit: 2
+        )
+        let document = ConversationTranscriptExport.makeDocument(
+            groupIdHex: "group",
+            groupName: "Test Group",
+            chronologicallySortedMessages: result.messages,
+            truncated: result.truncated
+        )
+        let json = try #require(
+            JSONSerialization.jsonObject(with: ConversationTranscriptExport.encodeJSON(document)) as? [String: Any]
+        )
+
+        #expect(result.messages.map(\.messageIdHex) == [records[1].messageIdHex, records[2].messageIdHex])
+        #expect(result.truncated)
+        #expect(runtime.timelineMessageQueries.count == 2)
+        #expect(json["event_count"] as? Int == 2)
+        #expect(json["truncated"] as? Bool == true)
+    }
+
+    @Test func conversationTranscriptExportDoesNotTruncateACompleteLimit() throws {
+        let runtime = FakeMarmotRuntime(accounts: [desktopAccount()])
+        let records = (1...2).map { index in
+            timelineMessage(
+                id: String(repeating: String(index), count: 64),
+                groupIdHex: "group",
+                sender: String(repeating: "a", count: 64),
+                plaintext: "message \(index)",
+                recordedAt: UInt64(index)
+            )
+        }
+        runtime.timelineMessagesHandler = { _ in
+            TimelinePageFfi(messages: records, hasMoreBefore: false, hasMoreAfter: false)
+        }
+
+        let result = try ConversationTranscriptExport.fetchMessages(
+            client: runtime,
+            accountRef: "Desktop Account",
+            groupIdHex: "group",
+            messageLimit: 2
+        )
+
+        #expect(result.messages.count == 2)
+        #expect(!result.truncated)
+        #expect(runtime.timelineMessageQueries.count == 1)
     }
 
     @Test func conversationTranscriptExportFailsWhenEmptyPageReportsMoreHistory() throws {
@@ -12598,7 +12671,7 @@ struct whitenoise_macTests {
         }
 
         #expect(throws: ConversationTranscriptExport.ExportError.self) {
-            try ConversationTranscriptExport.fetchAllMessages(
+            try ConversationTranscriptExport.fetchMessages(
                 client: runtime,
                 accountRef: "Desktop Account",
                 groupIdHex: "group"
@@ -12628,7 +12701,7 @@ struct whitenoise_macTests {
         }
 
         #expect(throws: ConversationTranscriptExport.ExportError.self) {
-            try ConversationTranscriptExport.fetchAllMessages(
+            try ConversationTranscriptExport.fetchMessages(
                 client: runtime,
                 accountRef: "Desktop Account",
                 groupIdHex: "group"
@@ -12644,12 +12717,13 @@ struct whitenoise_macTests {
             TimelinePageFfi(messages: [], hasMoreBefore: false, hasMoreAfter: false)
         }
 
-        let messages = try ConversationTranscriptExport.fetchAllMessages(
+        let result = try ConversationTranscriptExport.fetchMessages(
             client: runtime,
             accountRef: "Desktop Account",
             groupIdHex: "group"
         )
-        #expect(messages.isEmpty)
+        #expect(result.messages.isEmpty)
+        #expect(!result.truncated)
     }
 
     @Test func conversationTranscriptExportCancelsBeforeFetchingNextPage() async {
@@ -12679,7 +12753,7 @@ struct whitenoise_macTests {
         }
 
         let exportTask = Task.detached { () throws -> Void in
-            _ = try ConversationTranscriptExport.fetchAllMessages(
+            _ = try ConversationTranscriptExport.fetchMessages(
                 client: runtime,
                 accountRef: "Desktop Account",
                 groupIdHex: "group"

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -12617,6 +12617,33 @@ struct whitenoise_macTests {
         #expect(json["truncated"] as? Bool == true)
     }
 
+    @Test func conversationTranscriptExportMarksExactLimitTruncatedWhenMoreHistoryExists() throws {
+        let runtime = FakeMarmotRuntime(accounts: [desktopAccount()])
+        let records = (1...2).map { index in
+            timelineMessage(
+                id: String(repeating: String(index), count: 64),
+                groupIdHex: "group",
+                sender: String(repeating: "a", count: 64),
+                plaintext: "message \(index)",
+                recordedAt: UInt64(index)
+            )
+        }
+        runtime.timelineMessagesHandler = { _ in
+            TimelinePageFfi(messages: records, hasMoreBefore: true, hasMoreAfter: false)
+        }
+
+        let result = try ConversationTranscriptExport.fetchMessages(
+            client: runtime,
+            accountRef: "Desktop Account",
+            groupIdHex: "group",
+            messageLimit: 2
+        )
+
+        #expect(result.messages.map(\.messageIdHex) == records.map(\.messageIdHex))
+        #expect(result.truncated)
+        #expect(runtime.timelineMessageQueries.count == 1)
+    }
+
     @Test func conversationTranscriptExportDoesNotTruncateACompleteLimit() throws {
         let runtime = FakeMarmotRuntime(accounts: [desktopAccount()])
         let records = (1...2).map { index in


### PR DESCRIPTION
## Summary
- cap clipboard transcript exports at the latest 1,000 unique events
- stop pagination once the cap is reached while preserving chronological order
- add a `truncated` JSON marker when older events are omitted

## Test plan
- added cap, newest-suffix, truncation-marker, and exact-boundary regression coverage
- `git diff --check`
- local Xcode execution unavailable on this Linux worker; Mac CI is the executable verification path

Fixes #500

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->