### PR TITLE
Make texts selectable

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -30,6 +30,14 @@ struct ContentView: View {
             // Attached here, not on the conversation pane: a chat-list delete is most likely with
             // no chat selected, and the sidebar row menu cannot host its own dialog.
             .chatDestructiveActionsConfirmation()
+            // App-wide default: static text is selectable, so anything on screen — a startup
+            // failure message, a relay URL, an npub, a profile field — can be selected and
+            // copied without the view having to opt in. `.textSelection` propagates through the
+            // environment, so this single application covers every descendant.
+            //
+            // The one deliberate exception is the chat transcript, which re-disables it and
+            // re-enables per bubble on hover; see ConversationView (whitenoise-mac#205).
+            .textSelection(.enabled)
             .frame(minWidth: 940, minHeight: 620)
             .preferredColorScheme(workspace.preferredColorScheme)
             .environment(\.locale, workspace.preferredLocale)

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -444,10 +444,9 @@ struct MessageBubble: View {
                 compactMetadata.hidden()
             }
         }
-        // One hover-gated selection gate for the whole bubble: `.textSelection(.enabled)`
-        // propagates through the environment to the body + reply-quote Text, so only the
-        // active bubble (`isSelectable`) is backed by a selection NSView. Non-active bubbles
-        // get no modifier (Text is non-selectable by default). See whitenoise-mac#205.
+        // One hover-gated selection gate for the whole bubble: `.textSelection` propagates
+        // through the environment to the body + reply-quote Text, so only the active bubble
+        // (`isSelectable`) is backed by a selection NSView. See whitenoise-mac#205.
         .textSelectable(isSelectable)
         // Metadata is pinned to the bubble's bottom-trailing corner no matter how the text
         // wraps. The inline spacer (flowing text) or hidden row (structured Markdown, empty
@@ -539,14 +538,16 @@ struct MessageBubble: View {
 
 private extension View {
     /// Enable text selection only when `enabled`. `.textSelection(.enabled)` and `.disabled`
-    /// are distinct types (so a ternary won't type-check); a plain `Text` is non-selectable
-    /// by default, so the inactive case simply applies no modifier.
+    /// are distinct types, so a ternary won't type-check. The inactive case states `.disabled`
+    /// rather than leaving the bubble to inherit: the app enables selection globally
+    /// (ContentView), so a bubble that applied nothing would pick up a selection NSView from
+    /// the environment — exactly what whitenoise-mac#205 forbids across the transcript.
     @ViewBuilder
     func textSelectable(_ enabled: Bool) -> some View {
         if enabled {
             textSelection(.enabled)
         } else {
-            self
+            textSelection(.disabled)
         }
     }
 

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -459,6 +459,14 @@ private struct ConversationView: View {
                         .padding(.horizontal, 28)
                         .padding(.top, 18)
                         .padding(.bottom, 8)
+                        // The app enables text selection globally (ContentView); the transcript
+                        // is the one place that must not inherit it. Backing every Text in the
+                        // scrolling window with a selection NSView destabilises scroll-anchor
+                        // resolution into a multi-second main-thread layout loop
+                        // (whitenoise-mac#205). Bubbles re-enable selection individually on hover
+                        // via `.textSelectable(isSelectable)`, which — being closer to the leaf —
+                        // overrides this for the single active bubble.
+                        .textSelection(.disabled)
                         // While actively scrolling, make the transcript content transparent to
                         // hit-testing so SwiftUI skips per-frame hover/responder/tracking-area work
                         // for the moving rows (Instruments: HoverEventDispatcher /


### PR DESCRIPTION
I was getting an error on startup and it was super annoying that I couldn't select the error text, so this PR fixes that
<img width="594" height="357" alt="error" src="https://github.com/user-attachments/assets/24e317bc-986f-4fec-ac25-a7f4d3a8e4dc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added text selection and copying for static content throughout the app.
  - Preserved hover-based selection for active message bubbles.

- **Bug Fixes**
  - Prevented inactive message bubbles and conversation transcript content from unintentionally inheriting text selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->