### PR TITLE
Add leave and delete from chatlist

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -27,6 +27,9 @@ struct ContentView: View {
         @Bindable var workspace = workspace
 
         MessengerShellView()
+            // Attached here, not on the conversation pane: a chat-list delete is most likely with
+            // no chat selected, and the sidebar row menu cannot host its own dialog.
+            .chatDestructiveActionsConfirmation()
             .frame(minWidth: 940, minHeight: 620)
             .preferredColorScheme(workspace.preferredColorScheme)
             .environment(\.locale, workspace.preferredLocale)

--- a/whitenoise-mac/Core/ChatDestructiveActions.swift
+++ b/whitenoise-mac/Core/ChatDestructiveActions.swift
@@ -1,0 +1,222 @@
+//
+//  ChatDestructiveActions.swift
+//  whitenoise-mac
+//
+//  The single policy for the two destructive chat actions — leaving a chat and deleting its
+//  local copy. Both the sidebar row context menu and the group-details inspector evaluate the
+//  functions here, so the two surfaces cannot drift apart on when either action is legal.
+//
+
+import Foundation
+import MarmotKit
+
+/// The eligibility fields any surface needs to decide whether leaving is legal, lifted out of
+/// whichever type supplied them.
+///
+/// The inspector holds a `GroupDetailsSnapshot`; the chat-list path fetches a
+/// `GroupManagementStateFfi`. Both project into this one value (see the adapters below), so the
+/// rule is evaluated by one implementation rather than by two copies that can drift.
+nonisolated struct ChatLeaveEligibility: Equatable {
+    /// Core-computed: the account is a member, is *not* an admin, has no leave in flight, and
+    /// ordinary group actions are enabled.
+    let canLeave: Bool
+    /// Core-computed: true for *any* self-admin, **including the last admin**. Not a promise that
+    /// self-demotion is legal — always pair it with `isLastAdmin`.
+    let requiresSelfDemoteBeforeLeave: Bool
+    let leaveRequestPending: Bool
+    let isLastAdmin: Bool
+
+    init(
+        canLeave: Bool,
+        requiresSelfDemoteBeforeLeave: Bool,
+        leaveRequestPending: Bool,
+        isLastAdmin: Bool
+    ) {
+        self.canLeave = canLeave
+        self.requiresSelfDemoteBeforeLeave = requiresSelfDemoteBeforeLeave
+        self.leaveRequestPending = leaveRequestPending
+        self.isLastAdmin = isLastAdmin
+    }
+
+    nonisolated init(_ state: GroupManagementStateFfi) {
+        self.init(
+            canLeave: state.canLeave,
+            requiresSelfDemoteBeforeLeave: state.requiresSelfDemoteBeforeLeave,
+            leaveRequestPending: state.leaveRequestPending,
+            isLastAdmin: state.isLastAdmin
+        )
+    }
+}
+
+extension GroupDetailsSnapshot {
+    var leaveEligibility: ChatLeaveEligibility {
+        ChatLeaveEligibility(
+            canLeave: canLeave,
+            requiresSelfDemoteBeforeLeave: requiresSelfDemoteBeforeLeave,
+            leaveRequestPending: leaveRequestPending,
+            isLastAdmin: isLastAdmin
+        )
+    }
+
+    /// True when the local account left or was removed. Mirrors `ChatItem.isNoLongerMember` so the
+    /// inspector and the sidebar row read the same way.
+    var isNoLongerMember: Bool { selfMembership != .member }
+
+    /// The destructive action the inspector may offer — the same function the sidebar row uses, so
+    /// the two surfaces agree by construction rather than by convention.
+    var destructiveAction: ChatDestructiveActions.Action? {
+        ChatDestructiveActions.action(
+            membership: selfMembership,
+            leaveRequestPending: leaveRequestPending
+        )
+    }
+
+    var leaveBlocker: ChatDestructiveActions.LeaveBlocker? {
+        ChatDestructiveActions.leaveBlocker(membership: selfMembership, eligibility: leaveEligibility)
+    }
+}
+
+/// Chat awaiting a leave confirmation. `requiresSelfDemote` is captured at preparation time so the
+/// dialog can say so, and re-derived before the leave actually runs — eligibility can move between
+/// the two taps.
+nonisolated struct ChatLeaveTarget: Equatable, Identifiable {
+    let groupIdHex: String
+    let title: String
+    let requiresSelfDemote: Bool
+
+    var id: String { groupIdHex }
+}
+
+/// Chat awaiting a local-delete confirmation.
+nonisolated struct ChatLocalDeleteTarget: Equatable, Identifiable {
+    let groupIdHex: String
+    let title: String
+
+    var id: String { groupIdHex }
+}
+
+/// A destructive chat action's outcome that needs reporting.
+nonisolated struct ChatActionAlert: Equatable, Identifiable {
+    let title: String
+    let message: String
+
+    var id: String { "\(title)\u{1F}\(message)" }
+
+    static func leaveFailed() -> ChatActionAlert {
+        ChatActionAlert(
+            title: L10n.string("Couldn't leave chat"),
+            message: L10n.string("Try again.")
+        )
+    }
+
+    static func localDeleteFailed() -> ChatActionAlert {
+        ChatActionAlert(
+            title: L10n.string("Couldn't delete chat"),
+            message: L10n.string("Try again.")
+        )
+    }
+
+    /// Reports why a leave is unavailable, and nothing more.
+    ///
+    /// Deliberately offers no local-delete alternative: dropping the local copy while still a
+    /// member would leave the rest of the group sending messages to someone who can never read
+    /// them, with nothing on the wire to say so. The remedy the message names — promote another
+    /// member to admin, then leave — keeps the group informed.
+    static func leaveBlocked(_ blocker: ChatDestructiveActions.LeaveBlocker) -> ChatActionAlert {
+        ChatActionAlert(
+            title: L10n.string("Couldn't leave chat"),
+            message: blocker.message
+        )
+    }
+}
+
+nonisolated enum ChatDestructiveActions {
+    /// The destructive action a surface may offer for one chat. The two are mutually exclusive:
+    /// a chat you can still leave is not one you may silently drop from this device.
+    enum Action: Equatable {
+        case leave
+        case deleteLocally
+    }
+
+    /// Why leaving is unavailable. `nil` from `leaveBlocker(membership:eligibility:)` means
+    /// leaving is available.
+    enum LeaveBlocker: Equatable {
+        /// A leave is already in flight; the core would reject a second one with
+        /// `MarmotKitError.LeaveAlreadyRequested`.
+        case pending
+        /// The account is the group's only admin. MIP-03 §149/§150 forbids an admin self-removal
+        /// that would deplete the admin set, so no sequence of actions lets this account leave —
+        /// another member must be promoted to admin first.
+        case lastAdmin
+        /// Ordinary group actions are disabled (the group is disbanding, or its lifecycle is
+        /// terminal). Reachable from remote admin action even though this app never initiates a
+        /// disband itself.
+        case unavailable
+
+        var message: String {
+            switch self {
+            case .pending:
+                return L10n.string(
+                    "Your leave request is pending. This conversation will update when the group commits it."
+                )
+            case .lastAdmin:
+                return L10n.string("You're the only admin. Make another member an admin before you leave.")
+            case .unavailable:
+                return L10n.string("Leaving isn't available for this chat right now.")
+            }
+        }
+
+    }
+
+    /// Which destructive action a surface may offer, from membership alone.
+    ///
+    /// **Membership is the whole rule, on every surface.** A local delete is only ever offered once
+    /// the account has actually left or been removed. Offering it earlier — say as a fallback when
+    /// leaving is blocked — would let someone drop a chat locally while the group still counts them
+    /// as a member, so the others keep sending messages nobody will ever read and get no signal that
+    /// happened. Leaving is the only way out of a group, and it is a group commit precisely so the
+    /// rest of the group learns about it.
+    ///
+    /// A `ChatListRowFfi`-derived `ChatItem` carries membership but not `canLeave` / `isLastAdmin`,
+    /// and a SwiftUI `contextMenu` cannot await an FFI call to find out — so both surfaces offer
+    /// `.leave` for a member and report a `leaveBlocker` if leaving turns out to be unavailable. The
+    /// inspector, which holds eligibility up front, pre-disables the button and shows the blocker as
+    /// a footer instead.
+    static func action(membership: ChatSelfMembership, leaveRequestPending: Bool) -> Action? {
+        guard !leaveRequestPending else { return nil }
+        return membership == .member ? .leave : .deleteLocally
+    }
+
+    static func action(for chat: ChatItem) -> Action? {
+        action(membership: chat.selfMembership, leaveRequestPending: chat.leaveRequestPending)
+    }
+
+    /// Whether a leave would do anything, counting the self-demote-first path as available.
+    static func canLeave(_ eligibility: ChatLeaveEligibility) -> Bool {
+        eligibility.canLeave || shouldSelfDemoteBeforeLeave(eligibility)
+    }
+
+    /// Whether leaving must step the account down as admin first.
+    ///
+    /// `requiresSelfDemoteBeforeLeave` is true for the last admin too, but the core rejects that
+    /// self-removal, so the `!isLastAdmin` conjunct is load-bearing: without it this would fire a
+    /// `selfDemoteAdminDetailed` the core is guaranteed to refuse.
+    static func shouldSelfDemoteBeforeLeave(_ eligibility: ChatLeaveEligibility) -> Bool {
+        eligibility.requiresSelfDemoteBeforeLeave
+            && !eligibility.isLastAdmin
+            && !eligibility.leaveRequestPending
+    }
+
+    /// Why leaving is unavailable, or `nil` when it is available. Rendered as the inspector's
+    /// footer and as the row menu's post-tap alert message, so both surfaces explain the same rule
+    /// in the same words. `nil` for a non-member: there is nothing left to leave.
+    static func leaveBlocker(
+        membership: ChatSelfMembership,
+        eligibility: ChatLeaveEligibility
+    ) -> LeaveBlocker? {
+        guard membership == .member else { return nil }
+        if eligibility.leaveRequestPending { return .pending }
+        if canLeave(eligibility) { return nil }
+        return eligibility.isLastAdmin ? .lastAdmin : .unavailable
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -132,6 +132,9 @@ extension WorkspaceState {
         UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
         chatListFilter = .active
         archivingChatId = nil
+        // Destructive-action dialogs name a group id, which is only meaningful for the account that
+        // opened them; a confirmation surviving the switch would act on the wrong account's chat.
+        clearPendingChatDestructiveActions()
         closeNewChatComposer()
         resetComposeContacts()
         pruneMessageCache(keeping: groupIdHex)
@@ -457,6 +460,11 @@ extension WorkspaceState {
         deliveredNotificationKeys.removeAll()
         deliveredNotificationKeyOrder.removeAll()
         resetAccountScopedGroupAndNewChatUIState()
+        // Sign-out and account removal reach onboarding without going through
+        // `prepareForActiveAccountSwitch` when no signed-in account remains, so the destructive
+        // -action dialogs have to be dropped here too — they name a group id belonging to the
+        // account being torn down.
+        clearPendingChatDestructiveActions()
         profileDraft = ProfileDraft()
         keyPackages = []
         auditLogFiles = []
@@ -771,6 +779,7 @@ extension WorkspaceState {
         cancelTimelineLoad()
         accounts = []
         resetChats()
+        clearPendingChatDestructiveActions()
         cachedMessageChatIds = []
         for store in messageTimelineStores.values {
             store.clear()

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -658,36 +658,219 @@ extension WorkspaceState {
         }
     }
 
-    func leaveSelectedGroup() async {
+    // MARK: - Leaving a chat, and deleting its local copy
+    //
+    // Both actions are offered by the sidebar row context menu and by the group-details inspector,
+    // and both surfaces run these exact methods — the policy in `ChatDestructiveActions` decides
+    // *whether* to offer them, and nothing here is snapshot-coupled. This mirrors the invite
+    // convention above (`acceptGroupInvite(for:)` / `acceptSelectedGroupInvite()`): one
+    // `groupIdHex`-keyed implementation plus thin adapters.
+    //
+    // Leaving is two-phase because a chat-list row cannot know whether leaving is legal:
+    // `ChatListRowFfi` carries membership, but `canLeave` / `isLastAdmin` live only on
+    // `GroupManagementStateFfi`, and a `contextMenu` closure cannot await an FFI call. Phase 1
+    // resolves eligibility and either opens the confirmation or reports the blocker; phase 2 runs
+    // after the user confirms, re-reading eligibility because it can move between the two taps.
+
+    func prepareChatLeave(for chat: ChatItem) async {
+        await prepareChatLeave(groupIdHex: chat.id, title: chat.title)
+    }
+
+    func prepareSelectedChatLeave() async {
+        guard let snapshot = groupDetailsSnapshot else { return }
+        await prepareChatLeave(groupIdHex: snapshot.groupIdHex, title: snapshot.name)
+    }
+
+    func prepareChatLeave(groupIdHex: String, title: String) async {
+        // One preparation at a time, so two quick clicks on different rows cannot both resolve and
+        // leave the confirmation naming whichever eligibility fetch happened to finish last.
         guard let client,
             let activeAccount,
-            let snapshot = groupDetailsSnapshot,
-            !hasInFlightGroupCommit
+            leavingChatId == nil,
+            preparingChatLeaveId == nil,
+            chatPendingLeave == nil
         else { return }
-        guard !snapshot.leaveRequestPending else {
-            lastError = L10n.string("Your leave request is already pending.")
-            return
+
+        preparingChatLeaveId = groupIdHex
+        defer {
+            if preparingChatLeaveId == groupIdHex {
+                preparingChatLeaveId = nil
+            }
         }
-        guard snapshot.canLeave, !snapshot.requiresSelfDemoteBeforeLeave else {
-            lastError = L10n.string("Demote yourself from admin before leaving this group.")
+
+        let accountId = activeAccount.id
+        do {
+            let state = try await client.groupManagementState(
+                accountRef: activeAccount.accountRef,
+                groupIdHex: groupIdHex
+            )
+            guard activeAccountId == accountId else { return }
+            await presentChatLeaveDecision(
+                groupIdHex: groupIdHex,
+                title: title,
+                eligibility: ChatLeaveEligibility(state)
+            )
+        } catch {
+            guard activeAccountId == accountId else { return }
+            chatActionAlert = .leaveFailed()
+        }
+    }
+
+    /// Turn resolved eligibility into either a confirmation dialog or a blocker report. Shared by
+    /// both phases so the confirm path re-applies exactly the checks the prepare path applied.
+    private func presentChatLeaveDecision(
+        groupIdHex: String,
+        title: String,
+        eligibility: ChatLeaveEligibility
+    ) async {
+        // Both callers only reach here after their surface decided the action was `.leave`, which
+        // already implies an active membership — so `.member` is the right assumption rather than a
+        // re-lookup. If the account was in fact removed in the meantime, the core reports
+        // `canLeave: false` with `isLastAdmin: false`, which lands on `.unavailable`; the next chat
+        // -list reload then flips the row to `.deleteLocally` on its own.
+        guard
+            let blocker = ChatDestructiveActions.leaveBlocker(
+                membership: .member,
+                eligibility: eligibility
+            )
+        else {
+            chatPendingLeave = ChatLeaveTarget(
+                groupIdHex: groupIdHex,
+                title: title,
+                requiresSelfDemote: ChatDestructiveActions.shouldSelfDemoteBeforeLeave(eligibility)
+            )
             return
         }
 
-        lastError = nil
+        await reportLeaveBlocker(blocker)
+    }
+
+    /// Both phases resolve the same blocker and must react to it identically, so they share this.
+    private func reportLeaveBlocker(_ blocker: ChatDestructiveActions.LeaveBlocker) async {
+        switch blocker {
+        case .pending:
+            // Already leaving: no dialog and no error — refresh so the row shows its
+            // `LeavingGroupBadge` instead.
+            await reloadChats(forceFreshSnapshot: true)
+        case .lastAdmin, .unavailable:
+            chatActionAlert = .leaveBlocked(blocker)
+        }
+    }
+
+    func confirmChatLeave(_ target: ChatLeaveTarget) async {
+        guard let client,
+            let activeAccount,
+            leavingChatId == nil
+        else { return }
+
+        chatPendingLeave = nil
+        let accountId = activeAccount.id
+        let groupIdHex = target.groupIdHex
+        leavingChatId = groupIdHex
+        // A leave is a group commit, so it also participates in the inspector's commit exclusion.
+        // The converse does not hold: starting a leave deliberately does *not* consult
+        // `hasInFlightGroupCommit`, so an unrelated in-flight commit on another chat cannot block
+        // it. Cross-chat coupling is exactly what the per-chat `leavingChatId` guard avoids.
         isLeavingGroup = true
-        defer { isLeavingGroup = false }
+        defer {
+            isLeavingGroup = false
+            if leavingChatId == groupIdHex {
+                leavingChatId = nil
+            }
+        }
 
         do {
+            // Eligibility is re-read rather than trusted from `target`: the group can commit a
+            // membership or admin change between the menu tap and the confirmation.
+            let state = try await client.groupManagementState(
+                accountRef: activeAccount.accountRef,
+                groupIdHex: groupIdHex
+            )
+            guard activeAccountId == accountId else { return }
+            let eligibility = ChatLeaveEligibility(state)
+            if let blocker = ChatDestructiveActions.leaveBlocker(
+                membership: .member,
+                eligibility: eligibility
+            ) {
+                await reportLeaveBlocker(blocker)
+                return
+            }
+
+            if ChatDestructiveActions.shouldSelfDemoteBeforeLeave(eligibility) {
+                _ = try await client.selfDemoteAdminDetailed(
+                    accountRef: activeAccount.accountRef,
+                    groupIdHex: groupIdHex
+                )
+                guard activeAccountId == accountId else { return }
+            }
+
             _ = try await client.leaveGroup(
                 accountRef: activeAccount.accountRef,
-                groupIdHex: snapshot.groupIdHex
+                groupIdHex: groupIdHex
             )
-            clearMediaReferenceResolutionCache(forAccountId: activeAccount.id, groupIdHex: snapshot.groupIdHex)
-            closeGroupDetails()
+            guard activeAccountId == accountId else { return }
+            clearMediaReferenceResolutionCache(forAccountId: accountId, groupIdHex: groupIdHex)
+            if groupDetailsSnapshot?.groupIdHex == groupIdHex {
+                closeGroupDetails()
+            }
             await reloadChats(forceFreshSnapshot: true)
         } catch {
-            lastError = error.localizedDescription
+            guard activeAccountId == accountId else { return }
+            // A leave the core already recorded is a success, not a failure: re-requesting inside
+            // the same epoch surfaces as `LeaveAlreadyRequested`, and a retry can report the same
+            // condition under a different error, so fall back to re-reading the durable state.
+            if await leaveIsAlreadyPending(error, groupIdHex: groupIdHex, accountRef: activeAccount.accountRef) {
+                guard activeAccountId == accountId else { return }
+                await reloadChats(forceFreshSnapshot: true)
+                return
+            }
+            guard activeAccountId == accountId else { return }
+            chatActionAlert = .leaveFailed()
         }
+    }
+
+    private func leaveIsAlreadyPending(
+        _ error: Error,
+        groupIdHex: String,
+        accountRef: String
+    ) async -> Bool {
+        if let error = error as? MarmotKitError, case .LeaveAlreadyRequested = error {
+            return true
+        }
+        guard let client else { return false }
+        guard
+            let state = try? await client.groupManagementState(
+                accountRef: accountRef,
+                groupIdHex: groupIdHex
+            )
+        else { return false }
+        return state.leaveRequestPending
+    }
+
+    func requestChatLocalDelete(for chat: ChatItem) {
+        requestChatLocalDelete(groupIdHex: chat.id, title: chat.title)
+    }
+
+    func requestSelectedChatLocalDelete() {
+        guard let snapshot = groupDetailsSnapshot else { return }
+        requestChatLocalDelete(groupIdHex: snapshot.groupIdHex, title: snapshot.name)
+    }
+
+    func requestChatLocalDelete(groupIdHex: String, title: String) {
+        guard !isDeletingGroupLocally, chatPendingLocalDelete == nil else { return }
+        chatPendingLocalDelete = ChatLocalDeleteTarget(groupIdHex: groupIdHex, title: title)
+    }
+
+    func confirmChatLocalDelete(_ target: ChatLocalDeleteTarget) async {
+        chatPendingLocalDelete = nil
+        await deleteGroupLocally(groupIdHex: target.groupIdHex, reportsToChatAlert: true)
+    }
+
+    func clearPendingChatDestructiveActions() {
+        chatPendingLeave = nil
+        chatPendingLocalDelete = nil
+        chatActionAlert = nil
+        preparingChatLeaveId = nil
     }
 
     func showGroupImagePicker(for chat: ChatItem) {
@@ -998,11 +1181,23 @@ extension WorkspaceState {
 
     /// Remove a group from local storage only (no relay/leave traffic). Used to
     /// clear a stale or declined conversation from this device.
-    func deleteGroupLocally(groupIdHex: String) async {
+    ///
+    /// This primitive stays ungated on membership: the *surfaces* decide when to offer a local
+    /// delete (see `ChatDestructiveActions`), and non-user-initiated callers must keep working.
+    /// `reportsToChatAlert` routes failures to the destructive-action alert instead of `lastError`,
+    /// which is not rendered anywhere near the sidebar.
+    func deleteGroupLocally(groupIdHex: String, reportsToChatAlert: Bool = false) async {
         guard let client, let activeAccount, !isDeletingGroupLocally else { return }
         lastError = nil
         isDeletingGroupLocally = true
-        defer { isDeletingGroupLocally = false }
+        // Also recorded per-chat so a surface can say *which* chat is being removed. The re-entrancy
+        // guard above stays global on purpose, so every Delete affordance must remain disabled while
+        // any delete runs — a per-chat `disabled` would let a second click be silently dropped.
+        deletingChatId = groupIdHex
+        defer {
+            isDeletingGroupLocally = false
+            deletingChatId = nil
+        }
 
         do {
             _ = try await client.deleteGroupLocal(
@@ -1021,7 +1216,11 @@ extension WorkspaceState {
             }
             await reloadChats(forceFreshSnapshot: true)
         } catch {
-            lastError = error.localizedDescription
+            if reportsToChatAlert {
+                chatActionAlert = .localDeleteFailed()
+            } else {
+                lastError = error.localizedDescription
+            }
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1059,6 +1059,24 @@ final class WorkspaceState {
     @ObservationIgnored var globalMessageSearchGeneration: UInt64 = 0
     var chatListFilter: ChatListFilter = .active
     var archivingChatId: String?
+    /// Group currently running a confirmed leave, or `nil`. Per-chat rather than global so a leave
+    /// of one chat never blocks an unrelated action on another (unlike the inspector's
+    /// `hasInFlightGroupCommit`, which is deliberately group-details-wide).
+    var leavingChatId: String?
+    /// Group whose leave eligibility is being resolved before its confirmation opens, or `nil`.
+    /// Serializes the phase-1 fetch so overlapping clicks cannot leave the dialog naming the wrong
+    /// chat.
+    var preparingChatLeaveId: String?
+    /// Chat awaiting the user's leave confirmation, or `nil`. Owned by the workspace rather than by
+    /// a view because a SwiftUI `contextMenu` closure is torn down on selection and so cannot host
+    /// the dialog itself — the same reason `messagePendingDeletion` lives here.
+    var chatPendingLeave: ChatLeaveTarget?
+    /// Chat awaiting the user's local-delete confirmation, or `nil`.
+    var chatPendingLocalDelete: ChatLocalDeleteTarget?
+    /// Outcome of a chat-list-initiated destructive action that needs reporting, or `nil`.
+    /// `lastError` is not rendered anywhere near the sidebar, so these actions carry their own
+    /// alert surface.
+    var chatActionAlert: ChatActionAlert?
     var mutatingChatPreferenceIds: Set<String> = []
     var isChatListVisible = true
     var draftText: String {
@@ -1319,6 +1337,9 @@ final class WorkspaceState {
     var isUpdatingDisappearingMessages = false
     var isSecureDeletingExpired = false
     var isDeletingGroupLocally = false
+    /// Group whose local copy is being deleted, or `nil`. Lets a surface name the affected chat in
+    /// its progress label; `isDeletingGroupLocally` remains the re-entrancy guard.
+    var deletingChatId: String?
     var isExportingGroupTranscript = false
     var groupTranscriptExportTask: Task<Void, Never>?
     var groupTranscriptExportStatus: String?

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -12678,6 +12678,65 @@
         }
       }
     },
+    "Couldn't delete chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konnte den Chat nicht löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No pude eliminar el chat"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Je n'ai pas pu supprimer le chat"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile eliminare la chat"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível excluir o bate-papo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось удалить чат"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sohbet silinemedi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法刪除聊天"
+          }
+        }
+      }
+    },
     "Couldn't delete message": {
       "extractionState": "manual",
       "localizations": {
@@ -14743,6 +14802,65 @@
         }
       }
     },
+    "Delete From This Device": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von diesem Gerät löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar de este dispositivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer de cet appareil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina da questo dispositivo"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir deste dispositivo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить с этого устройства"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu cihazdan sil"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从此设备删除"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從此裝置刪除"
+          }
+        }
+      }
+    },
     "Delete all audit logs?": {
       "extractionState": "manual",
       "localizations": {
@@ -15270,6 +15388,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "在本機刪除此對話，且不通知群組"
+          }
+        }
+      }
+    },
+    "Delete “%@” from this device?": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„%@“ von diesem Gerät löschen?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Eliminar «%@» de este dispositivo?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer « %@ » de cet appareil ?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminare “%@” da questo dispositivo?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir “%@” deste dispositivo?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить «%@» с этого устройства?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@” bu cihazdan silinsin mi?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要将“%@”从此设备删除吗？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要將「%@」從此裝置刪除嗎？"
           }
         }
       }
@@ -24022,6 +24199,65 @@
         }
       }
     },
