### PR TITLE
Fix back arrow position

### DIFF
--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -138,6 +138,13 @@ struct GroupDetailsSheet: View {
 
         VStack(spacing: 0) {
             HStack(spacing: 12) {
+                // Leading, like the compose pane and the settings header: this pane slides
+                // in over the transcript, so the chevron is a back control and reads as one
+                // only on the side you came from.
+                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back to chat") {
+                    workspace.closeGroupDetails()
+                }
+
                 ProfileImageAvatarView(
                     seed: chat.avatarSeed,
                     initials: chat.title,
@@ -175,10 +182,6 @@ struct GroupDetailsSheet: View {
                     .buttonStyle(.plain)
                     .disabled(workspace.hasInFlightGroupCommit)
                     .help(L10n.string("Add members"))
-                }
-
-                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back to chat") {
-                    workspace.closeGroupDetails()
                 }
             }
             .padding(20)
@@ -832,6 +835,12 @@ struct ContactDetailsView: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 12) {
+                // Leading back control, matching GroupDetailsSheet: both panes slide in
+                // over the transcript and return to it.
+                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back") {
+                    workspace.closeContactDetails()
+                }
+
                 ProfileImageAvatarView(
                     seed: contact.accountIdHex,
                     initials: contact.title,
@@ -854,10 +863,6 @@ struct ContactDetailsView: View {
                 if workspace.isLoadingContactDetails {
                     ProgressView()
                         .controlSize(.small)
-                }
-
-                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back") {
-                    workspace.closeContactDetails()
                 }
             }
             .padding(20)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -18212,6 +18212,45 @@ struct whitenoise_macTests {
         #expect(shellSource.contains(".move(edge: .trailing)"))
     }
 
+    @Test func detailsPaneHeadersPlaceBackButtonAtLeadingEdge() throws {
+        // The group-info and contact-info panes slide in over the transcript, so their
+        // chevron is a *back* control and belongs on the leading edge — where the
+        // compose pane and the settings header already put theirs — not trailing next
+        // to the add-members button, which reads as an unrelated right-hand action.
+        let viewsDirURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+        let groupViewsSource = try String(
+            contentsOf: viewsDirURL.appendingPathComponent("GroupViews.swift"),
+            encoding: .utf8
+        )
+
+        for declaration in ["struct GroupDetailsSheet: View {", "struct ContactDetailsView: View {"] {
+            let start = try #require(groupViewsSource.range(of: declaration)?.upperBound)
+            let rest = groupViewsSource[start...]
+            let end =
+                [
+                    rest.range(of: "\nprivate struct ")?.lowerBound,
+                    rest.range(of: "\nstruct ")?.lowerBound,
+                ]
+                .compactMap { $0 }.min() ?? groupViewsSource.endIndex
+            let declarationBody = groupViewsSource[start..<end]
+            // Scope to `body` so helper views declared above it (the custom-duration
+            // popover has its own trailing `Spacer()`) can't stand in for the header's.
+            let bodyStart = try #require(declarationBody.range(of: "var body: some View {")?.upperBound)
+            let header = String(declarationBody[bodyStart...])
+
+            let backIndex = try #require(header.range(of: #"symbol: "chevron.backward""#)?.lowerBound)
+            let avatarIndex = try #require(header.range(of: "ProfileImageAvatarView(")?.lowerBound)
+            let spacerIndex = try #require(header.range(of: "Spacer()")?.lowerBound)
+            #expect(backIndex < avatarIndex, "\(declaration) back button must precede the avatar")
+            #expect(backIndex < spacerIndex, "\(declaration) back button must sit before the spacer")
+        }
+    }
+
     @MainActor
     @Test func directContactDetailsShowsAndNavigatesToGroupsInCommon() async throws {
         let account = desktopAccount()


### PR DESCRIPTION
In group info the back arrow was positioned at right, which looked super weird