### PR TITLE
Improve mentions styling

### DIFF
--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -7,6 +7,17 @@ import SwiftUI
 /// Injected through the builder so the transformation stays pure and off-main.
 typealias MarkdownMentionNames = [String: String]
 
+/// Which fill the rendered text will be drawn on top of, so a mention chip can be picked to
+/// contrast with it. Threaded through the builder rather than resolved in the view: the
+/// attributed string is built once, off-main, when the message is mapped, and body/layout
+/// passes must not rewrite it (see `MarkdownMessageView`, whitenoise-mac#205).
+nonisolated enum MarkdownMentionFill {
+    /// A neutral surface — received bubbles, agent rows, anything not filled with the accent.
+    case neutral
+    /// The accent-filled sent bubble.
+    case sentBubble
+}
+
 // Pure FFI → display-model transformation (built off-main while mapping a timeline window,
 // read on the main actor by the views). Marked `nonisolated` so it does not inherit the
 // module's default main-actor isolation — otherwise constructing it from `MessageItem.init`
@@ -42,13 +53,18 @@ nonisolated struct MarkdownDisplayDocument {
     /// children in one bubble.
     static let maxDisplayNodes = 256
 
-    init(document: MarkdownDocumentFfi, mentionNames: MarkdownMentionNames = [:]) {
+    init(
+        document: MarkdownDocumentFfi,
+        mentionNames: MarkdownMentionNames = [:],
+        mentionFill: MarkdownMentionFill = .neutral
+    ) {
         var swiftTruncated = false
         var budget = MarkdownDisplayBudget(limit: Self.maxDisplayNodes)
         self.blocks = Self.makeBlocks(
             from: document.blocks,
             remainingDepth: Self.maxDepth,
             mentionNames: mentionNames,
+            mentionFill: mentionFill,
             budget: &budget,
             truncated: &swiftTruncated
         )
@@ -59,6 +75,7 @@ nonisolated struct MarkdownDisplayDocument {
         from blocks: [MarkdownBlockFfi],
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
+        mentionFill: MarkdownMentionFill,
         budget: inout MarkdownDisplayBudget,
         truncated: inout Bool
     ) -> [MarkdownDisplayBlockNode] {
@@ -76,6 +93,7 @@ nonisolated struct MarkdownDisplayDocument {
                         block,
                         remainingDepth: remainingDepth,
                         mentionNames: mentionNames,
+                        mentionFill: mentionFill,
                         budget: &budget,
                         truncated: &truncated
                     )
@@ -133,6 +151,7 @@ nonisolated enum MarkdownDisplayBlock {
         _ block: MarkdownBlockFfi,
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
+        mentionFill: MarkdownMentionFill,
         budget: inout MarkdownDisplayBudget,
         truncated: inout Bool
     ) {
@@ -143,6 +162,7 @@ nonisolated enum MarkdownDisplayBlock {
                     from: inlines,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -153,6 +173,7 @@ nonisolated enum MarkdownDisplayBlock {
                     from: inlines,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -166,6 +187,7 @@ nonisolated enum MarkdownDisplayBlock {
                     from: blocks,
                     remainingDepth: remainingDepth - 1,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     budget: &budget,
                     truncated: &truncated
                 )
@@ -177,6 +199,7 @@ nonisolated enum MarkdownDisplayBlock {
                     items: items,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     budget: &budget,
                     truncated: &truncated
                 )
@@ -187,6 +210,7 @@ nonisolated enum MarkdownDisplayBlock {
                 from: Array(header.prefix(headerCount)),
                 remainingDepth: remainingDepth,
                 mentionNames: mentionNames,
+                mentionFill: mentionFill,
                 truncated: &truncated
             )
             var displayRows: [MarkdownDisplayTableRow] = []
@@ -197,6 +221,7 @@ nonisolated enum MarkdownDisplayBlock {
                     from: Array(row.prefix(cellCount)),
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
                 guard row.isEmpty || !cells.isEmpty else { break }
@@ -215,6 +240,7 @@ nonisolated enum MarkdownDisplayBlock {
         items: [MarkdownListItemFfi],
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
+        mentionFill: MarkdownMentionFill,
         budget: inout MarkdownDisplayBudget,
         truncated: inout Bool
     ) -> [MarkdownDisplayListItem] {
@@ -225,6 +251,7 @@ nonisolated enum MarkdownDisplayBlock {
                 from: item.blocks,
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
+                mentionFill: mentionFill,
                 budget: &budget,
                 truncated: &truncated
             )
@@ -262,6 +289,7 @@ nonisolated enum MarkdownDisplayBlock {
         from cells: [MarkdownTableCellFfi],
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
+        mentionFill: MarkdownMentionFill,
         truncated: inout Bool
     ) -> [MarkdownDisplayTableCell] {
         cells.enumerated().map { index, cell in
@@ -271,6 +299,7 @@ nonisolated enum MarkdownDisplayBlock {
                     from: cell.inlines,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -313,13 +342,15 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     static func attributedString(
         from inlines: [MarkdownInlineFfi],
         remainingDepth: Int,
-        mentionNames: MarkdownMentionNames = [:]
+        mentionNames: MarkdownMentionNames = [:],
+        mentionFill: MarkdownMentionFill = .neutral
     ) -> AttributedString {
         var truncated = false
         return attributedString(
             from: inlines,
             remainingDepth: remainingDepth,
             mentionNames: mentionNames,
+            mentionFill: mentionFill,
             truncated: &truncated
         )
     }
@@ -328,6 +359,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         from inlines: [MarkdownInlineFfi],
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
+        mentionFill: MarkdownMentionFill,
         truncated: inout Bool
     ) -> AttributedString {
         guard remainingDepth > 0 else {
@@ -343,6 +375,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     link: nil,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -356,6 +389,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         link: MarkdownDisplayLink?,
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
+        mentionFill: MarkdownMentionFill,
         truncated: inout Bool
     ) -> AttributedString {
         switch inline {
@@ -374,6 +408,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 link: link,
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
+                mentionFill: mentionFill,
                 truncated: &truncated
             )
         case .strong(let children):
@@ -383,6 +418,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 link: link,
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
+                mentionFill: mentionFill,
                 truncated: &truncated
             )
         case .strikethrough(let children):
@@ -392,6 +428,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 link: link,
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
+                mentionFill: mentionFill,
                 truncated: &truncated
             )
         case .link(let dest, _, let children, let classification):
@@ -401,6 +438,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 link: actionableURL(from: dest, classification: classification),
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
+                mentionFill: mentionFill,
                 truncated: &truncated
             )
         case .image(_, let title, let alt, _):
@@ -411,6 +449,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     link: link,
                     remainingDepth: remainingDepth - 1,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             }
@@ -420,7 +459,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         case .math(let content):
             return styled(content, intent: intent.union(.code), link: link)
         case .nostrMention(let entity), .nostrUri(let entity):
-            return nostrEntity(entity, intent: intent, mentionNames: mentionNames)
+            return nostrEntity(entity, intent: intent, mentionNames: mentionNames, mentionFill: mentionFill)
         @unknown default:
             return AttributedString()
         }
@@ -447,6 +486,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         link: MarkdownDisplayLink?,
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
+        mentionFill: MarkdownMentionFill,
         truncated: inout Bool
     ) -> AttributedString {
         guard remainingDepth > 0 else {
@@ -462,6 +502,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     link: link,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
+                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -498,7 +539,8 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func nostrEntity(
         _ entity: MarkdownNostrEntityFfi,
         intent: InlinePresentationIntent,
-        mentionNames: MarkdownMentionNames
+        mentionNames: MarkdownMentionNames,
+        mentionFill: MarkdownMentionFill
     ) -> AttributedString {
         let shortReference = shortBech32(entity.bech32)
         let displayText: String
@@ -521,9 +563,10 @@ nonisolated enum MarkdownDisplayInlineBuilder {
             presentation = .underlined
         }
         // No baked foreground color: the bubble owns `.tint` so the linked reference stays visible
-        // on both sent and received. A mention is set off by a subtle background pill (Signal's
-        // treatment) rather than bold weight, a color, or a decoration — `.primary` adapts to
-        // light/dark and the low alpha reads as a soft highlight over either bubble fill.
+        // on both sent and received, and the chip is picked to keep that inherited text legible.
+        // A mention is set off by a background chip (Signal's treatment) rather than bold weight,
+        // a foreground color, or a decoration — see `MentionChipPalette` for why the chip has to
+        // know its fill instead of being one translucent wash over all of them.
         var attributed = styled(
             displayText,
             intent: intent,
@@ -532,7 +575,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
             }
         )
         if presentation == .mention {
-            attributed.backgroundColor = Color.primary.opacity(0.14)
+            attributed.backgroundColor = MentionChipPalette.color(on: mentionFill)
         }
         return attributed
     }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1857,7 +1857,16 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         self.senderPictureURL = senderPictureURL
         self.body = body
         self.wireBody = wireBody ?? body
-        self.contentMarkdown = contentMarkdown.map { MarkdownDisplayDocument(document: $0, mentionNames: mentionNames) }
+        // The mention chip has to contrast with the bubble it lands in, and the attributed string
+        // is built here — once, off-main — rather than during a body pass, so the fill is decided
+        // here too, from the direction this row already knows.
+        self.contentMarkdown = contentMarkdown.map {
+            MarkdownDisplayDocument(
+                document: $0,
+                mentionNames: mentionNames,
+                mentionFill: isOutgoing ? .sentBubble : .neutral
+            )
+        }
         self.mentionNames = mentionNames
         self.trimmedBody = trimmedBody
         self.sentAt = sentAt

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -208,6 +208,15 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
     let onPasteMedia: ([OutgoingMediaPasteboardAttachment]) -> Void
     let onSend: () -> Void
 
+    /// Attributes typed text should carry when it is not part of a mention token. Reapplied after a
+    /// mention is inserted so the token's chip and identity markers cannot bleed into what follows.
+    static var plainTypingAttributes: [NSAttributedString.Key: Any] {
+        [
+            .font: NSFont.preferredFont(forTextStyle: .body),
+            .foregroundColor: NSColor.labelColor,
+        ]
+    }
+
     func makeCoordinator() -> Coordinator {
         Coordinator(
             text: $text,
@@ -238,6 +247,8 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         textView.font = .preferredFont(forTextStyle: .body)
         textView.textColor = .labelColor
         textView.insertionPointColor = .labelColor
+        // Plain text is the baseline; only a mention marker adds attributes on top of it.
+        textView.typingAttributes = Self.plainTypingAttributes
         textView.textContainerInset = NSSize(width: 0, height: 1)
         textView.textContainer?.lineFragmentPadding = 0
         textView.textContainer?.widthTracksTextView = true
@@ -388,6 +399,13 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
                 ),
                 to: textView
             )
+            // The caret is left just past the token, so pin the attributes the next keystroke
+            // continues with: without this, NSTextView carries on with whatever it derived at the
+            // insertion point and the first character typed after a mention could pick up the
+            // chip and the identity markers with it. (A chip smeared on by clicking into an
+            // existing token instead is undone by the repair pass in
+            // `ComposerMentionMarkerStore.selections(in:)`.)
+            textView.typingAttributes = ComposerMessageTextViewRepresentable.plainTypingAttributes
             text.wrappedValue = textView.string
             publishMentionSelections(for: textView)
             updateMeasuredHeight(for: textView)
@@ -486,19 +504,43 @@ enum ComposerMentionMarkerStore {
         let selection: ComposerMentionSelection
     }
 
+    /// Identity markers plus the visible chip. The chip is never maintained on its own: it is
+    /// written only by `add` and dropped wherever the markers are dropped, so styling cannot drift
+    /// from identity — a marker that later fails validation reverts to plain text with no separate
+    /// cleanup path. Sweeping `.backgroundColor` is safe over any range because the composer text
+    /// view is plain text (`isRichText = false`), so the chip is the only background in play.
+    private static let markerAttributes: [NSAttributedString.Key] = [
+        .composerMentionNpub,
+        .composerMentionDisplayText,
+        .backgroundColor,
+    ]
+
     static func add(_ selection: ComposerMentionSelection, to textView: NSTextView) {
         guard isExact(selection, in: textView.string), let storage = textView.textStorage else { return }
         storage.addAttribute(.composerMentionNpub, value: selection.npub, range: selection.range)
         storage.addAttribute(.composerMentionDisplayText, value: selection.displayText, range: selection.range)
+        // Same chip a received bubble draws: the draft token sits on the same neutral surface, so
+        // it reads as the same kind of object even though the sent bubble's accent fill needs a
+        // darker one.
+        storage.addAttribute(
+            .backgroundColor,
+            value: MentionChipPalette.neutralFillTextBackground,
+            range: selection.range
+        )
     }
 
     static func replaceAll(with selections: [ComposerMentionSelection], in textView: NSTextView) {
         guard let storage = textView.textStorage else { return }
         let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
-        storage.removeAttribute(.composerMentionNpub, range: fullRange)
-        storage.removeAttribute(.composerMentionDisplayText, range: fullRange)
+        removeMarkers(in: fullRange, from: storage)
         for selection in selections {
             add(selection, to: textView)
+        }
+    }
+
+    private static func removeMarkers(in range: NSRange, from storage: NSTextStorage) {
+        for key in markerAttributes {
+            storage.removeAttribute(key, range: range)
         }
     }
 
@@ -541,8 +583,7 @@ enum ComposerMentionMarkerStore {
         }
         storage.beginEditing()
         for range in invalidRanges + repairs.map(\.oldRange) {
-            storage.removeAttribute(.composerMentionNpub, range: range)
-            storage.removeAttribute(.composerMentionDisplayText, range: range)
+            removeMarkers(in: range, from: storage)
         }
         for repair in repairs {
             add(repair.selection, to: textView)

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -90,6 +90,62 @@ enum MessagesPalette {
     static let sentBubble = Color(nsColor: .systemBlue)
 }
 
+/// The background chip drawn behind an `@mention`'s glyphs, Signal's treatment: the mention keeps
+/// the body font, weight, and inherited foreground, and is set off by its fill alone. Each chip is
+/// the bubble's own fill pushed a step further, never a different hue — a mention should look like
+/// part of the bubble, not like something pasted into it.
+///
+/// The chip has to hold up over four different fills — the accent-filled sent bubble, plus the light
+/// and dark neutral fills shared by received bubbles, agent rows, and the composer. No single
+/// translucent wash does that, which is why the previous `primary.opacity(0.14)` read as smudged
+/// text everywhere: `.primary` flips direction between the appearances, so it darkened one neutral
+/// fill and lightened the other, too faintly to register either way.
+///
+/// Direction is per fill, and it is not a free choice. The sent bubble and the light neutral fill
+/// both take a darker chip. The dark neutral fill cannot: it is already close to black, so even a
+/// 45%-black wash only reaches 1.43 contrast against it, while a light step of the same gray reaches
+/// 1.86. There it steps lighter instead — same achromatic family, just the only direction with room.
+///
+/// Measured against the fill behind it (WCAG contrast, chip vs. bubble), every combination lands at
+/// 1.84–1.87 where the old chip managed 1.19–1.55, and the inherited body text keeps 6.1:1 or
+/// better against the chip:
+///
+/// | fill | chip | chip ÷ fill | was | text ÷ chip |
+/// | --- | --- | --- | --- | --- |
+/// | sent, light | `#0053AD` | 1.84 | 1.29 | 7.39 |
+/// | sent, dark | `#075AAD` | 1.87 | 1.19 | 6.83 |
+/// | received, light | `#AEAEAE` | 1.86 | 1.37 | 9.47 |
+/// | received, dark | `#616161` | 1.86 | 1.55 | 6.19 |
+///
+/// `nonisolated` because a message's attributed string is built off-main while mapping a timeline
+/// window (whitenoise-mac#285), so these must be reachable from outside the main actor.
+nonisolated enum MentionChipPalette {
+    /// Over the accent-filled sent bubble: the same blue, pushed distinctly darker. One value for
+    /// both appearances, because that fill is blue in either.
+    static let onSentBubble = Color.black.opacity(0.32)
+
+    /// Over a neutral fill: the same gray, one step away. Which way depends on the appearance — the
+    /// light fill has room to go darker, the dark fill only has room to go lighter — so this is a
+    /// dynamic color resolved at draw time rather than a fixed overlay.
+    static let neutralFillTextBackground = NSColor(name: "mentionChipOnNeutralFill") { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            ? NSColor(white: 1.0, alpha: 0.20)
+            : NSColor(white: 0.0, alpha: 0.26)
+    }
+
+    /// SwiftUI twin of `neutralFillTextBackground`. The composer's `NSTextView` draft token takes
+    /// the AppKit one; both are the same chip, because the draft sits on the same neutral surface a
+    /// received bubble does.
+    static let onNeutralFill = Color(nsColor: neutralFillTextBackground)
+
+    static func color(on fill: MarkdownMentionFill) -> Color {
+        switch fill {
+        case .neutral: onNeutralFill
+        case .sentBubble: onSentBubble
+        }
+    }
+}
+
 enum MessagesLayout {
     static let accountRailWidth: CGFloat = 80
     static let accountRailControlSize: CGFloat = 44

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -162,6 +162,48 @@ struct PureValueTests {
         #expect(ComposerMentionMarkerStore.selections(in: editedMentionView).isEmpty)
     }
 
+    /// The composer chip is derived from the identity markers rather than tracked on its own, so
+    /// the styled range must follow a repaired marker and vanish with an invalidated one. Drift
+    /// either way would leave a chip on text that is no longer a mention, or a mention with no
+    /// visible affordance.
+    @MainActor
+    @Test func mentionChipTracksTheIdentityRangeAndDisappearsWithTheMarker() throws {
+        let candidate = mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
+        let selection = ComposerMentionSelection(
+            range: NSRange(location: 0, length: 5),
+            displayText: "@Alex",
+            npub: candidate.npub
+        )
+
+        let textView = NSTextView()
+        textView.isRichText = false
+        textView.string = "@Alex "
+        ComposerMentionMarkerStore.replaceAll(with: [selection], in: textView)
+        #expect(chipRanges(in: textView) == [NSRange(location: 0, length: 5)])
+
+        // Boundary edit: the marker is repaired to the shifted range, and so is the chip.
+        textView.insertText("Hi ", replacementRange: NSRange(location: 0, length: 0))
+        let repaired = ComposerMentionMarkerStore.selections(in: textView)
+        #expect(repaired.map(\.range) == [NSRange(location: 3, length: 5)])
+        #expect(chipRanges(in: textView) == repaired.map(\.range))
+
+        // Internal edit: the marker is dropped, and the chip goes with it.
+        let editedMentionView = NSTextView()
+        editedMentionView.isRichText = false
+        editedMentionView.string = "@Alex "
+        ComposerMentionMarkerStore.replaceAll(with: [selection], in: editedMentionView)
+        editedMentionView.insertText("x", replacementRange: NSRange(location: 3, length: 0))
+        #expect(ComposerMentionMarkerStore.selections(in: editedMentionView).isEmpty)
+        #expect(chipRanges(in: editedMentionView).isEmpty)
+
+        // A draft with no picked mention is never chipped.
+        let plainView = NSTextView()
+        plainView.isRichText = false
+        plainView.string = "@Alex "
+        ComposerMentionMarkerStore.replaceAll(with: [], in: plainView)
+        #expect(chipRanges(in: plainView).isEmpty)
+    }
+
     @MainActor
     @Test func mentionSynchronizationDefersObservableWritesUntilAfterTheViewUpdate() async {
         let firstScope = WorkspaceState.ComposerDraftKey(accountId: "account", chatId: "first")
@@ -2655,6 +2697,18 @@ struct PureValueTests {
         #expect(mention.runs.allSatisfy { $0.backgroundColor != nil })
         #expect(underlineStyles(in: mention) == [nil])
 
+        // The chip has to contrast with the fill it is drawn on, so the sent bubble's accent fill
+        // gets a different one from a neutral surface. Collapsing the two back into a single
+        // translucent wash is the regression this guards.
+        let sentMention = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: npub))],
+            remainingDepth: 32,
+            mentionFill: .sentBubble
+        )
+        #expect(mention.runs.first?.backgroundColor == MentionChipPalette.onNeutralFill)
+        #expect(sentMention.runs.first?.backgroundColor == MentionChipPalette.onSentBubble)
+        #expect(String(sentMention.characters) == String(mention.characters))
+
         let note = "note1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
         let noteReference = MarkdownDisplayInlineBuilder.attributedString(
             from: [.nostrUri(entity: MarkdownNostrEntityFfi(hrp: .note, bech32: note))],
@@ -3039,6 +3093,24 @@ struct PureValueTests {
 
     private func underlineStyles(in attributed: AttributedString) -> [Text.LineStyle?] {
         attributed.runs.map(\.underlineStyle)
+    }
+
+    /// Ranges carrying the mention chip, read back from a composer text view's storage. The
+    /// identity markers use private attribute keys, so the chip is what a test can observe
+    /// directly; identity is observed through `ComposerMentionMarkerStore.selections(in:)`.
+    @MainActor
+    private func chipRanges(in textView: NSTextView) -> [NSRange] {
+        guard let storage = textView.textStorage else { return [] }
+        var result: [NSRange] = []
+        storage.enumerateAttribute(
+            .backgroundColor,
+            in: NSRange(location: 0, length: (textView.string as NSString).length)
+        ) { value, range, _ in
+            if value != nil {
+                result.append(range)
+            }
+        }
+        return result
     }
 
     private func groupDetailsSnapshot(avatarURL: String?, sanitizedAvatarURL: URL?) -> GroupDetailsSnapshot {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5288,6 +5288,38 @@ struct whitenoise_macTests {
         #expect(!structured.supportsInlineMetadata)
     }
 
+    /// A mention chip has to contrast with the bubble fill behind it, and the row's attributed
+    /// string is built once here — off-main, never rewritten during a body pass — so the fill is
+    /// chosen at mapping time from the direction the row already knows.
+    @Test func mentionChipFollowsTheBubbleDirectionOfTheMessage() {
+        let npub = "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+        let tokens = MarkdownDocumentFfi(
+            blocks: [
+                .paragraph(inlines: [
+                    .nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: npub))
+                ])
+            ],
+            truncated: false
+        )
+        func chip(isOutgoing: Bool) -> Color? {
+            MessageItem(
+                id: "mention-\(isOutgoing)",
+                senderName: "Alice",
+                body: "@Alex",
+                contentMarkdown: tokens,
+                mentionNames: [npub: "Alex"],
+                sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+                isOutgoing: isOutgoing
+            )
+            .contentMarkdown?.inlineParagraph?.runs.first?.backgroundColor
+        }
+
+        // Asserted against the palette constants rather than just "these two differ", so a
+        // reversed mapping fails here instead of passing with the chips swapped.
+        #expect(chip(isOutgoing: true) == MentionChipPalette.onSentBubble)
+        #expect(chip(isOutgoing: false) == MentionChipPalette.onNeutralFill)
+    }
+
     @Test func singleEmojiMessagesAreClassifiedForStickerPresentation() {
         let singleEmoji = [
             "😀",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mention chips now use colors tailored to their message bubble background, improving readability in incoming and outgoing messages.
  - Composer mention styling resets correctly after inserting a mention, so subsequent text appears normally.
- **Bug Fixes**
  - Mention chips remain aligned with their associated text and are removed correctly when mention markers are edited.
- **Tests**
  - Added coverage for chip contrast, message direction styling, appearance variations, and marker editing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->