### PR TITLE
Fix settings sidebar labels not changing on language change

### DIFF
--- a/whitenoise-mac/Core/L10n.swift
+++ b/whitenoise-mac/Core/L10n.swift
@@ -35,6 +35,32 @@ nonisolated enum L10n {
         return Bundle.main.localizedString(forKey: key, value: key, table: nil)
     }
 
+    /// Resolve `key` against an explicit locale instead of the stored language preference.
+    ///
+    /// SwiftUI cannot see `string(_:)` as a dependency: it reads the preference through a
+    /// cache, so a view whose only language-dependent input is an `L10n` lookup is never
+    /// invalidated by a language switch and keeps rendering the previous language until
+    /// something else re-renders it. Views localize through this overload with the
+    /// `\.locale` environment value — injected at the root from
+    /// `WorkspaceState.preferredLocale` — which makes the language a tracked dependency of
+    /// the body that renders it.
+    static func string(_ key: String, locale: Locale) -> String {
+        // The environment locale is the resolved preference in the common case, so reuse
+        // the cached-bundle fast path rather than re-resolving an `.lproj` bundle per call.
+        guard locale.identifier != AppLanguage.currentLocale.identifier else {
+            return string(key)
+        }
+
+        if let localizedBundle = localizedBundle(for: locale) {
+            let localized = localizedBundle.localizedString(forKey: key, value: nil, table: nil)
+            if localized != key {
+                return localized
+            }
+        }
+
+        return Bundle.main.localizedString(forKey: key, value: key, table: nil)
+    }
+
     static func plural(_ key: String, _ count: Int64) -> String {
         let locale = AppLanguage.currentLocale
         return formatPlural(string(key), count: count, locale: locale)

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2309,61 +2309,74 @@ enum SettingsPage: Equatable {
         .developerMode,
     ]
 
-    var title: String {
+    /// Localized against an explicit locale rather than the stored language preference, so
+    /// the settings sidebar can localize with the `\.locale` environment value and be
+    /// re-rendered on a language switch instead of showing the previous language until the
+    /// row is rebuilt (see `L10n.string(_:locale:)`).
+    func title(in locale: Locale) -> String {
+        L10n.string(titleKey, locale: locale)
+    }
+
+    /// See `title(in:)` for why the locale is passed in.
+    func sidebarSubtitle(in locale: Locale) -> String {
+        L10n.string(sidebarSubtitleKey, locale: locale)
+    }
+
+    private var titleKey: String {
         switch self {
         case .overview:
-            L10n.string("Settings")
+            "Settings"
         case .general:
-            L10n.string("General")
+            "General"
         case .accounts:
-            L10n.string("Accounts")
+            "Accounts"
         case .profile:
-            L10n.string("Profile")
+            "Profile"
         case .identityKeys:
-            L10n.string("Identity & Keys")
+            "Identity & Keys"
         case .relays:
-            L10n.string("Relays")
+            "Relays"
         case .keyPackages:
-            L10n.string("Key Packages")
+            "Key Packages"
         case .appearance:
-            L10n.string("Appearance")
+            "Appearance"
         case .privacySecurity:
-            L10n.string("Privacy & Security")
+            "Privacy & Security"
         case .notifications:
-            L10n.string("Notifications")
+            "Notifications"
         case .storage:
-            L10n.string("Storage")
+            "Storage"
         case .developerMode:
-            L10n.string("Developer mode")
+            "Developer mode"
         }
     }
 
-    var sidebarSubtitle: String {
+    private var sidebarSubtitleKey: String {
         switch self {
         case .overview:
-            L10n.string("Settings home")
+            "Settings home"
         case .general:
-            L10n.string("Startup preferences")
+            "Startup preferences"
         case .accounts:
-            L10n.string("Switch identities")
+            "Switch identities"
         case .profile:
-            L10n.string("Public display info")
+            "Public display info"
         case .identityKeys:
-            L10n.string("Public and private keys")
+            "Public and private keys"
         case .relays:
-            L10n.string("Relay lists")
+            "Relay lists"
         case .keyPackages:
-            L10n.string("Invite packages")
+            "Invite packages"
         case .appearance:
-            L10n.string("Theme")
+            "Theme"
         case .privacySecurity:
-            L10n.string("Telemetry and audit logs")
+            "Telemetry and audit logs"
         case .notifications:
-            L10n.string("Local alerts")
+            "Local alerts"
         case .storage:
-            L10n.string("Media cache")
+            "Media cache"
         case .developerMode:
-            L10n.string("Storage and diagnostics")
+            "Storage and diagnostics"
         }
     }
 

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -535,11 +535,14 @@ private struct ChatSidebarRowMenuItems: View {
 
 struct SettingsListDrawerView: View {
     @Environment(WorkspaceState.self) private var workspace
+    // Localizing through `\.locale` (not the stored preference) is what re-renders this
+    // drawer when the language changes while settings are open — see `L10n.string(_:locale:)`.
+    @Environment(\.locale) private var locale
 
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 14) {
-                Text(L10n.string("Settings"))
+                Text(L10n.string("Settings", locale: locale))
                     .font(.title2.weight(.semibold))
 
                 activeAccountSummary
@@ -589,8 +592,11 @@ struct SettingsListDrawerView: View {
                     CopyableKeyLabel(accountIdHex: account.accountIdHex, head: 8, tail: 6, showsCopyButton: false)
                 }
             } else {
-                Label(L10n.string("No account"), systemImage: "person.crop.circle.badge.exclamationmark")
-                    .font(.callout.weight(.semibold))
+                Label(
+                    L10n.string("No account", locale: locale),
+                    systemImage: "person.crop.circle.badge.exclamationmark"
+                )
+                .font(.callout.weight(.semibold))
             }
 
             Spacer(minLength: 0)
@@ -609,6 +615,9 @@ struct SettingsListDrawerView: View {
 
 struct SettingsSidebarRow: View {
     @Environment(WorkspaceState.self) private var workspace
+    // The row's labels are the only language-dependent thing in its body, so reading the
+    // locale here is what makes SwiftUI re-render it on a language switch.
+    @Environment(\.locale) private var locale
     let page: SettingsPage
 
     private var isSelected: Bool {
@@ -623,10 +632,10 @@ struct SettingsSidebarRow: View {
                 .frame(width: 28, height: 28)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(page.title)
+                Text(page.title(in: locale))
                     .font(.callout.weight(.semibold))
                     .foregroundStyle(.primary)
-                Text(page.sidebarSubtitle)
+                Text(page.sidebarSubtitle(in: locale))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5236,6 +5236,70 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func localizedStringWithExplicitLocaleIgnoresCachedPreference() async throws {
+        // `L10n.string(_:locale:)` is what SwiftUI views localize through so the language is
+        // a tracked dependency of their body. It must resolve the locale it is handed, not
+        // the cached preference, and must still be correct when the two agree.
+        let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
+        defer { restoreDefault(previousLanguage, forKey: AppLanguage.storageKey) }
+
+        UserDefaults.standard.set(AppLanguage.spanish.rawValue, forKey: AppLanguage.storageKey)
+        AppLanguage.refreshCachedLocale()
+
+        let spanish = Locale(identifier: AppLanguage.spanish.rawValue)
+        let german = Locale(identifier: AppLanguage.german.rawValue)
+        #expect(L10n.string("Save", locale: spanish) == "Guardar")
+        #expect(L10n.string("Save", locale: german) == "Speichern")
+        // An unknown key falls back to itself, like `string(_:)` does.
+        #expect(L10n.string("whitenoise.not.a.key", locale: german) == "whitenoise.not.a.key")
+    }
+
+    @Test func settingsPageSidebarLabelsFollowRequestedLocale() {
+        // Regression: the settings sidebar rows kept the previous language after a switch on
+        // the Appearance page because their labels resolved the preference through a cache
+        // SwiftUI cannot observe. The labels are locale-parameterized so the rows re-render
+        // from the `\.locale` environment value instead of needing a navigation round trip.
+        let spanish = Locale(identifier: AppLanguage.spanish.rawValue)
+        let german = Locale(identifier: AppLanguage.german.rawValue)
+
+        #expect(SettingsPage.general.title(in: german) == "Allgemein")
+        #expect(SettingsPage.appearance.title(in: spanish) == "Apariencia")
+        #expect(SettingsPage.overview.title(in: spanish) == "Configuración")
+        #expect(SettingsPage.general.sidebarSubtitle(in: spanish) == "Preferencias de inicio")
+        #expect(SettingsPage.general.sidebarSubtitle(in: german) == "Starteinstellungen")
+        #expect(SettingsPage.appearance.sidebarSubtitle(in: german) == "Design")
+    }
+
+    @Test func settingsDrawerLocalizesThroughEnvironmentLocale() throws {
+        // The re-render on a language switch comes from a SwiftUI dependency, which only a
+        // source contract can guard: both the drawer and its rows must read `\.locale` and
+        // localize through it. Dropping either read reintroduces the stale-label bug.
+        let sidebarViewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("SidebarViews.swift")
+        let source = try String(contentsOf: sidebarViewsURL, encoding: .utf8)
+
+        let drawerStart = try #require(source.range(of: "struct SettingsListDrawerView: View {"))
+        let rowStart = try #require(source.range(of: "struct SettingsSidebarRow: View {"))
+        let drawerSource = String(source[drawerStart.lowerBound..<rowStart.lowerBound])
+        let rowRest = source[rowStart.upperBound...]
+        let rowEnd = try #require(rowRest.range(of: "\nstruct ")?.lowerBound)
+        let rowSource = String(source[rowStart.lowerBound..<rowEnd])
+
+        for viewSource in [drawerSource, rowSource] {
+            let normalized = viewSource.components(separatedBy: .whitespacesAndNewlines).joined()
+            #expect(normalized.contains("@Environment(\\.locale)privatevarlocale"))
+        }
+        #expect(drawerSource.contains("L10n.string(\"Settings\", locale: locale)"))
+        #expect(rowSource.contains("Text(page.title(in: locale))"))
+        #expect(rowSource.contains("Text(page.sidebarSubtitle(in: locale))"))
+    }
+
+    @MainActor
     @Test func systemLocaleChangeInvalidatesLocalizedStringCacheWhenPreferenceIsSystem() async throws {
         let previousLanguage = UserDefaults.standard.object(forKey: AppLanguage.storageKey)
         defer {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings sidebar labels and subtitles now update when the app language changes.
  * Localization can resolve settings text for a specific language, including Spanish and German.

* **Bug Fixes**
  * Improved fallback behavior for missing localization keys and explicit language selections.

* **Tests**
  * Added coverage for localized settings labels, language changes, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->