### PR TITLE
Add user discovery

### DIFF
--- a/whitenoise-mac/Core/MarmotClient.swift
+++ b/whitenoise-mac/Core/MarmotClient.swift
@@ -72,6 +72,11 @@ nonisolated protocol MarmotRuntime: Sendable {
         -> SendSummaryFfi
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws -> ChatListSubscription
     func subscribeNotifications() async throws -> NotificationsSubscription
+    /// The one MarmotRuntime call that is not a local DB read: it traverses the searcher's web of
+    /// trust over relays and streams matches as each radius resolves. Note the parameter is an
+    /// `accountIdHex`, not the `accountRef` every neighbouring call takes.
+    func searchUsers(accountIdHex: String, query: String, radiusStart: UInt8, radiusEnd: UInt8) async throws
+        -> UserSearchSubscription
     func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi) throws -> TimelinePageFfi
     func subscribeTimelineMessages(accountRef: String, groupIdHex: String?, limit: UInt32?) async throws
         -> TimelineMessagesSubscription
@@ -458,6 +463,17 @@ nonisolated final class MarmotClient: MarmotRuntime, @unchecked Sendable {
 
     func subscribeNotifications() async throws -> NotificationsSubscription {
         try await marmot.subscribeNotifications()
+    }
+
+    func searchUsers(accountIdHex: String, query: String, radiusStart: UInt8, radiusEnd: UInt8) async throws
+        -> UserSearchSubscription
+    {
+        try await marmot.searchUsers(
+            accountIdHex: accountIdHex,
+            query: query,
+            radiusStart: radiusStart,
+            radiusEnd: radiusEnd
+        )
     }
 
     func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi) throws -> TimelinePageFfi {

--- a/whitenoise-mac/Core/WorkspaceState+Navigation.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Navigation.swift
@@ -80,8 +80,13 @@ extension WorkspaceState {
         }
     }
 
