### PR TITLE
fix: leaving status is kept forever

### DIFF
--- a/whitenoise-mac/Core/ChatDestructiveActions.swift
+++ b/whitenoise-mac/Core/ChatDestructiveActions.swift
@@ -130,6 +130,47 @@ nonisolated struct ChatActionAlert: Equatable, Identifiable {
     }
 }
 
+/// The one status badge a chat row shows, or `nil` for an ordinary active chat.
+///
+/// Lives beside `ChatDestructiveActions` because the two must agree: the only state that reads as
+/// `.leaving` is the only state that offers no destructive action, so a row can never both claim a
+/// leave is in progress and offer to leave again — nor, as it used to, show a `.leaving` badge
+/// forever while hiding the delete that would clear it.
+nonisolated enum ChatRowStatus: Equatable {
+    /// A leave the group has not seen yet. Genuinely transient.
+    case leaving
+    /// The account left or was removed. Terminal.
+    case membershipEnded(ChatSelfMembership)
+    case pendingInvite
+
+    /// Membership outranks both flags.
+    ///
+    /// `leaveRequestPending` stays true from the moment the SelfRemove publishes until some
+    /// remaining member commits it — possibly never. Reading it first pinned departed chats to a
+    /// progress badge they could never leave; reading membership first reports the settled fact and
+    /// leaves the outstanding commit as the protocol detail it is (the inspector still lists it).
+    ///
+    /// An ended membership also supersedes a pending invite, so the row shows a single badge rather
+    /// than a contradictory "Invite" + "Removed" pair if the FFI ever delivers both flags together.
+    static func status(
+        membership: ChatSelfMembership,
+        leaveRequestPending: Bool,
+        pendingConfirmation: Bool
+    ) -> ChatRowStatus? {
+        if membership != .member { return .membershipEnded(membership) }
+        if leaveRequestPending { return .leaving }
+        return pendingConfirmation ? .pendingInvite : nil
+    }
+
+    static func status(for chat: ChatItem) -> ChatRowStatus? {
+        status(
+            membership: chat.selfMembership,
+            leaveRequestPending: chat.leaveRequestPending,
+            pendingConfirmation: chat.pendingConfirmation
+        )
+    }
+}
+
 nonisolated enum ChatDestructiveActions {
     /// The destructive action a surface may offer for one chat. The two are mutually exclusive:
     /// a chat you can still leave is not one you may silently drop from this device.
@@ -182,9 +223,20 @@ nonisolated enum ChatDestructiveActions {
     /// `.leave` for a member and report a `leaveBlocker` if leaving turns out to be unavailable. The
     /// inspector, which holds eligibility up front, pre-disables the button and shows the blocker as
     /// a footer instead.
+    ///
+    /// `leaveRequestPending` only ever suppresses a *second* leave; it never withholds the local
+    /// delete. The flag is orthogonal to membership, not a precursor to it: the core sets it when
+    /// the SelfRemove is requested and clears it only once a remaining member commits that removal,
+    /// which for a group whose others never come back online is never. Gating the delete on it too
+    /// stranded every departed chat in a permanent "Leaving" state with no way out — the bug this
+    /// split fixes. Once membership has actually ended, the departure is already on the wire and the
+    /// local copy is the user's to drop.
     static func action(membership: ChatSelfMembership, leaveRequestPending: Bool) -> Action? {
-        guard !leaveRequestPending else { return nil }
-        return membership == .member ? .leave : .deleteLocally
+        guard membership == .member else { return .deleteLocally }
+        // Still a member with a request outstanding: the SelfRemove has not reached the group, so
+        // neither action is honest yet — the core rejects a repeat leave, and dropping the local
+        // copy here is the exact stranding the rule above forbids.
+        return leaveRequestPending ? nil : .leave
     }
 
     static func action(for chat: ChatItem) -> Action? {

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -675,15 +675,17 @@ struct ChatRowContent: View {
                     Text(chat.title)
                         .font(MessagesType.rowTitle)
                         .lineLimit(1)
-                    // An ended membership supersedes a pending invite: show a single
-                    // badge rather than a contradictory "Invite" + "Removed" pair if
-                    // the FFI ever delivers both flags together.
-                    if chat.leaveRequestPending {
+                    // Precedence lives in `ChatRowStatus` so the badge and the row's
+                    // destructive menu item are decided by one rule.
+                    switch ChatRowStatus.status(for: chat) {
+                    case .leaving:
                         LeavingGroupBadge()
-                    } else if chat.isNoLongerMember {
-                        MembershipEndedBadge(membership: chat.selfMembership)
-                    } else if chat.pendingConfirmation {
+                    case .membershipEnded(let membership):
+                        MembershipEndedBadge(membership: membership)
+                    case .pendingInvite:
                         PendingInviteBadge()
+                    case nil:
+                        EmptyView()
                     }
                     if isPinned {
                         Image(systemName: "pin.fill")

--- a/whitenoise-macTests/MarmotKitFixtureCompatibility.swift
+++ b/whitenoise-macTests/MarmotKitFixtureCompatibility.swift
@@ -158,7 +158,8 @@ nonisolated extension ChatListRowFfi {
         lastReadMessageIdHex: String?,
         lastReadTimelineAt: UInt64?,
         updatedAt: UInt64,
-        selfMembership: SelfMembershipFfi
+        selfMembership: SelfMembershipFfi,
+        leaveRequestPending: Bool = false
     ) {
         let previewTimelineAt = lastMessage?.timelineAt ?? 0
         let activitySortAt = previewTimelineAt > 0 ? previewTimelineAt : updatedAt
@@ -191,8 +192,8 @@ nonisolated extension ChatListRowFfi {
             conversationKind: .unknown,
             muted: false,
             mutedUntilMs: nil,
-            leaveRequestPending: false,
-            leaveRequestedAtMs: nil
+            leaveRequestPending: leaveRequestPending,
+            leaveRequestedAtMs: leaveRequestPending ? 1_700_000_000_000 : nil
         )
     }
 }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -3485,15 +3485,93 @@ struct PureValueTests {
         )
     }
 
-    /// A leave already in flight suppresses both actions, whatever the membership says — the row
-    /// must show progress, not offer a second destructive action.
-    @Test func pendingLeaveSuppressesBothDestructiveActionsForEveryMembership() {
-        for membership: ChatSelfMembership in [.member, .left, .removed] {
-            #expect(
-                ChatDestructiveActions.action(membership: membership, leaveRequestPending: true)
-                    == nil
-            )
+    /// A leave already in flight suppresses a *second* leave, and only while the group still counts
+    /// this account as a member — that is the one state where neither action is honest.
+    @Test func pendingLeaveSuppressesTheLeaveOnlyWhileStillAMember() {
+        #expect(
+            ChatDestructiveActions.action(membership: .member, leaveRequestPending: true) == nil
+        )
+    }
+
+    /// The regression this file exists to pin: `leaveRequestPending` stays true from the SelfRemove
+    /// publish until a remaining member commits it, which for a group whose others never return is
+    /// never. Withholding the local delete there left every departed chat stuck on a "Leaving" badge
+    /// with no action that could clear it, so a departed chat must always offer the delete.
+    @Test func departedChatOffersLocalDeleteEvenWithAnUnresolvedLeaveRequest() {
+        for membership: ChatSelfMembership in [.left, .removed] {
+            for pending in [false, true] {
+                #expect(
+                    ChatDestructiveActions.action(
+                        membership: membership,
+                        leaveRequestPending: pending
+                    ) == .deleteLocally,
+                    "\(membership) with pending=\(pending) must still offer the local delete"
+                )
+            }
         }
+    }
+
+    /// The badge and the menu are two readings of one state, so no chat may show a leave in progress
+    /// while its menu offers a destructive action, and none may sit on `.leaving` with no way out.
+    @Test func onlyTheBadgelessLeavingStateWithholdsEveryDestructiveAction() {
+        for membership: ChatSelfMembership in [.member, .left, .removed] {
+            for pending in [false, true] {
+                for invited in [false, true] {
+                    let status = ChatRowStatus.status(
+                        membership: membership,
+                        leaveRequestPending: pending,
+                        pendingConfirmation: invited
+                    )
+                    let action = ChatDestructiveActions.action(
+                        membership: membership,
+                        leaveRequestPending: pending
+                    )
+                    #expect(
+                        (status == .leaving) == (action == nil),
+                        "\(membership)/pending=\(pending): a stuck badge needs an action, and vice versa"
+                    )
+                }
+            }
+        }
+    }
+
+    @Test func rowStatusReportsTheSettledMembershipRatherThanAnUnresolvedLeave() {
+        #expect(
+            ChatRowStatus.status(
+                membership: .left,
+                leaveRequestPending: true,
+                pendingConfirmation: false
+            ) == .membershipEnded(.left)
+        )
+        #expect(
+            ChatRowStatus.status(
+                membership: .member,
+                leaveRequestPending: true,
+                pendingConfirmation: false
+            ) == .leaving
+        )
+        #expect(
+            ChatRowStatus.status(
+                membership: .member,
+                leaveRequestPending: false,
+                pendingConfirmation: true
+            ) == .pendingInvite
+        )
+        #expect(
+            ChatRowStatus.status(
+                membership: .member,
+                leaveRequestPending: false,
+                pendingConfirmation: false
+            ) == nil
+        )
+        // An ended membership outranks both flags, so the row never shows two contradictory badges.
+        #expect(
+            ChatRowStatus.status(
+                membership: .removed,
+                leaveRequestPending: true,
+                pendingConfirmation: true
+            ) == .membershipEnded(.removed)
+        )
     }
 
     /// The load-bearing invariant: **no leave eligibility, however bad, ever produces a local
