### PR TITLE
fix: preserve media cache for suppressed projections

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -364,7 +364,9 @@ extension WorkspaceState {
         let currentPaging = timelinePagingByChat[groupIdHex]
         // Keep "Delete for me" hides out of every full window replace, not just the incremental path.
         let visibleMessages = filterHiddenMessages(mappedMessages, groupIdHex: groupIdHex)
-        TimelineSignpost.store.interval("replaceMessages", count: visibleMessages.count) {
+        let didChangeMediaAttachments = TimelineSignpost.store.interval(
+            "replaceMessages", count: visibleMessages.count
+        ) {
             replaceMessages(
                 visibleMessages,
                 groupIdHex: groupIdHex,
@@ -376,6 +378,9 @@ extension WorkspaceState {
                 ),
                 editMutations: editMutations
             )
+        }
+        if didChangeMediaAttachments {
+            clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: groupIdHex)
         }
         await markLatestVisibleMessageRead(groupIdHex: groupIdHex, account: account, client: client)
     }
@@ -1190,12 +1195,13 @@ extension WorkspaceState {
         }
     }
 
+    @discardableResult
     func replaceMessages(
         _ messages: [MessageItem],
         groupIdHex: String,
         paging: TimelinePagingState? = nil,
         editMutations: [MessageEditMutation] = []
-    ) {
+    ) -> Bool {
         // The window is already ordered, deduped, and capped by the runtime subscription,
         // so render it as-is. The per-chat id/lookup caches live on the store
         // (`MessageTimelineStore.replace` rebuilds them); we only mark this chat as the one
@@ -1209,7 +1215,7 @@ extension WorkspaceState {
 
         cachedMessageChatIds = [groupIdHex]
         messageTimelineStores = [groupIdHex: timelineStore]
-        timelineStore.replace(
+        let didChangeMediaAttachments = timelineStore.replace(
             with: messages,
             editMutations: editMutations,
             windowLimit: Self.timelineWindowLimit
@@ -1221,6 +1227,7 @@ extension WorkspaceState {
         }
         finishTimelineInitialLoad(groupIdHex: groupIdHex)
         pruneMediaDownloadCache(keeping: groupIdHex)
+        return didChangeMediaAttachments
     }
 
     func finalizeTimelineStoreMutation(

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -548,21 +548,6 @@ extension WorkspaceState {
         let anchored = !paging.hasMoreAfter
         let timelineStore = ensureMessageTimelineStore(for: groupIdHex)
 
-        // Only invalidate the per-group media-reference resolution cache when a projection
-        // actually introduces new or changed media attachments. A single media send emits a
-        // burst of projection deltas (new row, delivery-state transitions, relay echo,
-        // per-relay acks) that re-carry the same media fields; clearing on every one of those
-        // re-runs full media resolution for visible `sourceEpoch == 0` tiles. Comparing the
-        // mapped `MessageItem.mediaAttachments` against the current store entry (still
-        // pre-mutation here — `applyProjection` mutates it below) skips the clear for those
-        // pure delivery-state/projection ticks. Read against `timelineStore.lookup` because it
-        // holds the current pre-mutation entry for any message already in the rendered window.
-        let introducesMediaChange = mappedUpserts.contains { upsert in
-            let currentAttachments = timelineStore.lookup[upsert.id]?.mediaAttachments ?? []
-            guard !currentAttachments.isEmpty || !upsert.mediaAttachments.isEmpty else { return false }
-            return currentAttachments != upsert.mediaAttachments
-        }
-
         guard
             canApplyTimelineWindow(
                 groupIdHex: groupIdHex,
@@ -570,10 +555,6 @@ extension WorkspaceState {
                 owner: owner
             )
         else { return }
-
-        if introducesMediaChange {
-            clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: groupIdHex)
-        }
 
         // Keep "Delete for me" messages out of the window across every reprojection.
         let (visibleUpserts, visibleRemovals) = partitionHiddenMessages(
@@ -591,6 +572,10 @@ extension WorkspaceState {
         }
         guard result.didChange else { return }
 
+        if result.didChangeMediaAttachments {
+            clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: groupIdHex)
+        }
+
         finalizeTimelineStoreMutation(
             groupIdHex: groupIdHex,
             paging: TimelinePagingState(
@@ -601,7 +586,7 @@ extension WorkspaceState {
             ),
             pruneMediaDownloads: result.didRemoveMessages
                 || result.didTrimOlderMessages
-                || introducesMediaChange
+                || result.didChangeMediaAttachments
         )
         await markLatestVisibleMessageRead(groupIdHex: groupIdHex, account: account, client: client)
     }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -273,6 +273,9 @@ final class MessageTimelineStore {
     @ObservationIgnored private var editCandidatesByTargetId: [String: [MessageEditOverlay]] = [:]
     /// Candidates inspected by the most recent full render pass. Diagnostic / test helper.
     @ObservationIgnored private(set) var lastRenderEditCandidateVisitCount = 0
+    /// Earliest sort key of a media-changing upsert suppressed from a detached window.
+    /// Consumed when an authoritative replace first retains media at/after this key.
+    @ObservationIgnored private var pendingSuppressedMediaSortKey: TimelineSortKey?
     private(set) var isLoaded: Bool
 
     init(messages: [MessageItem] = [], isLoaded: Bool = false) {
@@ -296,7 +299,13 @@ final class MessageTimelineStore {
         MessageTimelineStore(messages: messages, isLoaded: true)
     }
 
-    func replace(with messages: [MessageItem], editMutations: [MessageEditMutation] = [], windowLimit: Int? = nil) {
+    @discardableResult
+    func replace(
+        with messages: [MessageItem],
+        editMutations: [MessageEditMutation] = [],
+        windowLimit: Int? = nil
+    ) -> Bool {
+        let priorLookup = lookup
         let bases = Self.deduplicatedMessages(messages)
         self.messages = bases
         baseMessagesById = Dictionary(bases.map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
@@ -306,6 +315,7 @@ final class MessageTimelineStore {
         pruneEditCandidates(windowLimit: windowLimit ?? max(bases.count, 1))
         _ = recomputeAllRenderedMessages()
         self.isLoaded = true
+        return consumeMediaAttachmentInvalidation(afterAuthoritativeReplace: bases, priorLookup: priorLookup)
     }
 
     func clear() {
@@ -315,6 +325,7 @@ final class MessageTimelineStore {
         indexById = [:]
         baseMessagesById = [:]
         replaceEditCandidates(with: [:])
+        pendingSuppressedMediaSortKey = nil
         isLoaded = false
     }
 
@@ -406,6 +417,17 @@ final class MessageTimelineStore {
         let didChangeMediaAttachments = mediaAttachmentsBeforeUpserts.contains { id, previous in
             guard let retained = lookup[id] else { return false }
             return previous != retained.mediaAttachments
+        }
+        if didChangeMediaAttachments {
+            pendingSuppressedMediaSortKey = nil
+        } else {
+            for item in upserts {
+                guard let previous = mediaAttachmentsBeforeUpserts[item.id] else { continue }
+                guard lookup[item.id] == nil else { continue }
+                guard !previous.isEmpty || !item.mediaAttachments.isEmpty else { continue }
+                guard previous != item.mediaAttachments else { continue }
+                recordPendingSuppressedMediaSortKey(for: item)
+            }
         }
         return ProjectionApplyResult(
             didChange: didChange,
@@ -655,6 +677,42 @@ final class MessageTimelineStore {
         for index in startIndex..<messages.endIndex {
             indexById[messages[index].id] = index
         }
+    }
+
+    private func recordPendingSuppressedMediaSortKey(for item: MessageItem) {
+        guard !item.mediaAttachments.isEmpty else { return }
+        let key = TimelineSortKey(item)
+        if let existing = pendingSuppressedMediaSortKey, key >= existing {
+            return
+        }
+        pendingSuppressedMediaSortKey = key
+    }
+
+    private func consumeMediaAttachmentInvalidation(
+        afterAuthoritativeReplace bases: [MessageItem],
+        priorLookup: [String: MessageItem]
+    ) -> Bool {
+        let didChangeMediaAttachments = bases.contains { item in
+            guard let previous = priorLookup[item.id] else { return false }
+            let previousAttachments = previous.mediaAttachments
+            let nextAttachments = item.mediaAttachments
+            guard !previousAttachments.isEmpty || !nextAttachments.isEmpty else { return false }
+            return previousAttachments != nextAttachments
+        }
+        if didChangeMediaAttachments {
+            pendingSuppressedMediaSortKey = nil
+            return true
+        }
+        guard let watermark = pendingSuppressedMediaSortKey else { return false }
+        guard
+            bases.contains(where: { item in
+                !item.mediaAttachments.isEmpty && TimelineSortKey(item) >= watermark
+            })
+        else {
+            return false
+        }
+        pendingSuppressedMediaSortKey = nil
+        return true
     }
 
     private func insertionIndex(for item: MessageItem) -> Int {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -250,6 +250,7 @@ final class MessageTimelineStore {
         let didChange: Bool
         let didRemoveMessages: Bool
         let didTrimOlderMessages: Bool
+        let didChangeMediaAttachments: Bool
     }
 
     private(set) var messages: [MessageItem]
@@ -331,6 +332,16 @@ final class MessageTimelineStore {
         var didChange = false
         var didRemoveMessages = false
 
+        // Compare media-relevant upserts with the final lookup after trimming so suppressed or
+        // immediately-evicted rows do not trigger cache invalidation.
+        var mediaAttachmentsBeforeUpserts: [String: [MessageMediaAttachment]] = [:]
+        for item in upserts {
+            guard mediaAttachmentsBeforeUpserts[item.id] == nil else { continue }
+            let previous = lookup[item.id]?.mediaAttachments ?? []
+            guard !previous.isEmpty || !item.mediaAttachments.isEmpty else { continue }
+            mediaAttachmentsBeforeUpserts[item.id] = previous
+        }
+
         if !removalIds.isEmpty {
             let originalCount = messages.count
             let removedMessageIds = Set(messages.filter { removalIds.contains($0.id) }.map(\.id))
@@ -392,10 +403,15 @@ final class MessageTimelineStore {
         if didChange {
             isLoaded = true
         }
+        let didChangeMediaAttachments = mediaAttachmentsBeforeUpserts.contains { id, previous in
+            guard let retained = lookup[id] else { return false }
+            return previous != retained.mediaAttachments
+        }
         return ProjectionApplyResult(
             didChange: didChange,
             didRemoveMessages: didRemoveMessages,
-            didTrimOlderMessages: didTrimOlderMessages
+            didTrimOlderMessages: didTrimOlderMessages,
+            didChangeMediaAttachments: didChangeMediaAttachments
         )
     }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -794,14 +794,19 @@ struct PureValueTests {
         // current newest row and upserts a row newer than the post-removal head must suppress
         // that upsert — a detached window must not grow a new head — matching the runtime's
         // apply_projection_to_window.
-        func message(id: String, timelineAt: UInt64) -> MessageItem {
+        func message(
+            id: String,
+            timelineAt: UInt64,
+            mediaAttachments: [MessageMediaAttachment] = []
+        ) -> MessageItem {
             MessageItem(
                 id: id,
                 senderName: "sender",
                 body: id,
                 sentAt: Date(timeIntervalSince1970: 1_700_000_000),
                 timelineAt: timelineAt,
-                isOutgoing: false
+                isOutgoing: false,
+                mediaAttachments: mediaAttachments
             )
         }
 
@@ -813,8 +818,12 @@ struct PureValueTests {
 
         // The delta removes the current newest row M and upserts N(98). After M is gone the true
         // head is L(95); N(98) is strictly newer and must not become a new head.
+        let suppressedMedia = MessageMediaAttachment(
+            id: "suppressed-attachment",
+            reference: mediaReference(fileName: "suppressed.png", mediaType: "image/png")
+        )
         let result = store.applyProjection(
-            upserts: [message(id: "N", timelineAt: 98)],
+            upserts: [message(id: "N", timelineAt: 98, mediaAttachments: [suppressedMedia])],
             removals: ["M"],
             anchoredToNewest: false,
             windowLimit: 10
@@ -823,6 +832,7 @@ struct PureValueTests {
         #expect(store.messages.map(\.id) == ["L"])
         #expect(!store.containsMessage(id: "N"))
         #expect(result.didChange)
+        #expect(!result.didChangeMediaAttachments)
     }
 
     @MainActor

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -833,6 +833,29 @@ struct PureValueTests {
         #expect(!store.containsMessage(id: "N"))
         #expect(result.didChange)
         #expect(!result.didChangeMediaAttachments)
+
+        // #631: media added by unrelated backward pagination must not consume the pending
+        // invalidation. It fires once the suppressed media row is actually retained.
+        let olderMedia = MessageMediaAttachment(
+            id: "older-attachment",
+            reference: mediaReference(fileName: "older.png", mediaType: "image/png")
+        )
+        let pagingOlderMedia = store.replace(with: [
+            message(id: "O", timelineAt: 90, mediaAttachments: [olderMedia]),
+            message(id: "L", timelineAt: 95),
+        ])
+        #expect(!pagingOlderMedia)
+
+        let retainedSuppressedMedia = store.replace(with: [
+            message(id: "L", timelineAt: 95),
+            message(id: "N", timelineAt: 98, mediaAttachments: [suppressedMedia]),
+        ])
+        #expect(retainedSuppressedMedia)
+        #expect(
+            !store.replace(with: [
+                message(id: "L", timelineAt: 95),
+                message(id: "N", timelineAt: 98, mediaAttachments: [suppressedMedia]),
+            ]))
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6480,10 +6480,9 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func timelineMediaProjectionKeepsMediaReferenceCacheForSuppressedDetachedWindowMedia() async throws {
-        // Regression for whitenoise-mac#631: inbound media newer than a detached (scrolled-back)
-        // window head is suppressed, so the per-group media-reference resolution cache for visible
-        // historical tiles must stay warm.
+    @Test func timelineMediaProjectionDefersMediaReferenceCacheInvalidationUntilRetained() async throws {
+        // Regression for whitenoise-mac#631: inbound media newer than a detached window head is
+        // suppressed without invalidating the cache, then invalidates once the row is retained.
         let account = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -6504,26 +6503,21 @@ struct whitenoise_macTests {
             pictureURL: nil,
             unreadCount: 0
         )
-        let timelineReference = mediaAttachmentReference(
-            sourceEpoch: 0,
-            mediaType: "image/png",
-            fileName: "historical.png",
-            ciphertextSha256: String(repeating: "a", count: 64),
-            plaintextSha256: String(repeating: "b", count: 64)
-        )
-        let historicalAttachment = MessageMediaAttachment(
-            id: "historical-media-message#0#\(timelineReference.plaintextSha256)",
-            reference: timelineReference
-        )
         let historicalMessage = MessageItem(
-            id: "historical-media-message",
+            id: "historical-text-message",
             groupIdHex: "group",
             senderName: "alice",
-            body: "",
+            body: "historical",
             sentAt: Date(timeIntervalSince1970: 1_700_000_000),
             timelineAt: 1_700_000_000,
-            isOutgoing: false,
-            mediaAttachments: [historicalAttachment]
+            isOutgoing: false
+        )
+        let inboundReference = mediaAttachmentReference(
+            sourceEpoch: 0,
+            mediaType: "image/png",
+            fileName: "inbound.png",
+            ciphertextSha256: String(repeating: "c", count: 64),
+            plaintextSha256: String(repeating: "d", count: 64)
         )
         let state = WorkspaceState(
             accounts: [accountItem],
@@ -6543,7 +6537,7 @@ struct whitenoise_macTests {
         )
 
         let initial = try await state.resolvedMediaReference(
-            timelineReference,
+            inboundReference,
             accountId: accountItem.id,
             accountRef: accountItem.accountRef,
             groupIdHex: "group",
@@ -6552,12 +6546,31 @@ struct whitenoise_macTests {
         #expect(initial.sourceEpoch == 0)
         #expect(runtime.listMediaCallCount == 1)
 
-        let suppressedReference = mediaAttachmentReference(
-            sourceEpoch: 0,
+        let fullReference = mediaAttachmentReference(
+            sourceEpoch: 11,
             mediaType: "image/png",
             fileName: "inbound.png",
-            ciphertextSha256: String(repeating: "c", count: 64),
-            plaintextSha256: String(repeating: "d", count: 64)
+            ciphertextSha256: inboundReference.ciphertextSha256,
+            plaintextSha256: inboundReference.plaintextSha256
+        )
+        runtime.installMediaRecord(
+            MediaRecordFfi(
+                messageIdHex: "inbound-media-message",
+                attachmentIndex: 0,
+                direction: "inbound",
+                groupIdHex: "group",
+                sender: "alice",
+                reference: fullReference,
+                caption: nil,
+                recordedAt: 1_700_000_100,
+                receivedAt: 1_700_000_100
+            ),
+            download: MediaDownloadResultFfi(
+                plaintext: Data([0x01, 0x02, 0x03, 0x04]),
+                fileName: "inbound.png",
+                mediaType: "image/png",
+                sizeBytes: 4
+            )
         )
         await state.applyTimelineProjection(
             TimelineProjectionUpdateFfi(
@@ -6572,7 +6585,7 @@ struct whitenoise_macTests {
                             sender: "alice",
                             plaintext: "",
                             recordedAt: 1_700_000_100,
-                            mediaJson: mediaJson(for: suppressedReference)
+                            mediaJson: mediaJson(for: inboundReference)
                         ))
                 ],
                 chatListRow: nil,
@@ -6583,10 +6596,10 @@ struct whitenoise_macTests {
             client: runtime
         )
 
-        #expect(state.messagesByChat["group"]?.map(\.id) == ["historical-media-message"])
+        #expect(state.messagesByChat["group"]?.map(\.id) == ["historical-text-message"])
 
         let stillCachedMiss = try await state.resolvedMediaReference(
-            timelineReference,
+            inboundReference,
             accountId: accountItem.id,
             accountRef: accountItem.accountRef,
             groupIdHex: "group",
@@ -6594,6 +6607,54 @@ struct whitenoise_macTests {
         )
         #expect(stillCachedMiss.sourceEpoch == 0)
         #expect(runtime.listMediaCallCount == 1)
+
+        let acceptedRecords = [
+            timelineMessage(
+                id: "historical-text-message",
+                groupIdHex: "group",
+                sender: "alice",
+                plaintext: "historical",
+                recordedAt: 1_700_000_000
+            ),
+            timelineMessage(
+                id: "inbound-media-message",
+                groupIdHex: "group",
+                sender: "alice",
+                plaintext: "",
+                recordedAt: 1_700_000_100,
+                mediaJson: mediaJson(for: inboundReference)
+            ),
+        ]
+        let subscription = FakeTimelineMessagesSubscription(
+            messages: acceptedRecords,
+            limit: acceptedRecords.count,
+            windowCap: acceptedRecords.count
+        )
+        state.activeTimelineSubscription = subscription
+        state.activeTimelineGroupId = "group"
+        let acceptedPage = try #require(subscription.snapshot())
+        await state.applyTimelineWindow(
+            acceptedPage,
+            groupIdHex: "group",
+            account: accountItem,
+            client: runtime,
+            owner: .subscription(subscription)
+        )
+        #expect(
+            state.messagesByChat["group"]?.map(\.id) == [
+                "historical-text-message",
+                "inbound-media-message",
+            ])
+
+        let refreshed = try await state.resolvedMediaReference(
+            inboundReference,
+            accountId: accountItem.id,
+            accountRef: accountItem.accountRef,
+            groupIdHex: "group",
+            client: runtime
+        )
+        #expect(refreshed.sourceEpoch == fullReference.sourceEpoch)
+        #expect(runtime.listMediaCallCount == 2)
     }
 
     @MainActor

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6480,6 +6480,123 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func timelineMediaProjectionKeepsMediaReferenceCacheForSuppressedDetachedWindowMedia() async throws {
+        // Regression for whitenoise-mac#631: inbound media newer than a detached (scrolled-back)
+        // window head is suppressed, so the per-group media-reference resolution cache for visible
+        // historical tiles must stay warm.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let accountItem = AccountItem(summary: account)
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let chat = ChatItem(
+            id: "group",
+            title: "Test Group",
+            subtitle: "Group message",
+            preview: "Attachment",
+            updatedAt: nil,
+            avatarSeed: "group",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let timelineReference = mediaAttachmentReference(
+            sourceEpoch: 0,
+            mediaType: "image/png",
+            fileName: "historical.png",
+            ciphertextSha256: String(repeating: "a", count: 64),
+            plaintextSha256: String(repeating: "b", count: 64)
+        )
+        let historicalAttachment = MessageMediaAttachment(
+            id: "historical-media-message#0#\(timelineReference.plaintextSha256)",
+            reference: timelineReference
+        )
+        let historicalMessage = MessageItem(
+            id: "historical-media-message",
+            groupIdHex: "group",
+            senderName: "alice",
+            body: "",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            timelineAt: 1_700_000_000,
+            isOutgoing: false,
+            mediaAttachments: [historicalAttachment]
+        )
+        let state = WorkspaceState(
+            accounts: [accountItem],
+            chatsByAccount: [accountItem.id: [chat]],
+            messagesByChat: ["group": [historicalMessage]],
+            appActivityProvider: { true },
+            conversationWindowVisibilityProvider: { true },
+            clientFactory: { runtime }
+        )
+        state.activeAccountId = accountItem.id
+        state.selection = .chat("group")
+        state.timelinePagingByChat["group"] = TimelinePagingState(
+            hasMoreBefore: true,
+            hasMoreAfter: true,
+            isLoadingBefore: false,
+            isLoadingAfter: false
+        )
+
+        let initial = try await state.resolvedMediaReference(
+            timelineReference,
+            accountId: accountItem.id,
+            accountRef: accountItem.accountRef,
+            groupIdHex: "group",
+            client: runtime
+        )
+        #expect(initial.sourceEpoch == 0)
+        #expect(runtime.listMediaCallCount == 1)
+
+        let suppressedReference = mediaAttachmentReference(
+            sourceEpoch: 0,
+            mediaType: "image/png",
+            fileName: "inbound.png",
+            ciphertextSha256: String(repeating: "c", count: 64),
+            plaintextSha256: String(repeating: "d", count: 64)
+        )
+        await state.applyTimelineProjection(
+            TimelineProjectionUpdateFfi(
+                groupIdHex: "group",
+                messages: [],
+                changes: [
+                    .upsert(
+                        trigger: .newMessage,
+                        message: timelineMessage(
+                            id: "inbound-media-message",
+                            groupIdHex: "group",
+                            sender: "alice",
+                            plaintext: "",
+                            recordedAt: 1_700_000_100,
+                            mediaJson: mediaJson(for: suppressedReference)
+                        ))
+                ],
+                chatListRow: nil,
+                chatListTrigger: .newLastMessage
+            ),
+            groupIdHex: "group",
+            account: accountItem,
+            client: runtime
+        )
+
+        #expect(state.messagesByChat["group"]?.map(\.id) == ["historical-media-message"])
+
+        let stillCachedMiss = try await state.resolvedMediaReference(
+            timelineReference,
+            accountId: accountItem.id,
+            accountRef: accountItem.accountRef,
+            groupIdHex: "group",
+            client: runtime
+        )
+        #expect(stillCachedMiss.sourceEpoch == 0)
+        #expect(runtime.listMediaCallCount == 1)
+    }
+
+    @MainActor
     @Test func workspaceCoalescesAndCachesSourceEpochZeroMediaReferenceResolution() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
Fixes #631

## Summary
- report media-attachment changes from the final retained timeline projection, not proposed upserts
- keep the per-group media-reference cache warm when a detached window suppresses new media
- gate media-download pruning on the same retained-row result
- add store-level and end-to-end regression coverage

## Verification
- `git diff --check`
- signed commit and committed diff inspected
- macOS Xcode/Swift checks unavailable on this Linux worker; PR CI will run the exact project gates

## Sensitive paths
None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/669">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->