+    /// The single funnel for "the compose query went away" (pane hops, staging a member, going
+    /// back). Releasing the people search here rather than waiting for the view's `.task(id:)` to
+    /// notice keeps a relay traversal from outliving the panel that asked for it.
+    /// `closeNewChatComposer()` is covered too, via `resetNewChatComposer()`.
     func clearComposeSearch() {
         invalidateNewChatLookup()
+        invalidateUserDiscovery()
         newChatQuery = ""
         newChatRecipient = nil
         lastError = nil

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -270,6 +270,7 @@ extension WorkspaceState {
 
     func resetNewChatComposer() {
         invalidateNewChatLookup()
+        invalidateUserDiscovery()
         composePane = .newChat
         newChatQuery = ""
         newChatName = ""
@@ -282,10 +283,13 @@ extension WorkspaceState {
 
     /// Drops the active account's compose directory and invalidates any refresh that is
     /// still fetching group rosters, preventing it from restoring contacts after teardown.
+    /// Also releases any in-flight people search: it belongs to the account being torn down,
+    /// and its relay traversal must not outlive it.
     func resetComposeContacts() {
         composeContacts = []
         isLoadingComposeContacts = false
         composeContactsGeneration &+= 1
+        invalidateUserDiscovery()
     }
 
     func beginNewChatLookup() -> UInt64 {

--- a/whitenoise-mac/Core/WorkspaceState+UserDiscovery.swift
+++ b/whitenoise-mac/Core/WorkspaceState+UserDiscovery.swift
@@ -1,0 +1,415 @@
+//
+//  WorkspaceState+UserDiscovery.swift
+//  whitenoise-mac
+//
+//  Streaming web-of-trust people search for the compose flow: the model, the pure
+//  ranking/presentation rules, and the state extension that drives the subscription.
+//
+//  This is the only place in the app where the "MarmotKit calls are local DB reads" rule
+//  breaks — `searchUsers` traverses a social graph over relays. Four FFI contracts shape
+//  everything below (MarmotKit.swift:2333-2346, :6088-6092, :16066-16070):
+//
+//  1. `searchUsers` returns as soon as the traversal is *spawned*, not when results exist;
+//     the host drives `nextUpdate()` in a loop until it yields `nil`.
+//  2. Abandoning a search means *releasing* the subscription, not draining it — dropping it
+//     cancels the relay traversal at its next checkpoint. So a superseded search returns
+//     immediately and lets the subscription deinit; it never loops on to `searchCompleted`.
+//  3. `newResults` is pre-sorted only *within* a batch, so the host re-sorts the aggregate on
+//     every update.
+//  4. A search result is not a relationship. Discovered people are deliberately absent from
+//     the local directory, so nothing here may be written into `peerProfileFFICache` or
+//     `composeContacts`, and discovery rows must never be routed through
+//     `resolveNewChatRecipient(for:)` (which refreshes the profile over the network and
+//     invalidates that cache). Recipients are built locally from the search result's own
+//     profile snapshot instead.
+//
+
+import Foundation
+import MarmotKit
+
+/// One person a web-of-trust search found. Not a contact: this exists only for as long as the
+/// query that produced it, and never enters `composeContacts` or the profile cache.
+///
+/// Every string here came from a stranger, so `init` — not the call site — sanitizes the display
+/// name and runs the avatar URL through the SSRF policy. A discovery list is the app's
+/// highest-volume untrusted-avatar surface; making sanitization unskippable is the point.
+nonisolated struct DiscoveredPerson: Identifiable, Equatable, Sendable {
+    let accountIdHex: String
+    let npub: String
+    /// Social distance from the searcher: 1 is "in your network" (a follow *or* a shared-group
+    /// peer), 2 one hop further out. 255 is off-graph and must never read as a connection.
+    let radius: UInt8
+    /// Rank supplied by an off-graph discovery provider; absent for graph results.
+    let providerRank: Double?
+    let matchQualityRank: Int
+    let matchedFieldRank: Int
+    let displayName: String?
+    let pictureURL: String?
+    /// Pre-sanitized once from the stranger-controlled raw URL so rows only read this.
+    let sanitizedPictureURL: URL?
+
+    var id: String { accountIdHex }
+
+    init(
+        accountIdHex: String,
+        npub: String,
+        radius: UInt8,
+        providerRank: Double?,
+        matchQualityRank: Int,
+        matchedFieldRank: Int,
+        displayName: String?,
+        pictureURL: String?
+    ) {
+        self.accountIdHex = accountIdHex
+        self.npub = npub
+        self.radius = radius
+        self.providerRank = providerRank
+        self.matchQualityRank = matchQualityRank
+        self.matchedFieldRank = matchedFieldRank
+        self.displayName = PeerDisplayText.sanitize(displayName)
+        self.pictureURL = pictureURL
+        self.sanitizedPictureURL = RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
+    }
+
+    var memberRef: String {
+        npub.isEmpty ? accountIdHex : npub
+    }
+
+    var title: String {
+        displayName ?? DisplayText.short(memberRef)
+    }
+
+    var subtitle: String {
+        DisplayText.short(memberRef, head: 12, tail: 8)
+    }
+
+    /// The npub came from the core in this process, already canonical, so it is used directly as
+    /// the member ref — `createGroup` validates it anyway. Deliberately *not* re-resolved through
+    /// `resolveNewChatRecipient(for:)`, which would promote the profile into the local cache.
+    var recipient: NewChatRecipient {
+        NewChatRecipient(
+            sourceQuery: "",
+            memberRef: memberRef,
+            accountIdHex: accountIdHex,
+            npub: npub,
+            displayName: displayName,
+            pictureURL: pictureURL
+        )
+    }
+}
+
+/// Known contacts and discovered strangers, kept in separate sections rather than interleaved so
+/// a search snapshot never masquerades as someone you already talk to.
+nonisolated struct MergedComposeResults: Equatable, Sendable {
+    let known: [ComposeContact]
+    let discovered: [DiscoveredPerson]
+
+    var isEmpty: Bool { known.isEmpty && discovered.isEmpty }
+}
+
+nonisolated enum UserDiscoveryRanking {
+    /// Maps one FFI result into a `DiscoveredPerson`, dropping results with no usable identity.
+    static func person(from result: UserDirectorySearchResultFfi) -> DiscoveredPerson? {
+        let hex = result.accountIdHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !hex.isEmpty else { return nil }
+        return DiscoveredPerson(
+            accountIdHex: hex,
+            npub: result.npub,
+            radius: result.radius,
+            providerRank: result.providerRank,
+            matchQualityRank: rank(of: result.matchQuality),
+            matchedFieldRank: rank(of: result.matchedField),
+            displayName: firstNonBlank([
+                PeerDisplayText.sanitize(result.profile?.displayName),
+                PeerDisplayText.sanitize(result.profile?.name),
+            ]),
+            pictureURL: result.profile?.picture
+        )
+    }
+
+    /// Deduped by lowercased hex (first occurrence wins) and totally ordered, so re-sorting the
+    /// growing aggregate on every update never makes the rendered list jitter.
+    static func sortedUnique(_ people: [DiscoveredPerson]) -> [DiscoveredPerson] {
+        var seen = Set<String>()
+        var unique: [DiscoveredPerson] = []
+        unique.reserveCapacity(people.count)
+        for person in people where seen.insert(person.accountIdHex.lowercased()).inserted {
+            unique.append(person)
+        }
+        return unique.sorted(by: isOrderedBefore)
+    }
+
+    /// Known contacts keep their existing order and win any hex collision: a `ComposeContact` is
+    /// derived from a conversation you are actually in, so its name and picture come from a real
+    /// interaction and are strictly better than a search snapshot. (iOS back-fills a known
+    /// candidate's missing profile from the discovered duplicate; skipped deliberately, which also
+    /// keeps this a pure set operation.)
+    static func merged(
+        known: [ComposeContact],
+        discovered: [DiscoveredPerson],
+        excluding: Set<String>
+    ) -> MergedComposeResults {
+        let excluded = Set(excluding.map { $0.lowercased() })
+        let keptKnown = known.filter { !excluded.contains($0.accountIdHex.lowercased()) }
+        var claimed = excluded
+        claimed.formUnion(keptKnown.map { $0.accountIdHex.lowercased() })
+        let keptDiscovered = sortedUnique(discovered).filter {
+            !claimed.contains($0.accountIdHex.lowercased())
+        }
+        return MergedComposeResults(known: keptKnown, discovered: keptDiscovered)
+    }
+
+    /// iOS's comparator minus its followed-first tier (follow is out of scope here). Radius still
+    /// leads, and radius 1 already contains the follow list, so someone you follow generally still
+    /// sorts near the top — just not guaranteed above a shared-group peer.
+    static func isOrderedBefore(_ lhs: DiscoveredPerson, _ rhs: DiscoveredPerson) -> Bool {
+        if lhs.radius != rhs.radius { return lhs.radius < rhs.radius }
+        switch (lhs.providerRank, rhs.providerRank) {
+        case (let left?, let right?) where left != right:
+            return left > right
+        case (.some, nil):
+            return true
+        case (nil, .some):
+            return false
+        default:
+            break
+        }
+        if lhs.matchQualityRank != rhs.matchQualityRank {
+            return lhs.matchQualityRank < rhs.matchQualityRank
+        }
+        if lhs.matchedFieldRank != rhs.matchedFieldRank {
+            return lhs.matchedFieldRank < rhs.matchedFieldRank
+        }
+        // Total-order tiebreak: without it, two otherwise-identical results could swap places
+        // between updates because `sort` is not stable.
+        return lhs.accountIdHex.lowercased() < rhs.accountIdHex.lowercased()
+    }
+
+    /// Best first. Switched exhaustively so a bindings update that adds a quality breaks the build.
+    static func rank(of quality: MatchQualityFfi) -> Int {
+        switch quality {
+        case .exact: 0
+        case .prefix: 1
+        case .contains: 2
+        }
+    }
+
+    /// Most identifying first. Exhaustive for the same reason as `rank(of: MatchQualityFfi)`.
+    static func rank(of field: MatchedFieldFfi) -> Int {
+        switch field {
+        case .name: 0
+        case .nip05: 1
+        case .displayName: 2
+        case .about: 3
+        case .npub: 4
+        case .pubkey: 5
+        }
+    }
+}
+
+/// Row provenance and the search-status footer, kept out of the views so both are testable.
+nonisolated enum UserDiscoveryPresentation {
+    /// Provenance line for a discovered row. `nil` for radii the search never requests (0 is the
+    /// searcher; 3…254 are outside the 1…2 window), so an unexpected value renders no claim about
+    /// a connection rather than an invented one.
+    static func provenanceLabel(radius: UInt8) -> String? {
+        switch radius {
+        case 1: L10n.string("In your network")
+        case 2: L10n.string("Via your network")
+        case 255: L10n.string("Discovery")
+        default: nil
+        }
+    }
+
+    /// Exactly one status at a time. `searching` outranks `failed` because an `.error` trigger is
+    /// always followed by `searchCompleted` — the failure is reported once the loop actually ends,
+    /// never alongside a live spinner.
+    static func status(isSearching: Bool, didFail: Bool, isPartial: Bool) -> UserDiscoveryStatus {
+        if isSearching { return .searching }
+        if didFail { return .failed }
+        if isPartial { return .partial }
+        return .none
+    }
+
+    /// "No matches" must not flash between the debounce firing and the first update landing.
+    static func showsNoMatches(results: MergedComposeResults, isSearching: Bool) -> Bool {
+        results.isEmpty && !isSearching
+    }
+}
+
+nonisolated enum UserDiscoveryStatus: Equatable, Sendable {
+    case none
+    case searching
+    case failed
+    case partial
+}
+
+@MainActor
+extension WorkspaceState {
+    /// Matches iOS. The identifier path has its own separate 250 ms debounce
+    /// (`NewChatQueryResolutionModifier`); the two gate mutually exclusive query branches and
+    /// never both fire for one query, so they are deliberately not unified.
+    static let userDiscoveryDebounce = Duration.milliseconds(300)
+    /// iOS's window. Radius 0 is the searcher — excluded, not searched.
+    static let userDiscoveryRadiusStart: UInt8 = 1
+    static let userDiscoveryRadiusEnd: UInt8 = 2
+
+    /// Known matches plus discovered strangers for the current query, self always removed.
+    ///
+    /// Staged/selected members are *not* excluded: they stay visible with a filled checkmark,
+    /// exactly as known contacts already do in Choose members.
+    func composeSearchResults(matching query: String) -> MergedComposeResults {
+        var excluded: Set<String> = []
+        if let selfHex = activeAccount?.accountIdHex {
+            excluded.insert(selfHex.lowercased())
+        }
+        return UserDiscoveryRanking.merged(
+            known: filteredComposeContacts(matching: query),
+            discovered: discoveredPeopleForCurrentQuery,
+            excluding: excluded
+        )
+    }
+
+    /// Results are only shown against the query they were produced for, so an in-flight search
+    /// cannot leave the previous query's people on screen.
+    var discoveredPeopleForCurrentQuery: [DiscoveredPerson] {
+        let query = newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard discoveryResultsQuery == query else { return [] }
+        return discoveredPeople
+    }
+
+    var userDiscoveryStatus: UserDiscoveryStatus {
+        UserDiscoveryPresentation.status(
+            isSearching: isSearchingPeople,
+            didFail: discoveryDidFail,
+            isPartial: discoveryIsPartial
+        )
+    }
+
+    func scheduleUserDiscovery() {
+        discoveryTask?.cancel()
+        discoveryTask = nil
+        discoveryGeneration &+= 1
+        let generation = discoveryGeneration
+        discoveredPeople = []
+        discoveryResultsQuery = ""
+        discoveryIsPartial = false
+        discoveryDidFail = false
+
+        let query = newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        // A pasted npub/NIP-05 already names one person, so a graph traversal for it is pure
+        // waste — the identifier resolver owns that branch (mirrors iOS's `shouldSearch` gate).
+        guard !query.isEmpty, !looksLikeMemberRef(query) else {
+            isSearchingPeople = false
+            return
+        }
+        guard let client, let account = activeAccount else {
+            isSearchingPeople = false
+            return
+        }
+
+        isSearchingPeople = true
+        discoveryTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: WorkspaceState.userDiscoveryDebounce)
+                guard let self, self.ownsUserDiscovery(generation: generation) else { return }
+                // Spinner ownership is keyed on the generation ALONE, deliberately looser than the
+                // generation+query+account guard used to commit results. Every exit — terminal
+                // trigger, stream end, or abandoning a superseded search mid-stream — must clear
+                // the spinner, or editing the query while a traversal is in flight strands it at
+                // `true` (the shape of #110 and #255).
+                defer {
+                    if self.ownsUserDiscovery(generation: generation) {
+                        self.isSearchingPeople = false
+                        self.discoveryTask = nil
+                    }
+                }
+                let subscription = try await client.searchUsers(
+                    accountIdHex: account.accountIdHex,
+                    query: query,
+                    radiusStart: WorkspaceState.userDiscoveryRadiusStart,
+                    radiusEnd: WorkspaceState.userDiscoveryRadiusEnd
+                )
+                var aggregate: [DiscoveredPerson] = []
+                while let update = await subscription.nextUpdate() {
+                    // A superseded search returns here and lets `subscription` deinit, which
+                    // cancels the relay traversal. Draining on to `searchCompleted` instead would
+                    // keep a traversal alive for a query nobody is looking at.
+                    guard !Task.isCancelled,
+                        self.isCurrentUserDiscovery(
+                            generation: generation,
+                            query: query,
+                            accountId: account.id
+                        )
+                    else { return }
+
+                    aggregate.append(contentsOf: update.newResults.compactMap(UserDiscoveryRanking.person))
+                    self.discoveredPeople = UserDiscoveryRanking.sortedUnique(aggregate)
+                    self.discoveryResultsQuery = query
+                    if self.applyUserDiscovery(trigger: update.trigger) { break }
+                }
+                // A stream that ends without ever delivering a result still owns the query it
+                // answered, so "no matches" replaces the spinner instead of both showing.
+                if self.isCurrentUserDiscovery(generation: generation, query: query, accountId: account.id) {
+                    self.discoveryResultsQuery = query
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                guard let self, self.ownsUserDiscovery(generation: generation) else { return }
+                self.discoveryDidFail = true
+                self.isSearchingPeople = false
+                self.discoveryTask = nil
+            }
+        }
+    }
+
+    func invalidateUserDiscovery() {
+        discoveryTask?.cancel()
+        discoveryTask = nil
+        discoveryGeneration &+= 1
+        discoveredPeople = []
+        discoveryResultsQuery = ""
+        discoveryIsPartial = false
+        discoveryDidFail = false
+        isSearchingPeople = false
+    }
+
+    /// Returns `true` when this update was terminal.
+    ///
+    /// Switched exhaustively over all 8 triggers with no `default`, so a bindings update that adds
+    /// one breaks the build instead of being silently ignored.
+    private func applyUserDiscovery(trigger: SearchUpdateTriggerFfi) -> Bool {
+        switch trigger {
+        case .radiusTimeout, .radiusTruncated:
+            // Partial, not failed: everything already delivered is still correct, so keep the
+            // results on screen and keep looping.
+            discoveryIsPartial = true
+            return false
+        case .error:
+            // Always followed by `searchCompleted`, so keep looping and let that end the search.
+            discoveryDidFail = true
+            return false
+        case .searchCompleted:
+            return true
+        case .radiusStarted, .resultsFound, .discoveryResultsFound, .radiusCompleted:
+            return false
+        }
+    }
+
+    /// True while `generation` still owns the discovery spinner — i.e. no newer
+    /// `scheduleUserDiscovery`/`invalidateUserDiscovery` has bumped the generation. Deliberately
+    /// looser than `isCurrentUserDiscovery`: spinner ownership must transfer cleanly even when the
+    /// query changes mid-flight, or the spinner strands at `true` (the shape of #110 and #255).
+    func ownsUserDiscovery(generation: UInt64) -> Bool {
+        discoveryGeneration == generation
+    }
+
+    /// The stricter guard used before committing results: same generation, same live query, same
+    /// account. Any mismatch means this search has been abandoned.
+    func isCurrentUserDiscovery(generation: UInt64, query: String, accountId: String) -> Bool {
+        ownsUserDiscovery(generation: generation)
+            && activeAccountId == accountId
+            && newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1152,6 +1152,19 @@ final class WorkspaceState {
     /// parameter, so it is applied right after creation.
     var groupDraftRetentionSecs: UInt64 = 0
     @ObservationIgnored var composeContactsGeneration: UInt64 = 0
+    /// People the web-of-trust search found for the current compose query. Deliberately separate
+    /// from `composeContacts`: a search result is not a relationship, so nothing here is ever
+    /// promoted into the contact directory or the profile cache
+    /// (see WorkspaceState+UserDiscovery.swift).
+    var discoveredPeople: [DiscoveredPerson] = []
+    var isSearchingPeople = false
+    /// A radius timed out or hit its candidate cap. Partial, not failed — results stay on screen.
+    var discoveryIsPartial = false
+    var discoveryDidFail = false
+    @ObservationIgnored var discoveryGeneration: UInt64 = 0
+    @ObservationIgnored var discoveryTask: Task<Void, Never>?
+    /// The query `discoveredPeople` belongs to, so results are never rendered under a newer query.
+    @ObservationIgnored var discoveryResultsQuery = ""
     var newChatQuery = ""
     var newChatName = ""
     var newChatDescription = ""

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -16572,6 +16572,65 @@
         }
       }
     },
+    "Discovery": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Außerhalb deines Netzwerks"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuera de tu red"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hors de votre réseau"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuori dalla tua rete"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fora da sua rede"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вне вашей сети"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ağınızın dışından"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来自你的网络之外"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來自你的網路之外"
+          }
+        }
+      }
+    },
     "Dismiss": {
       "extractionState": "manual",
       "localizations": {
@@ -22187,6 +22246,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在匯入…"
+          }
+        }
+      }
+    },
+    "In your network": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In deinem Netzwerk"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En tu red"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dans votre réseau"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nella tua rete"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Na sua rede"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В вашей сети"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ağınızda"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在你的网络中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在你的網路中"
           }
         }
       }
