### PR TITLE
Upload images before sending them

### DIFF
--- a/whitenoise-mac/Core/MarmotClient.swift
+++ b/whitenoise-mac/Core/MarmotClient.swift
@@ -92,6 +92,12 @@ nonisolated protocol MarmotRuntime: Sendable {
         -> MediaDownloadResultFfi
     func uploadMedia(accountRef: String, groupIdHex: String, request: MediaUploadRequestFfi) async throws
         -> MediaUploadResultFfi
+    func sendMediaAttachments(
+        accountRef: String,
+        groupIdHex: String,
+        attachments: [MediaAttachmentReferenceFfi],
+        caption: String?
+    ) async throws -> SendSummaryFfi
     func sendText(accountRef: String, groupIdHex: String, text: String) async throws -> SendSummaryFfi
     func retryGroupConvergence(accountRef: String, groupIdHex: String) async throws -> SendSummaryFfi
     func replyToMessage(accountRef: String, groupIdHex: String, targetMessageId: String, text: String) async throws
@@ -529,6 +535,20 @@ nonisolated final class MarmotClient: MarmotRuntime, @unchecked Sendable {
         -> MediaUploadResultFfi
     {
         try await marmot.uploadMedia(accountRef: accountRef, groupIdHex: groupIdHex, request: request)
+    }
+
+    func sendMediaAttachments(
+        accountRef: String,
+        groupIdHex: String,
+        attachments: [MediaAttachmentReferenceFfi],
+        caption: String?
+    ) async throws -> SendSummaryFfi {
+        try await marmot.sendMediaAttachments(
+            accountRef: accountRef,
+            groupIdHex: groupIdHex,
+            attachments: attachments,
+            caption: caption
+        )
     }
 
     func sendText(accountRef: String, groupIdHex: String, text: String) async throws -> SendSummaryFfi {

--- a/whitenoise-mac/Core/WorkspaceState+Drafts.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Drafts.swift
@@ -165,6 +165,13 @@ extension WorkspaceState {
                 .map(Self.pendingMediaAttachment(from:))
             pendingMediaAttachmentsByConversation[key] = attachments.isEmpty ? nil : attachments
             pendingMediaUploadStatesByConversation[key] = nil
+            // Drafts persist plaintext, not Blossom references — deliberately, so a draft that sat
+            // across an epoch rotation cannot publish a stale `source_epoch`. Re-upload on restore
+            // instead, which is also the only staging path that bypasses
+            // `appendPendingMediaAttachment`.
+            for attachment in attachments {
+                beginPendingMediaUpload(attachment, for: key)
+            }
         } catch {
             restoredComposerDraftKeys.remove(key)
             setBackgroundStatus(

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -26,6 +26,7 @@ private nonisolated struct MediaAttachmentDownloadTaskFailure: Error {
 extension WorkspaceState {
     func clearAllComposerDrafts() {
         discardAllComposerDraftPersistenceState()
+        cancelAllPendingMediaUploads()
         draftTextByConversation.removeAll()
         composerMentionSelectionsByConversation.removeAll()
         replyDraftContextByConversation.removeAll()
@@ -92,6 +93,7 @@ extension WorkspaceState {
         for chatId in chatIds {
             let key = ComposerDraftKey(accountId: accountId, chatId: chatId)
             discardComposerDraftPersistenceState(for: key)
+            cancelPendingMediaUploads(for: key)
             draftTextByConversation[key] = nil
             composerMentionSelectionsByConversation[key] = nil
             replyDraftContextByConversation[key] = nil
@@ -103,6 +105,7 @@ extension WorkspaceState {
 
     func clearComposerDrafts(forAccountId accountId: String) {
         discardComposerDraftPersistenceState(forAccountId: accountId)
+        cancelPendingMediaUploads(forAccountId: accountId)
         for key in draftTextByConversation.keys.filter({ $0.accountId == accountId }) {
             draftTextByConversation[key] = nil
         }
@@ -481,6 +484,7 @@ extension WorkspaceState {
 
     func removePendingMediaAttachment(_ id: PendingMediaAttachment.ID) {
         guard let selectedComposerDraftKey else { return }
+        cancelPendingMediaUpload(id)
         var attachments = pendingMediaAttachmentsByConversation[selectedComposerDraftKey] ?? []
         attachments.removeAll { $0.id == id }
         pendingMediaAttachmentsByConversation[selectedComposerDraftKey] = attachments.isEmpty ? nil : attachments
@@ -488,6 +492,94 @@ extension WorkspaceState {
         uploadStates[id] = nil
         pendingMediaUploadStatesByConversation[selectedComposerDraftKey] = uploadStates.isEmpty ? nil : uploadStates
         composerDraftDidChange(for: selectedComposerDraftKey)
+    }
+
+    /// Upload a staged attachment to Blossom without publishing it, so pressing Send later only
+    /// has to hand the resulting reference to `sendMediaAttachments`. The core exposes exactly
+    /// this split: `uploadMedia(send: false)` is the first half of what `send: true` does.
+    func beginPendingMediaUpload(_ attachment: PendingMediaAttachment, for draftKey: ComposerDraftKey) {
+        guard let client, let activeAccount else { return }
+        setPendingMediaUploadState(.uploading, for: attachment.id, in: draftKey)
+        pendingMediaUploadTasks[attachment.id]?.cancel()
+        // The finished task stays in the map until the attachment is removed or sent: clearing it
+        // here would race a retry that has already installed its replacement under the same id.
+        pendingMediaUploadTasks[attachment.id] = Task { [weak self] in
+            do {
+                let result = try await client.uploadMedia(
+                    accountRef: activeAccount.accountRef,
+                    groupIdHex: draftKey.chatId,
+                    request: MediaUploadRequestFfi(
+                        attachments: [attachment.uploadRequest],
+                        caption: nil,
+                        send: false,
+                        blossomServer: nil
+                    )
+                )
+                guard !Task.isCancelled else { return }
+                // A result that carries no reference is a failed upload, not a cancelled one: leaving
+                // it `.uploading` would pin the tile on a spinner with no retry, and `canSend` gates
+                // on every attachment reporting a reference, so the whole draft would wedge.
+                guard let reference = result.attachments.first?.reference else {
+                    self?.setPendingMediaUploadState(.failed, for: attachment.id, in: draftKey)
+                    return
+                }
+                self?.setPendingMediaUploadState(.uploaded(reference), for: attachment.id, in: draftKey)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                self?.setPendingMediaUploadState(.failed, for: attachment.id, in: draftKey)
+                self?.lastError = error.localizedDescription
+            }
+        }
+    }
+
+    func retryPendingMediaUpload(_ id: PendingMediaAttachment.ID) {
+        guard let draftKey = selectedComposerDraftKey,
+            let attachment = pendingMediaAttachmentsByConversation[draftKey]?.first(where: { $0.id == id })
+        else { return }
+        beginPendingMediaUpload(attachment, for: draftKey)
+    }
+
+    func cancelPendingMediaUpload(_ id: PendingMediaAttachment.ID) {
+        pendingMediaUploadTasks.removeValue(forKey: id)?.cancel()
+    }
+
+    /// Bulk counterparts to `cancelPendingMediaUpload` for the paths that drop whole drafts. The task
+    /// map is keyed by attachment, not by draft, so a scoped cancel has to walk the staged
+    /// attachments — which means cancelling *before* the draft entries are dropped, or the ids are
+    /// already gone. Without this a logout or a chat deletion leaves the uploads running against a
+    /// composer that no longer exists and never reclaims their entries.
+    func cancelAllPendingMediaUploads() {
+        for task in pendingMediaUploadTasks.values {
+            task.cancel()
+        }
+        pendingMediaUploadTasks.removeAll()
+    }
+
+    func cancelPendingMediaUploads(for draftKey: ComposerDraftKey) {
+        for attachment in pendingMediaAttachmentsByConversation[draftKey] ?? [] {
+            cancelPendingMediaUpload(attachment.id)
+        }
+    }
+
+    func cancelPendingMediaUploads(forAccountId accountId: String) {
+        for draftKey in pendingMediaAttachmentsByConversation.keys where draftKey.accountId == accountId {
+            cancelPendingMediaUploads(for: draftKey)
+        }
+    }
+
+    /// Writes an upload outcome only while its attachment is still staged in the conversation it
+    /// was staged in. An upload that resolves after the user removed the tile — or after they
+    /// switched chats — must not resurrect it or leak into another conversation
+    /// (the same discipline as `appendPendingMediaAttachmentIfSelectionUnchanged`, #245).
+    private func setPendingMediaUploadState(
+        _ state: PendingMediaUploadState,
+        for id: PendingMediaAttachment.ID,
+        in draftKey: ComposerDraftKey
+    ) {
+        guard pendingMediaAttachmentsByConversation[draftKey]?.contains(where: { $0.id == id }) == true else { return }
+        pendingMediaUploadStatesByConversation[draftKey, default: [:]][id] = state
     }
 
     func toggleVoiceRecording() async {
@@ -635,6 +727,11 @@ extension WorkspaceState {
     func appendPendingMediaAttachment(_ attachment: PendingMediaAttachment, for draftKey: ComposerDraftKey) {
         var attachments = pendingMediaAttachmentsByConversation[draftKey] ?? []
         if attachment.kind == .audio {
+            // A new recording replaces the old one, so the superseded upload has nowhere to land.
+            for superseded in attachments where superseded.kind == .audio {
+                cancelPendingMediaUpload(superseded.id)
+                pendingMediaUploadStatesByConversation[draftKey]?[superseded.id] = nil
+            }
             attachments.removeAll { $0.kind == .audio }
         }
         guard attachments.count < OutgoingMediaDraftProcessor.maxAttachmentCount else {
@@ -650,6 +747,10 @@ extension WorkspaceState {
             draftTextByConversation[draftKey] = nil
             composerMentionSelectionsByConversation[draftKey] = nil
         }
+        // Upload straight away so Send only has to publish the reference. Every staging path
+        // (importer, drag-drop, paste, voice) funnels through here; restored drafts are the one
+        // bypass and kick their own uploads in `restoreComposerDraftIfNeeded`.
+        beginPendingMediaUpload(attachment, for: draftKey)
         composerDraftDidChange(for: draftKey)
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -14,10 +14,6 @@ import Observation
 import SwiftUI
 import UserNotifications
 
-private enum ComposerMediaUploadPresentation {
-    static let uploadedAcknowledgementDelayNanoseconds: UInt64 = 300_000_000
-}
-
 /// Ownership token for subscription, initial-load, or post-send timeline applies.
 /// Re-checked after every suspension in window and projection paths so a superseded
 /// listener or query cannot overwrite a replacement for the same account/chat.
@@ -614,7 +610,9 @@ extension WorkspaceState {
         // Media uploads cannot carry a reply target yet, so reply and pending media are
         // mutually exclusive — starting a reply drops any staged attachments.
         if let draftKey = selectedComposerDraftKey {
+            pendingMediaAttachmentsByConversation[draftKey]?.forEach { cancelPendingMediaUpload($0.id) }
             pendingMediaAttachmentsByConversation[draftKey] = nil
+            pendingMediaUploadStatesByConversation[draftKey] = nil
         }
         replyDraftContext = MessageReplyContext(
             targetMessageId: message.id,
@@ -1039,22 +1037,37 @@ extension WorkspaceState {
 
         do {
             if !mediaAttachments.isEmpty {
-                markMediaAttachmentsUploading(mediaAttachments, draftKey: draftKey)
-                let uploadResult = try await client.uploadMedia(
-                    accountRef: activeAccount.accountRef,
-                    groupIdHex: selectedChat.id,
-                    request: MediaUploadRequestFfi(
-                        attachments: mediaAttachments.map(\.uploadRequest),
-                        caption: text.isEmpty ? nil : text,
-                        send: true,
-                        blossomServer: nil
-                    )
+                // Blossom already has every blob — staging uploaded them. Order comes from the
+                // composer, never from the order the uploads happened to finish in.
+                let uploadStates = pendingMediaUploadStatesByConversation[draftKey] ?? [:]
+                let references = mediaAttachments.compactMap { uploadStates[$0.id]?.reference }
+                guard references.count == mediaAttachments.count else { return }
+
+                // We are holding the plaintext that produced these references, so the sender's own
+                // bubble has no reason to fetch its own image back from Blossom and decrypt it.
+                // Seed before publishing: the optimistic projection can render the bubble as soon
+                // as the send returns, and it must find a warm cache when it does.
+                await cacheOutgoingMediaPlaintext(
+                    mediaAttachments,
+                    references: references,
+                    accountId: activeAccount.id,
+                    groupIdHex: selectedChat.id
                 )
-                markUploadedMediaAttachments(mediaAttachments, uploadResult: uploadResult, draftKey: draftKey)
-                if pendingMediaUploadStatesByConversation[draftKey]?.isEmpty == false {
-                    try? await Task.sleep(
-                        nanoseconds: ComposerMediaUploadPresentation.uploadedAcknowledgementDelayNanoseconds
+
+                // The blobs are already uploaded, so publishing is a short relay round-trip rather
+                // than a transfer. Empty the composer now instead of leaving the thumbnails sitting
+                // there looking unsent; the catch below puts them back if the publish fails.
+                let restorePoint = clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
+                do {
+                    _ = try await client.sendMediaAttachments(
+                        accountRef: activeAccount.accountRef,
+                        groupIdHex: selectedChat.id,
+                        attachments: references,
+                        caption: text.isEmpty ? nil : text
                     )
+                } catch {
+                    restoreComposer(restorePoint, for: draftKey)
+                    throw error
                 }
                 clearMediaReferenceResolutionCache(forAccountId: activeAccount.id, groupIdHex: selectedChat.id)
             } else if let replyDraftContext {
@@ -1071,15 +1084,8 @@ extension WorkspaceState {
                     text: text
                 )
             }
-            // Clear via the captured `draftKey`, not the `draftText`/`replyDraftContext`
-            // setters — those resolve their key from the *live* selection, so if the user
-            // switched chats during the `await` above they would wipe the newly selected
-            // conversation's composer state instead of the one we just sent from.
-            draftTextByConversation[draftKey] = nil
-            composerMentionSelectionsByConversation[draftKey] = nil
-            replyDraftContextByConversation[draftKey] = nil
-            pendingMediaAttachmentsByConversation[draftKey] = nil
-            pendingMediaUploadStatesByConversation[draftKey] = nil
+            // Idempotent: the media branch already cleared optimistically before publishing.
+            _ = clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
             await deletePersistedComposerDraft(
                 for: draftKey,
                 accountRef: activeAccount.accountRef,
@@ -1092,33 +1098,85 @@ extension WorkspaceState {
             // full re-map per delivery.
             await refreshSelectedTimelineAfterSend(groupIdHex: selectedChat.id, account: activeAccount, client: client)
         } catch {
-            pendingMediaUploadStatesByConversation[draftKey] = nil
+            // A failed *publish* leaves the blobs on Blossom and the references valid, so the
+            // restored attachments stay `.uploaded` and the user can simply press Send again.
             lastError = error.localizedDescription
         }
     }
 
-    private func markMediaAttachmentsUploading(_ attachments: [PendingMediaAttachment], draftKey: ComposerDraftKey) {
-        let imageStates = Dictionary(
-            uniqueKeysWithValues:
-                attachments
-                .filter { $0.kind == .image }
-                .map { ($0.id, PendingMediaUploadState.uploading) }
+    /// Empties one conversation's composer and returns what it held, so an optimistic clear can be
+    /// undone if the publish fails.
+    ///
+    /// Always clears via the captured `draftKey`, never the `draftText`/`replyDraftContext`
+    /// setters — those resolve their key from the *live* selection, so if the user switched chats
+    /// during a send they would wipe the newly selected conversation's composer instead of the one
+    /// we sent from.
+    @discardableResult
+    private func clearComposerAfterSend(
+        for draftKey: ComposerDraftKey,
+        mediaAttachments: [PendingMediaAttachment]
+    ) -> ComposerSendRestorePoint {
+        let restorePoint = ComposerSendRestorePoint(
+            text: draftTextByConversation[draftKey],
+            mentionSelections: composerMentionSelectionsByConversation[draftKey],
+            replyContext: replyDraftContextByConversation[draftKey],
+            mediaAttachments: pendingMediaAttachmentsByConversation[draftKey],
+            mediaUploadStates: pendingMediaUploadStatesByConversation[draftKey]
         )
-        pendingMediaUploadStatesByConversation[draftKey] = imageStates.isEmpty ? nil : imageStates
+        draftTextByConversation[draftKey] = nil
+        composerMentionSelectionsByConversation[draftKey] = nil
+        replyDraftContextByConversation[draftKey] = nil
+        mediaAttachments.forEach { cancelPendingMediaUpload($0.id) }
+        let sentIds = Set(mediaAttachments.map(\.id))
+        let remainingAttachments = (pendingMediaAttachmentsByConversation[draftKey] ?? [])
+            .filter { !sentIds.contains($0.id) }
+        pendingMediaAttachmentsByConversation[draftKey] = remainingAttachments.isEmpty ? nil : remainingAttachments
+        var remainingUploadStates = pendingMediaUploadStatesByConversation[draftKey] ?? [:]
+        sentIds.forEach { remainingUploadStates[$0] = nil }
+        pendingMediaUploadStatesByConversation[draftKey] = remainingUploadStates.isEmpty ? nil : remainingUploadStates
+        return restorePoint
     }
 
-    private func markUploadedMediaAttachments(
-        _ attachments: [PendingMediaAttachment],
-        uploadResult: MediaUploadResultFfi,
-        draftKey: ComposerDraftKey
-    ) {
-        var uploadStates = pendingMediaUploadStatesByConversation[draftKey] ?? [:]
-        let uploadedCount = min(attachments.count, uploadResult.attachments.count)
-        for index in 0..<uploadedCount {
-            guard attachments[index].kind == .image else { continue }
-            uploadStates[attachments[index].id] = .uploaded
+    private func restoreComposer(_ restorePoint: ComposerSendRestorePoint, for draftKey: ComposerDraftKey) {
+        draftTextByConversation[draftKey] = restorePoint.text
+        composerMentionSelectionsByConversation[draftKey] = restorePoint.mentionSelections
+        replyDraftContextByConversation[draftKey] = restorePoint.replyContext
+        let restoredAttachments = restorePoint.mediaAttachments ?? []
+        let restoredIds = Set(restoredAttachments.map(\.id))
+        let stagedSinceSnapshot = (pendingMediaAttachmentsByConversation[draftKey] ?? [])
+            .filter { !restoredIds.contains($0.id) }
+        let mergedAttachments = restoredAttachments + stagedSinceSnapshot
+        pendingMediaAttachmentsByConversation[draftKey] = mergedAttachments.isEmpty ? nil : mergedAttachments
+        var mergedUploadStates = pendingMediaUploadStatesByConversation[draftKey] ?? [:]
+        for (id, state) in restorePoint.mediaUploadStates ?? [:] {
+            mergedUploadStates[id] = state
         }
-        pendingMediaUploadStatesByConversation[draftKey] = uploadStates.isEmpty ? nil : uploadStates
+        pendingMediaUploadStatesByConversation[draftKey] = mergedUploadStates.isEmpty ? nil : mergedUploadStates
+    }
+
+    /// Files the plaintext we just published under the same cache key the bubble will look it up
+    /// by, so an outgoing attachment renders from disk instead of round-tripping through Blossom.
+    private func cacheOutgoingMediaPlaintext(
+        _ attachments: [PendingMediaAttachment],
+        references: [MediaAttachmentReferenceFfi],
+        accountId: String,
+        groupIdHex: String
+    ) async {
+        for (attachment, reference) in zip(attachments, references) {
+            await mediaDiskCache.store(
+                MessageMediaDownload(
+                    data: attachment.data,
+                    fileName: attachment.fileName,
+                    mediaType: attachment.mediaType,
+                    sizeBytes: UInt64(attachment.data.count)
+                ),
+                for: MessageMediaDiskCacheKey(
+                    accountId: accountId,
+                    groupIdHex: groupIdHex,
+                    reference: reference
+                )
+            )
+        }
     }
 
     func startTimelineListener(

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1320,6 +1320,9 @@ final class WorkspaceState {
     var pendingMediaAttachmentsByConversation: [ComposerDraftKey: [PendingMediaAttachment]] = [:]
     var pendingMediaUploadStatesByConversation:
         [ComposerDraftKey: [PendingMediaAttachment.ID: PendingMediaUploadState]] = [:]
+    /// In-flight stage-time Blossom uploads, so removing an attachment (or tearing the composer
+    /// down) cancels the upload it started instead of letting it land on a tile that is gone.
+    @ObservationIgnored var pendingMediaUploadTasks: [PendingMediaAttachment.ID: Task<Void, Never>] = [:]
     @ObservationIgnored var composerDraftPersistenceTasks: [ComposerDraftKey: Task<Void, Never>] = [:]
     @ObservationIgnored var composerDraftMutationGenerations: [ComposerDraftKey: UInt64] = [:]
     @ObservationIgnored var dirtyComposerDraftKeys: Set<ComposerDraftKey> = []
@@ -2331,7 +2334,21 @@ final class WorkspaceState {
             && selectedChat?.canUseComposer == true
             && (!draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || !pendingMediaAttachments.isEmpty)
+            // Attachments upload as they are staged, so the composer refuses to send until every
+            // one carries a Blossom reference. Text-only drafts are unaffected.
+            && composerMediaUploadStatus == nil
             && !isSending
+    }
+
+    /// Why the selected composer is not sendable yet, or `nil` once every staged attachment
+    /// carries a reference. Drives both the `canSend` gate and the send button's tooltip, so
+    /// "the button is off" and "here is why" can never disagree.
+    var composerMediaUploadStatus: ComposerMediaUploadStatus? {
+        let attachments = pendingMediaAttachments
+        guard !attachments.isEmpty else { return nil }
+        let states = pendingMediaUploadStates
+        if attachments.contains(where: { states[$0.id] == .failed }) { return .failed }
+        return attachments.allSatisfy { states[$0.id]?.isUploaded == true } ? nil : .uploading
     }
 
     var showsMessengerChrome: Bool {

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -7527,6 +7527,65 @@
         }
       }
     },
+    "An attachment failed to upload": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Anhang konnte nicht hochgeladen werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo subir un adjunto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du téléversement d’une pièce jointe"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento di un allegato non riuscito"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha no upload de um anexo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось загрузить вложение"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir ek yüklenemedi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有附件上传失败"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有附件上傳失敗"
+          }
+        }
+      }
+    },
     "Animals & Nature": {
       "extractionState": "manual",
       "localizations": {
@@ -40635,6 +40694,65 @@
         }
       }
     },
+    "Retry upload": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upload wiederholen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar subida"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réessayer le téléversement"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riprova caricamento"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tentar upload novamente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повторить загрузку"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüklemeyi yeniden dene"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重试上传"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重試上傳"
+          }
+        }
+      }
+    },
     "Retry video": {
       "extractionState": "manual",
       "localizations": {
@@ -51519,6 +51637,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "無法開始語音錄製。"
+          }
+        }
+      }
+    },
+    "Waiting for attachments to finish uploading": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warten, bis die Anhänge hochgeladen sind"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando a que terminen de subirse los adjuntos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente de la fin du téléversement des pièces jointes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In attesa del completamento del caricamento degli allegati"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aguardando a conclusão do upload dos anexos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидание завершения загрузки вложений"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eklerin yüklenmesinin bitmesi bekleniyor"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在等待附件上传完成"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在等待附件上傳完成"
           }
         }
       }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -679,9 +679,39 @@ enum MediaDownloadState: Equatable {
     case failed(String)
 }
 
+/// Blossom upload status for one composer attachment. Attachments upload as soon as they are
+/// staged, so the composer can refuse to send until every one of them carries a reference —
+/// rather than uploading at send time and failing the message after the fact.
 nonisolated enum PendingMediaUploadState: Hashable, Sendable {
     case uploading
-    case uploaded
+    case uploaded(MediaAttachmentReferenceFfi)
+    case failed
+
+    /// The published reference, once the blob is on Blossom. `nil` while in flight or after a
+    /// failure, which is exactly the "not sendable yet" condition the composer gates on.
+    var reference: MediaAttachmentReferenceFfi? {
+        guard case .uploaded(let reference) = self else { return nil }
+        return reference
+    }
+
+    var isUploaded: Bool { reference != nil }
+}
+
+/// What a composer held just before an optimistic clear, so a failed publish can put it back
+/// rather than losing the user's text and attachments.
+nonisolated struct ComposerSendRestorePoint: Sendable {
+    let text: String?
+    let mentionSelections: [ComposerMentionSelection]?
+    let replyContext: MessageReplyContext?
+    let mediaAttachments: [PendingMediaAttachment]?
+    let mediaUploadStates: [PendingMediaAttachment.ID: PendingMediaUploadState]?
+}
+
+/// Why the composer's staged media is not ready to send yet. Present only while something is
+/// outstanding, so `nil` reads as "ready to send".
+nonisolated enum ComposerMediaUploadStatus: Hashable, Sendable {
+    case uploading
+    case failed
 }
 
 nonisolated struct PendingMediaAttachment: Identifiable, Hashable, Sendable {

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -679,6 +679,7 @@ struct PendingMediaDraftStrip: View {
     let uploadStates: [PendingMediaAttachment.ID: PendingMediaUploadState]
     let isSending: Bool
     let onRemove: (PendingMediaAttachment.ID) -> Void
+    let onRetryUpload: (PendingMediaAttachment.ID) -> Void
 
     private let tileSize = CGSize(width: 74, height: 74)
 
@@ -690,7 +691,8 @@ struct PendingMediaDraftStrip: View {
                         PendingMediaDraftTile(
                             attachment: attachment,
                             tileSize: tileSize,
-                            uploadState: uploadStates[attachment.id]
+                            uploadState: uploadStates[attachment.id],
+                            onRetry: { onRetryUpload(attachment.id) }
                         )
 
                         if !isSending {
@@ -721,6 +723,7 @@ struct PendingMediaDraftTile: View {
     let attachment: PendingMediaAttachment
     let tileSize: CGSize
     let uploadState: PendingMediaUploadState?
+    let onRetry: () -> Void
 
     @State private var decodedImagePreview: NSImage?
     @State private var decodedImageTaskID: String?
@@ -749,8 +752,8 @@ struct PendingMediaDraftTile: View {
                 .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
         }
         .overlay(alignment: .bottomTrailing) {
-            if attachment.kind == .image, let uploadState {
-                PendingMediaUploadStatusBadge(state: uploadState)
+            if let uploadState {
+                PendingMediaUploadStatusBadge(state: uploadState, onRetry: onRetry)
                     .padding(5)
             }
         }
@@ -846,30 +849,37 @@ struct PendingMediaDraftTile: View {
     }
 }
 
+/// Only the states that need the user's attention get a badge. A finished upload deliberately
+/// shows nothing: the spinner going away is the confirmation, and a green tick sitting on every
+/// thumbnail for the rest of the draft's life is clutter that says nothing new. What is left to
+/// wait for is reported once, on the send button.
 private struct PendingMediaUploadStatusBadge: View {
     let state: PendingMediaUploadState
+    let onRetry: () -> Void
 
     var body: some View {
-        ZStack {
-            Circle()
-                .fill(.regularMaterial)
-            Circle()
-                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
-
-            switch state {
-            case .uploading:
-                ProgressView()
-                    .controlSize(.small)
-                    .tint(.accentColor)
-                    .scaleEffect(0.62)
-            case .uploaded:
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(.green)
-            }
+        switch state {
+        case .uploading:
+            ProgressView()
+                .controlSize(.small)
+                .tint(.accentColor)
+                .scaleEffect(0.62)
+                .frame(width: 24, height: 24)
+                .background(.regularMaterial, in: .circle)
+                .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
+        case .uploaded:
+            EmptyView()
+        case .failed:
+            Button(L10n.string("Retry upload"), systemImage: "arrow.clockwise", action: onRetry)
+                .labelStyle(.iconOnly)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(.white)
+                .buttonStyle(.plain)
+                .frame(width: 24, height: 24)
+                .background(.red, in: .circle)
+                .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
+                .help(L10n.string("Retry upload"))
         }
-        .frame(width: 24, height: 24)
-        .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
     }
 }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -725,7 +725,8 @@ private struct ConversationView: View {
                 attachments: workspace.pendingMediaAttachments,
                 uploadStates: workspace.pendingMediaUploadStates,
                 isSending: workspace.isSending,
-                onRemove: workspace.removePendingMediaAttachment
+                onRemove: workspace.removePendingMediaAttachment,
+                onRetryUpload: workspace.retryPendingMediaUpload
             )
         }
 
@@ -881,8 +882,22 @@ private struct ConversationView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(!workspace.canSend)
-                .help(workspace.editingMessageContext == nil ? L10n.string("Send") : L10n.string("Save edit"))
+                .help(sendButtonHelp)
             }
+        }
+    }
+
+    /// Explains a Send that is disabled because media is still in flight. The thumbnails carry the
+    /// visible progress — a spinner while uploading, a retry button on failure — so the button
+    /// stays a plain disabled paperplane and only says why on hover.
+    private var sendButtonHelp: String {
+        switch workspace.composerMediaUploadStatus {
+        case .uploading:
+            L10n.string("Waiting for attachments to finish uploading")
+        case .failed:
+            L10n.string("An attachment failed to upload")
+        case nil:
+            workspace.editingMessageContext == nil ? L10n.string("Send") : L10n.string("Save edit")
         }
     }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -21,6 +21,44 @@ import UserNotifications
 @testable import whitenoise_mac
 
 struct PureValueTests {
+    @Test func pendingMediaUploadStateExposesItsReferenceOnlyWhenUploaded() {
+        let reference = mediaReference(fileName: "photo.png")
+
+        #expect(PendingMediaUploadState.uploaded(reference).reference == reference)
+        #expect(PendingMediaUploadState.uploaded(reference).isUploaded)
+        #expect(PendingMediaUploadState.uploading.reference == nil)
+        #expect(!PendingMediaUploadState.uploading.isUploaded)
+        #expect(PendingMediaUploadState.failed.reference == nil)
+        #expect(!PendingMediaUploadState.failed.isUploaded)
+    }
+
+    @Test func pendingMediaUploadStatesWithDifferentReferencesAreDistinct() {
+        // The composer stores these in a dictionary keyed by attachment, and the send path reads
+        // the reference back out — collapsing two distinct uploads into one value would publish
+        // the same blob twice.
+        let first = PendingMediaUploadState.uploaded(mediaReference(fileName: "first.png"))
+        let second = PendingMediaUploadState.uploaded(mediaReference(fileName: "second.png"))
+
+        #expect(first != second)
+        #expect(Set([first, second]).count == 2)
+        #expect(first == PendingMediaUploadState.uploaded(mediaReference(fileName: "first.png")))
+    }
+
+    private func mediaReference(fileName: String) -> MediaAttachmentReferenceFfi {
+        MediaAttachmentReferenceFfi(
+            locators: [MediaLocatorFfi(kind: "blossom", value: "https://example.com/\(fileName)")],
+            ciphertextSha256: "cipher-\(fileName)",
+            plaintextSha256: "plain-\(fileName)",
+            nonceHex: "nonce-\(fileName)",
+            fileName: fileName,
+            mediaType: "image/png",
+            version: .v1,
+            sourceEpoch: 1,
+            dim: nil,
+            thumbhash: nil
+        )
+    }
+
     @Test func selectedMentionsCanonicalizeByPickedNpubDespiteDisplayNameCollision() {
         let first = mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
         let second = mentionCandidate(id: "second", displayName: "Alex", npub: "npub1pppp")

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13907,12 +13907,15 @@ struct whitenoise_macTests {
         #expect(state.replyDraftContext == nil)
         #expect(state.pendingMediaAttachments.count == 1)
 
+        await Self.settleComposerMediaUploads(state)
         await state.sendDraft()
 
+        // Staging uploaded the blob; sending only published the reference it produced.
         #expect(runtime.uploadMediaCallCount == 1)
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
         #expect(runtime.replyToMessageCallCount == 0)
         #expect(runtime.repliedMessage == nil)
-        #expect(runtime.uploadedMedia?.request.caption == "Photo caption")
+        #expect(runtime.sentMediaAttachments.last?.caption == "Photo caption")
         #expect(state.pendingMediaAttachments.isEmpty)
 
         state.appendPendingMediaAttachment(attachment, for: draftKey)
@@ -13926,7 +13929,9 @@ struct whitenoise_macTests {
 
         await state.sendDraft()
 
-        #expect(runtime.uploadMediaCallCount == 1)
+        // The second staging kicked off its own upload, but starting a reply dropped the
+        // attachment, so nothing new was published as media.
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
         #expect(runtime.replyToMessageCallCount == 1)
         #expect(
             runtime.repliedMessage
@@ -14028,24 +14033,38 @@ struct whitenoise_macTests {
         state.draftText = "Project notes"
 
         #expect(state.pendingMediaAttachments.count == 1)
+
+        // Staging uploads the plaintext without publishing anything, and Send stays off until
+        // that upload lands — the whole point of the stage-time upload.
+        #expect(!state.canSend)
+
+        await Self.yieldUntil { runtime.uploadMediaCallCount == 1 }
+        #expect(runtime.uploadMediaCallCount == 1)
+        #expect(runtime.uploadedMedia?.groupIdHex == "direct-group")
+        #expect(runtime.uploadedMedia?.request.send == false)
+        #expect(runtime.uploadedMedia?.request.caption == nil)
+        #expect(runtime.uploadedMedia?.request.attachments.first?.fileName == "notes.txt")
+        #expect(runtime.uploadedMedia?.request.attachments.first?.mediaType == "text/plain")
+        #expect(runtime.uploadedMedia?.request.attachments.first?.plaintext == Data("hello media".utf8))
+
+        await Self.settleComposerMediaUploads(state)
         #expect(state.canSend)
 
         await state.sendDraft()
 
+        // The send publishes the staged reference; it does not upload again.
         #expect(runtime.uploadMediaCallCount == 1)
         #expect(runtime.sendTextCallCount == 0)
-        #expect(runtime.uploadedMedia?.groupIdHex == "direct-group")
-        #expect(runtime.uploadedMedia?.request.caption == "Project notes")
-        #expect(runtime.uploadedMedia?.request.send == true)
-        #expect(runtime.uploadedMedia?.request.attachments.first?.fileName == "notes.txt")
-        #expect(runtime.uploadedMedia?.request.attachments.first?.mediaType == "text/plain")
-        #expect(runtime.uploadedMedia?.request.attachments.first?.plaintext == Data("hello media".utf8))
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
+        #expect(runtime.sentMediaAttachments.last?.groupIdHex == "direct-group")
+        #expect(runtime.sentMediaAttachments.last?.caption == "Project notes")
+        #expect(runtime.sentMediaAttachments.last?.fileNames == ["notes.txt"])
         #expect(state.pendingMediaAttachments.isEmpty)
         #expect(state.draftText.isEmpty)
     }
 
     @MainActor
-    @Test func imageSendTracksUploadStateUntilComposerClears() async throws {
+    @Test func stagedImageTracksUploadStateUntilComposerClears() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -14078,27 +14097,543 @@ struct whitenoise_macTests {
         try Self.testPNGData(width: 40, height: 28).write(to: imageURL)
 
         await state.bootstrap()
+        // Hold the upload so the in-flight state is observable rather than a race.
+        await runtime.uploadReleaseGate.hold("screenshot.png")
         await state.addMediaAttachments(from: [imageURL])
         let attachment = try #require(state.pendingMediaAttachments.first)
         #expect(attachment.kind == .image)
 
+        #expect(state.pendingMediaUploadStates[attachment.id] == .uploading)
+        #expect(state.composerMediaUploadStatus == .uploading)
+        #expect(!state.canSend)
+
+        await runtime.uploadReleaseGate.release("screenshot.png")
+        await Self.settleComposerMediaUploads(state)
+
+        #expect(state.pendingMediaUploadStates[attachment.id]?.isUploaded == true)
+        #expect(state.canSend)
+
+        await state.sendDraft()
+        #expect(state.pendingMediaUploadStates.isEmpty)
+        #expect(state.pendingMediaAttachments.isEmpty)
+    }
+
+    @MainActor
+    @Test func stagedAttachmentsUploadIndependentlyAndPublishInComposerOrder() async throws {
+        // Uploads finish in whatever order Blossom returns them, but the published `imeta` order is
+        // the message's reading order — it must come from the composer, never from completion
+        // order. Release the second attachment first to prove the two are decoupled.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        await runtime.uploadReleaseGate.hold("first.txt", "second.txt")
+        for fileName in ["first.txt", "second.txt"] {
+            state.appendPendingMediaAttachment(
+                PendingMediaAttachment(
+                    fileName: fileName,
+                    mediaType: "text/plain",
+                    data: Data(fileName.utf8),
+                    dim: nil
+                ),
+                for: draftKey
+            )
+        }
+
+        // One upload call per attachment, each carrying exactly its own file.
+        await Self.yieldUntil { runtime.uploadMediaCallCount == 2 }
+        #expect(runtime.uploadMediaCallCount == 2)
+        #expect(runtime.uploadedMediaRequests.allSatisfy { $0.request.attachments.count == 1 })
+        #expect(runtime.uploadedMediaRequests.allSatisfy { $0.request.send == false })
+        #expect(state.composerMediaUploadStatus == .uploading)
+
+        // Let the *second* attachment land first. One of the two is now uploaded, and Send is
+        // still refused because the other is not.
+        await runtime.uploadReleaseGate.release("second.txt")
+        await Self.yieldUntil { state.pendingMediaUploadStates.values.contains(where: \.isUploaded) }
+        #expect(state.pendingMediaUploadStates.values.count(where: \.isUploaded) == 1)
+        #expect(state.composerMediaUploadStatus == .uploading)
+        #expect(!state.canSend)
+
+        await runtime.uploadReleaseGate.release("first.txt")
+        await Self.settleComposerMediaUploads(state)
+        #expect(state.canSend)
+
+        await state.sendDraft()
+
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
+        #expect(runtime.sentMediaAttachments.last?.fileNames == ["first.txt", "second.txt"])
+        #expect(runtime.sentMediaAttachments.last?.caption == nil)
+    }
+
+    @MainActor
+    @Test func stagedVoiceNoteUploadsAndGatesSendLikeAnyOtherAttachment() async throws {
+        // Upload feedback used to be image-only, so a voice note or a document showed no progress
+        // at all. Gating Send on uploads only works if every attachment kind reports one.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        let voiceNote = PendingMediaAttachment(
+            fileName: "voice.m4a",
+            mediaType: "audio/mp4",
+            data: Data("voice".utf8),
+            dim: nil,
+            durationSeconds: 3
+        )
+        #expect(voiceNote.kind == .audio)
+
+        await runtime.uploadReleaseGate.hold("voice.m4a")
+        state.appendPendingMediaAttachment(voiceNote, for: draftKey)
+
+        #expect(state.pendingMediaUploadStates[voiceNote.id] == .uploading)
+        #expect(!state.canSend)
+
+        await runtime.uploadReleaseGate.release("voice.m4a")
+        await Self.settleComposerMediaUploads(state)
+
+        #expect(state.pendingMediaUploadStates[voiceNote.id]?.isUploaded == true)
+        #expect(state.canSend)
+    }
+
+    @MainActor
+    @Test func failedStagedUploadIsRetryableWithoutLosingTheDraft() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        runtime.uploadMediaFailingFileNames = ["notes.txt"]
+        let attachment = PendingMediaAttachment(
+            fileName: "notes.txt",
+            mediaType: "text/plain",
+            data: Data("hello media".utf8),
+            dim: nil
+        )
+        state.appendPendingMediaAttachment(attachment, for: draftKey)
+        state.draftText = "Project notes"
+
+        for _ in 0..<1_000 where state.pendingMediaUploadStates[attachment.id] != .failed {
+            await Task.yield()
+        }
+
+        // A failed upload keeps the attachment and the text: the user retries, they do not retype.
+        #expect(state.pendingMediaUploadStates[attachment.id] == .failed)
+        #expect(state.pendingMediaAttachments.count == 1)
+        #expect(state.draftText == "Project notes")
+        #expect(state.composerMediaUploadStatus == .failed)
+        #expect(!state.canSend)
+
+        // Sending is refused outright rather than publishing a partial message.
+        await state.sendDraft()
+        #expect(runtime.sendMediaAttachmentsCallCount == 0)
+
+        state.retryPendingMediaUpload(attachment.id)
+        await Self.settleComposerMediaUploads(state)
+
+        #expect(runtime.uploadMediaCallCount == 2)
+        #expect(state.canSend)
+
+        await state.sendDraft()
+        #expect(runtime.sentMediaAttachments.last?.fileNames == ["notes.txt"])
+        #expect(state.pendingMediaAttachments.isEmpty)
+    }
+
+    @MainActor
+    @Test func stagedUploadWithoutAReferenceFailsInsteadOfSpinningForever() async throws {
+        // A result that reports success but carries no attachment used to hit the same silent
+        // `return` as cancellation, so the tile stayed `.uploading` with no retry and `canSend`
+        // never recovered — the draft was stuck for good.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        runtime.uploadMediaEmptyResultFileNames = ["notes.txt"]
+        let attachment = PendingMediaAttachment(
+            fileName: "notes.txt",
+            mediaType: "text/plain",
+            data: Data("hello media".utf8),
+            dim: nil
+        )
+        state.appendPendingMediaAttachment(attachment, for: draftKey)
+        state.draftText = "Project notes"
+
+        await Self.yieldUntil { state.pendingMediaUploadStates[attachment.id] == .failed }
+
+        #expect(state.pendingMediaUploadStates[attachment.id] == .failed)
+        #expect(state.composerMediaUploadStatus == .failed)
+        #expect(!state.canSend)
+        // The attachment and the text survive, so the failure is recoverable by retrying.
+        #expect(state.pendingMediaAttachments.count == 1)
+        #expect(state.draftText == "Project notes")
+
+        runtime.uploadMediaEmptyResultFileNames = []
+        state.retryPendingMediaUpload(attachment.id)
+        await Self.settleComposerMediaUploads(state)
+
+        #expect(state.pendingMediaUploadStates[attachment.id]?.isUploaded == true)
+        #expect(state.canSend)
+    }
+
+    @MainActor
+    @Test func uploadFinishingAfterRemovalDoesNotResurrectTheAttachment() async throws {
+        // Issue #245 discipline applied to the upload result: the user can remove a tile (or leave
+        // the conversation) while its upload is in flight, and the late result must not write back.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroups([messageGroup(), directGroup()])
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        // Pin the staging chat explicitly: the default selection is the other one, and switching
+        // to a chat that is already selected would prove nothing.
+        state.selectChat(try #require(state.activeChats.first { $0.id == "group" }))
+        let draftKey = try #require(state.selectedComposerDraftKey)
+        #expect(draftKey.chatId == "group")
+
+        await runtime.uploadReleaseGate.hold("removed.txt", "abandoned.txt")
+        let removed = PendingMediaAttachment(
+            fileName: "removed.txt",
+            mediaType: "text/plain",
+            data: Data("removed".utf8),
+            dim: nil
+        )
+        state.appendPendingMediaAttachment(removed, for: draftKey)
+        state.removePendingMediaAttachment(removed.id)
+
+        let abandoned = PendingMediaAttachment(
+            fileName: "abandoned.txt",
+            mediaType: "text/plain",
+            data: Data("abandoned".utf8),
+            dim: nil
+        )
+        state.appendPendingMediaAttachment(abandoned, for: draftKey)
+        let otherChat = try #require(state.activeChats.first { $0.id == "direct-group" })
+        state.selectChat(otherChat)
+
+        await runtime.uploadReleaseGate.release("removed.txt")
+        await runtime.uploadReleaseGate.release("abandoned.txt")
+        for _ in 0..<1_000 {
+            await Task.yield()
+        }
+
+        #expect(state.pendingMediaUploadStatesByConversation[draftKey]?[removed.id] == nil)
+        #expect(state.pendingMediaAttachmentsByConversation[draftKey]?.contains(removed) != true)
+        // The abandoned attachment is still staged in the chat it was staged in — switching away
+        // does not discard a draft — but nothing leaked into the newly selected conversation.
+        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(state.pendingMediaUploadStates.isEmpty)
+    }
+
+    @MainActor
+    @Test func failedPublishKeepsAttachmentsUploadedAndResendable() async throws {
+        // The blobs are already on Blossom and the references are still valid, so a failed publish
+        // must not force a full re-upload — pressing Send again is enough.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        let attachment = PendingMediaAttachment(
+            fileName: "notes.txt",
+            mediaType: "text/plain",
+            data: Data("hello media".utf8),
+            dim: nil
+        )
+        state.appendPendingMediaAttachment(attachment, for: draftKey)
+        await Self.settleComposerMediaUploads(state)
+
+        state.draftText = "Project notes"
+        runtime.sendMediaAttachmentsError = FakeMarmotRuntimeError.mediaUploadFailed
+        await state.sendDraft()
+
+        // The composer clears optimistically, so a failed publish has to put everything back —
+        // attachments, their uploaded state, and the caption the user typed.
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
+        #expect(state.pendingMediaAttachments == [attachment])
+        #expect(state.pendingMediaUploadStates[attachment.id]?.isUploaded == true)
+        #expect(state.draftText == "Project notes")
+        #expect(state.canSend)
+
+        runtime.sendMediaAttachmentsError = nil
+        await state.sendDraft()
+
+        #expect(runtime.uploadMediaCallCount == 1)
+        #expect(runtime.sendMediaAttachmentsCallCount == 2)
+        #expect(state.pendingMediaAttachments.isEmpty)
+    }
+
+    @MainActor
+    @Test func composerEmptiesBeforeThePublishReturns() async throws {
+        // The upload is already done by the time Send is pressable, so the thumbnails must not sit
+        // in the composer for the length of the relay round-trip looking like nothing happened.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(
+                fileName: "notes.txt",
+                mediaType: "text/plain",
+                data: Data("hello media".utf8),
+                dim: nil
+            ),
+            for: draftKey
+        )
+        state.draftText = "Project notes"
+        await Self.settleComposerMediaUploads(state)
+
+        // Arm the gate only now: staging would otherwise block on it too.
         runtime.messageActionGateEnabled = true
         async let send: Void = state.sendDraft()
         while !(state.isSending && runtime.didReachMessageActionGate) {
             await Task.yield()
         }
 
-        #expect(state.pendingMediaUploadStates[attachment.id] == .uploading)
+        // Still mid-publish, and the composer is already empty.
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
+        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(state.pendingMediaUploadStates.isEmpty)
+        #expect(state.draftText.isEmpty)
 
         runtime.releaseMessageActionGate()
-        for _ in 0..<1_000 where state.pendingMediaUploadStates[attachment.id] != .uploaded {
+        await send
+
+        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(state.draftText.isEmpty)
+    }
+
+    @MainActor
+    @Test func clearingComposerDraftsCancelsStagedUploads() async throws {
+        // Chat deletion, account removal and logout all drop drafts wholesale. The stage-time
+        // uploads used to keep running against a composer that no longer exists, and their entries
+        // were never reclaimed from `pendingMediaUploadTasks`.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        func stageHeldAttachment(_ fileName: String) async -> PendingMediaAttachment {
+            await runtime.uploadReleaseGate.hold(fileName)
+            let attachment = PendingMediaAttachment(
+                fileName: fileName,
+                mediaType: "text/plain",
+                data: Data(fileName.utf8),
+                dim: nil
+            )
+            state.appendPendingMediaAttachment(attachment, for: draftKey)
+            return attachment
+        }
+
+        let perChat = await stageHeldAttachment("per-chat.txt")
+        #expect(state.pendingMediaUploadTasks[perChat.id] != nil)
+        state.clearComposerDrafts(for: [draftKey.chatId], accountId: draftKey.accountId)
+        #expect(state.pendingMediaUploadTasks.isEmpty)
+
+        let perAccount = await stageHeldAttachment("per-account.txt")
+        #expect(state.pendingMediaUploadTasks[perAccount.id] != nil)
+        state.clearComposerDrafts(forAccountId: draftKey.accountId)
+        #expect(state.pendingMediaUploadTasks.isEmpty)
+
+        let all = await stageHeldAttachment("all.txt")
+        #expect(state.pendingMediaUploadTasks[all.id] != nil)
+        state.clearAllComposerDrafts()
+        #expect(state.pendingMediaUploadTasks.isEmpty)
+
+        for fileName in ["per-chat.txt", "per-account.txt", "all.txt"] {
+            await runtime.uploadReleaseGate.release(fileName)
+        }
+    }
+
+    @MainActor
+    @Test func attachmentStagedDuringSendSurvivesTheComposerClear() async throws {
+        // The remove button is hidden while `isSending`, but *adding* is only gated on the draft key
+        // and the free slot count — paste, drop and the importer all still work mid-publish. Clearing
+        // the whole draft entry after the send therefore used to discard an attachment the user
+        // staged while the publish was in flight, with no trace that it had ever been added.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(
+                fileName: "sent.txt",
+                mediaType: "text/plain",
+                data: Data("sent".utf8),
+                dim: nil
+            ),
+            for: draftKey
+        )
+        await Self.settleComposerMediaUploads(state)
+
+        // Arm the gate only now: staging would otherwise block on it too.
+        runtime.messageActionGateEnabled = true
+        async let send: Void = state.sendDraft()
+        while !(state.isSending && runtime.didReachMessageActionGate) {
+            await Task.yield()
+        }
+        #expect(state.pendingMediaAttachments.isEmpty)
+
+        let staged = PendingMediaAttachment(
+            fileName: "staged.txt",
+            mediaType: "text/plain",
+            data: Data("staged".utf8),
+            dim: nil
+        )
+        state.appendPendingMediaAttachment(staged, for: draftKey)
+        #expect(state.pendingMediaAttachments.map(\.fileName) == ["staged.txt"])
+
+        runtime.releaseMessageActionGate()
+        await send
+
+        // The publish carried only what Send snapshotted, and the late arrival is still staged.
+        #expect(runtime.sentMediaAttachments.last?.fileNames == ["sent.txt"])
+        #expect(state.pendingMediaAttachments.map(\.fileName) == ["staged.txt"])
+        #expect(state.pendingMediaUploadStates[staged.id] != nil)
+    }
+
+    @MainActor
+    @Test func failedSendRestoresItsAttachmentsWithoutDiscardingOnesStagedMeanwhile() async throws {
+        // The other half of the optimistic clear: the restore path put the pre-send snapshot back
+        // wholesale, so a publish that failed took a meanwhile-pasted attachment down with it.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        let sent = PendingMediaAttachment(
+            fileName: "sent.txt",
+            mediaType: "text/plain",
+            data: Data("sent".utf8),
+            dim: nil
+        )
+        state.appendPendingMediaAttachment(sent, for: draftKey)
+        state.draftText = "Project notes"
+        await Self.settleComposerMediaUploads(state)
+
+        runtime.sendMediaAttachmentsError = FakeMarmotRuntimeError.mediaUploadFailed
+        runtime.messageActionGateEnabled = true
+        async let send: Void = state.sendDraft()
+        while !(state.isSending && runtime.didReachMessageActionGate) {
             await Task.yield()
         }
 
-        #expect(state.pendingMediaUploadStates[attachment.id] == .uploaded)
+        let staged = PendingMediaAttachment(
+            fileName: "staged.txt",
+            mediaType: "text/plain",
+            data: Data("staged".utf8),
+            dim: nil
+        )
+        state.appendPendingMediaAttachment(staged, for: draftKey)
+
+        runtime.releaseMessageActionGate()
         await send
-        #expect(state.pendingMediaUploadStates.isEmpty)
-        #expect(state.pendingMediaAttachments.isEmpty)
+
+        // The failed send is fully recoverable, and the late arrival is still staged behind it.
+        #expect(state.pendingMediaAttachments.map(\.fileName) == ["sent.txt", "staged.txt"])
+        #expect(state.pendingMediaUploadStates[sent.id]?.isUploaded == true)
+        #expect(state.pendingMediaUploadStates[staged.id] != nil)
+        #expect(state.draftText == "Project notes")
+    }
+
+    @MainActor
+    @Test func outgoingMediaRendersFromCacheWithoutDownloadingItBack() async throws {
+        // The sender is holding the plaintext it just published, so its own bubble has no reason to
+        // fetch the blob back from Blossom and decrypt it. Before this was cached at send time the
+        // bubble sat in `.loading` and needed a manual retry once the media index caught up.
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-media-cache-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        // The projected message carries whichever reference was actually published, so the bubble
+        // looks the attachment up by the same key the send path cached it under.
+        runtime.timelineMessagesHandler = { [weak runtime] _ in
+            guard let reference = runtime?.sentMediaAttachments.last?.attachments.first else {
+                return TimelinePageFfi(messages: [], hasMoreBefore: false, hasMoreAfter: false)
+            }
+            return TimelinePageFfi(
+                messages: [
+                    timelineMessage(
+                        id: "media",
+                        direction: "outbound",
+                        groupIdHex: "direct-group",
+                        sender: account.accountIdHex,
+                        plaintext: "Project notes",
+                        recordedAt: 1_700_000_010,
+                        mediaJson: mediaJson(for: reference)
+                    )
+                ],
+                hasMoreBefore: false,
+                hasMoreAfter: false
+            )
+        }
+
+        let plaintext = Data("hello media".utf8)
+        let state = WorkspaceState(
+            mediaDiskCache: messageMediaDiskCache(root: root),
+            clientFactory: { runtime }
+        )
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(fileName: "notes.txt", mediaType: "text/plain", data: plaintext, dim: nil),
+            for: draftKey
+        )
+        state.draftText = "Project notes"
+        await Self.settleComposerMediaUploads(state)
+        await state.sendDraft()
+
+        let message = try #require(state.messagesByChat["direct-group"]?.first)
+        let attachment = try #require(message.mediaAttachments.first)
+
+        await state.loadMediaAttachment(attachment, for: message)
+
+        guard case .loaded(let download) = state.mediaDownloadState(for: message, attachment: attachment) else {
+            Issue.record("Expected the outgoing attachment to load straight from the cache")
+            return
+        }
+        #expect(download.data == plaintext)
+        #expect(download.fileName == "notes.txt")
+        #expect(runtime.downloadMediaCallCount == 0)
     }
 
     @MainActor
@@ -14144,6 +14679,10 @@ struct whitenoise_macTests {
         #expect(attachment.dim == "36x24")
         #expect(attachment.fileName.hasPrefix("pasted-image-"))
         #expect(attachment.fileName.hasSuffix(".jpg"))
+
+        // Send only opens once the pasted image has finished uploading.
+        #expect(!state.canSend)
+        await Self.settleComposerMediaUploads(state)
         #expect(state.canSend)
     }
 
@@ -14372,9 +14911,11 @@ struct whitenoise_macTests {
         await state.bootstrap()
         await state.addMediaAttachments(from: [attachmentURL])
         state.draftText = "Project notes"
+        await Self.settleComposerMediaUploads(state)
         await state.sendDraft()
 
         #expect(runtime.uploadMediaCallCount == 1)
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
         #expect(runtime.timelineMessageQueries.last?.groupIdHex == "direct-group")
         #expect(state.messagesByChat["direct-group"]?.map(\.id) == ["media"])
         #expect(state.messagesByChat["direct-group"]?.first?.mediaAttachments.count == 1)
@@ -19867,6 +20408,24 @@ struct whitenoise_macTests {
         return data as Data
     }
 
+    /// Attachments upload in a detached task as soon as they are staged, so tests that want to
+    /// reach a sendable composer have to let those tasks run. Yields until nothing is outstanding
+    /// (`composerMediaUploadStatus == nil`) or the budget runs out, so a hang fails the
+    /// assertion that follows rather than the whole suite.
+    @MainActor
+    private static func settleComposerMediaUploads(_ state: WorkspaceState, yields: Int = 1_000) async {
+        await yieldUntil(yields: yields) { state.composerMediaUploadStatus == nil }
+    }
+
+    /// `beginPendingMediaUpload` marks the attachment `.uploading` synchronously but reaches the
+    /// FFI inside a `Task`, so anything asserting on the runtime has to let that task start.
+    @MainActor
+    private static func yieldUntil(yields: Int = 1_000, _ condition: () -> Bool) async {
+        for _ in 0..<yields where !condition() {
+            await Task.yield()
+        }
+    }
+
     private static func testPNGData(width: Int, height: Int) throws -> Data {
         let bytesPerPixel = 4
         let bytesPerRow = width * bytesPerPixel
@@ -20195,6 +20754,14 @@ struct whitenoise_macTests {
         #expect(restoredState.composerMentionSelections.count == 1)
         #expect(restoredState.composerMentionSelections.first?.npub == "npub1alyce")
         #expect(restoredState.pendingMediaAttachments == [attachment])
+
+        // Drafts persist plaintext, not Blossom references, so restore has to re-upload before the
+        // composer becomes sendable again — one upload for the original staging, one for the
+        // restore.
+        await Self.settleComposerMediaUploads(restoredState)
+        #expect(runtime.uploadMediaCallCount == 2)
+        #expect(restoredState.pendingMediaUploadStates[attachment.id]?.isUploaded == true)
+        #expect(restoredState.canSend)
     }
 
     @MainActor
@@ -24973,7 +25540,44 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var editedMessage: EditedMessage?
     private(set) var sentText: SentText?
     private(set) var retriedGroupIdHex: String?
-    private(set) var uploadedMedia: UploadedMedia?
+    // Stage-time uploads run one detached task per attachment, and `uploadMedia` is `nonisolated
+    // async`, so those tasks execute it concurrently on the cooperative pool rather than on the
+    // caller's actor. Everything it records therefore lives behind `recordedStateLock`, read back
+    // through the same lock so a test's assertions cannot race an upload still in flight.
+    var uploadedMedia: UploadedMedia? {
+        recordedStateLock.withLock { _uploadedMedia }
+    }
+    private var _uploadedMedia: UploadedMedia?
+    /// Every stage-time upload, in call order — attachments now upload one call each, so the last
+    /// call alone no longer describes what the composer did.
+    var uploadedMediaRequests: [UploadedMedia] {
+        recordedStateLock.withLock { _uploadedMediaRequests }
+    }
+    private var _uploadedMediaRequests: [UploadedMedia] = []
+    var sentMediaAttachments: [SentMediaAttachments] {
+        recordedStateLock.withLock { _sentMediaAttachments }
+    }
+    private var _sentMediaAttachments: [SentMediaAttachments] = []
+    var sendMediaAttachmentsCallCount: Int {
+        recordedStateLock.withLock { _sendMediaAttachmentsCallCount }
+    }
+    private var _sendMediaAttachmentsCallCount = 0
+    var sendMediaAttachmentsError: Error?
+    /// File names whose *next* upload attempt throws, so a test can drive the failed → retry path.
+    var uploadMediaFailingFileNames: Set<String> {
+        get { recordedStateLock.withLock { _uploadMediaFailingFileNames } }
+        set { recordedStateLock.withLock { _uploadMediaFailingFileNames = newValue } }
+    }
+    private var _uploadMediaFailingFileNames: Set<String> = []
+    /// File names whose upload returns success but no attachment, so a test can drive the
+    /// reference-less result the composer has to treat as a failure rather than as still in flight.
+    var uploadMediaEmptyResultFileNames: Set<String> {
+        get { recordedStateLock.withLock { _uploadMediaEmptyResultFileNames } }
+        set { recordedStateLock.withLock { _uploadMediaEmptyResultFileNames = newValue } }
+    }
+    private var _uploadMediaEmptyResultFileNames: Set<String> = []
+    let uploadReleaseGate = UploadReleaseGate()
+    private var _uploadedAttachmentSequence = 0
     private var storedMessageDraftsByAccountRef: [String: [String: MessageDraftFfi]] = [:]
     private var messageDraftTimestamp: Int64 = 1_700_000_000_000
     private let messageDraftReadGate = BlockingFfiGate()
@@ -24993,7 +25597,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var reactToMessageCallCount = 0
     private(set) var deleteMessageCallCount = 0
     private(set) var editMessageCallCount = 0
-    private(set) var uploadMediaCallCount = 0
+    var uploadMediaCallCount: Int {
+        recordedStateLock.withLock { _uploadMediaCallCount }
+    }
+    private var _uploadMediaCallCount = 0
     var listMediaCallCount: Int {
         recordedStateLock.withLock { _listMediaCallCount }
     }
@@ -26486,16 +27093,49 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func uploadMedia(accountRef: String, groupIdHex: String, request: MediaUploadRequestFfi) async throws
         -> MediaUploadResultFfi
     {
-        uploadMediaCallCount += 1
-        uploadedMedia = UploadedMedia(groupIdHex: groupIdHex, request: request)
+        recordedStateLock.withLock {
+            _uploadMediaCallCount += 1
+            _uploadedMedia = UploadedMedia(groupIdHex: groupIdHex, request: request)
+            _uploadedMediaRequests.append(UploadedMedia(groupIdHex: groupIdHex, request: request))
+        }
         await messageActionGate.passIfArmed()
-        let attachments = request.attachments.enumerated().map { index, attachment in
-            MediaUploadAttachmentResultFfi(
+        for attachment in request.attachments {
+            await uploadReleaseGate.waitIfHeld(attachment.fileName)
+        }
+        // Claiming the failure inside the lock keeps two concurrent uploads of the same file name
+        // from both consuming the one-shot entry and both throwing.
+        let shouldFail = recordedStateLock.withLock { () -> Bool in
+            guard
+                let failing = request.attachments.first(where: {
+                    _uploadMediaFailingFileNames.contains($0.fileName)
+                })
+            else { return false }
+            _uploadMediaFailingFileNames.remove(failing.fileName)
+            return true
+        }
+        if shouldFail {
+            throw FakeMarmotRuntimeError.mediaUploadFailed
+        }
+        let returnsEmptyResult = recordedStateLock.withLock {
+            request.attachments.contains { _uploadMediaEmptyResultFileNames.contains($0.fileName) }
+        }
+        if returnsEmptyResult {
+            return MediaUploadResultFfi(attachments: [], sent: nil)
+        }
+        let attachments = request.attachments.map { attachment in
+            let sequence = recordedStateLock.withLock { () -> Int in
+                _uploadedAttachmentSequence += 1
+                return _uploadedAttachmentSequence
+            }
+            return MediaUploadAttachmentResultFfi(
+                // Real digests, like the core produces: the media disk cache verifies
+                // `plaintextSha256` against the bytes it reads back, so a placeholder here would
+                // make every cached outgoing attachment silently unreadable.
                 reference: MediaAttachmentReferenceFfi(
-                    locators: [MediaLocatorFfi(kind: "blossom", value: "https://example.com/media-\(index)")],
-                    ciphertextSha256: "cipher-\(index)",
-                    plaintextSha256: "plain-\(index)",
-                    nonceHex: "nonce-\(index)",
+                    locators: [MediaLocatorFfi(kind: "blossom", value: "https://example.com/media-\(sequence)")],
+                    ciphertextSha256: hexSHA256(Data("ciphertext-\(sequence)".utf8)),
+                    plaintextSha256: hexSHA256(attachment.plaintext),
+                    nonceHex: String(format: "%024x", sequence),
                     fileName: attachment.fileName,
                     mediaType: attachment.mediaType,
                     version: .v1,
@@ -26510,6 +27150,25 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
             attachments: attachments,
             sent: request.send ? SendSummaryFfi(published: 1, messageIds: ["media"]) : nil
         )
+    }
+
+    func sendMediaAttachments(
+        accountRef: String,
+        groupIdHex: String,
+        attachments: [MediaAttachmentReferenceFfi],
+        caption: String?
+    ) async throws -> SendSummaryFfi {
+        recordedStateLock.withLock {
+            _sendMediaAttachmentsCallCount += 1
+            _sentMediaAttachments.append(
+                SentMediaAttachments(groupIdHex: groupIdHex, attachments: attachments, caption: caption)
+            )
+        }
+        await messageActionGate.passIfArmed()
+        if let sendMediaAttachmentsError {
+            throw sendMediaAttachmentsError
+        }
+        return SendSummaryFfi(published: 1, messageIds: ["media"])
     }
 
     func sendText(accountRef: String, groupIdHex: String, text: String) async throws -> SendSummaryFfi {
@@ -26791,6 +27450,7 @@ private enum FakeMarmotRuntimeError: Error, LocalizedError {
     case missingCreatedAccount
     case auditLogDeleteFailed
     case observabilityConfigurationFailed
+    case mediaUploadFailed
     case unused
 
     var errorDescription: String? {
@@ -26801,6 +27461,8 @@ private enum FakeMarmotRuntimeError: Error, LocalizedError {
             return "Audit log delete failed."
         case .observabilityConfigurationFailed:
             return "Observability configuration failed."
+        case .mediaUploadFailed:
+            return "Media upload failed."
         case .unused:
             return "Unused fake runtime error."
         }
@@ -26821,6 +27483,37 @@ private struct SentText: Equatable {
 private struct UploadedMedia: Equatable {
     let groupIdHex: String
     let request: MediaUploadRequestFfi
+}
+
+private struct SentMediaAttachments: Equatable {
+    let groupIdHex: String
+    let attachments: [MediaAttachmentReferenceFfi]
+    let caption: String?
+
+    var fileNames: [String] { attachments.map(\.fileName) }
+}
+
+/// Non-blocking release gate keyed by attachment file name, so a test can let uploads finish in a
+/// chosen order (the composer must still publish them in composer order). Unlike `BlockingFfiGate`
+/// this suspends rather than parking a cooperative thread, which matters when several stage-time
+/// uploads are in flight at once.
+private actor UploadReleaseGate {
+    private var waiters: [String: CheckedContinuation<Void, Never>] = [:]
+    private var held: Set<String> = []
+
+    func hold(_ fileNames: String...) {
+        held.formUnion(fileNames)
+    }
+
+    func waitIfHeld(_ fileName: String) async {
+        guard held.contains(fileName) else { return }
+        await withCheckedContinuation { waiters[fileName] = $0 }
+    }
+
+    func release(_ fileName: String) {
+        held.remove(fileName)
+        waiters.removeValue(forKey: fileName)?.resume()
+    }
 }
 
 private struct MediaResolutionFixture {


### PR DESCRIPTION
I prefered the flutter app UX where images where uplaoded before sending the message. In my opinion, this makes it feel faster, because while you are selecting other images or while you are writing the message, they are already uploading, vs the current experience where while the user is writing the message, that time to uplaod images is lost and the loading is shown after in the bubble.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media attachments begin uploading as soon as they’re added.
  * Sending is enabled after all attachments upload successfully.
  * Added upload progress indicators and retry controls for failed attachments.
  * Restored drafts automatically resume media uploads.
  * Multiple uploaded attachments send together and appear immediately from cache.

* **Bug Fixes**
  * Removed attachments no longer reappear after cancellation.
  * Failed sends restore the composer and preserve uploaded media for retry.
  * Replying and clearing drafts now cancel pending uploads correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->