### PR TITLE
fix: neutralize bidi controls in Markdown text

### DIFF
--- a/whitenoise-mac/Core/PeerDisplayText.swift
+++ b/whitenoise-mac/Core/PeerDisplayText.swift
@@ -5,6 +5,20 @@ nonisolated enum PeerDisplayText {
     private static let firstStrongIsolate = "\u{2068}"
     private static let popDirectionalIsolate = "\u{2069}"
 
+    /// Removes bidi embedding, override, and isolate controls (U+202A–U+202E,
+    /// U+2066–U+2069) while preserving unrelated format characters such as ZWJ.
+    static func strippingBidiControls(_ text: String) -> String {
+        String(
+            String.UnicodeScalarView(
+                text.unicodeScalars.filter { scalar in
+                    let value = scalar.value
+                    if (0x202A...0x202E).contains(value) { return false }
+                    if (0x2066...0x2069).contains(value) { return false }
+                    return true
+                })
+        )
+    }
+
     /// Strips Unicode format controls (`Cf`), control characters (`Cc`), and line/
     /// paragraph separators (`Zl`/`Zp`), including bidi embedding/override/isolate
     /// scalars (U+202A–U+202E, U+2066–U+2069), then treats an all-blank result as absent.

--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -109,7 +109,7 @@ nonisolated enum MarkdownDisplayBlock {
         case .thematicBreak:
             self = .thematicBreak
         case .codeBlock(_, _, let content):
-            self = .codeBlock(content)
+            self = .codeBlock(PeerDisplayText.strippingBidiControls(content))
         case .blockQuote(let blocks):
             self = .blockQuote(
                 MarkdownDisplayDocument.makeBlocks(
@@ -150,7 +150,7 @@ nonisolated enum MarkdownDisplayBlock {
                 }
             )
         case .mathBlock(let content):
-            self = .mathBlock(content)
+            self = .mathBlock(PeerDisplayText.strippingBidiControls(content))
         @unknown default:
             self = .paragraph(AttributedString())
         }
@@ -392,7 +392,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         intent: InlinePresentationIntent,
         link: URL?
     ) -> AttributedString {
-        var attributed = AttributedString(string)
+        var attributed = AttributedString(PeerDisplayText.strippingBidiControls(string))
         if !intent.isEmpty {
             attributed.inlinePresentationIntent = intent
         }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -2200,6 +2200,73 @@ struct PureValueTests {
             RemoteImageURLPolicy.sanitizedURL(from: "https://[2001:0:0808:0808:0:0:f7f7:f7f7]/x.png") != nil)
     }
 
+    @Test func markdownDisplayStripsBidiControlsFromPeerControlledText() async throws {
+        let rtlOverride = "\u{202E}"
+        let ltrIsolate = "\u{2066}"
+        let zwj = "\u{200D}"
+
+        let spoofedLinkLabel = "\(rtlOverride)moc.elpmaxe//:sptth\(ltrIsolate)"
+        let linkAttributed = MarkdownDisplayInlineBuilder.attributedString(
+            from: [
+                .link(
+                    dest: "https://evil.example/phish",
+                    title: nil,
+                    children: [.text(content: spoofedLinkLabel)]
+                )
+            ],
+            remainingDepth: 32
+        )
+        #expect(!containsBidiEmbeddingOrIsolate(String(linkAttributed.characters)))
+        #expect(String(linkAttributed.characters) == "moc.elpmaxe//:sptth")
+        #expect(links(in: linkAttributed).map(\.absoluteString) == ["https://evil.example/phish"])
+
+        let spoofedAutolinkURL = "\(rtlOverride)https://example.com\(ltrIsolate)"
+        let autolinkAttributed = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.autolink(url: spoofedAutolinkURL, kind: .uri)],
+            remainingDepth: 32
+        )
+        #expect(!containsBidiEmbeddingOrIsolate(String(autolinkAttributed.characters)))
+        #expect(String(autolinkAttributed.characters) == "https://example.com")
+        let expectedAutolink = MarkdownLinkPolicy.sanitizedURL(from: spoofedAutolinkURL)
+        #expect(links(in: autolinkAttributed) == (expectedAutolink.map { [$0] } ?? []))
+
+        let familyEmoji = "👨\(zwj)👩\(zwj)👧"
+        let plainAttributed = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.text(content: familyEmoji)],
+            remainingDepth: 32
+        )
+        #expect(String(plainAttributed.characters) == familyEmoji)
+        #expect(
+            String(plainAttributed.characters).unicodeScalars.contains { $0.value == 0x200D }
+        )
+
+        let document = MarkdownDisplayDocument(
+            document: MarkdownDocumentFfi(
+                blocks: [
+                    .codeBlock(
+                        kind: .fenced,
+                        info: "",
+                        content: "\(rtlOverride)secret\(ltrIsolate)"
+                    ),
+                    .mathBlock(content: "\(rtlOverride)x^2\(ltrIsolate)"),
+                ],
+                truncated: false
+            )
+        )
+        guard case .codeBlock(let codeContent) = document.blocks.first?.block else {
+            Issue.record("expected a code block")
+            return
+        }
+        #expect(codeContent == "secret")
+        #expect(!containsBidiEmbeddingOrIsolate(codeContent))
+        guard case .mathBlock(let mathContent) = document.blocks.last?.block else {
+            Issue.record("expected a math block")
+            return
+        }
+        #expect(mathContent == "x^2")
+        #expect(!containsBidiEmbeddingOrIsolate(mathContent))
+    }
+
     @Test func markdownInlineBuilderDropsUnsafeMarkdownLinks() async throws {
         let safe = MarkdownDisplayInlineBuilder.attributedString(
             from: [
@@ -2396,6 +2463,13 @@ struct PureValueTests {
             dim: nil,
             thumbhash: nil
         )
+    }
+
+    private func containsBidiEmbeddingOrIsolate(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            let value = scalar.value
+            return (0x202A...0x202E).contains(value) || (0x2066...0x2069).contains(value)
+        }
     }
 
     private func links(in attributed: AttributedString) -> [URL] {


### PR DESCRIPTION
Fixes #641

## Summary
- Remove Unicode bidi embedding, override, and isolate controls from peer-controlled Markdown display text before rendering.
- Apply the boundary to inline content plus block code/math while preserving unrelated format characters such as emoji ZWJ.
- Keep URL destination validation unchanged and add focused coverage for spoofed links, autolinks, block content, and ZWJ preservation.

## Verification
- `git diff --check` — passed.
- `bash -n scripts/ci/macos-sanity-checks.sh` — passed.
- Portable source-boundary assertions — passed.
- `xcrun swift-format lint ...` — unavailable on Linux (`xcrun: command not found`).
- `scripts/ci/macos-sanity-checks.sh` — macOS portion unavailable (`xcodebuild: command not found`).
- `xcodebuild test ...` — unavailable on Linux (`xcodebuild: command not found`); macOS CI must run the regression and full suite.

## Sensitive paths
None. Display-only text sanitization; no crypto, MLS, key, auth, trust-anchor, or group-state paths changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/666">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sanitized bidirectional text controls from peer-provided Markdown, including links, URLs, code blocks, and math blocks.
  - Prevented misleading text display while preserving valid content such as emoji formatting and link destinations.

- **Tests**
  - Added regression coverage for bidirectional text controls across inline Markdown and block content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->