@@ -34013,6 +34131,65 @@
         }
       }
     },
+    "People": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Persone"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pessoas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Люди"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kişiler"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "用户"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用者"
+          }
+        }
+      }
+    },
     "People & Body": {
       "extractionState": "manual",
       "localizations": {
@@ -41522,6 +41699,65 @@
         }
       }
     },
+    "Search couldn't be completed.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Suche konnte nicht abgeschlossen werden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo completar la búsqueda."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La recherche n'a pas pu être effectuée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non è stato possibile completare la ricerca."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível concluir a pesquisa."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось выполнить поиск."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arama tamamlanamadı."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索无法完成。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋無法完成。"
+          }
+        }
+      }
+    },
     "Search emoji": {
       "extractionState": "manual",
       "localizations": {
@@ -42053,6 +42289,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在搜尋訊息記錄…"
+          }
+        }
+      }
+    },
+    "Searching your network...": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dein Netzwerk wird durchsucht..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscando en tu red..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherche dans votre réseau..."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricerca nella tua rete..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisando na sua rede..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поиск в вашей сети..."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ağınızda aranıyor..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在搜索你的网络..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在搜尋你的網路..."
           }
         }
       }
@@ -44486,6 +44781,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "部分群組無法檢查。"
+          }
+        }
+      }
+    },
+    "Some results may be missing.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einige Ergebnisse fehlen möglicherweise."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puede que falten algunos resultados."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certains résultats sont peut-être manquants."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcuni risultati potrebbero mancare."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alguns resultados podem estar em falta."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Некоторые результаты могут отсутствовать."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bazı sonuçlar eksik olabilir."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分结果可能缺失。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分結果可能缺失。"
           }
         }
       }
