### PR TITLE
Stop settings errors from leaking across other settings screens

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Navigation.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Navigation.swift
@@ -97,6 +97,11 @@ extension WorkspaceState {
         stopTimelineListener()
         cancelTimelineLoad()
         clearEnteredLoginIdentity()
+        // `lastError` is scoped to the user action on the current screen, but every settings
+        // pane renders it through the shared `SettingsScaffold`. Without clearing it here a
+        // failure raised in one pane (notification permission, relay save, …) follows the user
+        // into every other pane and stays there until some unrelated action overwrites it.
+        lastError = nil
         selection = .settings(page)
         closeNewChatComposer()
         pruneMessageCache(keeping: nil)

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -212,6 +212,20 @@ extension WorkspaceState {
         notificationAuthorizationStatus = await localNotificationCenter.authorizationStatus()
     }
 
+    /// Re-reads the system permission, which lives in System Settings and can change while
+    /// White Noise is in the background, and retires the "allow notifications, then try again"
+    /// guidance once the user has actually granted it. The guidance is the one error the user
+    /// resolves outside the app, so nothing else in the settings pane would ever clear it —
+    /// it stayed on screen even after permission was granted.
+    /// Only that exact message is cleared, so an unrelated failure on the pane survives.
+    func refreshNotificationPermissionState() async {
+        await refreshNotificationAuthorizationStatus()
+        guard notificationAuthorizationStatus.canPostNotifications,
+            lastError == Self.notificationPermissionGuidance
+        else { return }
+        lastError = nil
+    }
+
     func beginNotificationSettingsOperation() -> UInt64 {
         notificationSettingsGeneration &+= 1
         return notificationSettingsGeneration

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -1671,6 +1671,19 @@ struct NotificationsSettingsView: View {
             }
 
         }
+        .task {
+            await workspace.refreshNotificationPermissionState()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: NSApplication.didBecomeActiveNotification
+            )
+        ) { _ in
+            // Notification permission can be changed outside White Noise. Treat the system as
+            // the source of truth whenever the app returns from System Settings, so the pane
+            // stops asking for a permission the user has already granted.
+            Task { await workspace.refreshNotificationPermissionState() }
+        }
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -24525,6 +24525,96 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func refreshingNotificationPermissionRetiresGuidanceAfterSystemSettingsGrant() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: false)
+        let notificationCenter = FakeLocalNotificationCenter(
+            status: .notDetermined,
+            requestError: NSError(
+                domain: UNErrorDomain,
+                code: UNError.Code.notificationsNotAllowed.rawValue
+            )
+        )
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        await state.setLocalNotificationsEnabled(true)
+        #expect(state.lastError == WorkspaceState.notificationPermissionGuidance)
+
+        // The user grants the permission in System Settings and returns to White Noise.
+        notificationCenter.simulateSystemAuthorizationChange(.authorized)
+        await state.refreshNotificationPermissionState()
+
+        #expect(state.notificationAuthorizationStatus == .authorized)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
+    @Test func refreshingNotificationPermissionKeepsUnrelatedErrorAndStaleGuidance() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: false)
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        state.lastError = "Could not reach relay."
+        await state.refreshNotificationPermissionState()
+        #expect(state.lastError == "Could not reach relay.")
+
+        // Still denied: the guidance is exactly what the user needs to keep seeing.
+        notificationCenter.simulateSystemAuthorizationChange(.denied)
+        state.lastError = WorkspaceState.notificationPermissionGuidance
+        await state.refreshNotificationPermissionState()
+        #expect(state.notificationAuthorizationStatus == .denied)
+        #expect(state.lastError == WorkspaceState.notificationPermissionGuidance)
+    }
+
+    @MainActor
+    @Test func openingASettingsPageClearsThePreviousPanesError() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showSettingsPage(.notifications)
+        state.lastError = WorkspaceState.notificationPermissionGuidance
+
+        state.showSettingsPage(.accounts)
+
+        #expect(state.selection == .settings(.accounts))
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
     @Test func incomingNotificationPostsLocalAlertWhenEnabledAndInactive() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",
@@ -28704,6 +28794,12 @@ private final class FakeLocalNotificationCenter: LocalNotificationCenter {
         }
         status = requestedStatus
         return status
+    }
+
+    /// Mimics the user flipping the permission in System Settings while White Noise is in the
+    /// background — the app learns about it only on the next `authorizationStatus()` read.
+    func simulateSystemAuthorizationChange(_ newStatus: LocalNotificationAuthorizationStatus) {
+        status = newStatus
     }
 
     func releaseRequestAuthorizationGate() {


### PR DESCRIPTION
…ir cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification settings now accurately reflect permission changes made in macOS System Settings.
  * Outdated notification permission messages clear automatically once access is granted.
  * Errors no longer persist when switching between settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->