### PR TITLE
fix: stop recordings before selected group removal

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -593,6 +593,7 @@ extension WorkspaceState {
                 closeGroupDetails()
             }
             if case .chat(let selectedGroupId) = selection, selectedGroupId == groupIdHex {
+                leaveActiveConversation()
                 stopTimelineListener()
                 selection = nil
                 pruneMessageCache(keeping: nil)
@@ -692,6 +693,7 @@ extension WorkspaceState {
                 closeGroupDetails()
             }
             if case .chat(let selectedGroupId) = selection, selectedGroupId == groupIdHex {
+                leaveActiveConversation()
                 stopTimelineListener()
                 selection = nil
                 pruneMessageCache(keeping: nil)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -22425,6 +22425,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func deleteGroupLocal(accountRef: String, groupIdHex: String) async throws -> Bool {
         deleteGroupLocalCallCount += 1
         locallyDeletedGroupIds.append(groupIdHex)
+        guard let index = groups.firstIndex(where: { $0.groupIdHex == groupIdHex }) else { return false }
+        groups.remove(at: index)
+        groupDetailsById[groupIdHex] = nil
+        groupManagementStateById[groupIdHex] = nil
         return true
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -16761,6 +16761,69 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func decliningSelectedGroupInviteLeavesActiveConversation() async throws {
+        let account = desktopAccount()
+        var details = groupDetailsFixture(selfAccountIdHex: account.accountIdHex)
+        details.group.pendingConfirmation = true
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(details)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let selectedChat = try #require(state.selectedChat)
+        let recordingURL = try armInProgressVoiceRecording(on: state)
+        defer { state.cancelVoiceRecording() }
+        let transcriptExportTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        state.groupTranscriptExportTask = transcriptExportTask
+        defer { transcriptExportTask.cancel() }
+
+        await state.declineGroupInvite(for: selectedChat)
+
+        #expect(state.selection != .chat(selectedChat.id))
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: recordingURL.path))
+        #expect(transcriptExportTask.isCancelled)
+        transcriptExportTask.cancel()
+        await transcriptExportTask.value
+    }
+
+    @MainActor
+    @Test func deletingSelectedGroupLocallyLeavesActiveConversation() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let selectedChat = try #require(state.selectedChat)
+        let recordingURL = try armInProgressVoiceRecording(on: state)
+        defer { state.cancelVoiceRecording() }
+        let transcriptExportTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        state.groupTranscriptExportTask = transcriptExportTask
+        defer { transcriptExportTask.cancel() }
+
+        await state.deleteGroupLocally(groupIdHex: selectedChat.id)
+
+        #expect(runtime.locallyDeletedGroupIds == [selectedChat.id])
+        #expect(state.selection != .chat(selectedChat.id))
+        #expect(!state.isRecordingVoiceMessage)
+        #expect(state.voiceRecordingMeterTask == nil)
+        #expect(!FileManager.default.fileExists(atPath: recordingURL.path))
+        #expect(transcriptExportTask.isCancelled)
+        transcriptExportTask.cancel()
+        await transcriptExportTask.value
+    }
+
+    @MainActor
     @Test func activeAccountNotificationResponseStopsInProgressVoiceRecordingBeforeChatSwitch() async throws {
         // #374: tapping a same-account notification is an implicit chat switch. It must run
         // the same conversation teardown as `selectChat` before the composer belongs to the


### PR DESCRIPTION
## Summary
- run centralized active-conversation teardown before declining or locally deleting the selected group
- cancel recording/plaintext temp-audio and transcript-export work before composer removal
- make the fake runtime model successful local deletion
- cover both privacy-sensitive mutation paths with regression tests

## Verification
- rebased onto current `origin/master`
- signed two-commit fix range verified
- `git range-diff` proves the corrected #678 patch was preserved exactly
- `git diff --check origin/master...HEAD`
- committed-tree conflict-marker sweep
- structural verification of teardown ordering, fake-runtime deletion, and both privacy tests
- macOS PR CI and CodeRabbit pending

Replaces closed ever-red PRs #659 and #678. This replacement must remain held for Jeff because it changes privacy-sensitive microphone/plaintext-audio/transcript teardown.

Fixes #640

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise-mac/pull/680">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Declining an invitation or deleting the currently open group now exits the conversation cleanly.
  - Active voice recordings are stopped safely, temporary recording files are removed, and transcript exports are cancelled.
  - Deleted groups are removed immediately from the app, including related details and management information.
  - The app now reliably clears the active conversation and refreshes the chat list after these actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->