@@ -50752,6 +51106,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "版 %@ (%@)"
+          }
+        }
+      }
+    },
+    "Via your network": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Über dein Netzwerk"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A través de tu red"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Via votre réseau"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tramite la tua rete"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Através da sua rede"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Через вашу сеть"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ağınız aracılığıyla"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过你的网络"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透過你的網路"
           }
         }
       }

--- a/whitenoise-mac/Views/ComposeFlowViews.swift
+++ b/whitenoise-mac/Views/ComposeFlowViews.swift
@@ -35,6 +35,7 @@ struct NewChatPanelView: View {
             .padding(.horizontal, 12)
             .padding(.bottom, 12)
             .debouncedNewChatQueryResolution(for: workspace.newChatQuery)
+            .userDiscovery(for: workspace.newChatQuery)
 
             GlassSeparator(axis: .horizontal)
 
@@ -64,13 +65,22 @@ struct NewChatPanelView: View {
                             Task { await workspace.startDirectChat(with: recipient) }
                         }
                     } else {
-                        let matches = workspace.filteredComposeContacts(matching: trimmedQuery)
-                        if matches.isEmpty {
-                            ComposeNoMatchesView(onPaste: pasteIntoSearch)
-                        } else {
+                        let results = workspace.composeSearchResults(matching: trimmedQuery)
+                        if !results.known.isEmpty {
                             ComposeSectionHeader(title: L10n.string("Contacts"))
-                            contactRows(matches)
+                            contactRows(results.known)
                         }
+                        if !results.discovered.isEmpty {
+                            ComposeSectionHeader(title: L10n.string("People"))
+                            discoveredRows(results.discovered)
+                        }
+                        if UserDiscoveryPresentation.showsNoMatches(
+                            results: results,
+                            isSearching: workspace.isSearchingPeople
+                        ) {
+                            ComposeNoMatchesView(onPaste: pasteIntoSearch)
+                        }
+                        ComposeDiscoveryStatusRow()
                     }
 
                     if let lastError = workspace.lastError {
@@ -108,6 +118,20 @@ struct NewChatPanelView: View {
             }
             .accessibilityIdentifier("compose.contact.\(contact.accountIdHex)")
             .disabled(workspace.isCreatingChat && workspace.creatingDirectChatIdHex != contact.accountIdHex)
+        }
+    }
+
+    @ViewBuilder
+    private func discoveredRows(_ people: [DiscoveredPerson]) -> some View {
+        ForEach(people) { person in
+            DiscoveredPersonRow(
+                person: person,
+                isBusy: workspace.creatingDirectChatIdHex == person.accountIdHex
+            ) {
+                Task { await workspace.startDirectChat(with: person.recipient) }
+            }
+            .accessibilityIdentifier("compose.discovered.\(person.accountIdHex)")
+            .disabled(workspace.isCreatingChat && workspace.creatingDirectChatIdHex != person.accountIdHex)
         }
     }
 
@@ -156,6 +180,7 @@ struct ChooseMembersPanelView: View {
                     autofocus: true
                 )
                 .debouncedNewChatQueryResolution(for: workspace.newChatQuery)
+                .userDiscovery(for: workspace.newChatQuery)
 
                 if !workspace.newChatRecipients.isEmpty {
                     ScrollView {
@@ -190,13 +215,22 @@ struct ChooseMembersPanelView: View {
                             workspace.toggleComposeMember(recipient)
                         }
                     } else {
-                        let matches = workspace.filteredComposeContacts(matching: trimmedQuery)
-                        if matches.isEmpty {
-                            ComposeNoMatchesView()
-                        } else {
+                        let results = workspace.composeSearchResults(matching: trimmedQuery)
+                        if !results.known.isEmpty {
                             ComposeSectionHeader(title: L10n.string("Contacts"))
-                            selectableRows(matches)
+                            selectableRows(results.known)
                         }
+                        if !results.discovered.isEmpty {
+                            ComposeSectionHeader(title: L10n.string("People"))
+                            selectableDiscoveredRows(results.discovered)
+                        }
+                        if UserDiscoveryPresentation.showsNoMatches(
+                            results: results,
+                            isSearching: workspace.isSearchingPeople
+                        ) {
+                            ComposeNoMatchesView()
+                        }
+                        ComposeDiscoveryStatusRow()
                     }
                 }
                 .padding(.horizontal, 8)
@@ -241,6 +275,19 @@ struct ChooseMembersPanelView: View {
                 workspace.toggleComposeMember(contact.recipient)
             }
             .accessibilityIdentifier("compose.member.\(contact.accountIdHex)")
+        }
+    }
+
+    @ViewBuilder
+    private func selectableDiscoveredRows(_ people: [DiscoveredPerson]) -> some View {
+        ForEach(people) { person in
+            DiscoveredPersonRow(
+                person: person,
+                selection: isSelected(accountIdHex: person.accountIdHex)
+            ) {
+                workspace.toggleComposeMember(person.recipient)
+            }
+            .accessibilityIdentifier("compose.member.discovered.\(person.accountIdHex)")
         }
     }
 
@@ -417,8 +464,16 @@ private extension View {
     func debouncedNewChatQueryResolution(for query: String) -> some View {
         modifier(NewChatQueryResolutionModifier(query: query))
     }
+
+    func userDiscovery(for query: String) -> some View {
+        modifier(UserDiscoveryModifier(query: query))
+    }
 }
 
+/// Debounces the *identifier* branch (npub / nprofile / hex / NIP-05 resolution) only. The
+/// people-search branch has its own 300 ms debounce inside `scheduleUserDiscovery()`; the two are
+/// deliberately separate because they gate mutually exclusive query branches and never both fire
+/// for one query. Do not unify them — retuning one would silently retune the other.
 private struct NewChatQueryResolutionModifier: ViewModifier {
     @Environment(WorkspaceState.self) private var workspace
     let query: String
@@ -428,6 +483,20 @@ private struct NewChatQueryResolutionModifier: ViewModifier {
             try? await Task.sleep(nanoseconds: 250_000_000)
             guard !Task.isCancelled else { return }
             await workspace.resolveNewChatQueryIfReady()
+        }
+    }
+}
+
+/// Kicks off the web-of-trust people search on every query change. The 300 ms debounce lives
+/// inside `scheduleUserDiscovery()` (which cancels the previous traversal), not here — see the
+/// note on `NewChatQueryResolutionModifier` about keeping the two debounces separate.
+private struct UserDiscoveryModifier: ViewModifier {
+    @Environment(WorkspaceState.self) private var workspace
+    let query: String
+
+    func body(content: Content) -> some View {
+        content.task(id: query) {
+            workspace.scheduleUserDiscovery()
         }
     }
 }
