### PR TITLE
fix: defer composer emoji insertion

### DIFF
--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -273,7 +273,7 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         }
         context.coordinator.synchronizeMentionMarkers(in: textView)
         context.coordinator.synchronizeMentionContextScope(mentionContextScope, in: textView)
-        context.coordinator.insertEmojiIfNeeded(emojiInsertion, into: textView)
+        context.coordinator.scheduleEmojiInsertion(emojiInsertion, into: textView)
         context.coordinator.insertMentionIfNeeded(mentionInsertion, into: textView)
         DispatchQueue.main.async {
             context.coordinator.updateMeasuredHeight(for: textView)
@@ -326,15 +326,17 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
             self.onMentionContextChange = onMentionContextChange
         }
 
-        func insertEmojiIfNeeded(_ insertion: ComposerEmojiInsertion?, into textView: NSTextView) {
+        func scheduleEmojiInsertion(_ insertion: ComposerEmojiInsertion?, into textView: NSTextView) {
             guard let insertion, insertion.id != lastEmojiInsertionID else { return }
             lastEmojiInsertionID = insertion.id
-            let selectedRange = textView.selectedRange()
-            textView.insertText(insertion.emoji, replacementRange: selectedRange)
-            text.wrappedValue = textView.string
-            updateMeasuredHeight(for: textView)
-            textView.window?.makeFirstResponder(textView)
-            onEmojiInsertionConsumed(insertion.id)
+            DispatchQueue.main.async { [self] in
+                let selectedRange = textView.selectedRange()
+                textView.insertText(insertion.emoji, replacementRange: selectedRange)
+                text.wrappedValue = textView.string
+                updateMeasuredHeight(for: textView)
+                textView.window?.makeFirstResponder(textView)
+                onEmojiInsertionConsumed(insertion.id)
+            }
         }
 
         func insertMentionIfNeeded(_ insertion: ComposerMentionInsertion?, into textView: NSTextView) {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -386,6 +386,58 @@ struct PureValueTests {
         )
     }
 
+    @MainActor
+    @Test func emojiInsertionDefersObservableWritesUntilAfterViewUpdate() async {
+        var boundText = ""
+        var measuredHeight: CGFloat = -1
+        var measuredHeightWriteCount = 0
+        var boundSelections: [ComposerMentionSelection] = []
+        var consumedInsertions: [UUID] = []
+        let coordinator = ComposerMessageTextViewRepresentable.Coordinator(
+            text: Binding(get: { boundText }, set: { boundText = $0 }),
+            measuredHeight: Binding(
+                get: { measuredHeight },
+                set: {
+                    measuredHeight = $0
+                    measuredHeightWriteCount += 1
+                }
+            ),
+            mentionSelections: Binding(
+                get: { boundSelections },
+                set: { boundSelections = $0 }
+            ),
+            mentionContextScope: nil,
+            onPasteMedia: { _ in },
+            onSend: {},
+            onEmojiInsertionConsumed: { consumedInsertions.append($0) }
+        )
+        let textView = NSTextView()
+        textView.string = boundText
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        let insertion = ComposerEmojiInsertion(emoji: "🐾")
+
+        coordinator.scheduleEmojiInsertion(insertion, into: textView)
+        coordinator.scheduleEmojiInsertion(insertion, into: textView)
+
+        #expect(textView.string.isEmpty)
+        #expect(boundText.isEmpty)
+        #expect(measuredHeight == -1)
+        #expect(measuredHeightWriteCount == 0)
+        #expect(consumedInsertions.isEmpty)
+
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+
+        #expect(textView.string == "🐾")
+        #expect(boundText == "🐾")
+        #expect(measuredHeight > -1)
+        #expect(measuredHeightWriteCount == 1)
+        #expect(consumedInsertions == [insertion.id])
+    }
+
     @Test func composerReturnKeyPolicySendsPlainReturnOnly() async throws {
         #expect(ComposerKeyboardShortcutPolicy.returnKeyAction(for: NSEvent.ModifierFlags()) == .send)
         #expect(ComposerKeyboardShortcutPolicy.returnKeyAction(for: .shift) == .insertLineBreak)


### PR DESCRIPTION
## Summary
- defer composer emoji insertion work until after `updateNSView` returns
- keep duplicate insertion IDs suppressed before scheduling
- cover deferred text, height, and consumption writes with a coordinator regression test

## Test plan
- [x] `git diff --check`
- [x] static source assertion confirms all observable writes are below `DispatchQueue.main.async`
- [x] independent staged-diff review found no security or logic issues
- [ ] Mac CI (Linux worker has no Xcode/AppKit toolchain)

Fixes #634


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/661">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji insertion in the message composer to ensure updates occur safely after the view refreshes.
  * Prevented duplicate emoji insertions while preserving text, layout, and selection updates.

* **Tests**
  * Added coverage confirming deferred emoji insertion behavior and single processing of each insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->