### PR TITLE
perf: precompute emoji catalog indexes

### DIFF
--- a/whitenoise-mac/Views/EmojiPicker.swift
+++ b/whitenoise-mac/Views/EmojiPicker.swift
@@ -18,6 +18,29 @@ nonisolated struct ChatEmojiCatalogEntry: Codable, Identifiable, Hashable {
     }
 }
 
+nonisolated struct ChatEmojiCatalog {
+    let entries: [ChatEmojiCatalogEntry]
+
+    private let lookup: [String: ChatEmojiCatalogEntry]
+    private let entriesByGroup: [Int: [ChatEmojiCatalogEntry]]
+
+    init(entries: [ChatEmojiCatalogEntry]) {
+        self.entries = entries
+        lookup = Dictionary(entries.map { ($0.emoji, $0) }, uniquingKeysWith: { first, _ in first })
+        entriesByGroup = Dictionary(grouping: entries, by: \.group)
+    }
+
+    static let empty = ChatEmojiCatalog(entries: [])
+
+    func entries(forGroup group: Int) -> [ChatEmojiCatalogEntry] {
+        entriesByGroup[group] ?? []
+    }
+
+    func recents(from emojiOrder: [String]) -> [ChatEmojiCatalogEntry] {
+        emojiOrder.compactMap { lookup[$0] }
+    }
+}
+
 nonisolated enum ChatEmojiSearch {
     static func results(
         in entries: [ChatEmojiCatalogEntry],
@@ -85,15 +108,15 @@ private struct ChatEmojiCategory: Identifiable {
 
 @MainActor
 private final class ChatEmojiPickerModel: ObservableObject {
-    @Published private(set) var entries: [ChatEmojiCatalogEntry] = []
+    @Published private(set) var catalog = ChatEmojiCatalog.empty
     @Published private(set) var didFail = false
 
-    private static var cachedEntries: [ChatEmojiCatalogEntry]?
+    private static var cachedCatalog: ChatEmojiCatalog?
 
     func load() async {
-        guard entries.isEmpty else { return }
-        if let cachedEntries = Self.cachedEntries {
-            entries = cachedEntries
+        guard catalog.entries.isEmpty else { return }
+        if let cachedCatalog = Self.cachedCatalog {
+            catalog = cachedCatalog
             return
         }
         guard let url = Bundle.main.url(forResource: "emoji", withExtension: "json") else {
@@ -101,12 +124,13 @@ private final class ChatEmojiPickerModel: ObservableObject {
             return
         }
         do {
-            let decoded = try await Task.detached(priority: .userInitiated) {
+            let catalog = try await Task.detached(priority: .userInitiated) {
                 let data = try Data(contentsOf: url, options: [.mappedIfSafe])
-                return try JSONDecoder().decode([ChatEmojiCatalogEntry].self, from: data)
+                let entries = try JSONDecoder().decode([ChatEmojiCatalogEntry].self, from: data)
+                return ChatEmojiCatalog(entries: entries)
             }.value
-            Self.cachedEntries = decoded
-            entries = decoded
+            Self.cachedCatalog = catalog
+            self.catalog = catalog
         } catch {
             didFail = true
         }
@@ -177,7 +201,7 @@ struct ChatEmojiPicker: View {
 
     @ViewBuilder
     private var emojiGrid: some View {
-        if model.entries.isEmpty, !model.didFail {
+        if model.catalog.entries.isEmpty, !model.didFail {
             ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if model.didFail {
             ContentUnavailableView("Emoji unavailable", systemImage: "face.dashed")
@@ -185,8 +209,7 @@ struct ChatEmojiPicker: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 10, pinnedViews: [.sectionHeaders]) {
                     if query.isEmpty {
-                        let lookup = Dictionary(uniqueKeysWithValues: model.entries.map { ($0.emoji, $0) })
-                        let recents = ChatEmojiRecents.values.compactMap { lookup[$0] }
+                        let recents = model.catalog.recents(from: ChatEmojiRecents.values)
                         if !recents.isEmpty {
                             emojiSection(title: L10n.string("Recently used"), entries: recents)
                                 .id("recent")
@@ -194,14 +217,14 @@ struct ChatEmojiPicker: View {
                         ForEach(ChatEmojiCategory.all) { category in
                             emojiSection(
                                 title: category.title,
-                                entries: model.entries.filter { $0.group == category.id }
+                                entries: model.catalog.entries(forGroup: category.id)
                             )
                             .id("category-\(category.id)")
                         }
                     } else {
                         emojiSection(
                             title: L10n.string("Search results"),
-                            entries: ChatEmojiSearch.results(in: model.entries, query: query)
+                            entries: ChatEmojiSearch.results(in: model.catalog.entries, query: query)
                         )
                     }
                 }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -409,6 +409,28 @@ struct PureValueTests {
         #expect(ChatEmojiSearch.results(in: entries, query: "face").map(\.emoji) == ["😂", "😀"])
     }
 
+    @Test func emojiCatalogPreservesEntriesPartitionsByGroupAndToleratesDuplicateEmojiKeys() {
+        let entries = [
+            ChatEmojiCatalogEntry(emoji: "😀", name: "grinning face", group: 0, keywords: []),
+            ChatEmojiCatalogEntry(emoji: "👋", name: "waving hand", group: 1, keywords: []),
+            ChatEmojiCatalogEntry(emoji: "🐶", name: "dog", group: 2, keywords: []),
+            ChatEmojiCatalogEntry(emoji: "❤️", name: "red heart", group: 7, keywords: []),
+            ChatEmojiCatalogEntry(emoji: "❤️", name: "duplicate heart", group: 7, keywords: []),
+        ]
+        let catalog = ChatEmojiCatalog(entries: entries)
+
+        #expect(catalog.entries == entries)
+        #expect(catalog.entries(forGroup: 0).map(\.emoji) == ["😀"])
+        #expect(catalog.entries(forGroup: 1).map(\.emoji) == ["👋"])
+        #expect(catalog.entries(forGroup: 2).map(\.emoji) == ["🐶"])
+        #expect(catalog.entries(forGroup: 3).isEmpty)
+        #expect(catalog.entries(forGroup: 7).map(\.name) == ["red heart", "duplicate heart"])
+        #expect(
+            catalog.recents(from: ["👋", "❤️", "😀", "missing"]).map(\.name)
+                == ["waving hand", "red heart", "grinning face"]
+        )
+    }
+
     @Test func onlyOutgoingPlainTextMessagesCanEnterComposerEditing() async throws {
         let outgoing = MessageItem(
             id: "outgoing",


### PR DESCRIPTION
Fixes #633

## Summary
- Build one immutable emoji catalog off the main actor when the bundled JSON is decoded.
- Cache first-wins duplicate-tolerant emoji lookup and category groupings with the catalog.
- Reuse the cached lookup/group buckets during picker body renders instead of rebuilding a dictionary and filtering the full catalog nine times.
- Add a regression test for entry/group order, empty groups, duplicate keys, and recents order.

## Verification
- `git diff --check` — passed.
- Source regression contract against `origin/master` — baseline red; worktree green.
- Added-line security/debug scan — passed.
- Bundled catalog decode — 1,906 entries across groups 0–8; no current duplicate keys.
- Edited-file 120-column check — passed.
- Independent pre-commit review — passed with no security or logic findings.
- Native `xcodebuild test` and `swift-format` were not run: this worker host is Linux and has no Swift/Xcode toolchain. Mac CI will run the repository's exact checks.

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the emoji picker’s organization and lookup of emoji by category.
  * Recently used emojis now appear in a consistent, deterministic order.
  * Search and category browsing continue to display matching emoji accurately.

* **Bug Fixes**
  * Improved handling of duplicate emoji entries and unknown items in recent history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->