### PR TITLE
Enable mentions in dms

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Mentions.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Mentions.swift
@@ -12,10 +12,8 @@ import MarmotKit
 
 @MainActor
 extension WorkspaceState {
-    /// Mentionable members of the selected conversation, excluding the local account. Empty for
-    /// direct chats, where mentioning the sole peer carries no meaning.
     func mentionRoster() -> [ComposerMentionCandidate] {
-        guard let selectedChat, !selectedChat.isDirect,
+        guard let selectedChat,
             let members = groupMemberDetailsCache[selectedChat.id]
         else { return [] }
         if let cached = mentionRosterCache[selectedChat.id] { return cached }
@@ -33,10 +31,8 @@ extension WorkspaceState {
         ComposerMentionQuery.filter(mentionRoster(), matching: query)
     }
 
-    /// Pull the member roster into cache the first time a mention query opens in a group, so the
-    /// picker can populate. No-op for direct chats or once the cache is warm.
     func ensureMentionRosterLoaded() {
-        guard let selectedChat, !selectedChat.isDirect,
+        guard let selectedChat,
             groupMemberDetailsCache[selectedChat.id] == nil,
             let client, let activeAccount
         else { return }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -373,6 +373,31 @@ struct PureValueTests {
         #expect(state.mentionNamesBuildCount == 2)
     }
 
+    @MainActor
+    @Test func mentionRosterOffersTheSolePeerInADirectChat() {
+        let account = AccountItem.samples[0]
+        let direct = ChatItem.samples[1]
+        #expect(direct.isDirect)
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [direct]],
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(direct.id)
+
+        let local = mentionMember(id: "self", displayName: "Local", npub: "npub1self", isSelf: true)
+        let peer = mentionMember(id: "nvk", displayName: "NVK", npub: "npub1nvk")
+        state.storeGroupMembers([local, peer], for: direct.id)
+
+        #expect(state.mentionRoster().map(\.id) == ["nvk"])
+        #expect(state.mentionCandidates(matching: "nv").map(\.displayName) == ["NVK"])
+        // A single candidate can never trip the canonicaliser's duplicate-name ambiguity rule.
+        #expect(state.canonicalizeMentions(in: "hey @NVK") == "hey @npub1nvk")
+    }
+
     @Test func editedMessageAndHistoryResolveCanonicalMentionsButRetainWireText() async throws {
         let npub = "npub1qqqq"
         let base = MessageItem(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -15913,6 +15913,70 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func mentionRosterWarmUpFiresForDirectChatsWithAColdMemberCache() async throws {
+        let summary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [summary])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: summary.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let account = AccountItem(
+            id: summary.label,
+            accountRef: summary.label,
+            displayName: summary.label,
+            accountIdHex: summary.accountIdHex
+        )
+        // Seed the chat in memory rather than via `bootstrap()`, so the member cache starts cold
+        // and the warm-up is the only thing that can fill it.
+        let direct = ChatItem(
+            id: "direct-group",
+            title: "Alice",
+            subtitle: "Direct message",
+            preview: "",
+            updatedAt: nil,
+            avatarSeed: aliceId,
+            pictureURL: nil,
+            unreadCount: 0,
+            isDirect: true,
+            hasAuthoritativeConversationKind: true
+        )
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [direct]],
+            clientFactory: { runtime }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(direct.id)
+        state.client = runtime
+
+        #expect(state.mentionRoster().isEmpty)
+        state.ensureMentionRosterLoaded()
+        let didWarmRoster = await waitFor { !state.mentionRoster().isEmpty }
+
+        #expect(didWarmRoster)
+        #expect(state.mentionRoster().map(\.displayName) == ["Alice"])
+        #expect((runtime.groupDetailsCallCounts["direct-group"] ?? 0) == 1)
+    }
+
+    @MainActor
     @Test func chatListTriggerEnrichmentGatingMatchesMetadataInvariance() {
         // The enrichment gate must skip exactly the metadata-invariant triggers and enrich the
         // rest, so read-state-only deltas never pay for the per-row FFI fan-out (#251).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added mention support for direct chats.
  - Direct-chat mention suggestions now include the other participant when member details are available.
  - Mention aliases, such as `@NVK`, are correctly resolved to the selected participant.

- **Bug Fixes**
  - Direct-chat mention rosters now load automatically when needed, providing reliable suggestions and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->