+    "Leave Chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat verlassen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir del chat"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter le chat"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lascia la chat"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair do bate-papo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Покинуть чат"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sohbetten Ayrıl"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "离开聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "離開聊天"
+          }
+        }
+      }
+    },
     "Leave Group": {
       "extractionState": "manual",
       "localizations": {
@@ -24258,6 +24494,65 @@
         }
       }
     },
+    "Leave this chat?": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diesen Chat verlassen?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Salir de este chat?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter ce chat ?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lasciare questa chat?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair deste bate-papo?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Покинуть этот чат?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu sohbetten ayrılmak mı istiyorsunuz?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要离开此聊天吗？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要離開此聊天嗎？"
+          }
+        }
+      }
+    },
     "Leave this group?": {
       "extractionState": "manual",
       "localizations": {
@@ -24313,6 +24608,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "離開這個群嗎？"
+          }
+        }
+      }
+    },
+    "Leave “%@”?": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„%@“ verlassen?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Salir de «%@»?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter « %@ » ?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lasciare “%@”?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair de “%@”?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Покинуть «%@»?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@” sohbetinden ayrılmak mı istiyorsunuz?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要离开“%@”吗？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要離開「%@」嗎？"
           }
         }
       }
@@ -24433,6 +24787,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "離團…"
+          }
+        }
+      }
+    },
+    "Leaving isn't available for this chat right now.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Verlassen ist für diesen Chat derzeit nicht möglich."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir no está disponible para este chat en este momento."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter ce chat n’est pas possible pour le moment."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non è possibile lasciare questa chat in questo momento."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não é possível sair deste bate-papo agora."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сейчас выйти из этого чата нельзя."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şu anda bu sohbetten ayrılamazsınız."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前无法离开此聊天。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前無法離開此聊天。"
           }
         }
       }
