### PR TITLE
fix: coalesce media downloads across chat pruning

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -18,6 +18,10 @@ private nonisolated struct MediaReferenceIndexTaskFailure: Error {
     let underlying: Error
 }
 
+private nonisolated struct MediaAttachmentDownloadTaskFailure: Error {
+    let underlying: Error
+}
+
 @MainActor
 extension WorkspaceState {
     func clearAllComposerDrafts() {
@@ -277,13 +281,17 @@ extension WorkspaceState {
                 return
             }
 
-            let download = try await withMediaAttachmentDownloadTimeout {
-                try await client.downloadMedia(
-                    accountRef: accountRef,
-                    groupIdHex: groupIdHex,
-                    reference: reference
-                )
-            }
+            let download = try await sharedMessageMediaDownload(
+                cacheID: cacheKey.cacheID,
+                cacheKey: cacheKey,
+                mediaDownloadKey: key,
+                accountId: accountId,
+                accountRef: accountRef,
+                groupIdHex: groupIdHex,
+                reference: reference,
+                client: client,
+                storeGuard: storeGuard
+            )
             guard
                 canPublishMediaDownloadState(
                     forKey: key,
@@ -295,22 +303,7 @@ extension WorkspaceState {
                 stateStore.update(.idle)
                 return
             }
-            let mediaDownload = MessageMediaDownload(
-                payload: DownloadedMediaPayload(
-                    id: "\(key)|\(UUID().uuidString)",
-                    data: download.plaintext
-                ),
-                fileName: download.fileName,
-                mediaType: download.mediaType,
-                sizeBytes: download.sizeBytes
-            )
-            stateStore.update(.loaded(mediaDownload))
-            scheduleMediaDiskCacheStore(
-                mediaDownload,
-                for: cacheKey,
-                accountId: accountId,
-                storeGuard: storeGuard
-            )
+            stateStore.update(.loaded(download))
         } catch is CancellationError {
             guard isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: groupIdHex) else {
                 stateStore.update(.idle)
@@ -666,15 +659,16 @@ extension WorkspaceState {
             return
         }
 
-        let prefix = [activeAccountId, groupIdHex, ""].joined(separator: "\u{1F}")
+        let groupPrefix = [activeAccountId, groupIdHex, ""].joined(separator: "\u{1F}")
         let retainedKeys = retainedMediaDownloadKeys(groupIdHex: groupIdHex, accountId: activeAccountId)
         let removedKeys = mediaDownloads.keys.filter { key in
-            guard key.hasPrefix(prefix) else { return true }
+            guard key.hasPrefix(groupPrefix) else { return true }
             return !retainedKeys.contains(key)
         }
         for key in removedKeys {
+            guard let store = mediaDownloads[key] else { continue }
             // Notify any lingering per-attachment observers before dropping the store.
-            mediaDownloads[key]?.update(.idle)
+            store.update(.idle)
             mediaDownloads[key] = nil
         }
     }
@@ -700,8 +694,129 @@ extension WorkspaceState {
             store.update(.idle)
         }
         mediaDownloads.removeAll()
+        cancelAllMediaAttachmentDownloadTasks()
         clearMediaReferenceResolutionCache()
         MessageAudioMetadataCache.shared.clear()
+    }
+
+    private func sharedMessageMediaDownload(
+        cacheID: String,
+        cacheKey: MessageMediaDiskCacheKey,
+        mediaDownloadKey: String,
+        accountId: String,
+        accountRef: String,
+        groupIdHex: String,
+        reference: MediaAttachmentReferenceFfi,
+        client: any MarmotRuntime,
+        storeGuard: MediaDiskStoreGuard
+    ) async throws -> MessageMediaDownload {
+        let tracked = mediaAttachmentDownloadTask(
+            cacheID: cacheID,
+            cacheKey: cacheKey,
+            mediaDownloadKey: mediaDownloadKey,
+            accountId: accountId,
+            accountRef: accountRef,
+            groupIdHex: groupIdHex,
+            reference: reference,
+            client: client,
+            storeGuard: storeGuard
+        )
+        let task = tracked.task
+        do {
+            return try await withMediaAttachmentDownloadTimeout { [task] in
+                do {
+                    return try await task.value
+                } catch {
+                    throw MediaAttachmentDownloadTaskFailure(underlying: error)
+                }
+            }
+        } catch let failure as MediaAttachmentDownloadTaskFailure {
+            throw failure.underlying
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch is MediaAttachmentDownloadTimeoutError {
+            throw MediaAttachmentDownloadTimeoutError()
+        }
+    }
+
+    private func mediaAttachmentDownloadTask(
+        cacheID: String,
+        cacheKey: MessageMediaDiskCacheKey,
+        mediaDownloadKey: String,
+        accountId: String,
+        accountRef: String,
+        groupIdHex: String,
+        reference: MediaAttachmentReferenceFfi,
+        client: any MarmotRuntime,
+        storeGuard: MediaDiskStoreGuard
+    ) -> MediaAttachmentDownloadTask {
+        if let existing = mediaAttachmentDownloadTasks[cacheID] {
+            return existing
+        }
+
+        nextMediaAttachmentDownloadTaskToken &+= 1
+        let token = nextMediaAttachmentDownloadTaskToken
+        let downloadTask = Task.detached(priority: .userInitiated) {
+            [client, accountRef, groupIdHex, reference, mediaDownloadKey] in
+            let download = try await client.downloadMedia(
+                accountRef: accountRef,
+                groupIdHex: groupIdHex,
+                reference: reference
+            )
+            return MessageMediaDownload(
+                payload: DownloadedMediaPayload(
+                    id: "\(mediaDownloadKey)|\(UUID().uuidString)",
+                    data: download.plaintext
+                ),
+                fileName: download.fileName,
+                mediaType: download.mediaType,
+                sizeBytes: download.sizeBytes
+            )
+        }
+        let tracked = MediaAttachmentDownloadTask(
+            token: token,
+            task: downloadTask
+        )
+        mediaAttachmentDownloadTasks[cacheID] = tracked
+        Task { @MainActor [weak self, downloadTask, cacheID, cacheKey, accountId, storeGuard, token] in
+            defer {
+                self?.finishMediaAttachmentDownloadTask(cacheID: cacheID, token: token)
+            }
+            do {
+                let download = try await downloadTask.value
+                guard let self,
+                    self.mediaAttachmentDownloadTasks[cacheID]?.token == token,
+                    self.isMediaDiskStoreAllowed(forAccountId: accountId, storeGuard: storeGuard)
+                else {
+                    return
+                }
+                self.scheduleMediaDiskCacheStore(
+                    download,
+                    for: cacheKey,
+                    accountId: accountId,
+                    storeGuard: storeGuard
+                )
+                if let storeTask = self.mediaDiskStoreTasks[cacheID]?.task {
+                    await storeTask.value
+                }
+            } catch {
+                // Underlying failures are surfaced to waiters; cleanup happens in defer.
+            }
+        }
+        return tracked
+    }
+
+    private func finishMediaAttachmentDownloadTask(cacheID: String, token: UInt64) {
+        guard mediaAttachmentDownloadTasks[cacheID]?.token == token else { return }
+        mediaAttachmentDownloadTasks[cacheID] = nil
+    }
+
+    private func cancelAllMediaAttachmentDownloadTasks() {
+        let tracked = Array(mediaAttachmentDownloadTasks.values)
+        mediaAttachmentDownloadTasks.removeAll()
+        for entry in tracked {
+            entry.task.cancel()
+        }
     }
 
     func resolvedMediaReference(

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -755,6 +755,8 @@ final class WorkspaceState {
     @ObservationIgnored var mediaReferenceIndexTasks: [MediaReferenceCacheKey: MediaReferenceIndexTask] = [:]
     @ObservationIgnored var mediaReferenceIndexGeneration: UInt64 = 0
     @ObservationIgnored var mediaDiskStoreTasks: [String: MediaDiskStoreTask] = [:]
+    @ObservationIgnored var mediaAttachmentDownloadTasks: [String: MediaAttachmentDownloadTask] = [:]
+    @ObservationIgnored var nextMediaAttachmentDownloadTaskToken: UInt64 = 0
     @ObservationIgnored var isMediaDiskStoreGloballySuppressed = false
     @ObservationIgnored var mediaDiskStoreSuppressedAccountIds = Set<String>()
     @ObservationIgnored var mediaDiskStoreAccountGenerations: [String: UInt64] = [:]
@@ -1394,6 +1396,11 @@ final class WorkspaceState {
         var accountId: String
         var token: UInt64
         var task: Task<Void, Never>
+    }
+
+    struct MediaAttachmentDownloadTask {
+        var token: UInt64
+        var task: Task<MessageMediaDownload, Error>
     }
 
     /// Raw output of the per-account bootstrap/settings FFI lookups.

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -394,7 +394,7 @@ nonisolated final class DownloadedMediaPayload: @unchecked Sendable, Hashable {
     }
 }
 
-nonisolated struct MessageMediaDownload: Hashable {
+nonisolated struct MessageMediaDownload: Hashable, Sendable {
     let payload: DownloadedMediaPayload
     let fileName: String
     let mediaType: String

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6870,7 +6870,7 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func mediaDownloadFinishingAfterTimelinePruneDoesNotPublishPlaintext() async throws {
+    @Test func mediaDownloadCoalescesAcrossChatSwitchBeforeFirstFetchCompletes() async throws {
         let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
         defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
         UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
@@ -6950,25 +6950,81 @@ struct whitenoise_macTests {
         )
 
         runtime.mediaDownloadGateEnabled = true
-        async let load: Void = state.loadMediaAttachment(attachment, for: message)
-        while !runtime.didReachMediaDownloadGate {
-            await Task.yield()
+        defer {
+            runtime.releaseMediaDownloadGate()
+            runtime.mediaDownloadGateEnabled = false
         }
+        let load = Task { await state.loadMediaAttachment(attachment, for: message) }
+        guard await waitFor({ runtime.didReachMediaDownloadGate }) else {
+            Issue.record("Expected first media download to reach the fake runtime gate")
+            return
+        }
+        #expect(state.mediaAttachmentDownloadTasks[cacheKey.cacheID] != nil)
 
-        state.replaceMessages([], groupIdHex: "group")
-        #expect(state.mediaDownloads[key] == nil)
+        state.selection = .chat("other-group")
+        // Model AutomaticMediaDownloadModifier.onDisappear: the view stops waiting, but the
+        // underlying FFI download can remain in flight and must stay joinable by the returning tile.
+        load.cancel()
+        await load.value
         #expect(stateStore.state == .idle)
+        state.replaceMessages([], groupIdHex: "group")
+        state.pruneMediaDownloadCache(keeping: "other-group")
+        #expect(state.mediaDownloads[key] == nil)
+        #expect(state.mediaAttachmentDownloadTasks[cacheKey.cacheID] != nil)
+
+        state.selection = .chat("group")
+        state.replaceMessages([message], groupIdHex: "group")
+        let recreatedStateStore = state.mediaDownloadStateStore(for: message, attachment: attachment)
+        #expect(recreatedStateStore !== stateStore)
+        #expect(recreatedStateStore.state == .idle)
+
+        // Model AutomaticMediaDownloadModifier: replacement load starts while the first
+        // runtime download is still gated, before the prune-era fetch can finish.
+        async let replacementLoad: Void = state.loadMediaAttachment(attachment, for: message)
+        let replacementEngaged = await waitFor {
+            if case .loading = recreatedStateStore.state {
+                return true
+            }
+            return runtime.downloadMediaCallCount > 1
+        }
+        guard replacementEngaged else {
+            Issue.record("Expected replacement media load to engage while the first runtime download is gated")
+            return
+        }
+        #expect(runtime.downloadMediaCallCount == 1)
 
         runtime.releaseMediaDownloadGate()
-        await load
-        for _ in 0..<20 where !state.mediaDiskStoreTasks.isEmpty {
-            await Task.yield()
+        await replacementLoad
+        guard
+            await waitFor({
+                state.mediaDiskStoreTasks.isEmpty && state.mediaAttachmentDownloadTasks.isEmpty
+            })
+        else {
+            Issue.record("Expected media download and disk-cache store tasks to finish")
+            return
         }
 
-        #expect(state.mediaDownloads[key] == nil)
         #expect(stateStore.state == .idle)
+        guard case .loaded(let loadedFromCoalescedFetch) = recreatedStateStore.state else {
+            Issue.record("Expected recreated store to load from the coalesced runtime download")
+            return
+        }
+        #expect(loadedFromCoalescedFetch.data == plaintext)
         #expect(state.mediaDiskStoreTasks.isEmpty)
-        #expect(await mediaDiskCache.cachedDownload(for: cacheKey) == nil)
+        guard let cachedDownload = await mediaDiskCache.cachedDownload(for: cacheKey) else {
+            Issue.record("Expected pruned late download to persist to encrypted disk cache")
+            return
+        }
+        #expect(cachedDownload.data == plaintext)
+        #expect(runtime.downloadMediaCallCount == 1)
+
+        await state.loadMediaAttachment(attachment, for: message)
+        guard case .loaded(let loaded) = recreatedStateStore.state else {
+            Issue.record("Expected recreated store to load from disk cache without re-downloading")
+            return
+        }
+        #expect(loaded.data == plaintext)
+        #expect(runtime.downloadMediaCallCount == 1)
     }
 
     @MainActor
@@ -7051,6 +7107,7 @@ struct whitenoise_macTests {
         while !runtime.didReachMediaDownloadGate {
             await Task.yield()
         }
+        #expect(state.mediaAttachmentDownloadTasks[cacheKey.cacheID] != nil)
 
         await state.deleteAllData()
         #expect(!fileManager.fileExists(atPath: root.path))
@@ -7062,6 +7119,7 @@ struct whitenoise_macTests {
         }
 
         #expect(state.mediaDiskStoreTasks.isEmpty)
+        #expect(state.mediaAttachmentDownloadTasks.isEmpty)
         if case .loaded = stateStore.state {
             Issue.record("Late download should not update loaded state after deleteAllData()")
         }


### PR DESCRIPTION
Fixes #503

Supersedes #654. That PR intentionally recorded red Mac CI while proving the strengthened regression, so this clean replacement is required by Pip policy.

## Summary
- coalesce each underlying media runtime fetch by encrypted disk-cache key, independently of the transient SwiftUI waiter/state store
- let canceled or timed-out UI waiters release their limiter slots while a replacement tile can join the same cancellation-unaware UniFFI fetch
- persist a successful shared result exactly once through the existing generation-guarded encrypted disk cache, then token-clean the tracked task
- cancel/invalidate shared tasks on account/global media reset so stale completions cannot cache or publish
- add a deterministic A→B→A regression that cancels the first waiter, recreates the store, starts the replacement load before gate release, and proves one runtime download

## Verification
- RED: Mac run 29733609788 compiled the cancellation regression and failed with `downloadMediaCallCount == 2` at all three assertions
- GREEN: Mac workflow run 29734849804 passed Swift format, project sanity checks, all 541 unit tests, release arm64 build, and Static Analysis
- FINAL CLEAN PR: Mac run 29735336026 passed PR Checks and Static Analysis at signed head `a0fa3cf`
- rebased onto current `origin/master` (`a238a57`) with post-rebase marker, diff, source-order, task-lifecycle, and privacy assertions passing
- `git diff --check`
- `bash -n scripts/ci/macos-sanity-checks.sh`

## Sensitive paths
None.