### PR TITLE
fix: bound fallback locator string bytes

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -976,6 +976,10 @@ private nonisolated enum MessageMediaParser {
         OutgoingMediaDraftProcessor.maxAttachmentCount
     private static let maxFallbackLocatorsPerAttachment =
         maxFallbackAttachmentsPerMessage
+    /// Mirrors MDK `ENCRYPTED_MEDIA_LOCATOR_KIND_MAX_LEN` for legacy fallback parsing.
+    private static let maxFallbackLocatorKindUTF8Bytes = 64
+    /// Mirrors MDK `ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN` for legacy fallback parsing.
+    private static let maxFallbackLocatorValueUTF8Bytes = 2048
     private static let logger = Logger(subsystem: "com.whitenoise.media", category: "MessageMediaParser")
 
     static func attachments(
@@ -1192,9 +1196,10 @@ private nonisolated enum MessageMediaParser {
             {
                 let kind = String(locator[..<split])
                 let value = String(locator[locator.index(after: split)...])
-                guard !kind.isEmpty, !value.isEmpty else { continue }
-                if locators.count < maxFallbackLocatorsPerAttachment {
-                    locators.append(MediaLocatorFfi(kind: kind, value: value))
+                if locators.count < maxFallbackLocatorsPerAttachment,
+                    let validated = validatedLocator(kind: kind, value: value)
+                {
+                    locators.append(validated)
                 }
                 continue
             }
@@ -1233,8 +1238,17 @@ private nonisolated enum MessageMediaParser {
                 let kind = string(locator, keys: ["kind"]),
                 let value = string(locator, keys: ["value"])
             else { return nil }
-            return MediaLocatorFfi(kind: kind, value: value)
+            return validatedLocator(kind: kind, value: value)
         }
+    }
+
+    private static func validatedLocator(kind: String, value: String) -> MediaLocatorFfi? {
+        guard !kind.isEmpty,
+            !value.isEmpty,
+            kind.utf8.count <= maxFallbackLocatorKindUTF8Bytes,
+            value.utf8.count <= maxFallbackLocatorValueUTF8Bytes
+        else { return nil }
+        return MediaLocatorFfi(kind: kind, value: value)
     }
 
     private static func string(_ dictionary: [String: Any], keys: [String]) -> String? {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5865,19 +5865,21 @@ struct whitenoise_macTests {
                     groupIdHex: "group",
                     sender: "alice",
                     plaintext: "",
-                    tags: [MessageTagFfi(values: [
-                        "imeta",
-                        "locator \(overKind) https://blob.example/over-kind",
-                        "locator blossom \(overValue)",
-                        "locator \(boundaryKind) \(boundaryValue)",
-                        "locator blossom https://blob.example/valid",
-                        "ciphertext_sha256 \(reference.ciphertextSha256)",
-                        "plaintext_sha256 \(reference.plaintextSha256)",
-                        "nonce \(reference.nonceHex)",
-                        "filename \(reference.fileName)",
-                        "m \(reference.mediaType)",
-                        "v \(reference.version)",
-                    ])],
+                    tags: [
+                        MessageTagFfi(values: [
+                            "imeta",
+                            "locator \(overKind) https://blob.example/over-kind",
+                            "locator blossom \(overValue)",
+                            "locator \(boundaryKind) \(boundaryValue)",
+                            "locator blossom https://blob.example/valid",
+                            "ciphertext_sha256 \(reference.ciphertextSha256)",
+                            "plaintext_sha256 \(reference.plaintextSha256)",
+                            "nonce \(reference.nonceHex)",
+                            "filename \(reference.fileName)",
+                            "m \(reference.mediaType)",
+                            "v \(reference.version)",
+                        ])
+                    ],
                     recordedAt: 1_700_000_000
                 )
             ],

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5791,6 +5791,114 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func directMediaJSONBoundsFallbackLocatorUTF8Bytes() async throws {
+        // Regression for whitenoise-mac#673: reject oversized locators whole; limits are UTF-8 bytes.
+        let twoByte = "é"
+        let boundaryKind = String(repeating: twoByte, count: 32)
+        let overKind = String(repeating: twoByte, count: 33)
+        let boundaryValue = String(repeating: twoByte, count: 1024)
+        let overValue = String(repeating: twoByte, count: 1025)
+        #expect(boundaryKind.utf8.count == 64)
+        #expect(overKind.utf8.count == 66)
+        #expect(boundaryValue.utf8.count == 2048)
+        #expect(overValue.utf8.count == 2050)
+
+        let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "bounded-direct-locators",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    mediaJson: mediaJSONString(fromJSONObject: [
+                        "ciphertext_sha256": reference.ciphertextSha256,
+                        "plaintext_sha256": reference.plaintextSha256,
+                        "nonce": reference.nonceHex,
+                        "file_name": reference.fileName,
+                        "media_type": reference.mediaType,
+                        "version": reference.version,
+                        "locators": [
+                            ["kind": overKind, "value": "https://blob.example/over-kind"],
+                            ["kind": "blossom", "value": overValue],
+                            ["kind": boundaryKind, "value": boundaryValue],
+                            ["kind": "blossom", "value": "https://blob.example/valid"],
+                        ],
+                    ])
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+        let attachment = try #require(message.mediaAttachments.first)
+
+        #expect(message.mediaAttachments.count == 1)
+        #expect(attachment.reference.locators.count == 2)
+        #expect(attachment.reference.locators[0].kind == boundaryKind)
+        #expect(attachment.reference.locators[0].value == boundaryValue)
+        #expect(attachment.reference.locators[1].kind == "blossom")
+        #expect(attachment.reference.locators[1].value == "https://blob.example/valid")
+    }
+
+    @MainActor
+    @Test func imetaFallbackBoundsLocatorUTF8Bytes() async throws {
+        // Regression for whitenoise-mac#673: same locator bounds for imeta fallback parsing.
+        let twoByte = "é"
+        let boundaryKind = String(repeating: twoByte, count: 32)
+        let overKind = String(repeating: twoByte, count: 33)
+        let boundaryValue = String(repeating: twoByte, count: 1024)
+        let overValue = String(repeating: twoByte, count: 1025)
+        #expect(boundaryKind.utf8.count == 64)
+        #expect(overKind.utf8.count == 66)
+        #expect(boundaryValue.utf8.count == 2048)
+        #expect(overValue.utf8.count == 2050)
+
+        let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "bounded-imeta-locators",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "",
+                    tags: [MessageTagFfi(values: [
+                        "imeta",
+                        "locator \(overKind) https://blob.example/over-kind",
+                        "locator blossom \(overValue)",
+                        "locator \(boundaryKind) \(boundaryValue)",
+                        "locator blossom https://blob.example/valid",
+                        "ciphertext_sha256 \(reference.ciphertextSha256)",
+                        "plaintext_sha256 \(reference.plaintextSha256)",
+                        "nonce \(reference.nonceHex)",
+                        "filename \(reference.fileName)",
+                        "m \(reference.mediaType)",
+                        "v \(reference.version)",
+                    ])],
+                    recordedAt: 1_700_000_000
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let message = try #require(messages.first)
+        let attachment = try #require(message.mediaAttachments.first)
+
+        #expect(message.mediaAttachments.count == 1)
+        #expect(attachment.reference.locators.count == 2)
+        #expect(attachment.reference.locators[0].kind == boundaryKind)
+        #expect(attachment.reference.locators[0].value == boundaryValue)
+        #expect(attachment.reference.locators[1].kind == "blossom")
+        #expect(attachment.reference.locators[1].value == "https://blob.example/valid")
+        #expect(attachment.reference.fileName == reference.fileName)
+    }
+
+    @MainActor
     @Test func booleanMediaJSONStringAliasValuesFallThroughAndBadLocatorsAreDropped() async throws {
         // `string(_:keys:)` searches aliases in order. A boolean at an earlier alias
         // should be treated as malformed for that key, not as "1" and not as a reason


### PR DESCRIPTION
Fixes #673

## Summary
- bound legacy fallback locator kinds to 64 UTF-8 bytes and values to 2048 UTF-8 bytes, mirroring MDK encrypted-media policy
- reject oversized locators whole through one shared validator used by direct JSON and imeta parsing
- preserve at-limit and normal valid siblings, attachment metadata, and locator order
- add focused UTF-8 boundary/overflow regression coverage for both fallback paths

## Verification
- `git diff --check` — passed
- static RED/GREEN invariant check — confirmed `origin/master` lacks locator byte bounds and this branch enforces 64/2048 UTF-8-byte caps in both fallback paths without truncation
- duplicate Swift test-symbol scan — passed (473 unique `@Test` functions)
- `scripts/ci/macos-sanity-checks.sh` — unavailable on this Linux host (`xcodebuild: command not found`, exit 127)
- Swift format, Xcode unit tests, build, and analyzer require Mac CI

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/677">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->