@@ -50158,6 +50571,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "旅行與地點"
+          }
+        }
+      }
+    },
+    "Try again.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versuche es erneut."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réessayez."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riprova."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tente novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Попробуйте снова."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tekrar deneyin."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請重試。"
           }
         }
       }

--- a/whitenoise-mac/Views/ChatDestructiveActionsConfirmation.swift
+++ b/whitenoise-mac/Views/ChatDestructiveActionsConfirmation.swift
@@ -1,0 +1,108 @@
+//
+//  ChatDestructiveActionsConfirmation.swift
+//  whitenoise-mac
+//
+//  The single confirmation and reporting surface for the two destructive chat actions. Both the
+//  sidebar row context menu and the group-details inspector drive it through workspace state, so
+//  each action has exactly one dialog and one wording in the whole app.
+//
+//  It has to live on state rather than in a view for the same reason `messageDeletionConfirmation`
+//  does: a SwiftUI `contextMenu` closure is torn down when an item is chosen, so a dialog declared
+//  inside it never presents. Attached in `ContentView` rather than on the conversation pane,
+//  because deleting a dead chat is most likely with no chat selected at all.
+//
+
+import SwiftUI
+
+private struct ChatDestructiveActionsConfirmationModifier: ViewModifier {
+    @Environment(WorkspaceState.self) private var workspace
+
+    func body(content: Content) -> some View {
+        @Bindable var workspace = workspace
+
+        content
+            .confirmationDialog(
+                leaveTitle(workspace.chatPendingLeave),
+                isPresented: Binding(
+                    get: { workspace.chatPendingLeave != nil },
+                    set: { presented in
+                        if !presented { workspace.chatPendingLeave = nil }
+                    }
+                ),
+                titleVisibility: .visible,
+                presenting: workspace.chatPendingLeave
+            ) { target in
+                Button(L10n.string("Leave Chat"), role: .destructive) {
+                    Task { await workspace.confirmChatLeave(target) }
+                }
+                .disabled(workspace.leavingChatId != nil)
+                Button(L10n.string("Cancel"), role: .cancel) {}
+            } message: { target in
+                Text(leaveMessage(target))
+            }
+            .confirmationDialog(
+                localDeleteTitle(workspace.chatPendingLocalDelete),
+                isPresented: Binding(
+                    get: { workspace.chatPendingLocalDelete != nil },
+                    set: { presented in
+                        if !presented { workspace.chatPendingLocalDelete = nil }
+                    }
+                ),
+                titleVisibility: .visible,
+                presenting: workspace.chatPendingLocalDelete
+            ) { target in
+                Button(L10n.string("Remove From This Device"), role: .destructive) {
+                    Task { await workspace.confirmChatLocalDelete(target) }
+                }
+                .disabled(workspace.isDeletingGroupLocally)
+                Button(L10n.string("Cancel"), role: .cancel) {}
+            } message: { _ in
+                Text(
+                    L10n.string(
+                        "This deletes the local copy only. Other members are not notified, and you can be re-added later."
+                    )
+                )
+            }
+            .alert(
+                workspace.chatActionAlert?.title ?? "",
+                isPresented: Binding(
+                    get: { workspace.chatActionAlert != nil },
+                    set: { presented in
+                        if !presented { workspace.chatActionAlert = nil }
+                    }
+                ),
+                presenting: workspace.chatActionAlert
+            ) { _ in
+                // No local-delete alternative here on purpose: dropping the local copy while the
+                // group still counts you as a member would silently strand everyone else's messages.
+                Button(L10n.string("OK"), role: .cancel) {}
+            } message: { alert in
+                Text(alert.message)
+            }
+    }
+
+    private func leaveTitle(_ target: ChatLeaveTarget?) -> String {
+        guard let target else { return L10n.string("Leave this chat?") }
+        return String(format: L10n.string("Leave “%@”?"), target.title)
+    }
+
+    private func leaveMessage(_ target: ChatLeaveTarget) -> String {
+        if target.requiresSelfDemote {
+            return L10n.string(
+                "You'll step down as admin first, then stop receiving messages from this group."
+            )
+        }
+        return L10n.string("You will no longer receive messages from this group on this account.")
+    }
+
+    private func localDeleteTitle(_ target: ChatLocalDeleteTarget?) -> String {
+        guard let target else { return L10n.string("Remove this conversation from this device?") }
+        return String(format: L10n.string("Delete “%@” from this device?"), target.title)
+    }
+}
+
+extension View {
+    func chatDestructiveActionsConfirmation() -> some View {
+        modifier(ChatDestructiveActionsConfirmationModifier())
+    }
+}

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -21,9 +21,7 @@ private enum DisappearingChoice: Hashable {
 struct GroupDetailsSheet: View {
     @Environment(WorkspaceState.self) private var workspace
     @State private var showArchiveConfirmation = false
-    @State private var showLeaveConfirmation = false
     @State private var showSelfDemoteConfirmation = false
-    @State private var showRemoveLocallyConfirmation = false
     @State private var isAddMembersPresented = false
     @State private var isCustomDisappearingPresented = false
     // Kept as an exactly parsed decimal string: `UInt64.Stride` is `Int`, so any
@@ -454,50 +452,54 @@ struct GroupDetailsSheet: View {
                                 .disabled(workspace.hasInFlightGroupCommit || snapshot.isLastAdmin)
                             }
 
-                            Button(role: .destructive) {
-                                showLeaveConfirmation = true
-                            } label: {
-                                Label(
-                                    workspace.isLeavingGroup || snapshot.leaveRequestPending
-                                        ? L10n.string("Leaving...")
-                                        : L10n.string("Leave Group"),
-                                    systemImage: "rectangle.portrait.and.arrow.right")
-                            }
-                            .disabled(
-                                workspace.hasInFlightGroupCommit
-                                    || snapshot.leaveRequestPending
-                                    || !snapshot.canLeave
-                                    || snapshot.requiresSelfDemoteBeforeLeave
-                            )
+                            // Leave / Delete come from the same policy the sidebar row menu uses, so
+                            // the two surfaces cannot disagree on which is legal. Unlike a row, the
+                            // inspector holds full eligibility, so it can offer the local delete up
+                            // front when leaving is structurally impossible — the sole admin of a
+                            // chat can never leave it, and would otherwise be offered neither.
+                            switch snapshot.destructiveAction {
+                            case .leave:
+                                Button(role: .destructive) {
+                                    Task { await workspace.prepareSelectedChatLeave() }
+                                } label: {
+                                    Label(
+                                        workspace.leavingChatId == snapshot.groupIdHex
+                                            ? L10n.string("Leaving...")
+                                            : L10n.string("Leave Chat"),
+                                        systemImage: "rectangle.portrait.and.arrow.right")
+                                }
+                                .disabled(
+                                    workspace.leavingChatId != nil
+                                        || workspace.preparingChatLeaveId != nil)
 
-                            Button(role: .destructive) {
-                                showRemoveLocallyConfirmation = true
-                            } label: {
-                                Label(
-                                    workspace.isDeletingGroupLocally
-                                        ? L10n.string("Removing...") : L10n.string("Remove From This Device"),
-                                    systemImage: "trash.slash")
+                            case .deleteLocally:
+                                Button(role: .destructive) {
+                                    workspace.requestSelectedChatLocalDelete()
+                                } label: {
+                                    Label(
+                                        workspace.deletingChatId == snapshot.groupIdHex
+                                            ? L10n.string("Removing...")
+                                            : L10n.string("Remove From This Device"),
+                                        systemImage: "trash.slash")
+                                }
+                                // Progress is per-chat, but the guard in `deleteGroupLocally` is
+                                // global, so the affordance stays disabled for any in-flight delete.
+                                .disabled(workspace.isDeletingGroupLocally)
+                                .help(
+                                    L10n.string(
+                                        "Delete this conversation locally without notifying the group"))
+
+                            case nil:
+                                EmptyView()
                             }
-                            .disabled(workspace.isDeletingGroupLocally)
-                            .help(L10n.string("Delete this conversation locally without notifying the group"))
 
                             Spacer()
                         }
 
-                        if snapshot.leaveRequestPending {
-                            Text(
-                                L10n.string(
-                                    "Your leave request is pending. This conversation will update when the group commits it."
-                                )
-                            )
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                        } else if snapshot.requiresSelfDemoteBeforeLeave {
-                            Text(L10n.string("Demote yourself from admin before leaving this group."))
-                                .font(.callout)
-                                .foregroundStyle(.secondary)
-                        } else if snapshot.isLastAdmin {
-                            Text(L10n.string("Make another member an admin before stepping down or leaving."))
+                        // Sourced from the shared blocker so the footer and the row menu's alert
+                        // cannot drift apart.
+                        if let blocker = snapshot.leaveBlocker {
+                            Text(blocker.message)
                                 .font(.callout)
                                 .foregroundStyle(.secondary)
                         }
@@ -639,36 +641,9 @@ struct GroupDetailsSheet: View {
         } message: {
             Text(L10n.string("You'll stay in the group, but another admin will need to restore your admin status."))
         }
-        .confirmationDialog(
-            L10n.string("Leave this group?"),
-            isPresented: $showLeaveConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button(L10n.string("Leave Group"), role: .destructive) {
-                Task { await workspace.leaveSelectedGroup() }
-            }
-            .disabled(
-                workspace.hasInFlightGroupCommit
-                    || workspace.groupDetailsSnapshot?.leaveRequestPending == true
-            )
-            Button(L10n.string("Cancel"), role: .cancel) {}
-        } message: {
-            Text(L10n.string("You will no longer receive messages from this group on this account."))
-        }
-        .confirmationDialog(
-            L10n.string("Remove this conversation from this device?"),
-            isPresented: $showRemoveLocallyConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button(L10n.string("Remove From This Device"), role: .destructive) {
-                Task { await workspace.deleteGroupLocally(groupIdHex: chat.id) }
-            }
-            Button(L10n.string("Cancel"), role: .cancel) {}
-        } message: {
-            Text(
-                L10n.string(
-                    "This deletes the local copy only. Other members are not notified, and you can be re-added later."))
-        }
+        // The leave and local-delete confirmations are not declared here: both actions are also
+        // offered from the sidebar row menu, and they share the one dialog installed by
+        // `chatDestructiveActionsConfirmation()` in `ContentView` so each has a single wording.
     }
 
     private var archiveConfirmationTitle: String {

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -495,8 +495,41 @@ private struct ChatSidebarRowMenuItems: View {
                 }
                 .disabled(isArchiving)
             }
+
+            destructiveItems
         }
         .menuLabelIcons()
+    }
+
+    /// Leave / Delete, from the same policy the group-details inspector uses. A row knows only its
+    /// membership, so `.leave` here is optimistic: `prepareChatLeave` resolves eligibility and
+    /// reports a blocker if leaving turns out to be impossible.
+    @ViewBuilder
+    private var destructiveItems: some View {
+        if let action = ChatDestructiveActions.action(for: chat) {
+            Divider()
+
+            switch action {
+            case .leave:
+                Button(role: .destructive) {
+                    Task { await workspace.prepareChatLeave(for: chat) }
+                } label: {
+                    Label(
+                        L10n.string("Leave Chat"),
+                        systemImage: "rectangle.portrait.and.arrow.right"
+                    )
+                }
+                .disabled(workspace.leavingChatId != nil || workspace.preparingChatLeaveId != nil)
+
+            case .deleteLocally:
+                Button(role: .destructive) {
+                    workspace.requestChatLocalDelete(for: chat)
+                } label: {
+                    Label(L10n.string("Delete From This Device"), systemImage: "trash.slash")
+                }
+                .disabled(workspace.isDeletingGroupLocally)
+            }
+        }
     }
 }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -3468,6 +3468,157 @@ struct PureValueTests {
         )
         #expect(!UserDiscoveryPresentation.showsNoMatches(results: withResults, isSearching: false))
     }
