### PR TITLE
fix: clear conversation metadata on teardown

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -101,8 +101,7 @@ extension WorkspaceState {
         closeNewChatComposer()
         resetComposeContacts()
         pruneMessageCache(keeping: groupIdHex)
-        conversationMetadataByChat.removeAll()
-        conversationMetadataGenerationByChat.removeAll()
+        clearConversationMetadata()
         clearMediaReferenceResolutionCache()
         // Lookup caches are scoped to the active account's view (directory display names and
         // group membership visibility can differ per account); drop them on switch so the new
@@ -348,8 +347,7 @@ extension WorkspaceState {
         // process-lifetime image cache; profile metadata alone is not enough. See #177/#288.
         RemoteImageLoader.shared.clearCache()
         timelinePagingByChat.removeAll()
-        conversationMetadataByChat.removeAll()
-        conversationMetadataGenerationByChat.removeAll()
+        clearConversationMetadata()
         accountUnreadByIdHex.removeAll()
         // Read markers are keyed by groupIdHex; leaving them behind both retains a
         // record of which messages the signed-out identity read and lets a recurring
@@ -636,8 +634,7 @@ extension WorkspaceState {
         resetMediaDownloadStateStores()
         peerProfileFFICache.removeAll()
         clearGroupMemberCache()
-        conversationMetadataByChat.removeAll()
-        conversationMetadataGenerationByChat.removeAll()
+        clearConversationMetadata()
         accountUnreadByIdHex.removeAll()
         // "Delete All Local Data" must also evict decoded peer/group avatars held in the
         // process-lifetime decoded-image cache; those images derive from attacker-controlled

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -348,6 +348,8 @@ extension WorkspaceState {
         // process-lifetime image cache; profile metadata alone is not enough. See #177/#288.
         RemoteImageLoader.shared.clearCache()
         timelinePagingByChat.removeAll()
+        conversationMetadataByChat.removeAll()
+        conversationMetadataGenerationByChat.removeAll()
         accountUnreadByIdHex.removeAll()
         // Read markers are keyed by groupIdHex; leaving them behind both retains a
         // record of which messages the signed-out identity read and lets a recurring
@@ -634,6 +636,8 @@ extension WorkspaceState {
         resetMediaDownloadStateStores()
         peerProfileFFICache.removeAll()
         clearGroupMemberCache()
+        conversationMetadataByChat.removeAll()
+        conversationMetadataGenerationByChat.removeAll()
         accountUnreadByIdHex.removeAll()
         // "Delete All Local Data" must also evict decoded peer/group avatars held in the
         // process-lifetime decoded-image cache; those images derive from attacker-controlled

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -19,9 +19,12 @@ extension WorkspaceState {
     func refreshConversationMetadata(for chat: ChatItem) async {
         conversationMetadataGenerationByChat[chat.id, default: 0] &+= 1
         let generation = conversationMetadataGenerationByChat[chat.id] ?? 0
+        let epoch = conversationMetadataEpoch
 
         guard !chat.isDirect, let client, let activeAccount, let accountId = activeAccountId else {
-            if conversationMetadataGenerationByChat[chat.id] == generation {
+            if conversationMetadataEpoch == epoch,
+                conversationMetadataGenerationByChat[chat.id] == generation
+            {
                 conversationMetadataByChat[chat.id] = nil
             }
             return
@@ -38,6 +41,7 @@ extension WorkspaceState {
             let (resolvedDetails, resolvedManagement) = try await (details, management)
             guard
                 activeAccountId == accountId,
+                conversationMetadataEpoch == epoch,
                 conversationMetadataGenerationByChat[chat.id] == generation
             else { return }
             conversationMetadataByChat[chat.id] = ConversationMetadata(
@@ -48,10 +52,17 @@ extension WorkspaceState {
         } catch {
             guard
                 activeAccountId == accountId,
+                conversationMetadataEpoch == epoch,
                 conversationMetadataGenerationByChat[chat.id] == generation
             else { return }
             conversationMetadataByChat[chat.id] = nil
         }
+    }
+
+    func clearConversationMetadata() {
+        conversationMetadataEpoch &+= 1
+        conversationMetadataByChat.removeAll()
+        conversationMetadataGenerationByChat.removeAll()
     }
 
     func showGroupDetails(for chat: ChatItem) async {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -975,6 +975,9 @@ final class WorkspaceState {
     @ObservationIgnored var sharedMediaThumbnailCacheBytes = 0
     var conversationMetadataByChat: [String: ConversationMetadata] = [:]
     @ObservationIgnored var conversationMetadataGenerationByChat: [String: UInt64] = [:]
+    /// Survives cache clearing so a late pre-teardown refresh cannot regain ownership when the
+    /// same account and group recreate an identical per-chat generation token.
+    @ObservationIgnored var conversationMetadataEpoch: UInt64 = 0
     /// Message ids the local account hid via "Delete for me", keyed by `accountId\u{1F}groupId`.
     /// Filtered from the timeline projection so a local hide survives reprojection and restart, and
     /// never publishes anything. Persisted in `UserDefaults` under `Self.hiddenMessagesDefaultsKey`.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -12483,6 +12483,48 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func teardownInvalidatesHeldConversationMetadataRefreshAfterSameAccountReturns() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let chat = try #require(state.selectedChat)
+        let accountId = try #require(state.activeAccountId)
+        state.conversationMetadataGenerationByChat[chat.id] = 0
+
+        runtime.groupDetailsGateEnabled = true
+        async let staleRefresh: Void = state.refreshConversationMetadata(for: chat)
+        while !runtime.didReachGroupDetailsGate {
+            await Task.yield()
+        }
+
+        state.resetActiveAccountUIState()
+        state.activeAccountId = nil
+
+        var currentDetails = groupDetailsFixture(
+            selfAccountIdHex: account.accountIdHex,
+            selfIsAdmin: false
+        )
+        currentDetails.group.disappearingMessageSecs = 120
+        runtime.installGroupDetails(currentDetails)
+        state.activeAccountId = accountId
+        await state.refreshConversationMetadata(for: chat)
+
+        let currentMetadata = try #require(state.conversationMetadataByChat[chat.id])
+        #expect(currentMetadata.disappearingMessageSecs == 120)
+        #expect(!currentMetadata.isSelfAdmin)
+
+        runtime.releaseGroupDetailsGate()
+        _ = await staleRefresh
+
+        // A pre-teardown request must not regain ownership when the generation dictionary is
+        // rebuilt for the same account and group. See #628 adversarial review.
+        #expect(state.conversationMetadataByChat[chat.id] == currentMetadata)
+    }
+
+    @MainActor
     @Test func messageActionsRemoveOwnReactionByDeletingReactionEvent() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1599,6 +1599,24 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func resetActiveAccountUIStateClearsConversationMetadata() {
+        let state = WorkspaceState.preview()
+        state.conversationMetadataByChat["shared-group"] = ConversationMetadata(
+            memberCount: 3,
+            disappearingMessageSecs: 60,
+            isSelfAdmin: true
+        )
+        state.conversationMetadataGenerationByChat["shared-group"] = 41
+
+        state.resetActiveAccountUIState()
+
+        // Sign-out and active-account removal share this reset path; metadata keyed only by
+        // group id must not leak the previous identity's role or group details. See #628.
+        #expect(state.conversationMetadataByChat.isEmpty)
+        #expect(state.conversationMetadataGenerationByChat.isEmpty)
+    }
+
+    @MainActor
     @Test func prepareForActiveAccountSwitchClosesGroupDetails() async throws {
         let primary = desktopAccount()
         let backup = AccountSummaryFfi(
@@ -16509,6 +16527,24 @@ struct whitenoise_macTests {
         #expect(state.composeContacts.isEmpty)
         #expect(!state.isLoadingComposeContacts)
         #expect(state.composeContactsGeneration == 42)
+    }
+
+    @MainActor
+    @Test func resetToNewInstallStateClearsConversationMetadata() {
+        let state = WorkspaceState.preview()
+        state.conversationMetadataByChat["shared-group"] = ConversationMetadata(
+            memberCount: 3,
+            disappearingMessageSecs: 60,
+            isSelfAdmin: true
+        )
+        state.conversationMetadataGenerationByChat["shared-group"] = 41
+
+        state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-reset-test")
+
+        // A full local-data wipe must not retain metadata describing the departed identity's
+        // group role, membership, or disappearing-message timer. See #628.
+        #expect(state.conversationMetadataByChat.isEmpty)
+        #expect(state.conversationMetadataGenerationByChat.isEmpty)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Clear group-id-keyed conversation metadata and its refresh generations during shared active-account teardown.
- Clear the same state during Delete All Local Data.
- Add regression coverage for both teardown paths.

## Test plan
- Focused red/green source check for both teardown functions.
- git diff --check
- Post-rebase semantic sweep against current origin/master.
- Xcode and swift-format are unavailable on this Linux worker; GitHub macOS CI will run the Swift format, unit-test, release-build, and analyzer gates.

Fixes #628

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/665">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->