### PR TITLE
Add private account-scoped contact nicknames

### DIFF
--- a/whitenoise-mac/Core/ContactNicknameFileStore.swift
+++ b/whitenoise-mac/Core/ContactNicknameFileStore.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+nonisolated protocol ContactNicknameStoring: AnyObject {
+    func loadAll() throws -> [String: [String: String]]
+    func write(_ nicknames: [String: String], forOwnerAccountIdHex ownerAccountIdHex: String) throws
+    func remove(forOwnerAccountIdHex ownerAccountIdHex: String) throws
+    func removeAll() throws
+}
+
+nonisolated final class ContactNicknameFileStore: ContactNicknameStoring {
+    private struct Record: Codable {
+        let version: Int
+        let ownerAccountIdHex: String
+        let nicknamesByContactIdHex: [String: String]
+    }
+
+    private static let directoryName = "Contact Nicknames"
+    private let records: ProtectedLocalMetadataFileStore<Record>
+
+    init(fileManager: FileManager = .default, directoryURL: URL? = nil) {
+        records = ProtectedLocalMetadataFileStore(
+            directoryName: Self.directoryName,
+            fileManager: fileManager,
+            directoryURL: directoryURL
+        )
+    }
+
+    convenience init(fileManager: FileManager = .default, storageRootPath: String) {
+        self.init(
+            fileManager: fileManager,
+            directoryURL: URL(fileURLWithPath: storageRootPath, isDirectory: true)
+                .appendingPathComponent(Self.directoryName, isDirectory: true)
+        )
+    }
+
+    func loadAll() throws -> [String: [String: String]] {
+        var result: [String: [String: String]] = [:]
+        for record in try records.loadAll() where record.version == 1 {
+            guard let owner = ContactNicknames.normalizedHex(record.ownerAccountIdHex) else { continue }
+            result[owner, default: [:]].merge(record.nicknamesByContactIdHex) { _, new in new }
+        }
+        return result
+    }
+
+    func write(_ nicknames: [String: String], forOwnerAccountIdHex ownerAccountIdHex: String) throws {
+        guard let owner = ContactNicknames.normalizedHex(ownerAccountIdHex) else { return }
+        guard !nicknames.isEmpty else {
+            try remove(forOwnerAccountIdHex: owner)
+            return
+        }
+        try records.write(
+            Record(version: 1, ownerAccountIdHex: owner, nicknamesByContactIdHex: nicknames),
+            forKey: owner
+        )
+    }
+
+    func remove(forOwnerAccountIdHex ownerAccountIdHex: String) throws {
+        guard let owner = ContactNicknames.normalizedHex(ownerAccountIdHex) else { return }
+        try records.remove(forKey: owner)
+    }
+
+    func removeAll() throws {
+        try records.removeAll()
+    }
+}

