### PR TITLE
fix: cap fallback media locators

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -974,6 +974,8 @@ private nonisolated enum MessageMediaParser {
     // but keeps its own policy name so it can diverge from outgoing media limits.
     private static let maxFallbackAttachmentsPerMessage =
         OutgoingMediaDraftProcessor.maxAttachmentCount
+    private static let maxFallbackLocatorsPerAttachment =
+        maxFallbackAttachmentsPerMessage
     private static let logger = Logger(subsystem: "com.whitenoise.media", category: "MessageMediaParser")
 
     static func attachments(
@@ -1191,7 +1193,9 @@ private nonisolated enum MessageMediaParser {
                 let kind = String(locator[..<split])
                 let value = String(locator[locator.index(after: split)...])
                 guard !kind.isEmpty, !value.isEmpty else { continue }
-                locators.append(MediaLocatorFfi(kind: kind, value: value))
+                if locators.count < maxFallbackLocatorsPerAttachment {
+                    locators.append(MediaLocatorFfi(kind: kind, value: value))
+                }
                 continue
             }
             guard let split = field.firstIndex(of: " ") else { continue }
@@ -1224,7 +1228,7 @@ private nonisolated enum MessageMediaParser {
 
     private static func locators(fromJSONObject value: Any?) -> [MediaLocatorFfi] {
         guard let locators = value as? [Any] else { return [] }
-        return locators.compactMap { locator in
+        return locators.prefix(maxFallbackLocatorsPerAttachment).compactMap { locator in
             guard let locator = locator as? [String: Any],
                 let kind = string(locator, keys: ["kind"]),
                 let value = string(locator, keys: ["value"])

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5698,6 +5698,99 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func directMediaJSONCapsWideLocatorArrays() async throws {
+        // Regression for whitenoise-mac#629: attachment count is capped, but a single direct
+        // JSON reference must also bound its `locators` array so one attachment cannot retain
+        // an unbounded locator list for equality and rendering.
+        let cap = OutgoingMediaDraftProcessor.maxAttachmentCount
+        let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        let locators: [[String: String]] = (0..<(cap + 15)).map { index in
+            ["kind": "blossom", "value": "https://blob.example/locator-\(index)"]
+        }
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "wide-direct-locators",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJSONString(fromJSONObject: [
+                        "ciphertext_sha256": reference.ciphertextSha256,
+                        "plaintext_sha256": reference.plaintextSha256,
+                        "nonce": reference.nonceHex,
+                        "file_name": reference.fileName,
+                        "media_type": reference.mediaType,
+                        "version": reference.version,
+                        "locators": locators,
+                    ])
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+        let attachment = try #require(message.mediaAttachments.first)
+
+        #expect(message.mediaAttachments.count == 1)
+        #expect(attachment.reference.locators.count == cap)
+        #expect(
+            attachment.reference.locators.map(\.value)
+                == (0..<cap).map { "https://blob.example/locator-\($0)" }
+        )
+    }
+
+    @MainActor
+    @Test func imetaFallbackCapsWideLocatorFields() async throws {
+        // Regression for whitenoise-mac#629: excess `locator` imeta fields must be capped
+        // without dropping the attachment when required fields follow the wide locator run.
+        let cap = OutgoingMediaDraftProcessor.maxAttachmentCount
+        let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        var tagValues = ["imeta"]
+        tagValues.append(
+            contentsOf: (0..<(cap + 15)).map { index in
+                "locator blossom https://blob.example/locator-\(index)"
+            }
+        )
+        tagValues.append(contentsOf: [
+            "ciphertext_sha256 \(reference.ciphertextSha256)",
+            "plaintext_sha256 \(reference.plaintextSha256)",
+            "nonce \(reference.nonceHex)",
+            "filename \(reference.fileName)",
+            "m \(reference.mediaType)",
+            "v \(reference.version)",
+        ])
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "wide-imeta-locators",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    tags: [MessageTagFfi(values: tagValues)]
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+        let attachment = try #require(message.mediaAttachments.first)
+
+        #expect(message.mediaAttachments.count == 1)
+        #expect(attachment.reference.locators.count == cap)
+        #expect(
+            attachment.reference.locators.map(\.value)
+                == (0..<cap).map { "https://blob.example/locator-\($0)" }
+        )
+        #expect(attachment.reference.fileName == reference.fileName)
+    }
+
+    @MainActor
     @Test func booleanMediaJSONStringAliasValuesFallThroughAndBadLocatorsAreDropped() async throws {
         // `string(_:keys:)` searches aliases in order. A boolean at an earlier alias
         // should be treated as malformed for that key, not as "1" and not as a reason

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5769,8 +5769,8 @@ struct whitenoise_macTests {
                     groupIdHex: "group",
                     sender: "alice",
                     plaintext: "",
-                    recordedAt: 1_700_000_000,
-                    tags: [MessageTagFfi(values: tagValues)]
+                    tags: [MessageTagFfi(values: tagValues)],
+                    recordedAt: 1_700_000_000
                 )
             ],
             hasMoreBefore: false,


### PR DESCRIPTION
Fixes #629

## Summary
- cap peer-controlled fallback media locators per attachment using the existing inbound fallback limit
- bound direct JSON parsing to the first capped locator entries
- keep parsing required imeta metadata after excess locators while no longer appending beyond the cap
- add regression coverage for both direct JSON and imeta fallback paths, including retained order

## Verification
- `git diff --check` — passed
- static RED/GREEN invariant check — confirmed `origin/master` lacks the locator cap and the worktree contains both bounded parser paths plus both regression fixtures
- independent read-only Cursor review — passed with no security or logic findings
- `scripts/ci/macos-sanity-checks.sh` — unavailable on this Linux host (`xcodebuild: command not found`)
- macOS build, Swift format, and PR unit tests require Mac CI

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/672">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited the number of media locators processed for each attachment.
  * Prevented oversized locator data from causing excessive media metadata to be retained.
  * Preserved essential attachment details, including filenames, when locator data exceeds the limit.

* **Tests**
  * Added coverage for oversized locator arrays and fallback locator fields to verify consistent capping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->