### PR TITLE
Improve media layout in message bubbles

### DIFF
--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -544,7 +544,7 @@ nonisolated struct MessageMediaDownload: Hashable, Sendable {
 }
 
 nonisolated enum MessageMediaGridPresentation {
-    static let maxVisibleItems = 4
+    static let maxVisibleItems = 6
 
     static func visibleCount(totalCount: Int) -> Int {
         min(max(totalCount, 0), maxVisibleItems)
@@ -554,24 +554,41 @@ nonisolated enum MessageMediaGridPresentation {
         max(0, totalCount - maxVisibleItems)
     }
 
-    static func columnCount(totalCount: Int) -> Int {
-        totalCount <= 1 ? 1 : 2
+    static func rowCounts(totalCount: Int) -> [Int] {
+        switch visibleCount(totalCount: totalCount) {
+        case 1: [1]
+        case 2: [2]
+        case 3: [3]
+        case 4: [2, 2]
+        case 5: [3, 2]
+        case 6...: [3, 3]
+        default: []
+        }
     }
 
-    static func rowCount(totalCount: Int) -> Int {
-        totalCount <= 2 ? 1 : 2
+    static func rowRanges(totalCount: Int) -> [Range<Int>] {
+        var ranges: [Range<Int>] = []
+        var start = 0
+        for count in rowCounts(totalCount: totalCount) {
+            ranges.append(start..<(start + count))
+            start += count
+        }
+        return ranges
     }
 
-    static func tileSide(totalCount: Int, maxWidth: CGFloat, spacing: CGFloat) -> CGFloat {
-        let columns = columnCount(totalCount: totalCount)
-        let totalSpacing = CGFloat(columns - 1) * spacing
-        return max(1, (maxWidth - totalSpacing) / CGFloat(columns))
+    static func tileSide(rowCount: Int, maxWidth: CGFloat, spacing: CGFloat) -> CGFloat {
+        guard rowCount > 0 else { return 1 }
+        let totalSpacing = CGFloat(rowCount - 1) * spacing
+        return max(1, (maxWidth - totalSpacing) / CGFloat(rowCount))
     }
 
     static func gridHeight(totalCount: Int, maxWidth: CGFloat, spacing: CGFloat) -> CGFloat {
-        let rows = rowCount(totalCount: totalCount)
-        let side = tileSide(totalCount: totalCount, maxWidth: maxWidth, spacing: spacing)
-        return CGFloat(rows) * side + CGFloat(rows - 1) * spacing
+        let rows = rowCounts(totalCount: totalCount)
+        guard !rows.isEmpty else { return 0 }
+        let tileHeights = rows.reduce(0) { partial, count in
+            partial + tileSide(rowCount: count, maxWidth: maxWidth, spacing: spacing)
+        }
+        return tileHeights + CGFloat(rows.count - 1) * spacing
     }
 }
 

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -744,66 +744,64 @@ struct MessageVisualMediaGrid: View {
         MessageMediaGridPresentation.hiddenCount(totalCount: attachments.count)
     }
 
-    private var columnCount: Int {
-        MessageMediaGridPresentation.columnCount(totalCount: attachments.count)
-    }
-
-    private var tileSide: CGFloat {
-        MessageMediaGridPresentation.tileSide(totalCount: attachments.count, maxWidth: maxWidth, spacing: spacing)
-    }
-
     private var gridHeight: CGFloat {
         MessageMediaGridPresentation.gridHeight(totalCount: attachments.count, maxWidth: maxWidth, spacing: spacing)
     }
 
-    /// The visible attachments laid out row-major into `columnCount`-wide rows. Iterating
-    /// this (keyed by `attachment.id`) instead of `ForEach(0..<columnCount)` over grid
-    /// positions ties each tile's SwiftUI identity to its attachment, so a slot that comes
-    /// to hold a different attachment gets a fresh tile/player rather than reusing the
-    /// previous attachment's `@State` (and its decrypted scratch file). See #339.
-    private var rows: [[MessageMediaAttachment]] {
-        guard columnCount > 1 else { return visibleAttachments.map { [$0] } }
-        return stride(from: 0, to: visibleAttachments.count, by: columnCount).map { start in
-            Array(visibleAttachments[start..<min(start + columnCount, visibleAttachments.count)])
-        }
+    private var rows: [MediaGridRow] {
+        let visible = visibleAttachments
+        return MessageMediaGridPresentation.rowRanges(totalCount: attachments.count)
+            .enumerated()
+            .compactMap { index, range in
+                guard !range.isEmpty, range.upperBound <= visible.count else { return nil }
+                return MediaGridRow(
+                    id: index,
+                    side: MessageMediaGridPresentation.tileSide(
+                        rowCount: range.count,
+                        maxWidth: maxWidth,
+                        spacing: spacing
+                    ),
+                    attachments: Array(visible[range])
+                )
+            }
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: spacing) {
-            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+            ForEach(rows) { row in
                 HStack(spacing: spacing) {
-                    ForEach(row) { attachment in
-                        tile(for: attachment)
-                    }
-                    // Pad a short trailing row (e.g. 3 attachments in a 2×2 grid) so tiles
-                    // keep their square width instead of stretching to fill the row.
-                    if row.count < columnCount {
-                        Color.clear
-                            .frame(width: tileSide, height: tileSide)
+                    ForEach(row.attachments) { attachment in
+                        tile(for: attachment, side: row.side)
                     }
                 }
             }
         }
         .frame(width: maxWidth, height: gridHeight, alignment: .topLeading)
-        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .clipShape(.rect(cornerRadius: cornerRadius, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                 .strokeBorder(Color.primary.opacity(isOutgoing ? 0.16 : 0.1), lineWidth: 1)
         }
     }
 
-    private func tile(for attachment: MessageMediaAttachment) -> some View {
+    private func tile(for attachment: MessageMediaAttachment, side: CGFloat) -> some View {
         let isLastVisible = attachment.id == visibleAttachments.last?.id
         return MessageVisualMediaTile(
             downloadState: workspace.mediaDownloadStateStore(for: message, attachment: attachment),
             message: message,
             attachment: attachment,
             isOutgoing: isOutgoing,
-            sideLength: tileSide,
+            sideLength: side,
             hiddenCount: isLastVisible ? hiddenCount : 0,
             onOpenImageGallery: onOpenImageGallery
         )
     }
+}
+
+private struct MediaGridRow: Identifiable {
+    let id: Int
+    let side: CGFloat
+    let attachments: [MessageMediaAttachment]
 }
 
 struct MessageVisualMediaTile: View {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6971,17 +6971,70 @@ struct whitenoise_macTests {
         #expect(message.mediaAttachments.first?.reference.fileName == reference.fileName)
     }
 
-    @Test func mediaGridPresentationUsesSquareFourTileLayout() {
-        #expect(MessageMediaGridPresentation.visibleCount(totalCount: 6) == 4)
-        #expect(MessageMediaGridPresentation.hiddenCount(totalCount: 6) == 2)
-        #expect(MessageMediaGridPresentation.columnCount(totalCount: 1) == 1)
-        #expect(MessageMediaGridPresentation.rowCount(totalCount: 1) == 1)
-        #expect(MessageMediaGridPresentation.tileSide(totalCount: 1, maxWidth: 360, spacing: 3) == 360)
+    @Test func mediaGridRowCountsMatchFlutterLayout() {
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: 0) == [])
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: 1) == [1])
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: 2) == [2])
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: 3) == [3])
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: 4) == [2, 2])
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: 5) == [3, 2])
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: 6) == [3, 3])
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: 20) == [3, 3])
+        #expect(MessageMediaGridPresentation.rowCounts(totalCount: -1) == [])
+    }
+
+    @Test func mediaGridOverflowBadgeStartsAtSeven() {
+        #expect(MessageMediaGridPresentation.visibleCount(totalCount: 6) == 6)
+        #expect(MessageMediaGridPresentation.hiddenCount(totalCount: 6) == 0)
+        #expect(MessageMediaGridPresentation.visibleCount(totalCount: 7) == 6)
+        #expect(MessageMediaGridPresentation.hiddenCount(totalCount: 7) == 1)
+        #expect(MessageMediaGridPresentation.hiddenCount(totalCount: 0) == 0)
+        // rowCounts always sums to visibleCount — no short rows, ever.
+        for total in 0...12 {
+            #expect(
+                MessageMediaGridPresentation.rowCounts(totalCount: total).reduce(0, +)
+                    == MessageMediaGridPresentation.visibleCount(totalCount: total)
+            )
+        }
+    }
+
+    @Test func mediaGridRowRangesPartitionTheVisibleAttachments() {
+        #expect(MessageMediaGridPresentation.rowRanges(totalCount: 0) == [])
+        #expect(MessageMediaGridPresentation.rowRanges(totalCount: 1) == [0..<1])
+        #expect(MessageMediaGridPresentation.rowRanges(totalCount: 2) == [0..<2])
+        #expect(MessageMediaGridPresentation.rowRanges(totalCount: 3) == [0..<3])
+        #expect(MessageMediaGridPresentation.rowRanges(totalCount: 4) == [0..<2, 2..<4])
+        #expect(MessageMediaGridPresentation.rowRanges(totalCount: 5) == [0..<3, 3..<5])
+        #expect(MessageMediaGridPresentation.rowRanges(totalCount: 6) == [0..<3, 3..<6])
+        #expect(MessageMediaGridPresentation.rowRanges(totalCount: 9) == [0..<3, 3..<6])
+
+        // Contiguous from 0 and covering exactly the visible prefix: every visible tile is
+        // placed once, and no range can ever run past `visibleAttachments`.
+        for total in 0...12 {
+            let ranges = MessageMediaGridPresentation.rowRanges(totalCount: total)
+            let visible = MessageMediaGridPresentation.visibleCount(totalCount: total)
+            #expect((ranges.first?.lowerBound ?? 0) == 0)
+            #expect((ranges.last?.upperBound ?? 0) == visible)
+            #expect(ranges.allSatisfy { !$0.isEmpty })
+            for (previous, next) in zip(ranges, ranges.dropFirst()) {
+                #expect(previous.upperBound == next.lowerBound)
+            }
+        }
+    }
+
+    @Test func mediaGridTileSidesAreSquareAndFillTheWidth() {
+        #expect(MessageMediaGridPresentation.tileSide(rowCount: 1, maxWidth: 360, spacing: 3) == 360)
+        #expect(MessageMediaGridPresentation.tileSide(rowCount: 2, maxWidth: 360, spacing: 3) == 178.5)
+        #expect(MessageMediaGridPresentation.tileSide(rowCount: 3, maxWidth: 360, spacing: 3) == 118)
+        #expect(MessageMediaGridPresentation.tileSide(rowCount: 0, maxWidth: 360, spacing: 3) == 1)
+
+        #expect(MessageMediaGridPresentation.gridHeight(totalCount: 0, maxWidth: 360, spacing: 3) == 0)
         #expect(MessageMediaGridPresentation.gridHeight(totalCount: 1, maxWidth: 360, spacing: 3) == 360)
-        #expect(MessageMediaGridPresentation.columnCount(totalCount: 4) == 2)
-        #expect(MessageMediaGridPresentation.rowCount(totalCount: 4) == 2)
-        #expect(MessageMediaGridPresentation.tileSide(totalCount: 4, maxWidth: 360, spacing: 3) == 178.5)
+        #expect(MessageMediaGridPresentation.gridHeight(totalCount: 2, maxWidth: 360, spacing: 3) == 178.5)
+        #expect(MessageMediaGridPresentation.gridHeight(totalCount: 3, maxWidth: 360, spacing: 3) == 118)
         #expect(MessageMediaGridPresentation.gridHeight(totalCount: 4, maxWidth: 360, spacing: 3) == 360)
+        #expect(MessageMediaGridPresentation.gridHeight(totalCount: 5, maxWidth: 360, spacing: 3) == 299.5)
+        #expect(MessageMediaGridPresentation.gridHeight(totalCount: 6, maxWidth: 360, spacing: 3) == 239)
     }
 
     @MainActor


### PR DESCRIPTION
Media layout in bubbles looked weird. For example, for the case of 3 images, it left the 4th space empty.  This PR changes the media layout to match the layout of the flutter app 

| Before | After| 
|----|----|
|<img  alt="before" src="https://github.com/user-attachments/assets/07cc1551-7dc4-49f0-a8a8-0e4f98a516f8" />|<img alt="after" src="https://github.com/user-attachments/assets/942c87a2-39c0-4d4d-b94d-83c6f08c49c7" />|




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media galleries can now display up to six visible tiles.
  * Gallery layouts adapt tile sizes and row arrangements for different attachment counts.
  * Overflow indicators continue to show when additional media is available.

* **Bug Fixes**
  * Improved gallery sizing and spacing across varying numbers of media items.
  * Removed unnecessary empty placeholders in incomplete rows.

* **Tests**
  * Added coverage for row distribution, overflow behavior, tile sizing, and gallery height calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->