@@ -539,6 +608,8 @@ private struct ComposeContactRow: View {
     let subtitle: String
     let avatarSeed: String
     let sanitizedPictureURL: URL?
+    /// Third line describing where this person came from. Only discovery rows set it.
+    var provenance: String?
     var isBusy = false
     /// `nil` hides the selection indicator (tap opens a chat instead of toggling).
     var selection: Bool?
@@ -563,6 +634,12 @@ private struct ComposeContactRow: View {
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .truncationMode(.middle)
+                    if let provenance {
+                        Text(provenance)
+                            .font(MessagesType.meta)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
                 }
                 Spacer(minLength: 0)
                 if isBusy {
@@ -579,6 +656,73 @@ private struct ComposeContactRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+}
+
+/// A stranger found by the web-of-trust search. Same metrics as `ComposeContactRow` plus a
+/// provenance line, because a search result must be visibly distinguishable from a contact.
+private struct DiscoveredPersonRow: View {
+    let person: DiscoveredPerson
+    var isBusy = false
+    var selection: Bool?
+    let action: () -> Void
+
+    var body: some View {
+        ComposeContactRow(
+            title: person.title,
+            subtitle: person.subtitle,
+            avatarSeed: person.accountIdHex,
+            sanitizedPictureURL: person.sanitizedPictureURL,
+            provenance: UserDiscoveryPresentation.provenanceLabel(radius: person.radius),
+            isBusy: isBusy,
+            selection: selection,
+            action: action
+        )
+    }
+}
+
+/// Searching / partial / failed, never two at once — the resolution lives in
+/// `UserDiscoveryPresentation.status` so it is testable without a view.
+private struct ComposeDiscoveryStatusRow: View {
+    @Environment(WorkspaceState.self) private var workspace
+
+    @ViewBuilder
+    var body: some View {
+        switch workspace.userDiscoveryStatus {
+        case .none:
+            EmptyView()
+        case .searching:
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(L10n.string("Searching your network..."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(12)
+        case .failed:
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.secondary)
+                Text(L10n.string("Search couldn't be completed."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button(L10n.string("Retry")) {
+                    workspace.scheduleUserDiscovery()
+                }
+                .buttonStyle(.link)
+            }
+            .padding(12)
+        case .partial:
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(.secondary)
+                Text(L10n.string("Some results may be missing."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(12)
+        }
     }
 }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -2,9 +2,6 @@
 //  PureValueTests.swift
 //  whitenoise-macTests
 //
-//  Pure, self-contained value-type tests moved out of the serialized
-//  suite so they run in parallel (no shared global state).
-//
 
 import AppKit
 import Combine
@@ -20,6 +17,7 @@ import UserNotifications
 
 @testable import whitenoise_mac
 
+@Suite(.serialized)
 struct PureValueTests {
     @Test func selectedMentionsCanonicalizeByPickedNpubDespiteDisplayNameCollision() {
         let first = mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
@@ -3161,6 +3159,248 @@ struct PureValueTests {
         #expect(firstSelectable)
         #expect(!secondSelectable)
     }
+
+    // MARK: - User discovery ranking
+
+    @Test func discoveryRadiusDecidesOrderWhenEveryHigherTierIsTied() {
+        let near = discoveryResult(hex: "a", radius: 1)
+        let far = discoveryResult(hex: "b", radius: 2)
+
+        #expect(sortedHexes([far, near]) == [hex("a"), hex("b")])
+    }
+
+    @Test func discoveryProviderRankDecidesOrderWithinTheSameRadius() {
+        let strong = discoveryResult(hex: "a", radius: 2, providerRank: 0.9)
+        let weak = discoveryResult(hex: "b", radius: 2, providerRank: 0.1)
+
+        #expect(sortedHexes([weak, strong]) == [hex("a"), hex("b")])
+    }
+
+    @Test func discoveryAbsentProviderRankSortsAfterAPresentOne() {
+        let ranked = discoveryResult(hex: "b", radius: 2, providerRank: 0.01)
+        let unranked = discoveryResult(hex: "a", radius: 2, providerRank: nil)
+
+        #expect(sortedHexes([unranked, ranked]) == [hex("b"), hex("a")])
+    }
+
+    @Test func discoveryRadiusOutranksProviderRank() {
+        let nearUnranked = discoveryResult(hex: "b", radius: 1, providerRank: nil)
+        let farHighlyRanked = discoveryResult(hex: "a", radius: 255, providerRank: 0.99)
+
+        #expect(sortedHexes([farHighlyRanked, nearUnranked]) == [hex("b"), hex("a")])
+    }
+
+    @Test func discoveryMatchQualityDecidesOrderWhenRadiusAndRankAreTied() {
+        let contains = discoveryResult(hex: "a", radius: 1, matchQuality: .contains)
+        let prefix = discoveryResult(hex: "b", radius: 1, matchQuality: .prefix)
+        let exact = discoveryResult(hex: "c", radius: 1, matchQuality: .exact)
+
+        #expect(sortedHexes([contains, prefix, exact]) == [hex("c"), hex("b"), hex("a")])
+    }
+
+    @Test func discoveryMatchedFieldDecidesOrderWhenMatchQualityIsTied() {
+        let fields: [MatchedFieldFfi] = [.pubkey, .npub, .about, .displayName, .nip05, .name]
+        let results = fields.enumerated().map { index, field in
+            discoveryResult(hex: String(index), radius: 1, matchedField: field)
+        }
+
+        // Most identifying first, so the input order reverses exactly.
+        #expect(sortedHexes(results) == (0..<fields.count).reversed().map { hex(String($0)) })
+    }
+
+    @Test func discoveryDedupesByLowercasedHexKeepingTheFirstOccurrence() {
+        let first = discoveryResult(hex: "a", radius: 1, displayName: "First")
+        let duplicate = UserDirectorySearchResultFfi(
+            accountIdHex: hex("a").uppercased(),
+            npub: "npub1a",
+            radius: 2,
+            matchedField: .name,
+            matchQuality: .exact,
+            providerRank: nil,
+            profile: discoveryProfile(displayName: "Second")
+        )
+
+        let people = UserDiscoveryRanking.sortedUnique(
+            [first, duplicate].compactMap(UserDiscoveryRanking.person)
+        )
+
+        #expect(people.count == 1)
+        #expect(people.first?.displayName == "First")
+    }
+
+    @Test func discoveryHexTiebreakMakesOtherwiseIdenticalResultsDeterministic() {
+        let first = discoveryResult(hex: "a", radius: 1)
+        let second = discoveryResult(hex: "b", radius: 1)
+
+        // Sorting is not stable, so without the total-order hex tiebreak the rendered order could
+        // swap between updates for two results that tie on every meaningful key.
+        #expect(sortedHexes([first, second]) == sortedHexes([second, first]))
+        #expect(sortedHexes([second, first]) == [hex("a"), hex("b")])
+    }
+
+    @Test func discoveryStripsBidiControlsAndNewlinesFromStrangerDisplayNames() {
+        let result = discoveryResult(hex: "a", radius: 1, displayName: "Al\u{202E}ice\nBob")
+
+        #expect(UserDiscoveryRanking.person(from: result)?.displayName == "AliceBob")
+    }
+
+    @Test func discoveryRejectsUnsafeStrangerPictureURLs() {
+        let unsafe = [
+            "http://example.com/avatar.png",
+            "file:///etc/passwd",
+            "https://localhost/avatar.png",
+            "https://127.0.0.1/avatar.png",
+            "https://10.0.0.5/avatar.png",
+        ]
+
+        for raw in unsafe {
+            let result = discoveryResult(hex: "a", radius: 1, picture: raw)
+            let person = UserDiscoveryRanking.person(from: result)
+            #expect(person?.sanitizedPictureURL == nil, "\(raw) must not be fetchable")
+        }
+
+        let safe = discoveryResult(hex: "a", radius: 1, picture: "https://example.com/avatar.png")
+        #expect(UserDiscoveryRanking.person(from: safe)?.sanitizedPictureURL != nil)
+    }
+
+    @Test func discoveryMergeKeepsTheKnownContactForAHexPresentInBothSources() {
+        let known = ComposeContact(
+            accountIdHex: hex("a"),
+            npub: "npub1a",
+            displayName: "Real conversation name",
+            pictureURL: nil,
+            lastActivity: nil
+        )
+        let discovered = UserDiscoveryRanking.person(
+            from: discoveryResult(hex: "a", radius: 1, displayName: "Search snapshot name")
+        )
+
+        let merged = UserDiscoveryRanking.merged(
+            known: [known],
+            discovered: [discovered].compactMap { $0 },
+            excluding: []
+        )
+
+        #expect(merged.known.map(\.accountIdHex) == [hex("a")])
+        #expect(merged.known.first?.displayName == "Real conversation name")
+        #expect(merged.discovered.isEmpty)
+    }
+
+    @Test func discoveryMergeRemovesExcludedHexesFromEitherSource() {
+        let known = ComposeContact(
+            accountIdHex: hex("a"),
+            npub: "npub1a",
+            displayName: "Known",
+            pictureURL: nil,
+            lastActivity: nil
+        )
+        let discovered = [
+            discoveryResult(hex: "b", radius: 1),
+            discoveryResult(hex: "c", radius: 1),
+        ].compactMap(UserDiscoveryRanking.person)
+
+        let merged = UserDiscoveryRanking.merged(
+            known: [known],
+            discovered: discovered,
+            // Uppercased on purpose: exclusion is hex-case-insensitive.
+            excluding: [hex("a").uppercased(), hex("b")]
+        )
+
+        #expect(merged.known.isEmpty)
+        #expect(merged.discovered.map(\.accountIdHex) == [hex("c")])
+    }
+
+    // MARK: - User discovery presentation
+
+    @Test func discoveryProvenanceLabelsOnlyClaimAConnectionForRequestedRadii() {
+        #expect(UserDiscoveryPresentation.provenanceLabel(radius: 1) == L10n.string("In your network"))
+        #expect(UserDiscoveryPresentation.provenanceLabel(radius: 2) == L10n.string("Via your network"))
+        #expect(UserDiscoveryPresentation.provenanceLabel(radius: 255) == L10n.string("Discovery"))
+        // 0 is the searcher and 3...254 are outside the 1...2 window, so there is no honest
+        // provenance to show — and 255 must never read as a distance from the user.
+        #expect(UserDiscoveryPresentation.provenanceLabel(radius: 0) == nil)
+        #expect(UserDiscoveryPresentation.provenanceLabel(radius: 3) == nil)
+        #expect(UserDiscoveryPresentation.provenanceLabel(radius: 254) == nil)
+    }
+
+    @Test func discoveryStatusResolvesToExactlyOneRowForEveryFlagCombination() {
+        var seen: [UserDiscoveryStatus] = []
+        for isSearching in [false, true] {
+            for didFail in [false, true] {
+                for isPartial in [false, true] {
+                    seen.append(
+                        UserDiscoveryPresentation.status(
+                            isSearching: isSearching,
+                            didFail: didFail,
+                            isPartial: isPartial
+                        )
+                    )
+                }
+            }
+        }
+
+        #expect(
+            seen == [
+                .none, .partial, .failed, .failed,
+                .searching, .searching, .searching, .searching,
+            ]
+        )
+    }
+
+    @Test func discoveryNoMatchesIsSuppressedWhileSearchingWithNoResultsYet() {
+        let empty = MergedComposeResults(known: [], discovered: [])
+        #expect(!UserDiscoveryPresentation.showsNoMatches(results: empty, isSearching: true))
+        #expect(UserDiscoveryPresentation.showsNoMatches(results: empty, isSearching: false))
+
+        let withResults = MergedComposeResults(
+            known: [],
+            discovered: [discoveryResult(hex: "a", radius: 1)].compactMap(UserDiscoveryRanking.person)
+        )
+        #expect(!UserDiscoveryPresentation.showsNoMatches(results: withResults, isSearching: false))
+    }
+}
+
+/// 64-char hex built from a short seed, so tests read as `hex("a")` rather than a wall of digits.
+private func hex(_ seed: String) -> String {
+    String((seed + String(repeating: "0", count: 64)).prefix(64))
+}
+
+private func discoveryProfile(displayName: String? = nil, picture: String? = nil) -> UserProfileMetadataFfi {
+    UserProfileMetadataFfi(
+        name: nil,
+        displayName: displayName,
+        about: nil,
+        picture: picture,
+        nip05: nil,
+        lud16: nil
+    )
+}
+
+private func discoveryResult(
+    hex seed: String,
+    radius: UInt8,
+    matchedField: MatchedFieldFfi = .name,
+    matchQuality: MatchQualityFfi = .exact,
+    providerRank: Double? = nil,
+    displayName: String? = nil,
+    picture: String? = nil
+) -> UserDirectorySearchResultFfi {
+    UserDirectorySearchResultFfi(
+        accountIdHex: hex(seed),
+        npub: "npub1\(seed)",
+        radius: radius,
+        matchedField: matchedField,
+        matchQuality: matchQuality,
+        providerRank: providerRank,
+        profile: displayName == nil && picture == nil
+            ? nil
+            : discoveryProfile(displayName: displayName, picture: picture)
+    )
+}
+
+private func sortedHexes(_ results: [UserDirectorySearchResultFfi]) -> [String] {
+    UserDiscoveryRanking.sortedUnique(results.compactMap(UserDiscoveryRanking.person))
+        .map(\.accountIdHex)
 }
 
 private func mentionCandidate(id: String, displayName: String, npub: String) -> ComposerMentionCandidate {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -24442,6 +24442,414 @@ struct whitenoise_macTests {
         #expect(state.isInsecureRelay("ws://127.0.0.1:7000"))
     }
 
+    // MARK: - User discovery (web-of-trust people search)
+
+    @MainActor
+    @Test func userDiscoveryAccumulatesAcrossUpdatesThenClearsTheSpinner() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "b", radius: 1)]),
+            userSearchUpdate(.resultsFound(radius: 2), [searchResult(hex: "c", radius: 2)]),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { !state.isSearchingPeople && !state.discoveredPeople.isEmpty }))
+
+        #expect(state.discoveredPeople.map(\.accountIdHex) == [discoveryHex("b"), discoveryHex("c")])
+        #expect(state.discoveredPeople.map(\.accountIdHex) == sortedDiscoveryHexes(state.discoveredPeople))
+        #expect(!state.discoveryIsPartial)
+        #expect(!state.discoveryDidFail)
+        // No unit test can prove the traversal reached a relay, so pin the arguments instead. Note
+        // `searchUsers` takes an `accountIdHex` where almost every neighbouring call takes an
+        // `accountRef`, and the radius window is 1...2 (0 is the searcher, excluded not searched).
+        #expect(
+            runtime.userSearchCalls == [
+                FakeMarmotRuntime.UserSearchCall(
+                    accountIdHex: discoverySearcherAccount.accountIdHex,
+                    query: "al",
+                    radiusStart: 1,
+                    radiusEnd: 2
+                )
+            ]
+        )
+    }
+
+    @MainActor
+    @Test func userDiscoveryRendersProgressivelyWhileTheTraversalIsStillRunning() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "b", radius: 1)]),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        runtime.userSearchUpdateDelayNanoseconds = 150_000_000
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { !state.discoveredPeople.isEmpty }))
+
+        // The first batch is on screen while the search is still going: the spinner and results
+        // coexist, and "No matches" must not have flashed in between.
+        #expect(state.isSearchingPeople)
+        #expect(state.discoveredPeople.count == 1)
+        #expect(state.userDiscoveryStatus == .searching)
+    }
+
+    @MainActor
+    @Test func userDiscoveryReSortsTheAggregateWhenALaterUpdateDeliversACloserPerson() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        // The far result arrives first. `newResults` is pre-sorted only *within* a batch, so a host
+        // that sorts once at the end (or appends blindly) renders these in arrival order.
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 2), [searchResult(hex: "z", radius: 2)]),
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "a", radius: 1)]),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { state.discoveredPeople.count == 2 }))
+
+        #expect(state.discoveredPeople.map(\.accountIdHex) == [discoveryHex("a"), discoveryHex("z")])
+    }
+
+    @MainActor
+    @Test func userDiscoveryDebounceCoalescesRapidKeystrokesIntoOneTraversal() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [userSearchUpdate(.searchCompleted, [])]
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        for query in ["a", "al", "ali"] {
+            state.newChatQuery = query
+            state.scheduleUserDiscovery()
+        }
+        #expect(await pollUserDiscovery(until: { !state.isSearchingPeople }))
+
+        #expect(runtime.userSearchCalls.count == 1)
+        #expect(runtime.userSearchCalls.first?.query == "ali")
+    }
+
+    @MainActor
+    @Test func userDiscoveryNeverTraversesForAnIdentifierOrEmptyQuery() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "b", radius: 1)]),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        // A real search first, so the "no traversal" assertions below cannot pass by accident.
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { !state.discoveredPeople.isEmpty }))
+        #expect(runtime.userSearchCalls.count == 1)
+
+        // A pasted identifier already names one person: the resolver owns that branch, and a graph
+        // traversal for it would be pure waste.
+        state.newChatQuery = String(repeating: "f", count: 64)
+        state.scheduleUserDiscovery()
+        #expect(state.discoveredPeople.isEmpty)
+        #expect(!state.isSearchingPeople)
+
+        state.newChatQuery = "   "
+        state.scheduleUserDiscovery()
+        #expect(state.discoveredPeople.isEmpty)
+        #expect(!state.isSearchingPeople)
+
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(runtime.userSearchCalls.count == 1)
+    }
+
+    @MainActor
+    @Test func userDiscoveryDropsSupersededUpdatesWithoutStrandingTheSpinner() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 2), [searchResult(hex: "z", radius: 2)]),
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "a", radius: 1)]),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        runtime.userSearchUpdateDelayNanoseconds = 150_000_000
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { state.discoveredPeople.count == 1 }))
+
+        // Edit the query mid-stream *without* resubmitting, exactly as typing another character
+        // does before the view's `.task(id:)` fires.
+        state.newChatQuery = "alx"
+        try await Task.sleep(for: .milliseconds(500))
+
+        #expect(state.discoveredPeople.count == 1, "the superseded search's later update must not land")
+        #expect(state.discoveredPeopleForCurrentQuery.isEmpty, "old results must not render under a new query")
+        // Spinner ownership is keyed on the generation alone, so abandoning mid-stream still clears
+        // it. This is the shape of #110 and #255.
+        #expect(!state.isSearchingPeople)
+    }
+
+    @MainActor
+    @Test func userDiscoveryReleasesAnAbandonedSubscriptionWithoutDrainingIt() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "b", radius: 1)]),
+            userSearchUpdate(.resultsFound(radius: 2), [searchResult(hex: "c", radius: 2)]),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        runtime.userSearchUpdateDelayNanoseconds = 150_000_000
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { state.discoveredPeople.count == 1 }))
+
+        state.invalidateUserDiscovery()
+        try await Task.sleep(for: .milliseconds(600))
+
+        // Dropping the subscription is what cancels the relay traversal. Looping on to
+        // `searchCompleted` instead would keep a traversal alive for a query nobody is looking at,
+        // and this counter is the only observable consequence of getting it wrong. Three updates are
+        // scripted; one call fetched the first and one more was in flight when the search was
+        // abandoned, so a host that drained instead of releasing would reach 3 or 4.
+        #expect(
+            runtime.userSearchNextUpdateCount <= 2,
+            "abandoned search must be released, not drained to searchCompleted"
+        )
+        #expect(state.discoveredPeople.isEmpty)
+        #expect(!state.isSearchingPeople)
+    }
+
+    @MainActor
+    @Test func userDiscoveryLandsNoResultsUnderANewlySwitchedAccount() async throws {
+        let secondary = AccountSummaryFfi(
+            label: "Secondary Account",
+            accountIdHex: String(repeating: "7", count: 64),
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount, secondary])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "b", radius: 1)]),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        runtime.userSearchUpdateDelayNanoseconds = 250_000_000
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        try await Task.sleep(for: .milliseconds(350))
+        let target = try #require(state.accounts.first { $0.accountIdHex == secondary.accountIdHex })
+        state.selectAccount(target)
+        try await Task.sleep(for: .milliseconds(600))
+
+        #expect(state.activeAccountId == target.id)
+        #expect(state.discoveredPeople.isEmpty)
+        #expect(!state.isSearchingPeople)
+    }
+
+    @MainActor
+    @Test func userDiscoveryRadiusTimeoutKeepsResultsAndReportsPartialNotFailed() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "b", radius: 1)]),
+            userSearchUpdate(.radiusTimeout(radius: 2), []),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { !state.isSearchingPeople }))
+
+        // A timeout (or truncation) is partial, not failed: everything already delivered is correct.
+        #expect(state.discoveredPeople.count == 1)
+        #expect(state.discoveryIsPartial)
+        #expect(!state.discoveryDidFail)
+        #expect(state.userDiscoveryStatus == .partial)
+    }
+
+    @MainActor
+    @Test func userDiscoveryErrorTriggerReportsFailureAndKeepsDeliveredResults() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(.resultsFound(radius: 1), [searchResult(hex: "b", radius: 1)]),
+            userSearchUpdate(.error(message: "relay unreachable"), []),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { !state.isSearchingPeople }))
+
+        // `error` is always followed by `searchCompleted`, so the loop keeps going and the failure
+        // is reported only once the search actually ends — never alongside a live spinner.
+        #expect(state.discoveredPeople.count == 1)
+        #expect(state.discoveryDidFail)
+        #expect(state.userDiscoveryStatus == .failed)
+    }
+
+    @MainActor
+    @Test func userDiscoverySearchUsersThrowReportsFailureAndClearsTheSpinner() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.searchUsersError = FakeMarmotRuntimeError.unused
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { state.discoveryDidFail }))
+
+        #expect(!state.isSearchingPeople)
+        #expect(state.discoveredPeople.isEmpty)
+        #expect(state.userDiscoveryStatus == .failed)
+    }
+
+    @MainActor
+    @Test func userDiscoveryNeverRendersTheSearcherAndNeverPromotesResults() async throws {
+        let runtime = FakeMarmotRuntime(accounts: [discoverySearcherAccount])
+        runtime.userSearchUpdates = [
+            userSearchUpdate(
+                .resultsFound(radius: 1),
+                [
+                    // The searcher matching their own query must never render.
+                    searchResult(hex: discoverySearcherAccount.accountIdHex, radius: 1),
+                    searchResult(hex: "b", radius: 1),
+                ]
+            ),
+            userSearchUpdate(.searchCompleted, []),
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let profileLookups = ProfileLookupLog()
+        runtime.onUserProfileLookup = { profileLookups.record($0) }
+        runtime.clearRefreshedProfileIds()
+        state.newChatQuery = "al"
+        state.scheduleUserDiscovery()
+        #expect(await pollUserDiscovery(until: { !state.isSearchingPeople }))
+
+        let rendered = state.composeSearchResults(matching: "al")
+        #expect(rendered.discovered.map(\.accountIdHex) == [discoveryHex("b")])
+
+        // A search result is not a relationship: `user_profile` must keep answering only for
+        // accounts the user has actually interacted with. The tempting implementation (routing rows
+        // through `resolveNewChatRecipient`) refreshes the profile over the network and invalidates
+        // the cache — i.e. it promotes the stranger — so assert on the runtime's own call log.
+        #expect(state.composeContacts.isEmpty)
+        #expect(rendered.known.isEmpty)
+        #expect(!runtime.refreshedProfileIds.contains(discoveryHex("b")))
+        #expect(!profileLookups.recorded.contains(discoveryHex("b")))
+        #expect(state.peerProfileFFICache[discoveryHex("b")] == nil)
+    }
+
+}
+
+private var discoverySearcherAccount: AccountSummaryFfi {
+    AccountSummaryFfi(
+        label: "Searcher Account",
+        accountIdHex: String(repeating: "5", count: 64),
+        localSigning: true,
+        externalSigning: false,
+        signedOut: false,
+        running: false
+    )
+}
+
+/// Records which account ids `userProfile` was queried for, from whatever thread the runtime's
+/// off-main profile batch happens to run on.
+private final class ProfileLookupLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hexes: [String] = []
+
+    func record(_ accountIdHex: String) {
+        lock.withLock { hexes.append(accountIdHex) }
+    }
+
+    var recorded: [String] {
+        lock.withLock { hexes }
+    }
+}
+
+/// 64-char hex from a short seed, so the discovery fixtures read as `discoveryHex("b")`. A seed
+/// that is already a full hex passes straight through.
+private func discoveryHex(_ seed: String) -> String {
+    String((seed + String(repeating: "0", count: 64)).prefix(64))
+}
+
+private func searchResult(
+    hex seed: String,
+    radius: UInt8,
+    matchedField: MatchedFieldFfi = .name,
+    matchQuality: MatchQualityFfi = .exact,
+    providerRank: Double? = nil,
+    displayName: String? = nil,
+    picture: String? = nil
+) -> UserDirectorySearchResultFfi {
+    UserDirectorySearchResultFfi(
+        accountIdHex: discoveryHex(seed),
+        npub: "npub1\(seed.prefix(8))",
+        radius: radius,
+        matchedField: matchedField,
+        matchQuality: matchQuality,
+        providerRank: providerRank,
+        profile: UserProfileMetadataFfi(
+            name: nil,
+            displayName: displayName,
+            about: nil,
+            picture: picture,
+            nip05: nil,
+            lud16: nil
+        )
+    )
+}
+
+private func userSearchUpdate(
+    _ trigger: SearchUpdateTriggerFfi,
+    _ results: [UserDirectorySearchResultFfi]
+) -> UserSearchUpdateFfi {
+    UserSearchUpdateFfi(
+        trigger: trigger,
+        newResults: results,
+        totalResultCount: UInt32(results.count)
+    )
+}
+
+private func sortedDiscoveryHexes(_ people: [DiscoveredPerson]) -> [String] {
+    UserDiscoveryRanking.sortedUnique(people).map(\.accountIdHex)
+}
+
+/// Polls `condition` on the main actor until it holds or `timeout` elapses. The people search
+/// debounces for 300 ms before it even calls the runtime, so every assertion about its outcome has
+/// to wait rather than yield.
+@MainActor
+private func pollUserDiscovery(
+    timeout: Duration = .seconds(3),
+    until condition: @MainActor () -> Bool
+) async -> Bool {
+    let step = Duration.milliseconds(10)
+    var elapsed = Duration.zero
+    while elapsed < timeout {
+        if condition() { return true }
+        try? await Task.sleep(for: step)
+        elapsed += step
+    }
+    return condition()
 }
 
 @Suite(.serialized)
