### PR TITLE
fix: strip bidi controls from plain chat bubbles

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -740,7 +740,7 @@ nonisolated extension MessageItem {
             return nil
         }
         // Fast path: an unstyled single-paragraph message renders identically to the plain
-        // `Text(message.body)` fallback, which is dramatically cheaper for SwiftUI to size
+        // `Text(message.rawBubbleDisplayBody)` fallback, which is dramatically cheaper for SwiftUI to size
         // than the Markdown block/inline view tree (VStack → ForEach → MarkdownBlockView →
         // MarkdownInlineText → fixed-size Text). Most chat messages are exactly this, and
         // sizing/re-measuring that tree for ~100–200 rows during scroll-anchor resolution was

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1655,6 +1655,13 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         contentMarkdown == nil || contentMarkdown?.inlineParagraph != nil
     }
 
+    /// Body text shown when the bubble uses the plain `Text` fallback instead of the
+    /// pre-rendered Markdown AST. Strips bidi embedding/override/isolate controls while
+    /// preserving unrelated format characters such as ZWJ/ZWNJ.
+    var rawBubbleDisplayBody: String {
+        PeerDisplayText.strippingBidiControls(body)
+    }
+
     // `nonisolated` so the timeline record → view-model mapping (`MessageItem.timeline`)
     // can build items in the off-main window/projection closure (whitenoise-mac#285)
     // without inheriting the module's default main-actor isolation.

--- a/whitenoise-mac/Views/MarkdownMessageView.swift
+++ b/whitenoise-mac/Views/MarkdownMessageView.swift
@@ -45,7 +45,7 @@ struct MarkdownMessageView: View {
             // ScrollView/LazyVStack scroll-anchor resolution into a multi-second main-thread
             // layout loop on send (Instruments: continuous SelectionOverlay.updateNSView /
             // ScrollViewAdjustedState.adjustOffsetIfNeeded). See whitenoise-mac#205.
-            textWithMetadata(Text(message.body))
+            textWithMetadata(Text(message.rawBubbleDisplayBody))
                 .lineSpacing(2)
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/whitenoise-macTests/PeerDisplayTextTests.swift
+++ b/whitenoise-macTests/PeerDisplayTextTests.swift
@@ -179,6 +179,65 @@ struct PeerDisplayTextTests {
         #expect(body.contains(isolated("Team Two")))
     }
 
+    @Test func plainTimelineFastPathStripsBidiForRawBubbleDisplay() async throws {
+        let zwj = "\u{200D}"
+        let zwnj = "\u{200C}"
+        let maliciousPlaintext = "\(rtlOverride)safe.txt\(ltrIsolate)👨\(zwj)👩\(zwnj)👧"
+        let plainTokens = MarkdownDocumentFfi(
+            blocks: [.paragraph(inlines: [.text(content: maliciousPlaintext)])],
+            truncated: false
+        )
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "plain-bidi",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: maliciousPlaintext,
+                    recordedAt: 1_700_000_000,
+                    contentTokens: plainTokens
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let message = try #require(
+            MessageItem.timeline(from: page, activeAccountIdHex: "self").first
+        )
+        let expectedDisplay = "safe.txt👨\(zwj)👩\(zwnj)👧"
+
+        #expect(message.contentMarkdown == nil)
+        #expect(message.body == maliciousPlaintext)
+        #expect(message.rawBubbleDisplayBody == expectedDisplay)
+        #expect(!containsBidiEmbeddingOrIsolate(message.rawBubbleDisplayBody))
+        #expect(message.rawBubbleDisplayBody.unicodeScalars.contains { $0.value == 0x200D })
+        #expect(message.rawBubbleDisplayBody.unicodeScalars.contains { $0.value == 0x200C })
+    }
+
+    @Test func applyingEditStripsBidiForRawBubbleDisplay() async throws {
+        let zwj = "\u{200D}"
+        let zwnj = "\u{200C}"
+        let maliciousPlaintext = "\(rtlOverride)safe.txt\(ltrIsolate)👨\(zwj)👩\(zwnj)👧"
+        let base = MessageItem(
+            id: "message",
+            senderName: "Alice",
+            body: "Original",
+            sentAt: Date(timeIntervalSince1970: 1),
+            isOutgoing: false
+        )
+        let edited = base.applyingEdit(plaintext: maliciousPlaintext)
+        let expectedDisplay = "safe.txt👨\(zwj)👩\(zwnj)👧"
+
+        #expect(edited.contentMarkdown == nil)
+        #expect(edited.isEdited)
+        #expect(edited.body == maliciousPlaintext)
+        #expect(edited.rawBubbleDisplayBody == expectedDisplay)
+        #expect(!containsBidiEmbeddingOrIsolate(edited.rawBubbleDisplayBody))
+        #expect(edited.rawBubbleDisplayBody.unicodeScalars.contains { $0.value == 0x200D })
+        #expect(edited.rawBubbleDisplayBody.unicodeScalars.contains { $0.value == 0x200C })
+    }
+
     @Test func legacyGroupSystemPayloadTextIsSanitized() async throws {
         let page = TimelinePageFfi(
             messages: [
@@ -202,6 +261,13 @@ struct PeerDisplayTextTests {
     }
 }
 
+private func containsBidiEmbeddingOrIsolate(_ text: String) -> Bool {
+    text.unicodeScalars.contains { scalar in
+        let value = scalar.value
+        return (0x202A...0x202E).contains(value) || (0x2066...0x2069).contains(value)
+    }
+}
+
 private func timelineMessage(
     id: String,
     groupIdHex: String,
@@ -209,6 +275,7 @@ private func timelineMessage(
     plaintext: String,
     kind: UInt64 = 9,
     recordedAt: UInt64,
+    contentTokens: MarkdownDocumentFfi = MarkdownDocumentFfi(blocks: [], truncated: false),
     groupSystem: GroupSystemEventFfi? = nil
 ) -> TimelineMessageRecordFfi {
     TimelineMessageRecordFfi(
@@ -218,7 +285,7 @@ private func timelineMessage(
         groupIdHex: groupIdHex,
         sender: sender,
         plaintext: plaintext,
-        contentTokens: MarkdownDocumentFfi(blocks: [], truncated: false),
+        contentTokens: contentTokens,
         kind: kind,
         tags: [],
         timelineAt: recordedAt,


### PR DESCRIPTION
Fixes #667

## Summary
- strip U+202A–U+202E and U+2066–U+2069 from the exact `MessageItem` body value consumed by the plain chat-bubble fallback
- preserve `body`/`wireBody` for copy, reply, and edit semantics while preserving unrelated format characters such as ZWJ and ZWNJ in the display value
- cover both the plain timeline fast path and `applyingEdit` with end-to-end mapping regressions

## Verification
- `git diff --check` — pass
- `bash -n scripts/ci/macos-sanity-checks.sh` — pass
- regression tests added in `PeerDisplayTextTests` for plain timeline and edited messages
- macOS CI commands were not runnable on this Linux host: `xcodebuild`, `xcrun`, `swift`, and `swift-format` are unavailable; `scripts/ci/macos-sanity-checks.sh` exits 127 at `xcodebuild`

## Sensitive paths
None. Display-layer sanitization only; no crypto, MLS, key handling, authentication, group-state, or protocol code changed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/676">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->