+
+    // MARK: - ChatDestructiveActions
+
+    @Test func destructiveActionOffersLeaveOnlyWhileStillAMember() {
+        #expect(
+            ChatDestructiveActions.action(membership: .member, leaveRequestPending: false) == .leave
+        )
+        #expect(
+            ChatDestructiveActions.action(membership: .left, leaveRequestPending: false)
+                == .deleteLocally
+        )
+        #expect(
+            ChatDestructiveActions.action(membership: .removed, leaveRequestPending: false)
+                == .deleteLocally
+        )
+    }
+
+    /// A leave already in flight suppresses both actions, whatever the membership says — the row
+    /// must show progress, not offer a second destructive action.
+    @Test func pendingLeaveSuppressesBothDestructiveActionsForEveryMembership() {
+        for membership: ChatSelfMembership in [.member, .left, .removed] {
+            #expect(
+                ChatDestructiveActions.action(membership: membership, leaveRequestPending: true)
+                    == nil
+            )
+        }
+    }
+
+    /// The load-bearing invariant: **no leave eligibility, however bad, ever produces a local
+    /// delete for someone the group still counts as a member.** Deleting locally while a member
+    /// would strand every later message the group sends, with nothing on the wire to say so, so
+    /// membership alone decides — across the whole eligibility cross product.
+    @Test func noEligibilityStateOffersLocalDeleteWhileStillAMember() {
+        for pending in [false, true] {
+            for canLeave in [false, true] {
+                for requiresSelfDemote in [false, true] {
+                    for isLastAdmin in [false, true] {
+                        let eligibility = leaveEligibility(
+                            canLeave: canLeave,
+                            requiresSelfDemoteBeforeLeave: requiresSelfDemote,
+                            leaveRequestPending: pending,
+                            isLastAdmin: isLastAdmin
+                        )
+                        let action = ChatDestructiveActions.action(
+                            membership: .member,
+                            leaveRequestPending: pending
+                        )
+                        #expect(action != .deleteLocally)
+                        // Blocked or not, a member is only ever offered the leave.
+                        #expect(action == (pending ? nil : .leave))
+                        // And the blocker only ever explains itself — it carries no delete.
+                        if let blocker = ChatDestructiveActions.leaveBlocker(
+                            membership: .member,
+                            eligibility: eligibility
+                        ) {
+                            #expect(!ChatActionAlert.leaveBlocked(blocker).message.isEmpty)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// The last admin is the case the core makes unavoidable: it reports
+    /// `requiresSelfDemoteBeforeLeave` for *any* self-admin, but MIP-03 forbids the self-removal
+    /// that would empty the admin set. Self-demoting first must not be attempted there.
+    @Test func lastAdminCanNeitherLeaveNorSelfDemoteFirst() {
+        let lastAdmin = leaveEligibility(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: true
+        )
+        #expect(!ChatDestructiveActions.shouldSelfDemoteBeforeLeave(lastAdmin))
+        #expect(!ChatDestructiveActions.canLeave(lastAdmin))
+        #expect(
+            ChatDestructiveActions.leaveBlocker(membership: .member, eligibility: lastAdmin)
+                == .lastAdmin
+        )
+        // Leaving can never succeed here, and the answer is still Leave — reported as blocked, with
+        // the remedy named. It is deliberately *not* swapped for a local delete: the group has to
+        // learn that this account stopped reading, and only a leave tells them.
+        #expect(
+            ChatDestructiveActions.action(membership: .member, leaveRequestPending: false) == .leave
+        )
+        #expect(
+            ChatActionAlert.leaveBlocked(.lastAdmin).message
+                == L10n.string("You're the only admin. Make another member an admin before you leave.")
+        )
+    }
+
+    @Test func nonLastAdminLeavesBySteppingDownFirst() {
+        let admin = leaveEligibility(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: false
+        )
+        #expect(ChatDestructiveActions.shouldSelfDemoteBeforeLeave(admin))
+        #expect(ChatDestructiveActions.canLeave(admin))
+        #expect(ChatDestructiveActions.leaveBlocker(membership: .member, eligibility: admin) == nil)
+        #expect(
+            ChatDestructiveActions.action(membership: .member, leaveRequestPending: false) == .leave
+        )
+    }
+
+    /// `canLeave == false` without an admin role means ordinary group actions are disabled
+    /// (disbanding, or a terminal lifecycle). Reporting "you're the only admin" there would be a
+    /// plain lie, so it gets its own blocker.
+    @Test func blockedNonAdminReportsUnavailableRatherThanLastAdmin() {
+        let blocked = leaveEligibility(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: false,
+            isLastAdmin: false
+        )
+        #expect(
+            ChatDestructiveActions.leaveBlocker(membership: .member, eligibility: blocked)
+                == .unavailable
+        )
+        #expect(
+            ChatDestructiveActions.leaveBlocker(membership: .left, eligibility: blocked) == nil,
+            "a non-member has nothing left to leave, so nothing to explain"
+        )
+    }
+
+    /// Every blocker explains itself and stops there; none of them carries an alternative action.
+    @Test func everyLeaveBlockerReportsOnlyItsReason() {
+        for blocker: ChatDestructiveActions.LeaveBlocker in [.pending, .lastAdmin, .unavailable] {
+            let alert = ChatActionAlert.leaveBlocked(blocker)
+            #expect(alert.title == L10n.string("Couldn't leave chat"))
+            #expect(alert.message == blocker.message)
+        }
+    }
+
+    /// A direct message is a two-member MLS group here, so it must follow the same rule; the copy
+    /// is chat-neutral precisely so no `isDirect` branch is needed.
+    @Test func directChatsFollowTheSameDestructiveActionRule() {
+        for isDirect in [false, true] {
+            let chat = destructiveActionChat(
+                membership: .member,
+                leaveRequestPending: false,
+                isDirect: isDirect
+            )
+            #expect(ChatDestructiveActions.action(for: chat) == .leave)
+
+            let left = destructiveActionChat(
+                membership: .left,
+                leaveRequestPending: false,
+                isDirect: isDirect
+            )
+            #expect(ChatDestructiveActions.action(for: left) == .deleteLocally)
+        }
+    }
 }
 
 /// 64-char hex built from a short seed, so tests read as `hex("a")` rather than a wall of digits.
