### PR TITLE
fix: make media tiles keyboard accessible

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -4822,6 +4822,65 @@
         }
       }
     },
+    "Cancel video loading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Videoladen abbrechen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar carga del vídeo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler le chargement de la vidéo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla caricamento video"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar carregamento do vídeo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменить загрузку видео"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video yüklemeyi iptal et"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消加载视频"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消載入影片"
+          }
+        }
+      }
+    },
     "Chat archived" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -17735,6 +17794,65 @@
         }
       }
     },
+    "Open image" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bild öffnen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir imagen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir l'image"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri immagine"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir imagem"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть изображение"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Görüntüyü aç"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开图片"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打開圖片"
+          }
+        }
+      }
+    },
     "Open Diagnostics" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -18390,6 +18508,65 @@
     },
     "Previous image" : {
 
+    },
+    "Play video" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video abspielen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproducir vídeo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lire la vidéo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riproduci video"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reproduzir vídeo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Воспроизвести видео"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Videoyu oynat"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放视频"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放影片"
+          }
+        }
+      }
     },
     "Privacy" : {
       "extractionState" : "manual",
@@ -21873,6 +22050,124 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重試"
+          }
+        }
+      }
+    },
+    "Retry download" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download wiederholen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reintentar descarga"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessayer le téléchargement"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprova download"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tentar download novamente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторить загрузку"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İndirmeyi yeniden dene"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試下載"
+          }
+        }
+      }
+    },
+    "Retry video" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Video erneut versuchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reintentar vídeo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessayer la vidéo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprova video"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tentar vídeo novamente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторить видео"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Videoyu yeniden dene"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试视频"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試影片"
           }
         }
       }

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -629,19 +629,12 @@ enum MessageVisualMediaTileInteraction {
 }
 
 enum MessageVideoAttachmentPlayerAccessibility {
-    static func label(
-        isPlaying: Bool,
-        isPreparingPlayback: Bool,
-        didFail: Bool
-    ) -> String {
+    static func label(isPreparingPlayback: Bool, didFail: Bool) -> String {
         if didFail {
             return L10n.string("Retry video")
         }
         if isPreparingPlayback {
             return L10n.string("Cancel video loading")
-        }
-        if isPlaying {
-            return L10n.string("Pause video")
         }
         return L10n.string("Play video")
     }
@@ -1254,7 +1247,6 @@ struct MessageVideoAttachmentPlayer: View {
     @State private var player: AVPlayer?
     @State private var playbackURL: URL?
     @State private var isLoading = false
-    @State private var isPlaying = false
     @State private var didFail = false
     @State private var playbackPreparationID: UUID?
     @State private var playbackTask: Task<Void, Never>?
@@ -1265,52 +1257,26 @@ struct MessageVideoAttachmentPlayer: View {
     }
 
     var body: some View {
-        Button(action: activatePlayback) {
-            ZStack {
-                if let player {
-                    VideoPlayer(player: player)
-                        .frame(width: sideLength, height: sideLength)
-                        .background(Color.black)
-                        .allowsHitTesting(false)
-                } else {
-                    Color.black.opacity(0.86)
-                    Image(systemName: didFail ? "arrow.clockwise" : "play.fill")
-                        .font(.system(size: 24, weight: .bold))
-                        .foregroundStyle(.white)
-                        .frame(width: 48, height: 48)
-                        .background(Color.black.opacity(0.45), in: Circle())
-
-                    VStack {
-                        Spacer()
-                        Text(download.fileName.nilIfBlank ?? attachment.fileName)
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.white.opacity(0.86))
-                            .lineLimit(1)
-                            .padding(.horizontal, 8)
-                            .padding(.bottom, 8)
-                    }
+        ZStack {
+            if let player {
+                VideoPlayer(player: player)
+                    .frame(width: sideLength, height: sideLength)
+                    .background(Color.black)
+            } else {
+                Button(action: activatePlayback) {
+                    playbackPlaceholder
                 }
-
-                if isLoading {
-                    ProgressView()
-                        .controlSize(.small)
-                        .tint(.white)
-                        .frame(width: 42, height: 42)
-                        .background(Color.black.opacity(0.45), in: Circle())
-                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(
+                    MessageVideoAttachmentPlayerAccessibility.label(
+                        isPreparingPlayback: isPreparingPlayback,
+                        didFail: didFail
+                    )
+                )
             }
-            .frame(width: sideLength, height: sideLength)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(
-            MessageVideoAttachmentPlayerAccessibility.label(
-                isPlaying: isPlaying,
-                isPreparingPlayback: isPreparingPlayback,
-                didFail: didFail
-            )
-        )
+        .frame(width: sideLength, height: sideLength)
+        .contentShape(Rectangle())
         // Transcript rows are intentionally eager, so scrolling this tile out of the viewport
         // does not trigger onDisappear. Tear down here as well to release the player and delete
         // its decrypted playback scratch file as soon as the tile is no longer visible.
@@ -1331,6 +1297,37 @@ struct MessageVideoAttachmentPlayer: View {
         .onChange(of: download.payload.id) { _, _ in
             resetForAttachmentChange()
         }
+    }
+
+    private var playbackPlaceholder: some View {
+        ZStack {
+            Color.black.opacity(0.86)
+            Image(systemName: didFail ? "arrow.clockwise" : "play.fill")
+                .font(.system(size: 24, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 48, height: 48)
+                .background(Color.black.opacity(0.45), in: Circle())
+
+            VStack {
+                Spacer()
+                Text(download.fileName.nilIfBlank ?? attachment.fileName)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.86))
+                    .lineLimit(1)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 8)
+            }
+
+            if isLoading {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(.white)
+                    .frame(width: 42, height: 42)
+                    .background(Color.black.opacity(0.45), in: Circle())
+            }
+        }
+        .frame(width: sideLength, height: sideLength)
+        .contentShape(Rectangle())
     }
 
     private func activatePlayback() {
@@ -1356,17 +1353,6 @@ struct MessageVideoAttachmentPlayer: View {
     @MainActor
     private func togglePlayback() async {
         guard !Task.isCancelled else { return }
-
-        if let player {
-            if isPlaying {
-                player.pause()
-                isPlaying = false
-            } else {
-                player.play()
-                isPlaying = true
-            }
-            return
-        }
 
         if isPreparingPlayback {
             stopPlayback()
@@ -1418,7 +1404,6 @@ struct MessageVideoAttachmentPlayer: View {
         player = next
         observeEndOfPlayback(for: next)
         next.play()
-        isPlaying = true
     }
 
     /// Seeks the playhead back to the start when the item plays to completion so the next tap
@@ -1432,9 +1417,6 @@ struct MessageVideoAttachmentPlayer: View {
             queue: .main
         ) { _ in
             player.seek(to: .zero)
-            Task { @MainActor in
-                isPlaying = false
-            }
         }
     }
 
@@ -1450,7 +1432,6 @@ struct MessageVideoAttachmentPlayer: View {
     private func stopPlayback() {
         playbackPreparationID = nil
         isLoading = false
-        isPlaying = false
         removeEndOfPlaybackObserver()
         player?.pause()
         player = nil

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -615,6 +615,36 @@ enum MessageVisualMediaTileInteraction {
         if case .failed = downloadState { return .retryDownload }
         return attachmentKind == .image ? .openImageGallery : .none
     }
+
+    static func accessibilityLabel(for action: MessageVisualMediaTileTapAction) -> String? {
+        switch action {
+        case .retryDownload:
+            return L10n.string("Retry download")
+        case .openImageGallery:
+            return L10n.string("Open image")
+        case .none:
+            return nil
+        }
+    }
+}
+
+enum MessageVideoAttachmentPlayerAccessibility {
+    static func label(
+        isPlaying: Bool,
+        isPreparingPlayback: Bool,
+        didFail: Bool
+    ) -> String {
+        if didFail {
+            return L10n.string("Retry video")
+        }
+        if isPreparingPlayback {
+            return L10n.string("Cancel video loading")
+        }
+        if isPlaying {
+            return L10n.string("Pause video")
+        }
+        return L10n.string("Play video")
+    }
 }
 
 struct MessageVisualMediaGrid: View {
@@ -710,6 +740,27 @@ struct MessageVisualMediaTile: View {
     let onOpenImageGallery: (MessageImageGalleryPresentation) -> Void
 
     var body: some View {
+        let tapAction = MessageVisualMediaTileInteraction.tapAction(
+            downloadState: downloadState.state,
+            attachmentKind: attachment.kind
+        )
+        Group {
+            if tapAction == .none {
+                tileBody
+            } else {
+                Button(action: performPrimaryAction) {
+                    tileBody
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(
+                    MessageVisualMediaTileInteraction.accessibilityLabel(for: tapAction) ?? ""
+                )
+            }
+        }
+        .accessibilityIdentifier("message.media.visualTile.\(attachment.id)")
+    }
+
+    private var tileBody: some View {
         ZStack {
             content
 
@@ -728,25 +779,25 @@ struct MessageVisualMediaTile: View {
             attachment: attachment,
             message: message
         )
-        .onTapGesture {
-            switch MessageVisualMediaTileInteraction.tapAction(
-                downloadState: downloadState.state,
-                attachmentKind: attachment.kind
+    }
+
+    private func performPrimaryAction() {
+        switch MessageVisualMediaTileInteraction.tapAction(
+            downloadState: downloadState.state,
+            attachmentKind: attachment.kind
+        ) {
+        case .retryDownload:
+            Task { await workspace.loadMediaAttachment(attachment, for: message) }
+        case .openImageGallery:
+            if let gallery = MessageImageGalleryPresentation(
+                message: message,
+                initialAttachment: attachment
             ) {
-            case .retryDownload:
-                Task { await workspace.loadMediaAttachment(attachment, for: message) }
-            case .openImageGallery:
-                if let gallery = MessageImageGalleryPresentation(
-                    message: message,
-                    initialAttachment: attachment
-                ) {
-                    onOpenImageGallery(gallery)
-                }
-            case .none:
-                break
+                onOpenImageGallery(gallery)
             }
+        case .none:
+            break
         }
-        .accessibilityIdentifier("message.media.visualTile.\(attachment.id)")
     }
 
     @ViewBuilder
@@ -1203,6 +1254,7 @@ struct MessageVideoAttachmentPlayer: View {
     @State private var player: AVPlayer?
     @State private var playbackURL: URL?
     @State private var isLoading = false
+    @State private var isPlaying = false
     @State private var didFail = false
     @State private var playbackPreparationID: UUID?
     @State private var playbackTask: Task<Void, Never>?
@@ -1213,48 +1265,52 @@ struct MessageVideoAttachmentPlayer: View {
     }
 
     var body: some View {
-        ZStack {
-            if let player {
-                VideoPlayer(player: player)
-                    .frame(width: sideLength, height: sideLength)
-                    .background(Color.black)
-            } else {
-                Color.black.opacity(0.86)
-                Image(systemName: didFail ? "arrow.clockwise" : "play.fill")
-                    .font(.system(size: 24, weight: .bold))
-                    .foregroundStyle(.white)
-                    .frame(width: 48, height: 48)
-                    .background(Color.black.opacity(0.45), in: Circle())
+        Button(action: activatePlayback) {
+            ZStack {
+                if let player {
+                    VideoPlayer(player: player)
+                        .frame(width: sideLength, height: sideLength)
+                        .background(Color.black)
+                        .allowsHitTesting(false)
+                } else {
+                    Color.black.opacity(0.86)
+                    Image(systemName: didFail ? "arrow.clockwise" : "play.fill")
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 48, height: 48)
+                        .background(Color.black.opacity(0.45), in: Circle())
 
-                VStack {
-                    Spacer()
-                    Text(download.fileName.nilIfBlank ?? attachment.fileName)
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.white.opacity(0.86))
-                        .lineLimit(1)
-                        .padding(.horizontal, 8)
-                        .padding(.bottom, 8)
+                    VStack {
+                        Spacer()
+                        Text(download.fileName.nilIfBlank ?? attachment.fileName)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.white.opacity(0.86))
+                            .lineLimit(1)
+                            .padding(.horizontal, 8)
+                            .padding(.bottom, 8)
+                    }
+                }
+
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.white)
+                        .frame(width: 42, height: 42)
+                        .background(Color.black.opacity(0.45), in: Circle())
                 }
             }
-
-            if isLoading {
-                ProgressView()
-                    .controlSize(.small)
-                    .tint(.white)
-                    .frame(width: 42, height: 42)
-                    .background(Color.black.opacity(0.45), in: Circle())
-            }
+            .frame(width: sideLength, height: sideLength)
+            .contentShape(Rectangle())
         }
-        .frame(width: sideLength, height: sideLength)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            if isPreparingPlayback {
-                tearDownPlayback()
-            } else {
-                playbackTask?.cancel()
-                playbackTask = Task { await togglePlayback() }
-            }
-        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            MessageVideoAttachmentPlayerAccessibility.label(
+                isPlaying: isPlaying,
+                isPreparingPlayback: isPreparingPlayback,
+                didFail: didFail
+            )
+        )
         // Transcript rows are intentionally eager, so scrolling this tile out of the viewport
         // does not trigger onDisappear. Tear down here as well to release the player and delete
         // its decrypted playback scratch file as soon as the tile is no longer visible.
@@ -1275,7 +1331,15 @@ struct MessageVideoAttachmentPlayer: View {
         .onChange(of: download.payload.id) { _, _ in
             resetForAttachmentChange()
         }
-        .accessibilityLabel("Video attachment")
+    }
+
+    private func activatePlayback() {
+        if isPreparingPlayback {
+            tearDownPlayback()
+        } else {
+            playbackTask?.cancel()
+            playbackTask = Task { await togglePlayback() }
+        }
     }
 
     private func tearDownPlayback() {
@@ -1294,10 +1358,12 @@ struct MessageVideoAttachmentPlayer: View {
         guard !Task.isCancelled else { return }
 
         if let player {
-            if player.timeControlStatus == .playing {
+            if isPlaying {
                 player.pause()
+                isPlaying = false
             } else {
                 player.play()
+                isPlaying = true
             }
             return
         }
@@ -1352,6 +1418,7 @@ struct MessageVideoAttachmentPlayer: View {
         player = next
         observeEndOfPlayback(for: next)
         next.play()
+        isPlaying = true
     }
 
     /// Seeks the playhead back to the start when the item plays to completion so the next tap
@@ -1365,6 +1432,9 @@ struct MessageVideoAttachmentPlayer: View {
             queue: .main
         ) { _ in
             player.seek(to: .zero)
+            Task { @MainActor in
+                isPlaying = false
+            }
         }
     }
 
@@ -1380,6 +1450,7 @@ struct MessageVideoAttachmentPlayer: View {
     private func stopPlayback() {
         playbackPreparationID = nil
         isLoading = false
+        isPlaying = false
         removeEndOfPlaybackObserver()
         player?.pause()
         player = nil

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7642,28 +7642,18 @@ struct whitenoise_macTests {
     @Test func videoAttachmentPlayerAccessibilityLabelMatchesPlaybackState() {
         #expect(
             MessageVideoAttachmentPlayerAccessibility.label(
-                isPlaying: false,
                 isPreparingPlayback: false,
                 didFail: true
             ) == L10n.string("Retry video")
         )
         #expect(
             MessageVideoAttachmentPlayerAccessibility.label(
-                isPlaying: false,
                 isPreparingPlayback: true,
                 didFail: false
             ) == L10n.string("Cancel video loading")
         )
         #expect(
             MessageVideoAttachmentPlayerAccessibility.label(
-                isPlaying: true,
-                isPreparingPlayback: false,
-                didFail: false
-            ) == L10n.string("Pause video")
-        )
-        #expect(
-            MessageVideoAttachmentPlayerAccessibility.label(
-                isPlaying: false,
                 isPreparingPlayback: false,
                 didFail: false
             ) == L10n.string("Play video")
@@ -7674,7 +7664,9 @@ struct whitenoise_macTests {
         // MessageVisualMediaTile and MessageVideoAttachmentPlayer are SwiftUI surfaces
         // the unit tests cannot activate directly. Guard their source contract: pointer,
         // keyboard, and VoiceOver users must reach the same primary action through real
-        // Button controls with explicit labels instead of bare tap gestures.
+        // Button controls with explicit labels instead of bare tap gestures. Once playback
+        // starts, the live VideoPlayer must sit outside that button so AVKit controls stay
+        // interactive and exposed to assistive technologies.
         let viewsURL =
             URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -7705,17 +7697,36 @@ struct whitenoise_macTests {
         let playerSource = String(source[playerStart.lowerBound..<playerEnd])
         let normalizedPlayerSource = playerSource.components(separatedBy: .whitespacesAndNewlines).joined()
 
-        #expect(playerSource.contains("@State private var isPlaying = false"))
+        #expect(playerSource.contains("if let player {"))
+        #expect(playerSource.contains("VideoPlayer(player: player)"))
         #expect(playerSource.contains("Button(action: activatePlayback)"))
         #expect(normalizedPlayerSource.contains(".buttonStyle(.plain)"))
         #expect(playerSource.contains("MessageVideoAttachmentPlayerAccessibility.label("))
-        #expect(normalizedPlayerSource.contains(".accessibilityElement(children:.ignore)"))
-        #expect(normalizedPlayerSource.contains(".allowsHitTesting(false)"))
-        #expect(playerSource.contains("if isPlaying {"))
-        #expect(!playerSource.contains("if player.timeControlStatus == .playing {"))
-        #expect(playerSource.contains("isPlaying = true"))
-        #expect(playerSource.contains("isPlaying = false"))
+        #expect(!normalizedPlayerSource.contains(".allowsHitTesting(false)"))
+        #expect(!normalizedPlayerSource.contains(".accessibilityElement(children:.ignore)"))
+        #expect(!playerSource.contains("@State private var isPlaying"))
+        #expect(!playerSource.contains("Pause video"))
         #expect(!playerSource.contains(".onTapGesture"))
+
+        let livePlayerBranch = try #require(
+            playerSource.range(
+                of: "if let player {",
+                options: [],
+                range: nil,
+                locale: nil
+            )
+        )
+        let elseBranch = try #require(
+            playerSource.range(
+                of: "} else {",
+                options: [],
+                range: livePlayerBranch.upperBound..<playerSource.endIndex,
+                locale: nil
+            )
+        )
+        let livePlayerSource = String(playerSource[livePlayerBranch.upperBound..<elseBranch.lowerBound])
+        #expect(livePlayerSource.contains("VideoPlayer(player: player)"))
+        #expect(!livePlayerSource.contains("Button(action:"))
     }
 
     @Test func imageGalleryProvidesDismissalNavigationAndAccessibilityAffordances() throws {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7602,9 +7602,9 @@ struct whitenoise_macTests {
         )
     }
 
-    @Test func visualMediaTileTapGestureRoutesRetryActionToDownload() throws {
-        // MessageVisualMediaTile is a SwiftUI gesture surface that the unit tests cannot
-        // tap directly here. Guard the wiring shape so a failed-tile retry action remains
+    @Test func visualMediaTilePrimaryActionRoutesRetryToDownload() throws {
+        // MessageVisualMediaTile is a SwiftUI control that the unit tests cannot activate
+        // directly here. Guard the wiring shape so a failed-tile retry action remains
         // connected to the explicit download entry point, while the pure decision helper
         // above guards that failed video tiles choose that action.
         let viewsURL =
@@ -7623,6 +7623,99 @@ struct whitenoise_macTests {
         #expect(tileSource.contains("MessageVisualMediaTileInteraction.tapAction"))
         #expect(tileSource.contains("case .retryDownload:"))
         #expect(tileSource.contains("Task { await workspace.loadMediaAttachment(attachment, for: message) }"))
+    }
+
+    @MainActor
+    @Test func visualMediaTileAccessibilityLabelMatchesPrimaryAction() {
+        #expect(
+            MessageVisualMediaTileInteraction.accessibilityLabel(for: .retryDownload)
+                == L10n.string("Retry download")
+        )
+        #expect(
+            MessageVisualMediaTileInteraction.accessibilityLabel(for: .openImageGallery)
+                == L10n.string("Open image")
+        )
+        #expect(MessageVisualMediaTileInteraction.accessibilityLabel(for: .none) == nil)
+    }
+
+    @MainActor
+    @Test func videoAttachmentPlayerAccessibilityLabelMatchesPlaybackState() {
+        #expect(
+            MessageVideoAttachmentPlayerAccessibility.label(
+                isPlaying: false,
+                isPreparingPlayback: false,
+                didFail: true
+            ) == L10n.string("Retry video")
+        )
+        #expect(
+            MessageVideoAttachmentPlayerAccessibility.label(
+                isPlaying: false,
+                isPreparingPlayback: true,
+                didFail: false
+            ) == L10n.string("Cancel video loading")
+        )
+        #expect(
+            MessageVideoAttachmentPlayerAccessibility.label(
+                isPlaying: true,
+                isPreparingPlayback: false,
+                didFail: false
+            ) == L10n.string("Pause video")
+        )
+        #expect(
+            MessageVideoAttachmentPlayerAccessibility.label(
+                isPlaying: false,
+                isPreparingPlayback: false,
+                didFail: false
+            ) == L10n.string("Play video")
+        )
+    }
+
+    @Test func mediaTilesExposeButtonAccessibilitySemantics() throws {
+        // MessageVisualMediaTile and MessageVideoAttachmentPlayer are SwiftUI surfaces
+        // the unit tests cannot activate directly. Guard their source contract: pointer,
+        // keyboard, and VoiceOver users must reach the same primary action through real
+        // Button controls with explicit labels instead of bare tap gestures.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+
+        let tileStart = try #require(source.range(of: "struct MessageVisualMediaTile: View {"))
+        let tileRest = source[tileStart.upperBound...]
+        let tileEnd = try #require(tileRest.range(of: "\nstruct MessageMediaAttachmentView: View {")?.lowerBound)
+        let tileSource = String(source[tileStart.lowerBound..<tileEnd])
+        let normalizedTileSource = tileSource.components(separatedBy: .whitespacesAndNewlines).joined()
+
+        #expect(tileSource.contains("Button(action: performPrimaryAction)"))
+        #expect(normalizedTileSource.contains(".buttonStyle(.plain)"))
+        #expect(
+            normalizedTileSource.contains(
+                "MessageVisualMediaTileInteraction.accessibilityLabel(for:tapAction)"
+            )
+        )
+        #expect(!tileSource.contains(".onTapGesture"))
+
+        let playerStart = try #require(source.range(of: "struct MessageVideoAttachmentPlayer: View {"))
+        let playerRest = source[playerStart.upperBound...]
+        let playerEnd = try #require(playerRest.range(of: "\nenum MessageMediaPlaybackFileStore {")?.lowerBound)
+        let playerSource = String(source[playerStart.lowerBound..<playerEnd])
+        let normalizedPlayerSource = playerSource.components(separatedBy: .whitespacesAndNewlines).joined()
+
+        #expect(playerSource.contains("@State private var isPlaying = false"))
+        #expect(playerSource.contains("Button(action: activatePlayback)"))
+        #expect(normalizedPlayerSource.contains(".buttonStyle(.plain)"))
+        #expect(playerSource.contains("MessageVideoAttachmentPlayerAccessibility.label("))
+        #expect(normalizedPlayerSource.contains(".accessibilityElement(children:.ignore)"))
+        #expect(normalizedPlayerSource.contains(".allowsHitTesting(false)"))
+        #expect(playerSource.contains("if isPlaying {"))
+        #expect(!playerSource.contains("if player.timeControlStatus == .playing {"))
+        #expect(playerSource.contains("isPlaying = true"))
+        #expect(playerSource.contains("isPlaying = false"))
+        #expect(!playerSource.contains(".onTapGesture"))
     }
 
     @Test func imageGalleryProvidesDismissalNavigationAndAccessibilityAffordances() throws {


### PR DESCRIPTION
Fixes #643

## Summary
- expose image-open and failed-download retry tiles as plain buttons only when the tile owns a primary action
- expose video play/cancel-loading/retry as a labeled pre-play button, then render the loaded AVKit player outside it so native controls remain interactive and accessible
- preserve teardown behavior, remove shadow playback state, and localize all five media action labels across every supported locale

## Verification
- `git diff --check origin/master...HEAD`
- 16/16 static interaction and playback-lifecycle invariants passed
- `jq empty whitenoise-mac/Localizable.xcstrings`
- all five localization keys cover all nine supported non-English locales
- native macOS build/tests delegated to exact-head GitHub Mac CI (Xcode unavailable on this Linux host)

## Sensitive paths
None.

## Handoff context
Replacement for closed PR #663, which is permanently ineligible because CodeRabbit recorded a rate-limit failure. Fresh adversarial review must explicitly re-evaluate the prior AVKit interaction blocker against this PR exact head.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/679">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->