### PR TITLE
fix: stop recordings before selected group removal

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -582,6 +582,7 @@ extension WorkspaceState {
                 closeGroupDetails()
             }
             if case .chat(let selectedGroupId) = selection, selectedGroupId == groupIdHex {
+                leaveActiveConversation()
                 stopTimelineListener()
                 selection = nil
                 pruneMessageCache(keeping: nil)
@@ -681,6 +682,7 @@ extension WorkspaceState {
                 closeGroupDetails()
             }
             if case .chat(let selectedGroupId) = selection, selectedGroupId == groupIdHex {
+                leaveActiveConversation()
                 stopTimelineListener()
                 selection = nil
                 pruneMessageCache(keeping: nil)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -16204,6 +16204,69 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func decliningSelectedGroupInviteLeavesActiveConversation() async throws {
+        let account = desktopAccount()
+        var details = groupDetailsFixture(selfAccountIdHex: account.accountIdHex)
+        details.group.pendingConfirmation = true
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(details)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let selectedChat = try #require(state.selectedChat)
+        let recordingURL = try armInProgressVoiceRecording(on: state)
+        defer { state.cancelVoiceRecording() }
+        let transcriptExportTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        state.groupTranscriptExportTask = transcriptExportTask
+        defer { transcriptExportTask.cancel() }
+
+        await state.declineGroupInvite(for: selectedChat)
+
+        #expect(state.selection != .chat(selectedChat.id))
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: recordingURL.path))
+        #expect(transcriptExportTask.isCancelled)
+        transcriptExportTask.cancel()
+        await transcriptExportTask.value
+    }
+
+    @MainActor
+    @Test func deletingSelectedGroupLocallyLeavesActiveConversation() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let selectedChat = try #require(state.selectedChat)
+        let recordingURL = try armInProgressVoiceRecording(on: state)
+        defer { state.cancelVoiceRecording() }
+        let transcriptExportTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        state.groupTranscriptExportTask = transcriptExportTask
+        defer { transcriptExportTask.cancel() }
+
+        await state.deleteGroupLocally(groupIdHex: selectedChat.id)
+
+        #expect(runtime.locallyDeletedGroupIds == [selectedChat.id])
+        #expect(state.selection != .chat(selectedChat.id))
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: recordingURL.path))
+        #expect(transcriptExportTask.isCancelled)
+        transcriptExportTask.cancel()
+        await transcriptExportTask.value
+    }
+
+    @MainActor
     @Test func activeAccountNotificationResponseStopsInProgressVoiceRecordingBeforeChatSwitch() async throws {
         // #374: tapping a same-account notification is an implicit chat switch. It must run
         // the same conversation teardown as `selectChat` before the composer belongs to the


### PR DESCRIPTION
## Summary
- run the centralized active-conversation teardown before declining or locally deleting the selected group
- cancel both voice-recording state/plaintext temp audio and in-flight transcript export work before the composer disappears
- add regression coverage for both selected-group mutation paths

## Test plan
- [x] Source invariant check: both selected-chat branches call `leaveActiveConversation()` (RED before fix, GREEN after)
- [x] `git diff --cached --check`
- [ ] `xcodebuild test -project whitenoise-mac.xcodeproj -scheme whitenoise-mac -testPlan PR -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` (unavailable on Linux fixer host; PR CI runs this on macOS)

Fixes #640


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->