### PR TITLE
fix: handle reserved localhost subdomains

### DIFF
--- a/whitenoise-mac/Core/RelayURLValidator.swift
+++ b/whitenoise-mac/Core/RelayURLValidator.swift
@@ -10,8 +10,8 @@ import Foundation
 ///
 /// - `wss://` (TLS) relays are always accepted and considered secure.
 /// - `ws://` (cleartext) relays are accepted **only** when they point at a
-///   loopback host (`localhost`, `127.0.0.0/8`, `::1`), to keep local/dev
-///   relays usable. They are still flagged as insecure for the UI.
+///   loopback host (`localhost`, `*.localhost`, `127.0.0.0/8`, `::1`), to keep
+///   local/dev relays usable. They are still flagged as insecure for the UI.
 /// - Any other `ws://` relay, or any other scheme, is rejected.
 nonisolated enum RelayURLValidator {
     nonisolated enum Classification: Equatable {
@@ -118,7 +118,8 @@ nonisolated enum RelayURLValidator {
             normalized.removeLast()
         }
 
-        if normalized == "localhost" {
+        // RFC 6761 reserves the entire `.localhost` namespace for loopback.
+        if normalized == "localhost" || normalized.hasSuffix(".localhost") {
             return true
         }
 

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -42,9 +42,9 @@ nonisolated enum RemoteImageURLPolicy {
     /// Returns true if `url` is safe to fetch: `https` scheme with a non-empty, public host.
     ///
     /// "Public host" means the host is not a literal private/loopback/link-local/unspecified
-    /// IP address and not an obvious local hostname (`localhost`, `*.local`). This is the SSRF
-    /// guard: attacker-controlled avatar URLs must not be able to reach the viewer's internal
-    /// network.
+    /// IP address and not an obvious local hostname (`localhost`, `*.localhost`, `*.local`). This
+    /// is the SSRF guard: attacker-controlled avatar URLs must not be able to reach the viewer's
+    /// internal network.
     ///
     /// Limitation (documented, not silently ignored): a *public-looking* DNS hostname can still
     /// resolve to a private IP (DNS rebinding), because `URLSession` performs its own resolution
@@ -76,8 +76,9 @@ nonisolated enum RemoteImageURLPolicy {
 
         if normalized.isEmpty { return true }
 
-        // Obvious local hostnames. mDNS `.local` names resolve on the local link only.
-        if normalized == "localhost" || normalized.hasSuffix(".local") {
+        // RFC 6761 reserves the entire `.localhost` namespace for loopback; mDNS `.local` names
+        // resolve on the local link only.
+        if normalized == "localhost" || normalized.hasSuffix(".localhost") || normalized.hasSuffix(".local") {
             return true
         }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1483,6 +1483,8 @@ struct PureValueTests {
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://[::1]/x.png") == nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://localhost/x.png") == nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://localhost./x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://profile.localhost/x.png") == nil)
+        #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://profile.localhost./x.png") == nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://printer.local./x.png") == nil)
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://127.0.0.1./x.png") == nil)
         // whitenoise-mac#243: broadcast / multicast / reserved / CGNAT are non-public too,
@@ -1685,6 +1687,7 @@ struct PureValueTests {
         for url in [
             "ws://localhost",
             "ws://localhost:7000",
+            "ws://relay.localhost",
             "ws://127.0.0.1",
             "ws://127.0.0.1:8080/relay",
             "ws://127.1.2.3",
@@ -1701,6 +1704,7 @@ struct PureValueTests {
             "ws://localhost.",
             "ws://LOCALHOST.:7000",
             "ws://localhost..",
+            "ws://relay.localhost.:7000",
             "ws://127.0.0.1.",
             "ws://127.0.0.1.:8080/relay",
             "ws://127.0.0.1..",
@@ -2043,6 +2047,11 @@ struct PureValueTests {
         #expect(NIP05Identifier("npub1qqq@evil.example") != nil)
     }
 
+    @Test func nip05IdentifierRejectsReservedLocalhostNamespace() async throws {
+        #expect(NIP05Identifier("alice@app.localhost") == nil)
+        #expect(NIP05Identifier("alice@app.localhost.") == nil)
+    }
+
     @Test func nip05RedirectPolicyCapsRedirectHopsPerTask() async throws {
         // Delegate methods are exercised directly, no task is ever resumed so nothing touches
         // the network.
@@ -2100,6 +2109,8 @@ struct PureValueTests {
             "https://[fe80::1]/",
             "http://localhost/admin",
             "http://localhost./admin",
+            "https://foo.localhost:8080/x",
+            "https://foo.localhost.:8080/x",
             "https://printer.local/status",
             "https://printer.local./status",
             // Obfuscated loopback literal (decimal form of 127.0.0.1).


### PR DESCRIPTION
## Summary
- reject RFC 6761 localhost subdomains in the shared SSRF host policy
- classify localhost subdomains as loopback for cleartext development relays
- cover avatar, NIP-05, Markdown, trailing-dot, and relay cases

## Test plan
- [x] Added focused Swift regression coverage
- [x] git diff --check
- [ ] macOS unit suite (Linux worker has no Xcode toolchain; CI will run it)

Fixes #630

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/664">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->