@@ -3511,6 +3662,40 @@ private func discoveryResult(
 private func sortedHexes(_ results: [UserDirectorySearchResultFfi]) -> [String] {
     UserDiscoveryRanking.sortedUnique(results.compactMap(UserDiscoveryRanking.person))
         .map(\.accountIdHex)
+}
+
+private func leaveEligibility(
+    canLeave: Bool = true,
+    requiresSelfDemoteBeforeLeave: Bool = false,
+    leaveRequestPending: Bool = false,
+    isLastAdmin: Bool = false
+) -> ChatLeaveEligibility {
+    ChatLeaveEligibility(
+        canLeave: canLeave,
+        requiresSelfDemoteBeforeLeave: requiresSelfDemoteBeforeLeave,
+        leaveRequestPending: leaveRequestPending,
+        isLastAdmin: isLastAdmin
+    )
+}
+
+private func destructiveActionChat(
+    membership: ChatSelfMembership,
+    leaveRequestPending: Bool,
+    isDirect: Bool
+) -> ChatItem {
+    ChatItem(
+        id: "group",
+        title: "Planning",
+        subtitle: "",
+        preview: "",
+        updatedAt: nil,
+        avatarSeed: "seed",
+        pictureURL: nil,
+        unreadCount: 0,
+        isDirect: isDirect,
+        leaveRequestPending: leaveRequestPending,
+        selfMembership: membership
+    )
 }
 
 private func mentionCandidate(id: String, displayName: String, npub: String) -> ComposerMentionCandidate {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -18821,7 +18821,11 @@ struct whitenoise_macTests {
         }
 
         await leaveState.showGroupDetails(for: leaveChat)
-        await leaveState.leaveSelectedGroup()
+        // Leaving is two-phase on every surface now: resolve eligibility, then act on confirmation.
+        await leaveState.prepareSelectedChatLeave()
+        let leaveTarget = try #require(leaveState.chatPendingLeave)
+        #expect(leaveRuntime.leaveGroupCallCount == 0)
+        await leaveState.confirmChatLeave(leaveTarget)
 
         #expect(leaveRuntime.leftGroupIdHex == "group")
         #expect(!leaveState.isGroupDetailsPresented)
@@ -18940,6 +18944,41 @@ struct whitenoise_macTests {
         state.chatListFilter = .active
         #expect(state.filteredChats.isEmpty)
         #expect(state.filteredArchivedChats.count == 1)
+    }
+
+    /// A workspace holding one group whose leave eligibility is exactly as specified, so a test can
+    /// pin the core-side answer (`canLeave` / `requiresSelfDemoteBeforeLeave` / `isLastAdmin`)
+    /// instead of inferring it from the fixture's admin set.
+    @MainActor
+    private func leavableChatState(
+        canLeave: Bool,
+        requiresSelfDemoteBeforeLeave: Bool = false,
+        isLastAdmin: Bool = false,
+        leaveRequestPending: Bool = false,
+        selfIsAdmin: Bool = false,
+        openingInspector: Bool = false
+    ) async throws -> WorkspaceState {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(
+            groupDetailsFixture(selfAccountIdHex: account.accountIdHex, selfIsAdmin: selfIsAdmin),
+            managementState: GroupManagementStateFfi(
+                myAccountIdHex: account.accountIdHex,
+                isSelfAdmin: selfIsAdmin,
+                isLastAdmin: isLastAdmin,
+                canInvite: selfIsAdmin,
+                canLeave: canLeave,
+                requiresSelfDemoteBeforeLeave: requiresSelfDemoteBeforeLeave,
+                leaveRequestPending: leaveRequestPending,
+                memberActions: []
+            )
+        )
+        if openingInspector {
+            return try await openInstalledGroupDetails(runtime: runtime)
+        }
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        return state
     }
 
     @MainActor
@@ -19332,8 +19371,12 @@ struct whitenoise_macTests {
         await firstRetention
     }
 
+    /// Preparing a leave deliberately does **not** consult `hasInFlightGroupCommit`: that token is
+    /// the group-details panel's own mutual exclusion, and gating on it would let an unrelated
+    /// in-flight commit block leaving a different chat from the sidebar. The per-chat
+    /// `leavingChatId` guard is what serializes leaves.
     @MainActor
-    @Test func leaveSelectedGroupDropsWhileProfileSaveIsInFlight() async throws {
+    @Test func chatLeavePreparationSurvivesUnrelatedInFlightGroupCommit() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
         let details = groupDetailsFixture(selfAccountIdHex: account.accountIdHex, selfIsAdmin: false)
@@ -19366,7 +19409,10 @@ struct whitenoise_macTests {
             return
         }
 
-        await state.leaveSelectedGroup()
+        // The confirmation still opens; nothing has been published yet, because publishing waits on
+        // the user's confirmation rather than on the unrelated save.
+        await state.prepareSelectedChatLeave()
+        #expect(state.chatPendingLeave?.groupIdHex == details.group.groupIdHex)
         #expect(runtime.leaveGroupCallCount == 0)
         #expect(!state.isLeavingGroup)
 
@@ -19439,21 +19485,267 @@ struct whitenoise_macTests {
             )
         )
         let state = try await openInstalledGroupDetails(runtime: runtime)
+        let target = ChatLeaveTarget(
+            groupIdHex: details.group.groupIdHex,
+            title: details.group.name,
+            requiresSelfDemote: false
+        )
 
         runtime.groupMutationGateEnabled = true
-        async let firstLeave: Void = state.leaveSelectedGroup()
-        while !(state.isLeavingGroup && runtime.didReachGroupMutationGate) {
+        async let firstLeave: Void = state.confirmChatLeave(target)
+        while !(state.leavingChatId == target.groupIdHex && runtime.didReachGroupMutationGate) {
             await Task.yield()
         }
 
-        await state.leaveSelectedGroup()
+        await state.confirmChatLeave(target)
         #expect(runtime.leaveGroupCallCount == 1)
 
         runtime.releaseGroupMutationGate()
         await firstLeave
 
         #expect(runtime.leaveGroupCallCount == 1)
+        #expect(state.leavingChatId == nil)
         #expect(!state.isLeavingGroup)
+    }
+
+    // MARK: - Chat-list leave / local delete
+
+    /// Preparing a leave resolves eligibility and opens the confirmation — it must not publish
+    /// anything, or a context-menu click would leave the chat without asking.
+    @MainActor
+    @Test func chatListLeavePreparationOnlyOpensTheConfirmation() async throws {
+        let state = try await leavableChatState(canLeave: true)
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+
+        #expect(state.chatPendingLeave?.groupIdHex == chat.id)
+        #expect(state.chatPendingLeave?.requiresSelfDemote == false)
+        #expect(state.chatActionAlert == nil)
+        #expect(runtime.leaveGroupCallCount == 0)
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+    }
+
+    /// The two surfaces must resolve to the same thing. The sidebar row and the inspector reach the
+    /// same shared entry point, so the same group produces the same pending confirmation.
+    @MainActor
+    @Test func chatListAndInspectorLeavePreparationAgree() async throws {
+        let rowState = try await leavableChatState(canLeave: true)
+        let rowChat = try #require(rowState.activeChats.first)
+        await rowState.prepareChatLeave(for: rowChat)
+
+        let inspectorState = try await leavableChatState(canLeave: true, openingInspector: true)
+        await inspectorState.prepareSelectedChatLeave()
+
+        #expect(rowState.chatPendingLeave?.groupIdHex == inspectorState.chatPendingLeave?.groupIdHex)
+        #expect(
+            rowState.chatPendingLeave?.requiresSelfDemote
+                == inspectorState.chatPendingLeave?.requiresSelfDemote
+        )
+    }
+
+    /// Two quick clicks must not race: whichever eligibility fetch finishes last would otherwise own
+    /// the confirmation, so the dialog could name a chat the user did not click.
+    @MainActor
+    @Test func overlappingLeavePreparationsCannotRetargetTheConfirmation() async throws {
+        let state = try await leavableChatState(canLeave: true)
+        let chat = try #require(state.activeChats.first)
+
+        async let first: Void = state.prepareChatLeave(groupIdHex: chat.id, title: "First")
+        async let second: Void = state.prepareChatLeave(groupIdHex: "other-group", title: "Second")
+        _ = await (first, second)
+
+        #expect(state.chatPendingLeave?.groupIdHex == chat.id)
+        #expect(state.chatPendingLeave?.title == "First")
+        #expect(state.preparingChatLeaveId == nil)
+    }
+
+    /// The core makes the creator of a chat its sole admin and MIP-03 forbids the self-removal that
+    /// would empty the admin set, so leaving is blocked until another member is promoted. The report
+    /// says exactly that and offers no local delete: dropping the local copy while the group still
+    /// counts this account as a member would strand every message they send afterwards.
+    @MainActor
+    @Test func lastAdminLeaveIsReportedWithoutOfferingALocalDelete() async throws {
+        let state = try await leavableChatState(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: true,
+            selfIsAdmin: true
+        )
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+
+        #expect(state.chatPendingLeave == nil)
+        #expect(state.chatPendingLocalDelete == nil)
+        #expect(runtime.leaveGroupCallCount == 0)
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+        #expect(runtime.locallyDeletedGroupIds.isEmpty)
+        let alert = try #require(state.chatActionAlert)
+        #expect(alert.message == ChatDestructiveActions.LeaveBlocker.lastAdmin.message)
+        // The chat is still listed and still a member's chat — nothing was silently dropped.
+        #expect(state.activeChats.contains { $0.id == chat.id })
+        #expect(ChatDestructiveActions.action(for: chat) == .leave)
+    }
+
+    @MainActor
+    @Test func nonLastAdminLeaveStepsDownBeforeLeaving() async throws {
+        let state = try await leavableChatState(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: false,
+            selfIsAdmin: true
+        )
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+        let target = try #require(state.chatPendingLeave)
+        #expect(target.requiresSelfDemote)
+        await state.confirmChatLeave(target)
+
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 1)
+        #expect(runtime.leaveGroupCallCount == 1)
+        #expect(runtime.groupMutationOrder == ["selfDemote", "leave"])
+        #expect(state.leavingChatId == nil)
+    }
+
+    @MainActor
+    @Test func ordinaryMemberLeaveDoesNotSelfDemote() async throws {
+        let state = try await leavableChatState(canLeave: true)
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+        await state.confirmChatLeave(try #require(state.chatPendingLeave))
+
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+        #expect(runtime.groupMutationOrder == ["leave"])
+        #expect(runtime.leftGroupIdHex == chat.id)
+        #expect(state.chatActionAlert == nil)
+    }
+
+    /// A leave the core already recorded is a success. Re-requesting inside the same epoch raises
+    /// `LeaveAlreadyRequested`, and surfacing that as a failure would tell the user the leave did
+    /// not happen when in fact it did.
+    @MainActor
+    @Test func alreadyRequestedLeaveIsTreatedAsSuccess() async throws {
+        let state = try await leavableChatState(canLeave: true)
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+        runtime.leaveGroupError = MarmotKitError.LeaveAlreadyRequested(groupIdHex: chat.id)
+
+        await state.prepareChatLeave(for: chat)
+        await state.confirmChatLeave(try #require(state.chatPendingLeave))
+
+        #expect(runtime.leaveGroupCallCount == 1)
+        #expect(state.chatActionAlert == nil)
+        #expect(state.leavingChatId == nil)
+    }
+
+    @MainActor
+    @Test func genuineLeaveFailureIsReportedInTheChatActionAlert() async throws {
+        let state = try await leavableChatState(canLeave: true)
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+        runtime.leaveGroupError = FakeMarmotRuntimeError.unused
+
+        await state.prepareChatLeave(for: chat)
+        await state.confirmChatLeave(try #require(state.chatPendingLeave))
+
+        #expect(runtime.leaveGroupCallCount == 1)
+        #expect(state.chatActionAlert?.title == L10n.string("Couldn't leave chat"))
+        #expect(state.chatPendingLocalDelete == nil)
+        #expect(state.leavingChatId == nil)
+    }
+
+    /// Deleting the chat you are looking at has to tear the conversation down too. The primitive
+    /// already does this; this asserts the confirmation path still routes through it.
+    @MainActor
+    @Test func confirmedLocalDeleteOfSelectedChatClearsTheConversation() async throws {
+        let state = try await leavableChatState(canLeave: true)
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.selectedChat)
+
+        state.requestChatLocalDelete(for: chat)
+        let target = try #require(state.chatPendingLocalDelete)
+        await state.confirmChatLocalDelete(target)
+
+        #expect(runtime.locallyDeletedGroupIds == [chat.id])
+        #expect(state.chatPendingLocalDelete == nil)
+        #expect(state.selection != .chat(chat.id))
+        #expect(state.chatActionAlert == nil)
+    }
+
+    /// Group ids only mean something within the account that produced them, so a confirmation must
+    /// never outlive the account switch — otherwise confirming would act on a different identity's
+    /// chat, or on nothing at all.
+    @MainActor
+    @Test func accountSwitchDiscardsPendingDestructiveConfirmations() async throws {
+        let second = AccountSummaryFfi(
+            label: "Second Account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [desktopAccount(), second])
+        runtime.installGroups([messageGroup()])
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+        UserDefaults.standard.set("Desktop Account", forKey: WorkspaceState.activeAccountKey)
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let chat = try #require(state.activeChats.first)
+
+        state.requestChatLocalDelete(for: chat)
+        state.chatPendingLeave = ChatLeaveTarget(
+            groupIdHex: chat.id,
+            title: chat.title,
+            requiresSelfDemote: false
+        )
+        state.chatActionAlert = .leaveFailed()
+        #expect(state.chatPendingLocalDelete != nil)
+
+        let target = try #require(state.accounts.first { $0.id == "Second Account" })
+        state.switchActiveAccount(target, finalSelection: nil)
+
+        #expect(state.chatPendingLeave == nil)
+        #expect(state.chatPendingLocalDelete == nil)
+        #expect(state.chatActionAlert == nil)
+    }
+
+    /// Signing out the last account reaches onboarding without going through
+    /// `prepareForActiveAccountSwitch`, so the switch-time clear does not run — the teardown itself
+    /// has to drop the dialogs, or one survives into onboarding still naming the old account's group.
+    @MainActor
+    @Test func signingOutTheLastAccountDiscardsPendingDestructiveConfirmations() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [desktopAccount()])
+        runtime.installGroups([messageGroup()])
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+        UserDefaults.standard.set("Desktop Account", forKey: WorkspaceState.activeAccountKey)
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let chat = try #require(state.activeChats.first)
+        let account = try #require(state.accounts.first)
+
+        state.requestChatLocalDelete(for: chat)
+        state.chatPendingLeave = ChatLeaveTarget(
+            groupIdHex: chat.id,
+            title: chat.title,
+            requiresSelfDemote: false
+        )
+        state.chatActionAlert = .leaveFailed()
+
+        await state.signOutAccount(account)
+
+        #expect(state.chatPendingLeave == nil)
+        #expect(state.chatPendingLocalDelete == nil)
+        #expect(state.chatActionAlert == nil)
     }
 
     @MainActor
@@ -25808,6 +26100,8 @@ struct MarmotKit098IntegrationTests {
         #expect(runtime.recordedHostPerformance.last?.2 == .success)
     }
 
+    /// A leave already recorded by the core is neither an error nor an invitation to publish a
+    /// second one: the affordance resolves to "already leaving", with no dialog and no alert.
     @MainActor
     @Test func pendingLeaveIntentBlocksDuplicatePublish() async throws {
         let account = desktopAccount()
@@ -25831,11 +26125,13 @@ struct MarmotKit098IntegrationTests {
         let chat = try #require(state.activeChats.first)
         await state.showGroupDetails(for: chat)
 
-        await state.leaveSelectedGroup()
+        await state.prepareSelectedChatLeave()
 
         #expect(state.groupDetailsSnapshot?.leaveRequestPending == true)
         #expect(runtime.leaveGroupCallCount == 0)
-        #expect(state.lastError == L10n.string("Your leave request is already pending."))
+        #expect(state.chatPendingLeave == nil)
+        #expect(state.chatActionAlert == nil)
+        #expect(state.lastError == nil)
     }
 }
 
@@ -26036,6 +26332,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var setGroupArchivedError: Error?
     private(set) var leftGroupIdHex: String?
     private(set) var leaveGroupCallCount = 0
+    var leaveGroupError: Error?
+    /// Ordered log of the group mutations a leave can issue, so tests can assert that a
+    /// self-demote precedes the leave it unblocks rather than merely accompanying it.
+    private(set) var groupMutationOrder: [String] = []
     private(set) var acceptedInviteGroupIds: [String] = []
     private(set) var acceptGroupInviteCallCount = 0
     private(set) var declinedInviteGroupIds: [String] = []
@@ -27075,7 +27375,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func leaveGroup(accountRef: String, groupIdHex: String) async throws -> SendSummaryFfi {
         leaveGroupCallCount += 1
+        groupMutationOrder.append("leave")
         await groupMutationGate.passIfArmed()
+        if let leaveGroupError { throw leaveGroupError }
         leftGroupIdHex = groupIdHex
         groups.removeAll { $0.groupIdHex == groupIdHex }
         groupDetailsById[groupIdHex] = nil
@@ -27126,6 +27428,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func selfDemoteAdminDetailed(accountRef: String, groupIdHex: String) async throws -> GroupMutationResultFfi {
         selfDemoteAdminDetailedCallCount += 1
+        groupMutationOrder.append("selfDemote")
         await groupMutationGate.passIfArmed()
         selfDemotedGroupIdHex = groupIdHex
         guard var details = groupDetailsById[groupIdHex] else {


### PR DESCRIPTION
Leave and delete chat from chatlist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent confirmation dialogs for leaving chats and deleting local chat copies.
  * Added destructive chat actions to chat menus and group details.
  * Added safeguards for pending leave requests, last-admin restrictions, and unavailable actions.
  * Added localized messaging for chat actions and errors.

* **Bug Fixes**
  * Improved handling of account switching and chat-action failures.
  * Added local deletion as a fallback when leaving a chat is unavailable.

* **Tests**
  * Expanded coverage for chat leaving, deletion, blockers, errors, and account changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->