@@ -3618,6 +3696,26 @@ struct PureValueTests {
             )
             #expect(ChatDestructiveActions.action(for: left) == .deleteLocally)
         }
+    }
+
+    /// The `ChatItem` adapters the sidebar row actually calls, so it cannot read a different rule
+    /// than the one the cases above pin.
+    @Test func departedChatItemShowsTheEndedBadgeAndStillOffersTheDelete() {
+        let left = destructiveActionChat(
+            membership: .left,
+            leaveRequestPending: true,
+            isDirect: false
+        )
+        #expect(ChatRowStatus.status(for: left) == .membershipEnded(.left))
+        #expect(ChatDestructiveActions.action(for: left) == .deleteLocally)
+
+        let leaving = destructiveActionChat(
+            membership: .member,
+            leaveRequestPending: true,
+            isDirect: false
+        )
+        #expect(ChatRowStatus.status(for: leaving) == .leaving)
+        #expect(ChatDestructiveActions.action(for: leaving) == nil)
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -18893,7 +18893,14 @@ struct whitenoise_macTests {
 
         #expect(leaveRuntime.leftGroupIdHex == "group")
         #expect(!leaveState.isGroupDetailsPresented)
-        #expect(leaveState.activeChats.isEmpty)
+        // The row survives the leave — the core keeps the conversation with `Left` membership and
+        // an uncommitted leave request — so the list must show the departure as settled and offer
+        // the local delete, not park it on a "Leaving" badge it can never leave.
+        let departed = try #require(leaveState.activeChats.first { $0.id == "group" })
+        #expect(departed.selfMembership == .left)
+        #expect(departed.leaveRequestPending)
+        #expect(ChatRowStatus.status(for: departed) == .membershipEnded(.left))
+        #expect(ChatDestructiveActions.action(for: departed) == .deleteLocally)
     }
 
     @MainActor
@@ -26489,6 +26496,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         ),
     ]
     private var groups: [AppGroupRecordFfi] = []