@@ -24816,6 +25224,30 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var chatListStreamEndsAfterUpdates = false
     /// Simulates async relay/runtime latency before a chat-list subscription is ready.
     var chatListSubscriptionDelayNanoseconds: UInt64 = 0
+    /// Ordered script of web-of-trust search updates every `searchUsers` subscription replays.
+    var userSearchUpdates: [UserSearchUpdateFfi] = []
+    /// Per-update latency, so a test can change the query or switch accounts mid-stream.
+    var userSearchUpdateDelayNanoseconds: UInt64 = 0
+    /// When set, `searchUsers` throws instead of returning a subscription.
+    var searchUsersError: Error?
+    var userSearchCalls: [UserSearchCall] {
+        recordedStateLock.withLock { _userSearchCalls }
+    }
+    private var _userSearchCalls: [UserSearchCall] = []
+    /// Total `nextUpdate()` calls across every subscription this runtime handed out. A host that
+    /// abandons a search must release the subscription rather than draining it, and this counter
+    /// is the only observable consequence of getting that wrong.
+    var userSearchNextUpdateCount: Int {
+        recordedStateLock.withLock { _userSearchNextUpdateCount }
+    }
+    private var _userSearchNextUpdateCount = 0
+
+    struct UserSearchCall: Equatable {
+        let accountIdHex: String
+        let query: String
+        let radiusStart: UInt8
+        let radiusEnd: UInt8
+    }
     var notificationStreamEndsImmediately = false
     var timelineStreamEndsAfterUpdates = false
     private(set) var timelineMessageQueries: [TimelineMessageQueryFfi] = []
