### PR TITLE
Render urls as links in message bubbles

### DIFF
--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -299,6 +299,16 @@ nonisolated struct MarkdownDisplayTableRow: Identifiable {
     let cells: [MarkdownDisplayTableCell]
 }
 
+nonisolated fileprivate struct MarkdownDisplayLink {
+    enum Presentation {
+        case underlined
+        case mention
+    }
+
+    let url: URL
+    let presentation: Presentation
+}
+
 nonisolated enum MarkdownDisplayInlineBuilder {
     static func attributedString(
         from inlines: [MarkdownInlineFfi],
@@ -343,7 +353,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func render(
         _ inline: MarkdownInlineFfi,
         intent: InlinePresentationIntent,
-        link: URL?,
+        link: MarkdownDisplayLink?,
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
         truncated: inout Bool
@@ -419,11 +429,12 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func actionableURL(
         from destination: String,
         classification: MarkdownLinkDestinationKindFfi
-    ) -> URL? {
+    ) -> MarkdownDisplayLink? {
         switch classification {
-        case .web, .contact, .app, .nostr:
-            return MarkdownLinkPolicy.sanitizedURL(from: destination)
-        case .relative, .unknown, .dangerous, .sensitive:
+        case .web, .app, .nostr:
+            guard let url = MarkdownLinkPolicy.sanitizedURL(from: destination) else { return nil }
+            return MarkdownDisplayLink(url: url, presentation: .underlined)
+        case .contact, .relative, .unknown, .dangerous, .sensitive:
             return nil
         @unknown default:
             return nil
@@ -433,7 +444,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func concat(
         _ inlines: [MarkdownInlineFfi],
         intent: InlinePresentationIntent,
-        link: URL?,
+        link: MarkdownDisplayLink?,
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
         truncated: inout Bool
@@ -461,7 +472,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func concat(
         _ text: String,
         intent: InlinePresentationIntent,
-        link: URL?
+        link: MarkdownDisplayLink?
     ) -> AttributedString {
         styled(text, intent: intent, link: link)
     }
@@ -469,14 +480,17 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func styled(
         _ string: String,
         intent: InlinePresentationIntent,
-        link: URL?
+        link: MarkdownDisplayLink?
     ) -> AttributedString {
         var attributed = AttributedString(PeerDisplayText.strippingBidiControls(string))
         if !intent.isEmpty {
             attributed.inlinePresentationIntent = intent
         }
         if let link {
-            attributed.link = link
+            attributed.link = link.url
+            if link.presentation == .underlined {
+                attributed.underlineStyle = .single
+            }
         }
         return attributed
     }
@@ -488,7 +502,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     ) -> AttributedString {
         let shortReference = shortBech32(entity.bech32)
         let displayText: String
-        var isMention = false
+        let presentation: MarkdownDisplayLink.Presentation
         switch entity.hrp {
         case .npub, .nprofile:
             // A known group member renders as "@Display Name"; otherwise the truncated bech32
@@ -498,22 +512,26 @@ nonisolated enum MarkdownDisplayInlineBuilder {
             } else {
                 displayText = "@\(shortReference)"
             }
-            isMention = true
+            presentation = .mention
         case .note, .nevent, .naddr, .nrelay:
             displayText = shortReference
+            presentation = .underlined
         @unknown default:
             displayText = shortReference
+            presentation = .underlined
         }
         // No baked foreground color: the bubble owns `.tint` so the linked reference stays visible
         // on both sent and received. A mention is set off by a subtle background pill (Signal's
-        // treatment) rather than bold weight or a color — `.primary` adapts to light/dark and the
-        // low alpha reads as a soft highlight over either bubble fill.
+        // treatment) rather than bold weight, a color, or a decoration — `.primary` adapts to
+        // light/dark and the low alpha reads as a soft highlight over either bubble fill.
         var attributed = styled(
             displayText,
             intent: intent,
-            link: MarkdownLinkPolicy.nostrURL(for: entity.bech32)
+            link: MarkdownLinkPolicy.nostrURL(for: entity.bech32).map {
+                MarkdownDisplayLink(url: $0, presentation: presentation)
+            }
         )
-        if isMention {
+        if presentation == .mention {
             attributed.backgroundColor = Color.primary.opacity(0.14)
         }
         return attributed

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -436,8 +436,6 @@ struct MessageBubble: View {
                 )
                 .font(.system(size: 15.5))
                 .foregroundStyle(message.isOutgoing ? .white : .primary)
-                // Links and @-mentions (no baked color) render in the tint: white on the sent
-                // gradient so they stay visible, accent on received so they read as links.
                 .tint(message.isOutgoing ? .white : .accentColor)
                 .multilineTextAlignment(.leading)
             }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -2591,6 +2591,131 @@ struct PureValueTests {
         #expect(!containsBidiEmbeddingOrIsolate(mathContent))
     }
 
+    @Test func markdownDisplayUnderlinesLinksButNotMentions() async throws {
+        let webAutolink = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.autolink(url: "https://example.com", kind: .uri, classification: .web)],
+            remainingDepth: 32
+        )
+        #expect(links(in: webAutolink).map(\.absoluteString) == ["https://example.com"])
+        #expect(underlineStyles(in: webAutolink) == [.single])
+
+        let emphasizedLink = MarkdownDisplayInlineBuilder.attributedString(
+            from: [
+                .link(
+                    dest: "https://example.com/docs",
+                    title: nil,
+                    children: [
+                        .strong(children: [.text(content: "bold")]),
+                        .text(content: " plain"),
+                    ],
+                    classification: .web
+                )
+            ],
+            remainingDepth: 32
+        )
+        #expect(String(emphasizedLink.characters) == "bold plain")
+        #expect(underlineStyles(in: emphasizedLink) == [.single, .single])
+        #expect(
+            links(in: emphasizedLink).map(\.absoluteString) == [
+                "https://example.com/docs", "https://example.com/docs",
+            ])
+        #expect(emphasizedLink.runs.first?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
+
+        let npub = "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+        let mention = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: npub))],
+            remainingDepth: 32
+        )
+        #expect(links(in: mention).map(\.absoluteString) == ["nostr:\(npub)"])
+        #expect(mention.runs.allSatisfy { $0.backgroundColor != nil })
+        #expect(underlineStyles(in: mention) == [nil])
+
+        let note = "note1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+        let noteReference = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.nostrUri(entity: MarkdownNostrEntityFfi(hrp: .note, bech32: note))],
+            remainingDepth: 32
+        )
+        #expect(links(in: noteReference).map(\.absoluteString) == ["nostr:\(note)"])
+        #expect(noteReference.runs.allSatisfy { $0.backgroundColor == nil })
+        #expect(underlineStyles(in: noteReference) == [.single])
+
+        let mentionInsideLink = MarkdownDisplayInlineBuilder.attributedString(
+            from: [
+                .link(
+                    dest: "https://example.com",
+                    title: nil,
+                    children: [
+                        .text(content: "see "),
+                        .nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: npub)),
+                    ],
+                    classification: .web
+                )
+            ],
+            remainingDepth: 32
+        )
+        #expect(underlineStyles(in: mentionInsideLink) == [.single, nil])
+        #expect(
+            links(in: mentionInsideLink).map(\.absoluteString) == [
+                "https://example.com", "nostr:\(npub)",
+            ])
+
+        let plain = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.text(content: "plain")],
+            remainingDepth: 32
+        )
+        #expect(underlineStyles(in: plain) == [nil])
+
+        let rejected: [MarkdownLinkDestinationKindFfi] = [.dangerous, .sensitive, .relative, .unknown]
+        for classification in rejected {
+            let dropped = MarkdownDisplayInlineBuilder.attributedString(
+                from: [
+                    .link(
+                        dest: "https://example.com",
+                        title: nil,
+                        children: [.text(content: "label")],
+                        classification: classification
+                    )
+                ],
+                remainingDepth: 32
+            )
+            #expect(links(in: dropped).isEmpty, "expected no link for \(classification)")
+            #expect(underlineStyles(in: dropped) == [nil], "expected no underline for \(classification)")
+        }
+    }
+
+    @Test func markdownDisplayLeavesContactAndForeignAppAutolinksInert() async throws {
+        let contactAutolinks: [MarkdownInlineFfi] = [
+            .autolink(url: "a@b.com", kind: .email, classification: .contact),
+            .autolink(url: "mailto:foo@bar.com", kind: .uri, classification: .contact),
+            .autolink(url: "tel:+15551234567", kind: .uri, classification: .contact),
+        ]
+        for inline in contactAutolinks {
+            let attributed = MarkdownDisplayInlineBuilder.attributedString(
+                from: [inline],
+                remainingDepth: 32
+            )
+            #expect(links(in: attributed).isEmpty, "expected no link for \(inline)")
+            #expect(underlineStyles(in: attributed) == [nil], "expected no underline for \(inline)")
+        }
+
+        // `whitenoise://` classifies as `.app` and stays inert — this app registers `marmot://`.
+        let foreignAppScheme = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.autolink(url: "whitenoise://group/abc", kind: .uri, classification: .app)],
+            remainingDepth: 32
+        )
+        #expect(links(in: foreignAppScheme).isEmpty)
+        #expect(underlineStyles(in: foreignAppScheme) == [nil])
+
+        // ...while `marmot://profile/<nprofile>` is the `.app` form the app does consume, so the
+        // branch is not dead.
+        let profileLink = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.autolink(url: "marmot://profile/nprofile1alyce", kind: .uri, classification: .app)],
+            remainingDepth: 32
+        )
+        #expect(links(in: profileLink).map(\.absoluteString) == ["marmot://profile/nprofile1alyce"])
+        #expect(underlineStyles(in: profileLink) == [.single])
+    }
+
     @Test func markdownInlineBuilderDropsUnsafeMarkdownLinks() async throws {
         let safe = MarkdownDisplayInlineBuilder.attributedString(
             from: [
@@ -2885,6 +3010,10 @@ struct PureValueTests {
             }
         }
         return result
+    }
+
+    private func underlineStyles(in attributed: AttributedString) -> [Text.LineStyle?] {
+        attributed.runs.map(\.underlineStyle)
     }
 
     private func groupDetailsSnapshot(avatarURL: String?, sanitizedAvatarURL: URL?) -> GroupDetailsSnapshot {


### PR DESCRIPTION
Links were rendering in message bubbles as plain text. This PR adds underlined styling and make them clickable. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Markdown link presentation with clearer underlining for supported web, app, and Nostr links.
  * Nostr mentions now display distinctly from clickable links.
  * Unsupported or sensitive link types are no longer made interactive.
* **Bug Fixes**
  * Corrected styling for nested links and supported app links.
  * Added coverage to ensure invalid and unrecognized links remain inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->