+    /// Groups whose SelfRemove has published but not yet been committed by a remaining member —
+    /// the durable, possibly permanent `leaveRequestPending` the chat list has to render.
+    private var pendingLeaveGroupIds: Set<String> = []
     private var messagesByGroupId: [String: [AppMessageRecordFfi]] = [:]
     private var timelinePagesByGroupId: [String: TimelinePageFfi] = [:]
     private var timelineUpdatesByGroupId: [String: [TimelineSubscriptionUpdateFfi]] = [:]
@@ -27639,9 +27649,25 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         await groupMutationGate.passIfArmed()
         if let leaveGroupError { throw leaveGroupError }
         leftGroupIdHex = groupIdHex
-        groups.removeAll { $0.groupIdHex == groupIdHex }
-        groupDetailsById[groupIdHex] = nil
-        groupManagementStateById[groupIdHex] = nil
+        // The core records a *departure*; it does not drop the conversation. `selfMembership`
+        // becomes `Left` as soon as the SelfRemove publishes, and `leaveRequestPending` stays true
+        // until a remaining member commits it — which for a group whose others never come back is
+        // never. Deleting the row here modelled a state the core does not produce, and hid the fact
+        // that a departed chat has to stay actionable so its local copy can be deleted.
+        pendingLeaveGroupIds.insert(groupIdHex)
+        if let index = groups.firstIndex(where: { $0.groupIdHex == groupIdHex }) {
+            groups[index].selfMembership = .left
+        }
+        if var details = groupDetailsById[groupIdHex] {
+            details.group.selfMembership = .left
+            groupDetailsById[groupIdHex] = details
+        }
+        if var managementState = groupManagementStateById[groupIdHex] {
+            managementState.canLeave = false
+            managementState.leaveRequestPending = true
+            managementState.leaveRequestedAtMs = 1_700_000_000_000
+            groupManagementStateById[groupIdHex] = managementState
+        }
         return SendSummaryFfi(published: 1, messageIds: ["group-leave"])
     }
 
@@ -28462,7 +28488,8 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
             lastReadMessageIdHex: nil,
             lastReadTimelineAt: latest?.timelineAt,
             updatedAt: latest?.timelineAt ?? 0,
-            selfMembership: group.selfMembership
+            selfMembership: group.selfMembership,
+            leaveRequestPending: pendingLeaveGroupIds.contains(group.groupIdHex)
         )
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer chat status badges for leaving, ended membership, and pending invitations.
  * Departed chats can now be deleted locally, even when a leave request is pending.
  * Group conversations remain visible after leaving, with their ended-membership status displayed.

* **Bug Fixes**
  * Prevented members with pending leave requests from taking conflicting actions.
  * Preserved relevant conversation details after leaving a group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->