@@ -26044,6 +26476,32 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         return FakeNotificationsSubscription(endsImmediately: notificationStreamEndsImmediately)
     }
 
+    func searchUsers(accountIdHex: String, query: String, radiusStart: UInt8, radiusEnd: UInt8) async throws
+        -> UserSearchSubscription
+    {
+        recordedStateLock.withLock {
+            _userSearchCalls.append(
+                UserSearchCall(
+                    accountIdHex: accountIdHex,
+                    query: query,
+                    radiusStart: radiusStart,
+                    radiusEnd: radiusEnd
+                )
+            )
+        }
+        if let searchUsersError {
+            throw searchUsersError
+        }
+        return FakeUserSearchSubscription(
+            updates: userSearchUpdates,
+            updateDelayNanoseconds: userSearchUpdateDelayNanoseconds,
+            recordNextUpdate: { [weak self] in
+                guard let self else { return }
+                self.recordedStateLock.withLock { self._userSearchNextUpdateCount += 1 }
+            }
+        )
+    }
+
     func timelineMessages(accountRef: String, query: TimelineMessageQueryFfi) throws -> TimelinePageFfi {
         recordSyncCall("timelineMessages")
         timelineMessageQueries.append(query)
@@ -26990,6 +27448,51 @@ private final class FakeNotificationsSubscription: NotificationsSubscription {
     override func next() async -> NotificationUpdateFfi? {
         if endsImmediately { return nil }
         return await awaitSubscriptionCancellation()
+    }
+}
+
+/// Replays a scripted web-of-trust search. Unlike the runtime subscriptions there is no
+/// `snapshot()` — a search has no initial state, only results as each radius resolves.
+///
+/// Once the script is exhausted this suspends until cancelled rather than returning `nil`, so a
+/// test can distinguish "the search ended" from "the host stopped asking". `recordNextUpdate`
+/// counts every call, which is how the release-without-draining contract becomes assertable.
+private final class FakeUserSearchSubscription: UserSearchSubscription {
+    private var updates: [UserSearchUpdateFfi]
+    private let updateDelayNanoseconds: UInt64
+    private let recordNextUpdate: () -> Void
+
+    required init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.updates = []
+        self.updateDelayNanoseconds = 0
+        self.recordNextUpdate = {}
+        super.init(unsafeFromRawPointer: pointer)
+    }
+
+    init(
+        updates: [UserSearchUpdateFfi],
+        updateDelayNanoseconds: UInt64 = 0,
+        recordNextUpdate: @escaping () -> Void = {}
+    ) {
+        self.updates = updates
+        self.updateDelayNanoseconds = updateDelayNanoseconds
+        self.recordNextUpdate = recordNextUpdate
+        super.init(noPointer: NoPointer())
+    }
+
+    override func nextUpdate() async -> UserSearchUpdateFfi? {
+        recordNextUpdate()
+        guard !updates.isEmpty else {
+            return await awaitSubscriptionCancellation()
+        }
+        if updateDelayNanoseconds > 0 {
+            do {
+                try await Task.sleep(nanoseconds: updateDelayNanoseconds)
+            } catch {
+                return nil
+            }
+        }
+        return updates.removeFirst()
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added People search using web-of-trust discovery in new chats and group-member selection.
  * Displays known contacts and discovered people separately, with source details and consistent ranking.
  * Supports starting direct chats and adding discovered people to groups.
  * Shows search progress, partial results, errors, and no-match states.
  * Added translations for discovery statuses and People search labels.

* **Bug Fixes**
  * Cancels outdated searches when queries, panels, or accounts change, preventing stale results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->