### PR TITLE
fix: normalize pasted marmot profile links

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -354,6 +354,11 @@ extension WorkspaceState {
     }
 
     func memberRefCandidate(for query: String) async throws -> String {
+        if let url = URL(string: query),
+            let reference = MarmotProfileLink.profileReference(from: url)
+        {
+            return "nostr:\(reference)"
+        }
         // A query carrying a nostr marker must never resolve as NIP-05 — an embedded `@domain`
         // would fire a request at that host before the authoritative FFI parse runs.
         if MarkdownLinkPolicy.containsNostrReferenceMarker(query) {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -16968,6 +16968,16 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func pastedMarmotProfileLinkBecomesNostrMemberRefCandidate() async throws {
+        let state = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+        let payload = MarmotProfileLink.qrPayload(npub: "npub1alyce")
+
+        #expect(state.looksLikeMemberRef(payload))
+        let candidate = try await state.memberRefCandidate(for: payload)
+        #expect(candidate == "nostr:npub1alyce")
+    }
+
+    @MainActor
     @Test func resolvingNewChatRecipientUsesNIP05() async throws {
         let account = desktopAccount()
         let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"


### PR DESCRIPTION
## Summary
- unwrap strict marmot://profile links before FFI member-reference normalization
- pass the extracted profile reference in the same nostr: form used by deep links
- cover the app-generated QR payload with a regression test

## Verification
- source contract check: pass
- git diff --check: pass
- xcodebuild unavailable on this Linux worker; macOS CI must compile and run the Swift test

Fixes #632

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/662">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->