--- a/whitenoise-mac/Core/ContactNicknames.swift
+++ b/whitenoise-mac/Core/ContactNicknames.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+nonisolated struct ContactNicknames: Equatable, Sendable {
+    static let maxLength = 64
+
+    let ownerAccountIdHex: String
+    private let byContactIdHex: [String: String]
+    static let none = ContactNicknames(ownerAccountIdHex: "", byContactIdHex: [:])
+
+    init(ownerAccountIdHex: String, byContactIdHex: [String: String]) {
+        self.ownerAccountIdHex = Self.normalizedHex(ownerAccountIdHex) ?? ""
+        self.byContactIdHex = byContactIdHex.reduce(into: [String: String]()) { result, entry in
+            guard
+                let contact = Self.normalizedHex(entry.key),
+                let nickname = Self.sanitized(entry.value)
+            else { return }
+            result[contact] = nickname
+        }
+    }
+
+    var isEmpty: Bool { byContactIdHex.isEmpty }
+
+    func nickname(forContactAccountIdHex hex: String) -> String? {
+        guard !ownerAccountIdHex.isEmpty, let contact = Self.normalizedHex(hex) else { return nil }
+        return byContactIdHex[contact]
+    }
+
+    func displayName(forContactAccountIdHex hex: String, published: String?) -> String? {
+        nickname(forContactAccountIdHex: hex) ?? published
+    }
+
+    static func owner(
+        activeAccountIdHex: String?,
+        localAccountIdsHex: [String],
+        contactAccountIdHex: String
+    ) -> String? {
+        guard let owner = normalizedHex(activeAccountIdHex ?? ""),
+            let contact = normalizedHex(contactAccountIdHex)
+        else { return nil }
+        let contactIsLocalAccount = localAccountIdsHex.contains { normalizedHex($0) == contact }
+        return contactIsLocalAccount ? nil : owner
+    }
+
+    static func normalizedHex(_ value: String) -> String? {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().nilIfBlank
+    }
+
+    static func sanitized(_ raw: String?) -> String? {
+        guard let sanitized = PeerDisplayText.sanitize(raw) else { return nil }
+        return sanitized.count <= maxLength ? sanitized : String(sanitized.prefix(maxLength))
+    }
+}

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -44,15 +44,21 @@ extension ChatItem {
         let groupName = PeerDisplayText.sanitize(row.groupName) ?? ""
         let peerName = PeerDisplayText.sanitize(directPeer?.displayName)
         let projectedTitle = PeerDisplayText.sanitize(row.title) ?? ""
-        let title: String
-        if let peerName, !peerName.isEmpty {
-            title = peerName
-        } else if !projectedTitle.isEmpty {
-            title = projectedTitle
-        } else if !groupName.isEmpty {
-            title = groupName
-        } else {
-            title = DisplayText.short(directPeer?.accountIdHex ?? row.groupIdHex)
+        let fallbackId = directPeer?.accountIdHex ?? row.groupIdHex
+        let title = Self.resolvedTitle(
+            peerName: peerName,
+            projectedTitle: projectedTitle,
+            groupName: groupName,
+            fallbackId: fallbackId
+        )
+
+        let publishedTitle = directPeer?.publishedDisplayName?.nilIfBlank.map { peerPublishedName in
+            Self.resolvedTitle(
+                peerName: PeerDisplayText.sanitize(peerPublishedName),
+                projectedTitle: projectedTitle,
+                groupName: groupName,
+                fallbackId: fallbackId
+            )
         }
         let preview = row.lastMessage.map {
             ChatItem.previewText(for: $0, activeAccountIdHex: activeAccountIdHex, mentionNames: mentionNames)
@@ -76,6 +82,7 @@ extension ChatItem {
         self.init(
             id: row.groupIdHex,
             title: title,
+            publishedTitle: publishedTitle,
             subtitle: subtitle,
             preview: preview?.isEmpty == false ? preview! : L10n.string("No messages yet"),
             updatedAt: updatedAt,
@@ -96,6 +103,24 @@ extension ChatItem {
             pendingConfirmation: row.pendingConfirmation,
             selfMembership: ChatSelfMembership(row.selfMembership)
         )
+    }
+
+    private static func resolvedTitle(
+        peerName: String?,
+        projectedTitle: String,
+        groupName: String,
+        fallbackId: String
+    ) -> String {
+        if let peerName, !peerName.isEmpty {
+            return peerName
+        }
+        if !projectedTitle.isEmpty {
+            return projectedTitle
+        }
+        if !groupName.isEmpty {
+            return groupName
+        }
+        return DisplayText.short(fallbackId)
     }
 
     private static func previewText(
@@ -299,6 +324,11 @@ nonisolated extension MessageItem {
             replyTargetIdHex: record.replyToMessageIdHex,
             senderAccountIdHex: record.sender,
             senderName: MessageItem.senderName(
+                for: record.sender,
+                profile: senderProfile,
+                presentation: presentation
+            ),
+            publishedSenderName: MessageItem.publishedSenderName(
                 for: record.sender,
                 profile: senderProfile,
                 presentation: presentation
@@ -944,6 +974,20 @@ nonisolated extension MessageItem {
 
     private static func displayName(for sender: String, profile: ChatPeerProfile?) -> String {
         PeerDisplayText.sanitize(profile?.displayName) ?? DisplayText.short(sender)
+    }
+
+    private static func publishedSenderName(
+        for sender: String,
+        profile: ChatPeerProfile?,
+        presentation: MessagePresentation
+    ) -> String? {
+        switch presentation {
+        case .agentStreamStart, .agentActivity, .agentOperation, .groupSystem:
+            return nil
+        case .chat, .unsupported:
+            guard profile?.publishedDisplayName != nil else { return nil }
+            return PeerDisplayText.sanitize(profile?.publishedDisplayName) ?? DisplayText.short(sender)
+        }
     }
 
     private static func tagValue(_ name: String, in tags: [MessageTagFfi]) -> String? {

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -38,8 +38,12 @@ extension WorkspaceState {
             if pinnedChatStore == nil {
                 pinnedChatStore = PinnedChatFileStore(storageRootPath: storageRootPath)
             }
+            if contactNicknameStore == nil {
+                contactNicknameStore = ContactNicknameFileStore(storageRootPath: storageRootPath)
+            }
             loadHiddenMessages()
             loadPinnedChats()
+            loadContactNicknames()
             let summaries = try await runOffMain {
                 try runtime.listAccounts()
             }
@@ -361,6 +365,7 @@ extension WorkspaceState {
             clearComposerDrafts(forAccountId: removedAccountId)
             purgeHiddenMessages(accountId: removedAccountId)
             purgePinnedChats(accountId: removedAccountId)
+            purgeContactNicknames(ownerAccountIdHex: removedAccountIdHex)
             await mediaDiskCache.purgeAccount(removedAccountId)
             clearMediaReferenceResolutionCache(forAccountId: removedAccountId)
             accounts = try await accountItemsFromRuntime(client: client)
@@ -805,6 +810,7 @@ extension WorkspaceState {
         clearAllComposerDrafts()
         clearAllHiddenMessages()
         clearAllPinnedChats()
+        clearAllContactNicknames()
         clearChatRestorationTargets()
         isRefreshing = false
         isSending = false

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -633,6 +633,7 @@ extension WorkspaceState {
         ChatItem(
             id: current.id,
             title: enrichedItem.title,
+            publishedTitle: enrichedItem.publishedTitle,
             subtitle: enrichedItem.subtitle,
             preview: current.preview,
             updatedAt: current.updatedAt,
@@ -772,16 +773,21 @@ extension WorkspaceState {
             activeAccount: activeAccount,
             client: client
         )
-        let displayName = firstNonBlank([
+        let published = firstNonBlank([
             resolved?.profileDisplayName,
             resolved?.profileName,
             otherMember.displayName,
             resolved?.directoryDisplayName,
         ])
+        // A private nickname outranks every published source. Folding it in here is what makes
+        // the override reach the DM's chat-row title, and through that the forward picker,
+        // compose contacts, and the sidebar filter.
+        let nickname = activeContactNicknames.nickname(forContactAccountIdHex: memberId)
 
         return ChatPeerProfile(
             accountIdHex: memberId,
-            displayName: displayName,
+            displayName: nickname ?? published,
+            publishedDisplayName: nickname == nil ? nil : published,
             pictureURL: resolved?.profilePicture?.nilIfBlank
         )
     }
@@ -917,6 +923,9 @@ extension WorkspaceState {
             }
         }
 
+        // One snapshot for the whole batch. The self branch below deliberately skips it: you
+        // cannot nickname your own account, so your own label never changes.
+        let nicknames = activeContactNicknames
         var profiles: [String: ChatPeerProfile] = [:]
         for senderId in senderIds {
             if senderId == activeAccount.accountIdHex {
@@ -929,14 +938,17 @@ extension WorkspaceState {
             }
 
             let resolved = peerProfileFFICache[senderId]?.resolved
+            let published = firstNonBlank([
+                resolved?.profileDisplayName,
+                resolved?.profileName,
+                groupMemberNames[senderId],
+                resolved?.directoryDisplayName,
+            ])
+            let nickname = nicknames.nickname(forContactAccountIdHex: senderId)
             profiles[senderId] = ChatPeerProfile(
                 accountIdHex: senderId,
-                displayName: firstNonBlank([
-                    resolved?.profileDisplayName,
-                    resolved?.profileName,
-                    groupMemberNames[senderId],
-                    resolved?.directoryDisplayName,
-                ]),
+                displayName: nickname ?? published,
+                publishedDisplayName: nickname == nil ? nil : published,
                 pictureURL: resolved?.profilePicture?.nilIfBlank
             )
         }

--- a/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
@@ -1,0 +1,252 @@
+//
+//  WorkspaceState+ContactNicknames.swift
+//  whitenoise-mac
+//
+//  Private per-contact nicknames: a local, owner-scoped display-name override. Setting one
+//  publishes nothing — the value is folded into the same projections that resolve published
+//  names, and persisted in protected, backup-excluded per-owner files.
+//
+
+import Foundation
+import OSLog
+
+private let contactNicknameLogger = Logger(subsystem: "com.whitenoise.storage", category: "ContactNicknames")
+
+@MainActor
+extension WorkspaceState {
+    // MARK: - Load
+
+    func loadContactNicknames() {
+        guard let contactNicknameStore else { return }
+        do {
+            contactNicknamesByOwner = try contactNicknameStore.loadAll()
+        } catch {
+            contactNicknameLogger.error(
+                "Failed to load protected contact-nickname state: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+        invalidateContactNicknameCache()
+    }
+
+    // MARK: - Reads
+
+    /// The active account's nickname map. Every projection reads through this, so the override
+    /// lands on chat rows, sender labels, member rows, and recipient search from one place.
+    var activeContactNicknames: ContactNicknames {
+        // Read the observed map before the memo so a SwiftUI body that resolves a nickname stays
+        // subscribed to nickname writes even when the snapshot itself is cached.
+        _ = contactNicknamesByOwner
+        return contactNicknames(forOwnerAccountIdHex: activeAccount?.accountIdHex ?? "")
+    }
+
+    /// One specific owner's nickname map. The notification path needs this: an update can target
+    /// a background account, and resolving from `activeAccount` there would render one account's
+    /// private label on another account's banner.
+    func contactNicknames(forOwnerAccountIdHex ownerAccountIdHex: String) -> ContactNicknames {
+        guard let owner = ContactNicknames.normalizedHex(ownerAccountIdHex) else { return .none }
+        if let cached = cachedContactNicknames,
+            cached.ownerAccountIdHex == owner,
+            cached.revision == contactNicknameRevision
+        {
+            return cached.value
+        }
+        let value = ContactNicknames(
+            ownerAccountIdHex: owner,
+            byContactIdHex: contactNicknamesByOwner[owner] ?? [:]
+        )
+        cachedContactNicknames = CachedContactNicknames(
+            ownerAccountIdHex: owner,
+            revision: contactNicknameRevision,
+            value: value
+        )
+        return value
+    }
+
+    func contactNickname(forContactAccountIdHex contactAccountIdHex: String) -> String? {
+        activeContactNicknames.nickname(forContactAccountIdHex: contactAccountIdHex)
+    }
+
+    /// Whether the nickname affordance applies to this contact at all. False for one of this
+    /// device's own accounts — their local label wins — and while no account is active.
+    func canSetContactNickname(forContactAccountIdHex contactAccountIdHex: String) -> Bool {
+        contactNicknameOwner(forContactAccountIdHex: contactAccountIdHex) != nil
+    }
+
+    // MARK: - Write
+
+    /// Sets or clears the active account's private nickname for a contact. A value the
+    /// display-name sanitizer rejects (empty, whitespace/control-only) clears the entry, so
+    /// "save an empty field" and an explicit Remove land on one code path.
+    func setContactNickname(_ rawNickname: String?, forContactAccountIdHex contactAccountIdHex: String) {
+        guard let owner = contactNicknameOwner(forContactAccountIdHex: contactAccountIdHex),
+            let contact = ContactNicknames.normalizedHex(contactAccountIdHex)
+        else { return }
+
+        var byContact = contactNicknamesByOwner[owner] ?? [:]
+        byContact[contact] = ContactNicknames.sanitized(rawNickname)
+        guard byContact != (contactNicknamesByOwner[owner] ?? [:]) else { return }
+
+        contactNicknamesByOwner[owner] = byContact.isEmpty ? nil : byContact
+        invalidateContactNicknameCache()
+        persistContactNicknames(forOwnerAccountIdHex: owner)
+        applyContactNicknameChange(forContactAccountIdHex: contact)
+    }
+
+    // MARK: - Cleanup
+
+    /// Forget every nickname an account authored. Called on account removal, where the owner is
+    /// gone and its private labels have no meaning; ordinary sign-out deliberately retains them,
+    /// like pinned chats and hidden messages.
+    func purgeContactNicknames(ownerAccountIdHex: String) {
+        guard let owner = ContactNicknames.normalizedHex(ownerAccountIdHex) else { return }
+        contactNicknamesByOwner[owner] = nil
+        invalidateContactNicknameCache()
+        do {
+            try contactNicknameStore?.remove(forOwnerAccountIdHex: owner)
+        } catch {
+            contactNicknameLogger.error(
+                "Failed to purge contact-nickname state for an account: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Forget every nickname on the device — part of the "Delete All Local Data" reset.
+    func clearAllContactNicknames() {
+        contactNicknamesByOwner = [:]
+        invalidateContactNicknameCache()
+        do {
+            try contactNicknameStore?.removeAll()
+        } catch {
+            contactNicknameLogger.error(
+                "Failed to clear contact-nickname state: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    // MARK: - Projection
+
+    /// Apply a nickname change to everything already materialized, so a user gesture lands
+    /// immediately instead of waiting for the next projection. No FFI: every input is either the
+    /// in-memory nickname map or a view model already in hand.
+    func applyContactNicknameChange(forContactAccountIdHex contactAccountIdHex: String) {
+        guard let accountId = activeAccountId,
+            let contact = ContactNicknames.normalizedHex(contactAccountIdHex)
+        else { return }
+        let nickname = activeContactNicknames.nickname(forContactAccountIdHex: contact)
+
+        relabelDirectChats(forAccountId: accountId, peerAccountIdHex: contact, nickname: nickname)
+        relabelTimelineSenders(accountIdHex: contact, nickname: nickname)
+        relabelComposeContacts(accountIdHex: contact, nickname: nickname)
+        relabelContactDetailsTarget(accountIdHex: contact, nickname: nickname)
+    }
+
+    // MARK: - Private
+
+    private func contactNicknameOwner(forContactAccountIdHex contactAccountIdHex: String) -> String? {
+        ContactNicknames.owner(
+            activeAccountIdHex: activeAccount?.accountIdHex,
+            localAccountIdsHex: accounts.map(\.accountIdHex),
+            contactAccountIdHex: contactAccountIdHex
+        )
+    }
+
+    private func invalidateContactNicknameCache() {
+        contactNicknameRevision &+= 1
+        cachedContactNicknames = nil
+    }
+
+    private func persistContactNicknames(forOwnerAccountIdHex owner: String) {
+        guard let contactNicknameStore else { return }
+        do {
+            let byContact = contactNicknamesByOwner[owner] ?? [:]
+            if byContact.isEmpty {
+                try contactNicknameStore.remove(forOwnerAccountIdHex: owner)
+            } else {
+                try contactNicknameStore.write(byContact, forOwnerAccountIdHex: owner)
+            }
+        } catch {
+            contactNicknameLogger.error(
+                "Failed to persist contact-nickname state: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Retitle the direct chats whose peer is this contact. `avatarSeed` is the peer's account
+    /// hex for a direct chat, so this touches exactly those rows and never a group.
+    private func relabelDirectChats(forAccountId accountId: String, peerAccountIdHex: String, nickname: String?) {
+        // Returns nil when nothing moved, so an unrelated contact's nickname never churns the
+        // chat-list generation (and with it the memoized sidebar filter).
+        let relabeled: ([ChatItem]) -> [ChatItem]? = { chats in
+            var next = chats
+            var didChange = false
+            for index in next.indices {
+                guard next[index].isDirect,
+                    ContactNicknames.normalizedHex(next[index].avatarSeed) == peerAccountIdHex
+                else { continue }
+                let candidate = next[index].applyingNickname(nickname)
+                guard candidate != next[index] else { continue }
+                next[index] = candidate
+                didChange = true
+            }
+            return didChange ? next : nil
+        }
+
+        // Route through the setters so the chat-list generation bumps and the memoized sidebar
+        // filter recomputes against the new titles.
+        if let chats = relabeled(chatsByAccount[accountId] ?? []) {
+            setChats(chats, forAccountId: accountId)
+        }
+        if let archived = relabeled(archivedChatsByAccount[accountId] ?? []) {
+            setArchivedChats(archived, forAccountId: accountId)
+        }
+    }
+
+    /// Relabel this sender in every materialized timeline window, not just the selected chat: a
+    /// background chat's cached window would otherwise keep the stale label until reprojection.
+    private func relabelTimelineSenders(accountIdHex: String, nickname: String?) {
+        var didChangeSelectedChat = false
+        for (groupIdHex, store) in messageTimelineStores {
+            guard store.relabelSender(accountIdHex: accountIdHex, nickname: nickname) else { continue }
+            if case .chat(let selectedGroupIdHex) = selection, selectedGroupIdHex == groupIdHex {
+                didChangeSelectedChat = true
+            }
+        }
+        if didChangeSelectedChat {
+            selectedChatRevision &+= 1
+        }
+    }
+
+    private func relabelComposeContacts(accountIdHex: String, nickname: String?) {
+        guard
+            let index = composeContacts.firstIndex(where: {
+                ContactNicknames.normalizedHex($0.accountIdHex) == accountIdHex
+            })
+        else { return }
+        let existing = composeContacts[index]
+        let published = existing.publishedDisplayName ?? existing.displayName
+        composeContacts[index] = ComposeContact(
+            accountIdHex: existing.accountIdHex,
+            npub: existing.npub,
+            displayName: nickname ?? published,
+            publishedDisplayName: nickname == nil ? nil : published,
+            pictureURL: existing.pictureURL,
+            lastActivity: existing.lastActivity
+        )
+    }
+
+    private func relabelContactDetailsTarget(accountIdHex: String, nickname: String?) {
+        guard let existing = contactDetailsTarget,
+            ContactNicknames.normalizedHex(existing.accountIdHex) == accountIdHex
+        else { return }
+        let published = existing.publishedDisplayName ?? existing.displayName
+        contactDetailsTarget = NewChatRecipient(
+            sourceQuery: existing.sourceQuery,
+            memberRef: existing.memberRef,
+            accountIdHex: existing.accountIdHex,
+            npub: existing.npub,
+            displayName: nickname ?? published,
+            publishedDisplayName: nickname == nil ? nil : published,
+            pictureURL: existing.pictureURL
+        )
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+GlobalMessageSearch.swift
+++ b/whitenoise-mac/Core/WorkspaceState+GlobalMessageSearch.swift
@@ -147,6 +147,7 @@ nonisolated enum GlobalMessageSearchEngine {
         accountRef: String,
         localAccountId: String,
         localDisplayName: String,
+        nicknames: ContactNicknames = .none,
         scopes: [GlobalMessageSearchScope],
         query: String,
         checkCancellation: @escaping @Sendable () throws -> Void
@@ -207,6 +208,7 @@ nonisolated enum GlobalMessageSearchEngine {
             client: client,
             localAccountId: localAccountId,
             localDisplayName: localDisplayName,
+            nicknames: nicknames,
             tokens: tokens,
             checkCancellation: checkCancellation
         )
@@ -217,6 +219,7 @@ nonisolated enum GlobalMessageSearchEngine {
         accountRef: String,
         localAccountId: String,
         localDisplayName: String,
+        nicknames: ContactNicknames = .none,
         scopes: [GlobalMessageSearchScope],
         query: String,
         checkCancellation: @escaping @Sendable () throws -> Void
@@ -273,6 +276,7 @@ nonisolated enum GlobalMessageSearchEngine {
             client: client,
             localAccountId: localAccountId,
             localDisplayName: localDisplayName,
+            nicknames: nicknames,
             tokens: tokens,
             checkCancellation: checkCancellation
         )
@@ -283,6 +287,7 @@ nonisolated enum GlobalMessageSearchEngine {
         client: any MarmotRuntime,
         localAccountId: String,
         localDisplayName: String,
+        nicknames: ContactNicknames = .none,
         tokens: [String],
         checkCancellation: @escaping @Sendable () throws -> Void
     ) throws -> [GlobalMessageSearchResult] {
@@ -293,6 +298,13 @@ nonisolated enum GlobalMessageSearchEngine {
         ]
         for senderId in senderIds where senderId != localAccountId {
             try checkCancellation()
+            // The viewer's private nickname outranks the published sources, exactly as it does in
+            // the timeline projection. `chatTitle` needs no equivalent: the scopes it comes from
+            // are the already-nicknamed chat rows.
+            if let nickname = nicknames.nickname(forContactAccountIdHex: senderId) {
+                senderNames[senderId] = nickname
+                continue
+            }
             let profile = try? client.userProfile(accountIdHex: senderId)
             senderNames[senderId] =
                 firstNonBlank([
@@ -380,6 +392,7 @@ extension WorkspaceState {
 
         let scopes = activeChats.map { GlobalMessageSearchScope(groupId: $0.id, title: $0.title) }
         let visibleGroupIds = Set(scopes.map(\.groupId))
+        let nicknames = activeContactNicknames
         isSearchingAllMessages = true
         globalMessageSearchTask = Task { [weak self] in
             do {
@@ -391,6 +404,7 @@ extension WorkspaceState {
                         accountRef: account.accountRef,
                         localAccountId: account.accountIdHex,
                         localDisplayName: account.displayName,
+                        nicknames: nicknames,
                         scopes: scopes,
                         query: query,
                         checkCancellation: checkCancellation
@@ -450,6 +464,7 @@ extension WorkspaceState {
 
         let scopes = sidebarMessageSearchScopes
         let visibleGroupIds = Set(scopes.map(\.groupId))
+        let nicknames = activeContactNicknames
         isSearchingSidebarMessages = true
         sidebarMessageSearchTask = Task { [weak self] in
             do {
@@ -461,6 +476,7 @@ extension WorkspaceState {
                         accountRef: account.accountRef,
                         localAccountId: account.accountIdHex,
                         localDisplayName: account.displayName,
+                        nicknames: nicknames,
                         scopes: scopes,
                         query: query,
                         checkCancellation: checkCancellation

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -146,12 +146,14 @@ extension WorkspaceState {
 
         contactDetailsLoadGeneration &+= 1
         let generation = contactDetailsLoadGeneration
+        let nickname = activeContactNicknames.nickname(forContactAccountIdHex: accountIdHex)
         let fallback = NewChatRecipient(
             sourceQuery: accountIdHex,
             memberRef: npub.isEmpty ? accountIdHex : npub,
             accountIdHex: accountIdHex,
             npub: npub,
-            displayName: displayName,
+            displayName: nickname ?? displayName,
+            publishedDisplayName: Self.publishedContactName(displayName, overriddenBy: nickname),
             pictureURL: pictureURL
         )
         contactDetailsTarget = fallback
@@ -169,17 +171,19 @@ extension WorkspaceState {
             contactDetailsTarget?.accountIdHex == accountIdHex
         else { return }
 
+        let published = firstNonBlank([
+            PeerDisplayText.sanitize(resolved?.profileDisplayName),
+            PeerDisplayText.sanitize(resolved?.profileName),
+            displayName,
+            PeerDisplayText.sanitize(resolved?.directoryDisplayName),
+        ])
         contactDetailsTarget = NewChatRecipient(
             sourceQuery: accountIdHex,
             memberRef: npub.isEmpty ? accountIdHex : npub,
             accountIdHex: accountIdHex,
             npub: npub,
-            displayName: firstNonBlank([
-                PeerDisplayText.sanitize(resolved?.profileDisplayName),
-                PeerDisplayText.sanitize(resolved?.profileName),
-                displayName,
-                PeerDisplayText.sanitize(resolved?.directoryDisplayName),
-            ]),
+            displayName: nickname ?? published,
+            publishedDisplayName: Self.publishedContactName(published, overriddenBy: nickname),
             pictureURL: resolved?.profilePicture?.nilIfBlank ?? pictureURL
         )
         await commonGroups
@@ -188,11 +192,16 @@ extension WorkspaceState {
         }
     }
 
+    static func publishedContactName(_ published: String?, overriddenBy nickname: String?) -> String? {
+        guard let nickname, let published = published?.nilIfBlank, published != nickname else { return nil }
+        return published
+    }
+
     func showContactDetails(for member: GroupMemberItem) async {
         await showContactDetails(
             accountIdHex: member.id,
             npub: member.npub,
-            displayName: member.displayName,
+            displayName: member.publishedDisplayName ?? member.displayName,
             pictureURL: nil
         )
     }
@@ -200,7 +209,7 @@ extension WorkspaceState {
     func showContactDetails(for message: MessageItem) async {
         await showContactDetails(
             accountIdHex: message.senderAccountIdHex,
-            displayName: message.senderName,
+            displayName: message.publishedSenderName ?? message.senderName,
             pictureURL: message.senderPictureURL
         )
     }

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -79,17 +79,19 @@ extension WorkspaceState {
                 directoryDisplayName: client.displayName(accountIdHex: member.accountIdHex)
             )
         }
-        let displayName = firstNonBlank([
+        let published = firstNonBlank([
             PeerDisplayText.sanitize(resolved?.profileDisplayName),
             PeerDisplayText.sanitize(resolved?.profileName),
             PeerDisplayText.sanitize(resolved?.directoryDisplayName),
         ])
+        let nickname = activeContactNicknames.nickname(forContactAccountIdHex: member.accountIdHex)
         return NewChatRecipient(
             sourceQuery: query,
             memberRef: member.memberRef,
             accountIdHex: member.accountIdHex,
             npub: member.npub,
-            displayName: displayName,
+            displayName: nickname ?? published,
+            publishedDisplayName: Self.publishedContactName(published, overriddenBy: nickname),
             pictureURL: resolved?.profilePicture
         )
     }
@@ -377,6 +379,7 @@ extension WorkspaceState {
         let generation = composeContactsGeneration
         let accountId = activeAccount.id
         let selfHex = activeAccount.accountIdHex
+        let nicknames = activeContactNicknames
 
         var byHex: [String: ComposeContact] = [:]
         let chats = (chatsByAccount[accountId] ?? []) + (archivedChatsByAccount[accountId] ?? [])
@@ -388,6 +391,7 @@ extension WorkspaceState {
                 accountIdHex: hex,
                 npub: existing?.npub ?? "",
                 displayName: chat.title,
+                publishedDisplayName: chat.publishedTitle,
                 pictureURL: chat.pictureURL ?? existing?.pictureURL,
                 lastActivity: latestDate(existing?.lastActivity, chat.updatedAt)
             )
@@ -427,10 +431,13 @@ extension WorkspaceState {
                 if let existing, !existing.npub.isEmpty {
                     npub = existing.npub
                 }
+                let published = existing?.publishedDisplayName ?? existing?.displayName ?? member.displayName
+                let nickname = nicknames.nickname(forContactAccountIdHex: hex)
                 byHex[hex] = ComposeContact(
                     accountIdHex: hex,
                     npub: npub,
-                    displayName: existing?.displayName ?? member.displayName,
+                    displayName: nickname ?? published,
+                    publishedDisplayName: Self.publishedContactName(published, overriddenBy: nickname),
                     pictureURL: existing?.pictureURL,
                     lastActivity: latestDate(existing?.lastActivity, group.updatedAt)
                 )
@@ -439,19 +446,25 @@ extension WorkspaceState {
         }
     }
 
-    /// Name-filtered contacts, prefix matches ranked before contained matches.
     func filteredComposeContacts(matching query: String) -> [ComposeContact] {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else { return composeContacts }
         var prefixMatches: [ComposeContact] = []
         var containedMatches: [ComposeContact] = []
         for contact in composeContacts {
-            let title = contact.title
-            guard let range = title.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive])
-            else { continue }
-            if range.lowerBound == title.startIndex {
+            let isPrefixMatch = contact.searchableNames.contains { name in
+                guard let range = name.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive])
+                else { return false }
+                return range.lowerBound == name.startIndex
+            }
+            if isPrefixMatch {
                 prefixMatches.append(contact)
-            } else {
+                continue
+            }
+            let isContainedMatch = contact.searchableNames.contains { name in
+                name.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+            }
+            if isContainedMatch {
                 containedMatches.append(contact)
             }
         }

--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -212,8 +212,11 @@ extension WorkspaceState {
     }
 
     func localNotificationRequest(for update: NotificationUpdateFfi) -> LocalNotificationRequest {
+        let nickname = contactNicknames(forOwnerAccountIdHex: update.accountIdHex)
+            .nickname(forContactAccountIdHex: update.sender.accountIdHex)
         let senderName =
-            PeerDisplayText.sanitize(update.sender.displayName)
+            nickname
+            ?? PeerDisplayText.sanitize(update.sender.displayName)
             ?? PeerDisplayText.sanitize(update.sender.accountIdHex)
             ?? L10n.string("Someone")
         let senderTemplateName = PeerDisplayText.templateFragment(senderName)

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -513,6 +513,54 @@ final class MessageTimelineStore {
         )
     }
 
+    @discardableResult
+    func relabelSender(accountIdHex: String, nickname: String?) -> Bool {
+        var didChange = false
+        for index in messages.indices {
+            guard messages[index].senderAccountIdHex == accountIdHex,
+                let relabeled = messages[index].applyingSenderNickname(nickname)
+            else { continue }
+            messages[index] = relabeled
+            lookup[relabeled.id] = relabeled
+            didChange = true
+        }
+        for (id, base) in baseMessagesById where base.senderAccountIdHex == accountIdHex {
+            guard let relabeled = base.applyingSenderNickname(nickname) else { continue }
+            baseMessagesById[id] = relabeled
+            didChange = true
+        }
+        if relabelReplyQuotes(ofSender: accountIdHex) {
+            didChange = true
+        }
+        guard didChange else { return false }
+        rebuildDisplayItems()
+        return true
+    }
+
+    private func relabelReplyQuotes(ofSender accountIdHex: String) -> Bool {
+        var didChange = false
+        for index in messages.indices {
+            guard let targetId = messages[index].replyContext?.targetMessageId,
+                let target = lookup[targetId],
+                target.senderAccountIdHex == accountIdHex,
+                let relabeled = messages[index].applyingReplyContextSenderName(target.senderName)
+            else { continue }
+            messages[index] = relabeled
+            lookup[relabeled.id] = relabeled
+            didChange = true
+        }
+        for (id, base) in baseMessagesById {
+            guard let targetId = base.replyContext?.targetMessageId,
+                let target = lookup[targetId],
+                target.senderAccountIdHex == accountIdHex,
+                let relabeled = base.applyingReplyContextSenderName(target.senderName)
+            else { continue }
+            baseMessagesById[id] = relabeled
+            didChange = true
+        }
+        return didChange
+    }
+
     /// Refreshes date-sensitive day labels after a calendar rollover or locale change. Calls made
     /// repeatedly within the same calendar day and locale are intentionally O(1).
     func refreshDisplayItems(
@@ -937,6 +985,10 @@ final class WorkspaceState {
     @ObservationIgnored let mediaDiskCache: MessageMediaDiskCache
     @ObservationIgnored var hiddenMessageStore: (any HiddenMessageStoring)?
     @ObservationIgnored var pinnedChatStore: (any PinnedChatStoring)?
+    @ObservationIgnored var contactNicknameStore: (any ContactNicknameStoring)?
+    var contactNicknamesByOwner: [String: [String: String]] = [:]
+    @ObservationIgnored var contactNicknameRevision: UInt64 = 0
+    @ObservationIgnored var cachedContactNicknames: CachedContactNicknames?
     @ObservationIgnored let chatRestorationStore: any ChatRestorationStoring
     @ObservationIgnored var shouldResolveStartupChatSelection = true
     @ObservationIgnored let quickReactionStore: any QuickReactionStoring
@@ -1574,6 +1626,12 @@ final class WorkspaceState {
         }
     }
 
+    struct CachedContactNicknames {
+        let ownerAccountIdHex: String
+        let revision: UInt64
+        let value: ContactNicknames
+    }
+
     /// Cached raw output of the per-sender profile FFI lookups.
     struct ResolvedPeerFFI: Sendable {
         var profileDisplayName: String?
@@ -1766,6 +1824,7 @@ final class WorkspaceState {
         mediaDiskCache: MessageMediaDiskCache = .shared,
         hiddenMessageStore: (any HiddenMessageStoring)? = nil,
         pinnedChatStore: (any PinnedChatStoring)? = nil,
+        contactNicknameStore: (any ContactNicknameStoring)? = nil,
         chatRestorationStore: (any ChatRestorationStoring)? = nil,
         quickReactionStore: (any QuickReactionStoring)? = nil,
         clientFactory: @escaping @MainActor () throws -> any MarmotRuntime = { try MarmotClient() }
@@ -1789,6 +1848,7 @@ final class WorkspaceState {
         self.mediaDiskCache = mediaDiskCache
         self.hiddenMessageStore = hiddenMessageStore
         self.pinnedChatStore = pinnedChatStore
+        self.contactNicknameStore = contactNicknameStore
         let resolvedChatRestorationStore =
             chatRestorationStore ?? UserDefaultsChatRestorationStore()
         self.chatRestorationStore = resolvedChatRestorationStore
@@ -2318,17 +2378,24 @@ final class WorkspaceState {
             managementState.memberActions.map { ($0.memberIdHex, $0) },
             uniquingKeysWith: { _, new in new }
         )
+        let nicknames = activeContactNicknames
         let members = details.members
             .map { member in
                 let action = actionByMemberId[member.memberIdHex]
-                let displayName =
+                let published =
                     firstNonBlank([
                         PeerDisplayText.sanitize(member.displayName),
                         PeerDisplayText.sanitize(member.account),
                     ]) ?? DisplayText.short(member.npub, head: 12, tail: 8)
+                // You cannot nickname yourself, so `isSelf` rows always read the published name.
+                let nickname =
+                    member.isSelf
+                    ? nil : nicknames.nickname(forContactAccountIdHex: member.memberIdHex)
+                let displayName = nickname ?? published
                 return GroupMemberItem(
                     id: member.memberIdHex,
                     displayName: displayName,
+                    publishedDisplayName: nickname == nil ? nil : published,
                     npub: member.npub,
                     accountLabel: PeerDisplayText.sanitize(member.account),
                     isLocal: member.local,

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -17046,6 +17046,65 @@
         }
       }
     },
+    "Edit Nickname": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spitznamen bearbeiten"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar apodo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier le surnom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica soprannome"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar apelido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить псевдоним"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Takma adı düzenle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑昵称"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯暱稱"
+          }
+        }
+      }
+    },
     "Edit group name": {
       "extractionState": "manual",
       "localizations": {
@@ -17341,6 +17400,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在編輯訊息"
+          }
+        }
+      }
+    },
+    "Edit…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bearbeiten …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Düzenle…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯…"
           }
         }
       }
@@ -29051,6 +29169,65 @@
         }
       }
     },
+    "Name from profile: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name im Profil: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del perfil: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom du profil : %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome dal profilo: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome do perfil: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Имя из профиля: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profildeki ad: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "资料中的名称：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "個人資料名稱：%@"
+          }
+        }
+      }
+    },
     "Name or npub": {
       "extractionState": "manual",
       "localizations": {
@@ -29814,6 +29991,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "下一張圖片"
+          }
+        }
+      }
+    },
+    "Nickname": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spitzname"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apodo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surnom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soprannome"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apelido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Псевдоним"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Takma ad"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昵称"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暱稱"
           }
         }
       }
@@ -33006,6 +33242,124 @@
           "stringUnit": {
             "state": "translated",
             "value": "只有管​​理員可以管理群組成員。"
+          }
+        }
+      }
+    },
+    "Only you see this on this device. Clearing it restores their profile name.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur du siehst das auf diesem Gerät. Wenn du es löschst, gilt wieder der Profilname."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo tú lo ves en este dispositivo. Si lo borras, se restaura el nombre de su perfil."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous seul le voyez sur cet appareil. En l’effaçant, le nom du profil est rétabli."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo tu lo vedi su questo dispositivo. Cancellandolo torna il nome del profilo."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Só você vê isto neste dispositivo. Ao apagar, o nome do perfil volta a ser usado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это видно только вам на этом устройстве. Если удалить, вернётся имя из профиля."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bunu bu cihazda yalnızca sen görürsün. Silersen profil adı geri gelir."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅你在此设备上可见。清空后将恢复其资料名称。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "只有你在這台裝置上看得到。清空後會恢復其個人資料名稱。"
+          }
+        }
+      }
+    },
+    "Only you see this on this device. It is never published.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nur du siehst das auf diesem Gerät. Es wird nie veröffentlicht."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo tú lo ves en este dispositivo. Nunca se publica."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous seul le voyez sur cet appareil. Il n’est jamais publié."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solo tu lo vedi su questo dispositivo. Non viene mai pubblicato."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Só você vê isto neste dispositivo. Nunca é publicado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это видно только вам на этом устройстве и никогда не публикуется."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bunu bu cihazda yalnızca sen görürsün. Asla yayımlanmaz."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅你在此设备上可见，绝不会发布。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "只有你在這台裝置上看得到，絕不會發布。"
           }
         }
       }
@@ -43062,6 +43416,65 @@
         }
       }
     },
+    "Set Nickname": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spitznamen festlegen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poner apodo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir un surnom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta soprannome"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir apelido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Задать псевдоним"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Takma ad belirle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置昵称"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定暱稱"
+          }
+        }
+      }
+    },
     "Set group image": {
       "comment": "A button that lets the user set a group image.",
       "extractionState": "manual",
@@ -43296,6 +43709,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "設定首頁"
+          }
+        }
+      }
+    },
+    "Set…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Festlegen …"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poner…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Définir…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imposta…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definir…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Задать…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belirle…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定…"
           }
         }
       }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -107,7 +107,8 @@ nonisolated enum ChatSelfMembership: Hashable {
 
 nonisolated struct ChatItem: Identifiable, Hashable {
     let id: String
-    let title: String
+    var title: String
+    var publishedTitle: String?
     let subtitle: String
     let preview: String
     let updatedAt: Date?
@@ -149,6 +150,35 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     /// True when the local account can use the outbound composer for this chat.
     var canUseComposer: Bool { !pendingConfirmation && !isNoLongerMember }
 
+    /// The other party's account hex, for a direct chat whose peer has actually resolved.
+    ///
+    /// `avatarSeed` carries that hex, but falls back to the group id whenever no peer resolved —
+    /// before roster enrichment lands, and permanently for a note-to-self chat, which has no other
+    /// member. Contact affordances must key off this rather than the seed, so they never offer to
+    /// act on a group id as though it were a person.
+    var directPeerAccountIdHex: String? {
+        guard isDirect, avatarSeed != id else { return nil }
+        return avatarSeed
+    }
+
+    /// A copy whose title reflects `nickname`, leaving every other field identical.
+    ///
+    /// Applying a private nickname must not re-run chat-list enrichment, so a nickname write
+    /// patches the affected rows through here instead. `publishedTitle` records the title being
+    /// overridden, which is also what restores it when the nickname is cleared.
+    nonisolated func applyingNickname(_ nickname: String?) -> ChatItem {
+        let published = publishedTitle ?? title
+        var copy = self
+        if let nickname {
+            copy.title = nickname
+            copy.publishedTitle = nickname == published ? nil : published
+        } else {
+            copy.title = published
+            copy.publishedTitle = nil
+        }
+        return copy
+    }
+
     /// Re-derives the relative spelling against a wall-clock reference date. Views use
     /// this when the calendar day changes; `timestampLabel` remains the cheap mapping-time
     /// value used during ordinary renders.
@@ -163,6 +193,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     init(
         id: String,
         title: String,
+        publishedTitle: String? = nil,
         subtitle: String,
         preview: String,
         updatedAt: Date?,
@@ -186,6 +217,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     ) {
         self.id = id
         self.title = title
+        self.publishedTitle = publishedTitle
         self.subtitle = subtitle
         self.preview = preview
         self.updatedAt = updatedAt
@@ -230,12 +262,28 @@ nonisolated enum ChatMessageDeliveryState: Hashable, Sendable {
 nonisolated struct ChatPeerProfile: Hashable, Sendable {
     let accountIdHex: String
     let displayName: String?
+    let publishedDisplayName: String?
     let pictureURL: String?
+
+    init(
+        accountIdHex: String,
+        displayName: String?,
+        publishedDisplayName: String? = nil,
+        pictureURL: String?
+    ) {
+        self.accountIdHex = accountIdHex
+        self.displayName = displayName
+        self.publishedDisplayName = publishedDisplayName
+        self.pictureURL = pictureURL
+    }
 }
 
 struct GroupMemberItem: Identifiable, Hashable {
     let id: String
+    /// The viewer's private nickname for this member when one is set, else the published name.
     let displayName: String
+    /// The published name `displayName` overrides; nil when no nickname applies.
+    let publishedDisplayName: String?
     let npub: String
     let accountLabel: String?
     let isLocal: Bool
@@ -392,7 +440,9 @@ nonisolated struct MessageReaction: Identifiable, Hashable {
 
 nonisolated struct MessageReplyContext: Hashable {
     let targetMessageId: String
-    let senderName: String
+    /// `var` so a private-nickname write can relabel a quote already on screen without
+    /// re-projecting the timeline. See `MessageItem.applyingSenderNickname(_:)`.
+    var senderName: String
     let body: String
 }
 
@@ -1734,7 +1784,13 @@ nonisolated struct MessageItem: Identifiable, Hashable {
     let retentionExpiresAt: UInt64?
     let replyTargetIdHex: String?
     let senderAccountIdHex: String
-    let senderName: String
+    /// The viewer's private nickname for the sender when one is set, else the resolved
+    /// published name. `var` so a nickname write can relabel rows already materialized in a
+    /// timeline window — see `applyingSenderNickname(_:)`.
+    var senderName: String
+    /// The published sender name `senderName` overrides; nil when no nickname applies. Carried on
+    /// the row so clearing a nickname restores the real name without consulting a profile cache.
+    var publishedSenderName: String?
     let senderPictureURL: String?
     let body: String
     /// Canonical plaintext used when editing or forwarding. For edited messages, `body` is the
@@ -1754,7 +1810,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
     let isEdited: Bool
     let isOutgoing: Bool
     let reactions: [MessageReaction]
-    let replyContext: MessageReplyContext?
+    var replyContext: MessageReplyContext?
     let mediaAttachments: [MessageMediaAttachment]
     let visualMediaAttachments: [MessageMediaAttachment]
     let nonvisualMediaAttachments: [MessageMediaAttachment]
@@ -1766,6 +1822,29 @@ nonisolated struct MessageItem: Identifiable, Hashable {
 
     /// Whether the bubble should render the parsed Markdown AST instead of plain text.
     var rendersMarkdown: Bool { contentMarkdown != nil }
+    nonisolated func applyingSenderNickname(_ nickname: String?) -> MessageItem? {
+        let published = publishedSenderName ?? senderName
+        var copy = self
+        if let nickname {
+            copy.senderName = nickname
+            copy.publishedSenderName = nickname == published ? nil : published
+        } else {
+            copy.senderName = published
+            copy.publishedSenderName = nil
+        }
+        return copy == self ? nil : copy
+    }
+
+    /// Relabels the sender of the message this row quotes. A quote stores a resolved name rather
+    /// than an account id, so the timeline store resolves the quoted row and hands over its
+    /// post-relabel `senderName`. Returns nil when nothing changes.
+    nonisolated func applyingReplyContextSenderName(_ senderName: String) -> MessageItem? {
+        guard var context = replyContext, context.senderName != senderName else { return nil }
+        context.senderName = senderName
+        var copy = self
+        copy.replyContext = context
+        return copy
+    }
 
     /// A single rendered emoji, including multi-scalar flags, skin tones, keycaps, and
     /// joined families. Used by the chat row to opt into the large, bubble-free treatment.
@@ -1825,6 +1904,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         replyTargetIdHex: String? = nil,
         senderAccountIdHex: String? = nil,
         senderName: String,
+        publishedSenderName: String? = nil,
         senderPictureURL: String? = nil,
         body: String,
         wireBody: String? = nil,
@@ -1854,6 +1934,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         self.replyTargetIdHex = Self.nonBlank(replyTargetIdHex)
         self.senderAccountIdHex = senderAccountIdHex ?? senderName
         self.senderName = senderName
+        self.publishedSenderName = publishedSenderName
         self.senderPictureURL = senderPictureURL
         self.body = body
         self.wireBody = wireBody ?? body
@@ -1938,6 +2019,7 @@ nonisolated struct MessageItem: Identifiable, Hashable {
             replyTargetIdHex: replyTargetIdHex,
             senderAccountIdHex: senderAccountIdHex,
             senderName: senderName,
+            publishedSenderName: publishedSenderName,
             senderPictureURL: senderPictureURL,
             body: body,
             wireBody: wireBody,
@@ -2568,6 +2650,7 @@ struct NewChatRecipient: Equatable {
     let accountIdHex: String
     let npub: String
     let displayName: String?
+    let publishedDisplayName: String?
     let pictureURL: String?
     /// Pre-sanitized once from the peer-controlled raw URL so recipient rows only read it.
     let sanitizedPictureURL: URL?
@@ -2578,6 +2661,7 @@ struct NewChatRecipient: Equatable {
         accountIdHex: String,
         npub: String,
         displayName: String?,
+        publishedDisplayName: String? = nil,
         pictureURL: String?
     ) {
         self.sourceQuery = sourceQuery
@@ -2585,6 +2669,7 @@ struct NewChatRecipient: Equatable {
         self.accountIdHex = accountIdHex
         self.npub = npub
         self.displayName = PeerDisplayText.sanitize(displayName)
+        self.publishedDisplayName = PeerDisplayText.sanitize(publishedDisplayName)
         self.pictureURL = pictureURL
         self.sanitizedPictureURL = RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
     }
@@ -2615,6 +2700,7 @@ struct ComposeContact: Identifiable, Equatable {
     let accountIdHex: String
     let npub: String
     let displayName: String?
+    let publishedDisplayName: String?
     let pictureURL: String?
     let sanitizedPictureURL: URL?
     let lastActivity: Date?
@@ -2625,12 +2711,14 @@ struct ComposeContact: Identifiable, Equatable {
         accountIdHex: String,
         npub: String,
         displayName: String?,
+        publishedDisplayName: String? = nil,
         pictureURL: String?,
         lastActivity: Date?
     ) {
         self.accountIdHex = accountIdHex
         self.npub = npub
         self.displayName = PeerDisplayText.sanitize(displayName)
+        self.publishedDisplayName = PeerDisplayText.sanitize(publishedDisplayName)
         self.pictureURL = pictureURL
         self.sanitizedPictureURL = RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
         self.lastActivity = lastActivity
@@ -2638,6 +2726,10 @@ struct ComposeContact: Identifiable, Equatable {
 
     var title: String {
         displayName ?? DisplayText.short(npub.isEmpty ? accountIdHex : npub)
+    }
+
+    var searchableNames: [String] {
+        [title, publishedDisplayName].compactMap { $0 }
     }
 
     var subtitle: String {
@@ -2655,6 +2747,7 @@ struct ComposeContact: Identifiable, Equatable {
             accountIdHex: accountIdHex,
             npub: npub,
             displayName: displayName,
+            publishedDisplayName: publishedDisplayName,
             pictureURL: pictureURL
         )
     }
@@ -2666,6 +2759,7 @@ enum ChatFilter {
         guard !needle.isEmpty else { return chats }
         return chats.filter { chat in
             chat.title.localizedCaseInsensitiveContains(needle)
+                || chat.publishedTitle?.localizedCaseInsensitiveContains(needle) == true
                 || chat.subtitle.localizedCaseInsensitiveContains(needle)
                 || chat.preview.localizedCaseInsensitiveContains(needle)
         }

--- a/whitenoise-mac/Views/ContactNicknameViews.swift
+++ b/whitenoise-mac/Views/ContactNicknameViews.swift
@@ -1,0 +1,91 @@
+//
+//  ContactNicknameViews.swift
+//  whitenoise-mac
+//
+//  Set / Edit / Remove a private nickname for one contact. Shared by the contact-details pane
+//  and the direct-message details pane so the gesture behaves identically wherever it appears.
+//
+
+import SwiftUI
+
+struct ContactNicknameRow: View {
+    @Environment(WorkspaceState.self) private var workspace
+
+    let accountIdHex: String
+    /// The contact's published name, shown as secondary context while a nickname hides it. Pass
+    /// nil when nothing is being overridden or no published name has resolved yet.
+    let publishedName: String?
+
+    @State private var isEditingNickname = false
+    @State private var nicknameDraft = ""
+
+    private var nickname: String? {
+        workspace.contactNickname(forContactAccountIdHex: accountIdHex)
+    }
+
+    var body: some View {
+        // Absent for one of this device's own accounts: a local account's own label wins, so
+        // there is no override to offer rather than a dead control.
+        if workspace.canSetContactNickname(forContactAccountIdHex: accountIdHex) {
+            VStack(alignment: .leading, spacing: 6) {
+                LabeledContent(L10n.string("Nickname")) {
+                    HStack(spacing: 10) {
+                        if let nickname {
+                            Text(nickname)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        } else {
+                            Text(L10n.string("None"))
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        Button(nickname == nil ? L10n.string("Set…") : L10n.string("Edit…")) {
+                            nicknameDraft = nickname ?? ""
+                            isEditingNickname = true
+                        }
+
+                        if nickname != nil {
+                            Button(L10n.string("Remove"), role: .destructive) {
+                                workspace.setContactNickname(nil, forContactAccountIdHex: accountIdHex)
+                            }
+                        }
+                    }
+                }
+
+                // Never let a private label be silently mistaken for what the contact calls
+                // themselves: while a nickname is in force, the published name stays visible.
+                if nickname != nil, let publishedName {
+                    Text(
+                        String(
+                            format: L10n.string("Name from profile: %@"),
+                            PeerDisplayText.templateFragment(publishedName)
+                        )
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                }
+
+                Text(L10n.string("Only you see this on this device. It is never published."))
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            .alert(
+                nickname == nil ? L10n.string("Set Nickname") : L10n.string("Edit Nickname"),
+                isPresented: $isEditingNickname
+            ) {
+                TextField(L10n.string("Nickname"), text: $nicknameDraft)
+                Button(L10n.string("Save")) {
+                    // An emptied field is the remove gesture, so Save and Remove converge on one
+                    // code path in `setContactNickname`.
+                    workspace.setContactNickname(nicknameDraft, forContactAccountIdHex: accountIdHex)
+                }
+                Button(L10n.string("Cancel"), role: .cancel) {}
+            } message: {
+                Text(L10n.string("Only you see this on this device. Clearing it restores their profile name."))
+            }
+        }
+    }
+}

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -249,6 +249,14 @@ struct GroupDetailsSheet: View {
                             }
                         }
                     }
+                    if let contactAccountIdHex = chat.directPeerAccountIdHex {
+                        Section(L10n.string("Contact")) {
+                            ContactNicknameRow(
+                                accountIdHex: contactAccountIdHex,
+                                publishedName: chat.publishedTitle
+                            )
+                        }
+                    }
 
                     Section(L10n.string("Profile")) {
                         TextField(L10n.string("Group name"), text: $workspace.groupProfileDraftName)
@@ -871,6 +879,11 @@ struct ContactDetailsView: View {
 
             Form {
                 Section(L10n.string("Contact")) {
+                    ContactNicknameRow(
+                        accountIdHex: contact.accountIdHex,
+                        publishedName: contact.publishedDisplayName
+                    )
+
                     LabeledContent(L10n.string("Public key")) {
                         Text(contact.npub.isEmpty ? contact.accountIdHex : contact.npub)
                             .font(.callout.monospaced())

--- a/whitenoise-macTests/ContactNicknameTests.swift
+++ b/whitenoise-macTests/ContactNicknameTests.swift
@@ -1,0 +1,460 @@
+import Foundation
+import MarmotKit
+import Testing
+
+@testable import whitenoise_mac
+
+private let aliceAccountIdHex = String(repeating: "a", count: 64)
+private let bidiOnlyPublishedName = "\u{202E}\u{200F}"
+
+struct ContactNicknameValueTests {
+
+    @Test func hexComponentsAreTrimmedAndLowercased() {
+        let nicknames = ContactNicknames(
+            ownerAccountIdHex: "  OWNER  ",
+            byContactIdHex: ["  CONTACT  ": "Mum"]
+        )
+
+        #expect(nicknames.ownerAccountIdHex == "owner")
+        #expect(nicknames.nickname(forContactAccountIdHex: "contact") == "Mum")
+        #expect(nicknames.nickname(forContactAccountIdHex: " CoNtAcT ") == "Mum")
+    }
+
+    @Test func blankComponentsNeverResolve() {
+        let nicknames = ContactNicknames(ownerAccountIdHex: "owner", byContactIdHex: ["": "Mum", "  ": "Dad"])
+
+        #expect(nicknames.isEmpty)
+        #expect(nicknames.nickname(forContactAccountIdHex: "") == nil)
+        #expect(nicknames.nickname(forContactAccountIdHex: "   ") == nil)
+    }
+
+    /// An unresolved owner must read as "no nicknames" rather than falling through to whatever
+    /// entries happen to be in hand — that is what keeps the signed-out window from borrowing
+    /// another account's private labels.
+    @Test func emptyOwnerResolvesNothing() {
+        let nicknames = ContactNicknames(ownerAccountIdHex: "   ", byContactIdHex: ["contact": "Mum"])
+
+        #expect(nicknames.ownerAccountIdHex.isEmpty)
+        #expect(nicknames.nickname(forContactAccountIdHex: "contact") == nil)
+        #expect(nicknames.displayName(forContactAccountIdHex: "contact", published: "Alice") == "Alice")
+        #expect(ContactNicknames.none.nickname(forContactAccountIdHex: "contact") == nil)
+    }
+
+    @Test func nicknameOutranksThePublishedNameAndFallsBackWhenAbsent() {
+        let nicknames = ContactNicknames(ownerAccountIdHex: "owner", byContactIdHex: ["alice": "Mum"])
+
+        #expect(nicknames.displayName(forContactAccountIdHex: "alice", published: "Alice") == "Mum")
+        #expect(nicknames.displayName(forContactAccountIdHex: "alice", published: nil) == "Mum")
+        #expect(nicknames.displayName(forContactAccountIdHex: "bob", published: "Bob") == "Bob")
+        #expect(nicknames.displayName(forContactAccountIdHex: "bob", published: nil) == nil)
+    }
+
+    @Test func twoOwnersResolveIndependently() {
+        let first = ContactNicknames(ownerAccountIdHex: "owner-a", byContactIdHex: ["alice": "Mum"])
+        let second = ContactNicknames(ownerAccountIdHex: "owner-b", byContactIdHex: ["alice": "Boss"])
+
+        #expect(first.nickname(forContactAccountIdHex: "alice") == "Mum")
+        #expect(second.nickname(forContactAccountIdHex: "alice") == "Boss")
+        #expect(first != second)
+    }
+
+    @Test func storedValuesAreReSanitizedOnConstruction() {
+        let nicknames = ContactNicknames(
+            ownerAccountIdHex: "owner",
+            byContactIdHex: [
+                "alice": "M\u{202E}um",
+                "bob": "\u{202E}\u{200F}",
+                "carol": "   ",
+                "dave": "\u{0007}",
+            ]
+        )
+
+        #expect(nicknames.nickname(forContactAccountIdHex: "alice") == "Mum")
+        #expect(nicknames.nickname(forContactAccountIdHex: "bob") == nil)
+        #expect(nicknames.nickname(forContactAccountIdHex: "carol") == nil)
+        #expect(nicknames.nickname(forContactAccountIdHex: "dave") == nil)
+    }
+
+    @Test func sanitizedRejectsBlankInputAndBoundsLength() {
+        #expect(ContactNicknames.sanitized(nil) == nil)
+        #expect(ContactNicknames.sanitized("") == nil)
+        #expect(ContactNicknames.sanitized("   \n ") == nil)
+        #expect(ContactNicknames.sanitized(" Mum ") == "Mum")
+
+        let long = String(repeating: "a", count: ContactNicknames.maxLength + 25)
+        #expect(ContactNicknames.sanitized(long)?.count == ContactNicknames.maxLength)
+    }
+
+    // MARK: - Owner gate
+
+    @Test func noActiveAccountMeansNoOwner() {
+        #expect(
+            ContactNicknames.owner(
+                activeAccountIdHex: nil,
+                localAccountIdsHex: ["owner"],
+                contactAccountIdHex: "alice"
+            ) == nil
+        )
+        #expect(
+            ContactNicknames.owner(
+                activeAccountIdHex: "   ",
+                localAccountIdsHex: ["owner"],
+                contactAccountIdHex: "alice"
+            ) == nil
+        )
+    }
+
+    @Test func blankContactHasNoOwner() {
+        #expect(
+            ContactNicknames.owner(
+                activeAccountIdHex: "owner",
+                localAccountIdsHex: ["owner"],
+                contactAccountIdHex: "  "
+            ) == nil
+        )
+    }
+
+    @Test func ownAccountsCannotBeNicknamed() {
+        #expect(
+            ContactNicknames.owner(
+                activeAccountIdHex: "OWNER",
+                localAccountIdsHex: ["owner", "second-local"],
+                contactAccountIdHex: "owner"
+            ) == nil
+        )
+        #expect(
+            ContactNicknames.owner(
+                activeAccountIdHex: "owner",
+                localAccountIdsHex: ["owner", "SECOND-LOCAL"],
+                contactAccountIdHex: "second-local"
+            ) == nil
+        )
+    }
+
+    @Test func otherContactsResolveToTheActiveOwner() {
+        #expect(
+            ContactNicknames.owner(
+                activeAccountIdHex: " OWNER ",
+                localAccountIdsHex: ["owner"],
+                contactAccountIdHex: " ALICE "
+            ) == "owner"
+        )
+    }
+
+    @Test func storeRoundTripsPerOwnerMaps() throws {
+        let (store, directory) = temporaryStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try store.write(["alice": "Mum", "bob": "Boss"], forOwnerAccountIdHex: "owner-a")
+        try store.write(["alice": "Landlord"], forOwnerAccountIdHex: "owner-b")
+
+        #expect(
+            try store.loadAll() == [
+                "owner-a": ["alice": "Mum", "bob": "Boss"],
+                "owner-b": ["alice": "Landlord"],
+            ]
+        )
+    }
+
+    @Test func storeNormalizesTheOwnerKey() throws {
+        let (store, directory) = temporaryStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try store.write(["alice": "Mum"], forOwnerAccountIdHex: "  OWNER-A  ")
+
+        #expect(try store.loadAll() == ["owner-a": ["alice": "Mum"]])
+        try store.remove(forOwnerAccountIdHex: "Owner-A")
+        #expect(try store.loadAll().isEmpty)
+    }
+
+    @Test func storeWritingAnEmptyMapRemovesTheRecord() throws {
+        let (store, directory) = temporaryStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try store.write(["alice": "Mum"], forOwnerAccountIdHex: "owner-a")
+        try store.write([:], forOwnerAccountIdHex: "owner-a")
+
+        #expect(try store.loadAll().isEmpty)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+    }
+
+    @Test func storeRemovingOneOwnerLeavesTheOthers() throws {
+        let (store, directory) = temporaryStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try store.write(["alice": "Mum"], forOwnerAccountIdHex: "owner-a")
+        try store.write(["alice": "Landlord"], forOwnerAccountIdHex: "owner-b")
+        try store.remove(forOwnerAccountIdHex: "owner-b")
+
+        #expect(try store.loadAll() == ["owner-a": ["alice": "Mum"]])
+    }
+
+    @Test func storeRemoveAllClearsEveryOwner() throws {
+        let (store, directory) = temporaryStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try store.write(["alice": "Mum"], forOwnerAccountIdHex: "owner-a")
+        try store.write(["alice": "Landlord"], forOwnerAccountIdHex: "owner-b")
+        try store.removeAll()
+
+        #expect(try store.loadAll().isEmpty)
+    }
+
+    @Test func storeIgnoresRecordsFromAnotherVersion() throws {
+        let (store, directory) = temporaryStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try store.write(["alice": "Mum"], forOwnerAccountIdHex: "owner-a")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let future = """
+            {"version":2,"ownerAccountIdHex":"owner-b","nicknamesByContactIdHex":{"alice":"Landlord"}}
+            """
+        try Data(future.utf8).write(to: directory.appendingPathComponent("future.json"))
+
+        #expect(try store.loadAll() == ["owner-a": ["alice": "Mum"]])
+    }
+
+    @Test func applyingNicknameRetitlesAndRemembersThePublishedTitle() {
+        let row = chatItem(title: "Alice", isDirect: true)
+
+        let renamed = row.applyingNickname("Mum")
+        #expect(renamed.title == "Mum")
+        #expect(renamed.publishedTitle == "Alice")
+
+        let renamedAgain = renamed.applyingNickname("Mother")
+        #expect(renamedAgain.title == "Mother")
+        #expect(renamedAgain.publishedTitle == "Alice")
+
+        let cleared = renamedAgain.applyingNickname(nil)
+        #expect(cleared.title == "Alice")
+        #expect(cleared.publishedTitle == nil)
+        #expect(cleared == row)
+    }
+
+    @Test func applyingANicknameEqualToThePublishedTitleRecordsNoOverride() {
+        let renamed = chatItem(title: "Alice", isDirect: true).applyingNickname("Alice")
+
+        #expect(renamed.title == "Alice")
+        #expect(renamed.publishedTitle == nil)
+    }
+
+    /// A published name the sanitizer strips to nothing must still leave the row a baseline title.
+    /// `applyingNickname(nil)` restores `publishedTitle ?? title`, so without one, clearing the
+    /// nickname promotes the nickname itself to the contact's published name.
+    @Test func directChatKeepsABaselineWhenThePublishedNameSanitizesAway() {
+        let peer = ChatPeerProfile(
+            accountIdHex: aliceAccountIdHex,
+            displayName: "Mum",
+            publishedDisplayName: bidiOnlyPublishedName,
+            pictureURL: nil
+        )
+
+        // Nothing usable from any source: the baseline is the shortened peer account id.
+        let shortened = DisplayText.short(aliceAccountIdHex)
+        let unprojected = ChatItem(row: directChatRow(title: ""), activeAccountIdHex: "self", directPeer: peer)
+        #expect(unprojected.title == "Mum")
+        #expect(unprojected.publishedTitle == shortened)
+        #expect(unprojected.applyingNickname(nil).title == shortened)
+
+        // The row's own projected title keeps precedence over that fallback.
+        let projected = ChatItem(row: directChatRow(title: "Alice"), activeAccountIdHex: "self", directPeer: peer)
+        #expect(projected.publishedTitle == "Alice")
+        #expect(projected.applyingNickname(nil).title == "Alice")
+    }
+
+    @Test func directChatRecordsNoBaselineWhenNoPublishedNameIsOverridden() {
+        let chat = ChatItem(
+            row: directChatRow(title: "Alice"),
+            activeAccountIdHex: "self",
+            directPeer: ChatPeerProfile(
+                accountIdHex: aliceAccountIdHex,
+                displayName: "Alice",
+                publishedDisplayName: nil,
+                pictureURL: nil
+            )
+        )
+
+        #expect(chat.title == "Alice")
+        #expect(chat.publishedTitle == nil)
+    }
+
+    /// The contact affordance is offered from this and nothing else, so it must never hand back a
+    /// group id: a nickname keyed on one would be written against a conversation, not a person.
+    @Test func directPeerAccountIdHexResolvesOnlyWhenAPeerIsKnown() {
+        let resolved = ChatItem(
+            row: directChatRow(title: "Alice"),
+            activeAccountIdHex: "self",
+            directPeer: ChatPeerProfile(accountIdHex: aliceAccountIdHex, displayName: "Alice", pictureURL: nil)
+        )
+        #expect(resolved.directPeerAccountIdHex == aliceAccountIdHex)
+
+        // A direct chat whose peer never resolved, so the seed fell back to the group id — the
+        // state a note-to-self chat stays in permanently — and an ordinary group.
+        let unresolved = chatItem(id: "dm", title: "Alice", isDirect: true, avatarSeed: "dm")
+        #expect(unresolved.avatarSeed == unresolved.id)
+        #expect(unresolved.directPeerAccountIdHex == nil)
+        #expect(chatItem(id: "group", title: "Book club").directPeerAccountIdHex == nil)
+    }
+
+    @Test func chatFilterMatchesTheNicknameAndThePublishedTitle() {
+        let nicknamed = chatItem(id: "dm", title: "Mum", publishedTitle: "Alice", isDirect: true)
+        let group = chatItem(id: "group", title: "Book club")
+        let chats = [nicknamed, group]
+
+        #expect(ChatFilter.filtered(chats, query: "mum").map(\.id) == ["dm"])
+        #expect(ChatFilter.filtered(chats, query: "alice").map(\.id) == ["dm"])
+        #expect(ChatFilter.filtered(chats, query: "book").map(\.id) == ["group"])
+        #expect(ChatFilter.filtered(chats, query: "nobody").isEmpty)
+    }
+
+    @Test func applyingSenderNicknameRelabelsAndRestoresFromTheRowItself() throws {
+        let message = messageItem(senderAccountIdHex: "alice", senderName: "Alice")
+
+        #expect(message.applyingSenderNickname(nil) == nil)
+        #expect(message.applyingSenderNickname("Alice") == nil)
+
+        let renamed = try #require(message.applyingSenderNickname("Mum"))
+        #expect(renamed.senderName == "Mum")
+        #expect(renamed.publishedSenderName == "Alice")
+        #expect(renamed.id == message.id)
+        #expect(renamed.body == message.body)
+        let restored = try #require(renamed.applyingSenderNickname(nil))
+        #expect(restored.senderName == "Alice")
+        #expect(restored.publishedSenderName == nil)
+        #expect(restored == message)
+    }
+
+    /// An edit re-derives the row from its base, so it must carry the published name forward:
+    /// otherwise clearing the nickname later restores the nickname itself as the "real" name.
+    @Test func editingAMessagePreservesTheOverriddenPublishedName() throws {
+        let renamed = try #require(
+            messageItem(senderAccountIdHex: "alice", senderName: "Alice").applyingSenderNickname("Mum")
+        )
+
+        let edited = renamed.applyingEdit(plaintext: "Hello again")
+        #expect(edited.senderName == "Mum")
+        #expect(edited.publishedSenderName == "Alice")
+
+        let restored = try #require(edited.applyingSenderNickname(nil))
+        #expect(restored.senderName == "Alice")
+        #expect(restored.publishedSenderName == nil)
+    }
+
+    @Test func applyingReplyContextSenderNameRelabelsOnlyTheQuote() throws {
+        let quote = MessageReplyContext(targetMessageId: "message-1", senderName: "Alice", body: "Hello")
+        let reply = messageItem(senderAccountIdHex: "bob", senderName: "Bob", replyContext: quote)
+
+        #expect(reply.applyingReplyContextSenderName("Alice") == nil)
+        #expect(messageItem(senderAccountIdHex: "bob", senderName: "Bob").applyingReplyContextSenderName("Mum") == nil)
+
+        let relabeled = try #require(reply.applyingReplyContextSenderName("Mum"))
+        #expect(relabeled.replyContext?.senderName == "Mum")
+        #expect(relabeled.replyContext?.targetMessageId == "message-1")
+        #expect(relabeled.replyContext?.body == "Hello")
+        #expect(relabeled.senderName == "Bob")
+    }
+
+    @Test func composeContactIsSearchableByBothNames() {
+        let nicknamed = composeContact(displayName: "Mum", publishedDisplayName: "Alice")
+        #expect(nicknamed.searchableNames == ["Mum", "Alice"])
+
+        let plain = composeContact(displayName: "Alice", publishedDisplayName: nil)
+        #expect(plain.searchableNames == ["Alice"])
+    }
+
+    @MainActor
+    @Test func publishedContactNameOnlyReportsAnActualOverride() {
+        #expect(WorkspaceState.publishedContactName("Alice", overriddenBy: nil) == nil)
+        #expect(WorkspaceState.publishedContactName("Alice", overriddenBy: "Mum") == "Alice")
+        #expect(WorkspaceState.publishedContactName("Mum", overriddenBy: "Mum") == nil)
+        #expect(WorkspaceState.publishedContactName(nil, overriddenBy: "Mum") == nil)
+        #expect(WorkspaceState.publishedContactName("  ", overriddenBy: "Mum") == nil)
+    }
+
+    private func directChatRow(title: String) -> ChatListRowFfi {
+        ChatListRowFfi(
+            groupIdHex: "dm",
+            archived: false,
+            pendingConfirmation: false,
+            title: title,
+            groupName: "",
+            avatarUrl: nil,
+            avatar: nil,
+            lastMessage: ChatListMessagePreviewFfi(
+                messageIdHex: "message-1",
+                sender: aliceAccountIdHex,
+                senderDisplayName: nil,
+                plaintext: "Hello",
+                contentTokens: MarkdownDocumentFfi(blocks: [], truncated: false),
+                kind: 9,
+                timelineAt: 1_700_000_000,
+                deleted: false
+            ),
+            unreadCount: 0,
+            hasUnread: false,
+            unreadMentionCount: 0,
+            unreadMention: false,
+            firstUnreadMessageIdHex: nil,
+            lastReadMessageIdHex: nil,
+            lastReadTimelineAt: nil,
+            updatedAt: 1_700_000_000,
+            selfMembership: .member
+        )
+    }
+
+    private func temporaryStore() -> (ContactNicknameFileStore, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-nicknames-\(UUID().uuidString)", isDirectory: true)
+        return (ContactNicknameFileStore(directoryURL: directory), directory)
+    }
+
+    private func chatItem(
+        id: String = "chat",
+        title: String,
+        publishedTitle: String? = nil,
+        isDirect: Bool = false,
+        avatarSeed: String? = nil
+    ) -> ChatItem {
+        ChatItem(
+            id: id,
+            title: title,
+            publishedTitle: publishedTitle,
+            subtitle: isDirect ? "Direct message" : "Group message",
+            preview: "Hello",
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            avatarSeed: avatarSeed ?? (isDirect ? "alice" : id),
+            pictureURL: nil,
+            unreadCount: 0,
+            isDirect: isDirect
+        )
+    }
+
+    private func messageItem(
+        senderAccountIdHex: String,
+        senderName: String,
+        replyContext: MessageReplyContext? = nil
+    ) -> MessageItem {
+        MessageItem(
+            id: "message-1",
+            groupIdHex: "chat",
+            senderAccountIdHex: senderAccountIdHex,
+            senderName: senderName,
+            body: "Hello",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            timelineAt: 1_700_000_000,
+            isOutgoing: false,
+            replyContext: replyContext
+        )
+    }
+
+    private func composeContact(displayName: String, publishedDisplayName: String?) -> ComposeContact {
+        ComposeContact(
+            accountIdHex: String(repeating: "a", count: 64),
+            npub: "npub1alice",
+            displayName: displayName,
+            publishedDisplayName: publishedDisplayName,
+            pictureURL: nil,
+            lastActivity: nil
+        )
+    }
+}

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1695,6 +1695,247 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func contactNicknamesAreOwnerScopedAndSurviveSignOutButNotRemovalOrLocalWipe() async throws {
+        let primary = desktopAccount()
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: String(repeating: "1", count: 64),
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let contact = String(repeating: "2", count: 64)
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-nickname-cleanup-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactNicknameFileStore(directoryURL: directory)
+        try store.write([contact: "Mum"], forOwnerAccountIdHex: primary.accountIdHex)
+        try store.write([contact: "Landlord"], forOwnerAccountIdHex: secondary.accountIdHex)
+
+        let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")
+        defer { restoreDefault(previousActiveAccount, forKey: "whitenoise.mac.activeAccountId") }
+        UserDefaults.standard.set(primary.label, forKey: "whitenoise.mac.activeAccountId")
+
+        let state = WorkspaceState(contactNicknameStore: store, clientFactory: { runtime })
+        await state.bootstrap()
+
+        #expect(state.contactNickname(forContactAccountIdHex: contact) == "Mum")
+        #expect(
+            state.contactNicknames(forOwnerAccountIdHex: secondary.accountIdHex)
+                .nickname(forContactAccountIdHex: contact) == "Landlord"
+        )
+
+        let backupAccount = try #require(state.accounts.first { $0.id == secondary.label })
+        await state.signOutAccount(backupAccount)
+        #expect(try store.loadAll().count == 2)
+
+        let signedOutBackup = try #require(state.accounts.first { $0.id == secondary.label })
+        await state.removeAccount(signedOutBackup)
+        #expect(try store.loadAll() == [primary.accountIdHex: [contact: "Mum"]])
+        #expect(state.contactNickname(forContactAccountIdHex: contact) == "Mum")
+        #expect(
+            state.contactNicknames(forOwnerAccountIdHex: secondary.accountIdHex)
+                .nickname(forContactAccountIdHex: contact) == nil
+        )
+
+        await state.deleteAllData()
+
+        #expect(try store.loadAll().isEmpty)
+        #expect(state.contactNicknamesByOwner.isEmpty)
+    }
+
+    @MainActor
+    @Test func settingANicknameRelabelsChatRowsAndTheLiveTimelineWithoutTouchingOtherRows() async throws {
+        let account = desktopAccount()
+        let contact = String(repeating: "2", count: 64)
+        let other = String(repeating: "3", count: 64)
+        let directMessage = ChatItem(
+            id: "dm",
+            title: "Alice",
+            subtitle: "Direct message",
+            preview: "Hello",
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            avatarSeed: contact,
+            pictureURL: nil,
+            unreadCount: 0,
+            isDirect: true
+        )
+        let otherDirectMessage = ChatItem(
+            id: "dm-other",
+            title: "Bob",
+            subtitle: "Direct message",
+            preview: "Hi",
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_001),
+            avatarSeed: other,
+            pictureURL: nil,
+            unreadCount: 0,
+            isDirect: true
+        )
+        let group = ChatItem(
+            id: "group",
+            title: "Book club",
+            subtitle: "Group message",
+            preview: "Hey",
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_002),
+            avatarSeed: "group",
+            pictureURL: nil,
+            unreadCount: 0
+        )
+        let fromContact = MessageItem(
+            id: "m1",
+            groupIdHex: "dm",
+            senderAccountIdHex: contact,
+            senderName: "Alice",
+            body: "Hello",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            timelineAt: 1_700_000_000,
+            isOutgoing: false
+        )
+        let fromOther = MessageItem(
+            id: "m2",
+            groupIdHex: "dm",
+            senderAccountIdHex: other,
+            senderName: "Bob",
+            body: "Hi",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_001),
+            timelineAt: 1_700_000_001,
+            isOutgoing: false,
+            replyContext: MessageReplyContext(targetMessageId: "m1", senderName: "Alice", body: "Hello")
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-nickname-projection-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let state = WorkspaceState(
+            accounts: [AccountItem(summary: account)],
+            chatsByAccount: [account.label: [group, otherDirectMessage, directMessage]],
+            messagesByChat: ["dm": [fromContact, fromOther]],
+            contactNicknameStore: ContactNicknameFileStore(directoryURL: directory),
+            clientFactory: { FakeMarmotRuntime(accounts: [account]) }
+        )
+        state.activeAccountId = account.label
+        state.selection = .chat("dm")
+
+        state.setContactNickname("Mum", forContactAccountIdHex: contact)
+
+        let renamed = try #require(state.chatItem(accountId: account.label, chatId: "dm"))
+        #expect(renamed.title == "Mum")
+        #expect(renamed.publishedTitle == "Alice")
+        #expect(state.chatItem(accountId: account.label, chatId: "dm-other") == otherDirectMessage)
+        #expect(state.chatItem(accountId: account.label, chatId: "group") == group)
+        #expect(state.timelineMessage(groupIdHex: "dm", messageId: "m1")?.senderName == "Mum")
+        #expect(state.timelineMessage(groupIdHex: "dm", messageId: "m1")?.publishedSenderName == "Alice")
+        #expect(state.timelineMessage(groupIdHex: "dm", messageId: "m2")?.senderName == "Bob")
+        #expect(state.timelineMessage(groupIdHex: "dm", messageId: "m2")?.publishedSenderName == nil)
+        // The quote of the relabeled sender follows without waiting for a reprojection.
+        #expect(state.timelineMessage(groupIdHex: "dm", messageId: "m2")?.replyContext?.senderName == "Mum")
+        #expect(state.filteredChats(matching: "mum").map(\.id) == ["dm"])
+        #expect(state.filteredChats(matching: "alice").map(\.id) == ["dm"])
+
+        state.setContactNickname("   ", forContactAccountIdHex: contact)
+
+        let restored = try #require(state.chatItem(accountId: account.label, chatId: "dm"))
+        #expect(restored.title == "Alice")
+        #expect(restored.publishedTitle == nil)
+        #expect(state.timelineMessage(groupIdHex: "dm", messageId: "m1")?.senderName == "Alice")
+        #expect(state.timelineMessage(groupIdHex: "dm", messageId: "m2")?.replyContext?.senderName == "Alice")
+        #expect(state.contactNickname(forContactAccountIdHex: contact) == nil)
+    }
+
+    @MainActor
+    @Test func ownAccountsCannotBeNicknamed() async throws {
+        let account = desktopAccount()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-nickname-self-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactNicknameFileStore(directoryURL: directory)
+
+        let state = WorkspaceState(
+            accounts: [AccountItem(summary: account)],
+            contactNicknameStore: store,
+            clientFactory: { FakeMarmotRuntime(accounts: [account]) }
+        )
+        state.activeAccountId = account.label
+
+        #expect(!state.canSetContactNickname(forContactAccountIdHex: account.accountIdHex))
+        state.setContactNickname("Me", forContactAccountIdHex: account.accountIdHex)
+
+        #expect(state.contactNickname(forContactAccountIdHex: account.accountIdHex) == nil)
+        #expect(try store.loadAll().isEmpty)
+    }
+
+    @MainActor
+    @Test func notificationTitlesUseTheTargetedAccountsNickname() async throws {
+        let primary = desktopAccount()
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: String(repeating: "1", count: 64),
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let sender = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-nickname-notifications-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ContactNicknameFileStore(directoryURL: directory)
+        try store.write([sender: "Mum"], forOwnerAccountIdHex: primary.accountIdHex)
+
+        let previousPreviewMode = UserDefaults.standard.object(forKey: WorkspaceState.notificationPreviewModeKey)
+        defer { restoreDefault(previousPreviewMode, forKey: WorkspaceState.notificationPreviewModeKey) }
+        UserDefaults.standard.set(
+            NotificationPreviewMode.full.rawValue,
+            forKey: WorkspaceState.notificationPreviewModeKey
+        )
+
+        let state = WorkspaceState(
+            accounts: [AccountItem(summary: primary), AccountItem(summary: secondary)],
+            contactNicknameStore: store,
+            clientFactory: { FakeMarmotRuntime(accounts: [primary, secondary]) }
+        )
+        state.activeAccountId = primary.label
+        state.loadContactNicknames()
+
+        let toPrimary = state.localNotificationRequest(
+            for: notificationUpdate(
+                account: primary,
+                notificationKey: "primary-dm",
+                senderName: "Alice",
+                previewText: "See you soon"
+            )
+        )
+        #expect(toPrimary.title == "Mum")
+
+        let toSecondary = state.localNotificationRequest(
+            for: notificationUpdate(
+                account: secondary,
+                notificationKey: "secondary-dm",
+                senderName: "Alice",
+                previewText: "See you soon"
+            )
+        )
+        #expect(toSecondary.title == "Alice")
+
+        let groupBody = state.localNotificationRequest(
+            for: notificationUpdate(
+                account: primary,
+                notificationKey: "primary-group",
+                groupIdHex: "group",
+                senderName: "Alice",
+                previewText: "See you soon",
+                isDm: false,
+                groupName: "Book club"
+            )
+        )
+        #expect(groupBody.title == "Book club")
+        #expect(groupBody.body.contains("Mum"))
+        #expect(!groupBody.body.contains("Alice"))
+    }
+
+    @MainActor
     @Test func accountSwitchAndNewInstallResetClearDecryptedSharedMediaCache() async throws {
         let primary = desktopAccount()
         let secondary = AccountSummaryFfi(


### PR DESCRIPTION
Solves #621  by adding nicknames (local and account scoped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device-only contact nicknames with set/edit/remove controls in contact details and group/direct chat views.
  * Nicknames now drive displayed names across chat list titles, compose/new-chat recipients, sender labels (including reply context), and notification sender previews—while preserving/restoring the original published names when no nickname is set.
  * Global search (including latest-by-chat) now prioritizes nicknames, with fallback to published titles.
* **Bug Fixes**
  * Nicknames are sanitized and truncated, scoped per account, persisted across restarts, and automatically cleared when emptied or when local data is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->