### PR TITLE
Add media icons in chatlist preview

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -61,7 +61,7 @@ extension ChatItem {
             )
         }
         let preview = row.lastMessage.map {
-            ChatItem.previewText(for: $0, activeAccountIdHex: activeAccountIdHex, mentionNames: mentionNames)
+            ChatItem.previewProjection(for: $0, activeAccountIdHex: activeAccountIdHex, mentionNames: mentionNames)
         }
         // MDK owns durable chat ordering. `updatedAt` includes maintenance-only
         // writes and must not make a conversation jump in the sidebar.
@@ -84,7 +84,8 @@ extension ChatItem {
             title: title,
             publishedTitle: publishedTitle,
             subtitle: subtitle,
-            preview: preview?.isEmpty == false ? preview! : L10n.string("No messages yet"),
+            preview: preview?.text.isEmpty == false ? preview!.text : L10n.string("No messages yet"),
+            previewAttachmentKind: preview?.attachmentKind,
             updatedAt: updatedAt,
             avatarSeed: directPeer?.accountIdHex ?? row.groupIdHex,
             pictureURL: directPeer?.pictureURL ?? groupAvatarURL,
@@ -123,13 +124,22 @@ extension ChatItem {
         return DisplayText.short(fallbackId)
     }
 
-    private static func previewText(
+    /// A chat row's last-message text together with the media glyph that belongs beside it.
+    ///
+    /// Both come out of one pass so a row can never pair a photo glyph with a plain-text
+    /// preview, or drop the glyph from a preview that reads "Photo".
+    private struct PreviewProjection {
+        let text: String
+        var attachmentKind: ChatPreviewAttachmentKind?
+    }
+
+    private static func previewProjection(
         for preview: ChatListMessagePreviewFfi,
         activeAccountIdHex: String?,
         mentionNames: MarkdownMentionNames = [:]
-    ) -> String {
+    ) -> PreviewProjection {
         if preview.deleted {
-            return L10n.string("Message deleted")
+            return PreviewProjection(text: L10n.string("Message deleted"))
         }
 
         let presentation = MessageItem.presentation(for: preview.kind)
@@ -149,23 +159,34 @@ extension ChatItem {
         // Resolve the body first so the sender prefix applies to media-only previews too, not
         // just text — otherwise a group attachment shows up unattributed.
         let body: String
+        // A captioned attachment shows its caption, so the glyph is the only thing marking the
+        // row as media; a media-only preview gets it alongside the "Photo"/"2 videos" wording.
+        var attachmentKind: ChatPreviewAttachmentKind?
         if text.isEmpty || isMediaOnlyChat {
             body =
                 presentation.isChatBubble
                 ? attachmentPreview(kind: preview.attachmentKind, count: preview.attachmentCount)
                 : L10n.string("Unsupported message")
+            attachmentKind = presentation.isChatBubble ? ChatPreviewAttachmentKind(preview.attachmentKind) : nil
         } else {
             body = MentionDisplayResolver.resolve(in: text, mentionNames: mentionNames)
+            attachmentKind =
+                presentation.isChatBubble && preview.attachmentCount > 0
+                ? ChatPreviewAttachmentKind(preview.attachmentKind)
+                : nil
         }
         guard presentation.isChatBubble,
             preview.sender != activeAccountIdHex,
             let senderName = PeerDisplayText.sanitize(preview.senderDisplayName),
             !senderName.isEmpty
         else {
-            return body
+            return PreviewProjection(text: body, attachmentKind: attachmentKind)
         }
 
-        return "\(PeerDisplayText.templateFragment(senderName)): \(body)"
+        return PreviewProjection(
+            text: "\(PeerDisplayText.templateFragment(senderName)): \(body)",
+            attachmentKind: attachmentKind
+        )
     }
 
     private static func attachmentPreview(kind: ChatListAttachmentKindFfi?, count: UInt32) -> String {
@@ -197,6 +218,25 @@ extension ChatItem {
         }
     }
 
+}
+
+extension ChatPreviewAttachmentKind {
+    /// A missing kind still means "there is an attachment here" — the core reports `nil` for a
+    /// media type it does not classify, and for legacy rows that predate the kind field.
+    nonisolated init(_ kind: ChatListAttachmentKindFfi?) {
+        switch kind {
+        case .photo:
+            self = .photo
+        case .video:
+            self = .video
+        case .audio:
+            self = .audio
+        case .file:
+            self = .file
+        case .mixed, .none:
+            self = .mixed
+        }
+    }
 }
 
 extension ChatMessageDeliveryState {

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -636,6 +636,7 @@ extension WorkspaceState {
             publishedTitle: enrichedItem.publishedTitle,
             subtitle: enrichedItem.subtitle,
             preview: current.preview,
+            previewAttachmentKind: current.previewAttachmentKind,
             updatedAt: current.updatedAt,
             avatarSeed: enrichedItem.avatarSeed,
             pictureURL: enrichedItem.pictureURL ?? current.pictureURL,

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -190,6 +190,7 @@ nonisolated struct ChatListOrdering {
             title: current.title,
             subtitle: current.subtitle,
             preview: chat.preview,
+            previewAttachmentKind: chat.previewAttachmentKind,
             updatedAt: chat.updatedAt,
             avatarSeed: current.avatarSeed,
             pictureURL: current.pictureURL,

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -111,6 +111,9 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     var publishedTitle: String?
     let subtitle: String
     let preview: String
+    /// Set when the last message carries attachments, so the row can mark the preview with a
+    /// media glyph. Travels with `preview` — anything that carries one forward carries both.
+    let previewAttachmentKind: ChatPreviewAttachmentKind?
     let updatedAt: Date?
     let avatarSeed: String
     let pictureURL: String?
@@ -196,6 +199,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         publishedTitle: String? = nil,
         subtitle: String,
         preview: String,
+        previewAttachmentKind: ChatPreviewAttachmentKind? = nil,
         updatedAt: Date?,
         avatarSeed: String,
         pictureURL: String?,
@@ -220,6 +224,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         self.publishedTitle = publishedTitle
         self.subtitle = subtitle
         self.preview = preview
+        self.previewAttachmentKind = previewAttachmentKind
         self.updatedAt = updatedAt
         self.avatarSeed = avatarSeed
         self.pictureURL = pictureURL
@@ -252,6 +257,34 @@ nonisolated enum ChatMessageDeliveryState: Hashable, Sendable {
     case pending
     case delivered
     case failed
+}
+
+/// Which attachment glyph a chat row draws ahead of its last-message preview.
+///
+/// Mirrors MDK's `ChatListAttachmentKindFfi`. `mixed` covers both a message carrying more than
+/// one kind at once and one whose kind the core did not report, so an attachment always reads as
+/// an attachment even when its media type is unknown.
+nonisolated enum ChatPreviewAttachmentKind: Hashable, Sendable {
+    case photo
+    case video
+    case audio
+    case file
+    case mixed
+
+    var systemImageName: String {
+        switch self {
+        case .photo:
+            "photo"
+        case .video:
+            "video"
+        case .audio:
+            "waveform"
+        case .file:
+            "doc"
+        case .mixed:
+            "paperclip"
+        }
+    }
 }
 
 /// What one bubble's delivery footer should read right now — the timeline counterpart of the

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -749,7 +749,14 @@ struct ChatRowContent: View {
     }
 
     private var previewText: Text {
-        guard let searchResult else { return Text(chat.preview) }
+        // A search hit shows the matched message rather than the chat's last one, so the
+        // last-message glyph would describe the wrong message.
+        guard let searchResult else {
+            guard let kind = chat.previewAttachmentKind else { return Text(chat.preview) }
+            // Inline in the same `Text` so the glyph wraps, truncates and picks up the row's
+            // preview font and secondary style along with the words.
+            return Text(Image(systemName: kind.systemImageName)) + Text(verbatim: " ") + Text(chat.preview)
+        }
         return Text(verbatim: "\(searchResult.senderName): ").bold()
             + Text(searchResult.snippet.leading)
             + Text(searchResult.snippet.match).bold().foregroundColor(.primary)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -26434,6 +26434,110 @@ struct MarmotKit098IntegrationTests {
         let chat = ChatItem(row: row, activeAccountIdHex: "self")
 
         #expect(chat.preview == L10n.string("Attachment"))
+        // No reported kind still means the row carries media, so it keeps the generic glyph.
+        #expect(chat.previewAttachmentKind == .mixed)
+    }
+
+    @MainActor
+    @Test func chatRowProjectsAttachmentGlyphMatchingTheReportedKind() async throws {
+        let expectedKinds: [(ChatListAttachmentKindFfi?, ChatPreviewAttachmentKind)] = [
+            (.photo, .photo),
+            (.video, .video),
+            (.audio, .audio),
+            (.file, .file),
+            (.mixed, .mixed),
+            (nil, .mixed),
+        ]
+
+        for (reported, expected) in expectedKinds {
+            let row = chatListRow(
+                groupIdHex: "group",
+                title: "Planning",
+                preview: "",
+                sender: "alice",
+                timelineAt: 1_700_000_000,
+                attachmentKind: reported,
+                attachmentCount: 1
+            )
+
+            let chat = ChatItem(row: row, activeAccountIdHex: "self")
+
+            #expect(chat.previewAttachmentKind == expected)
+        }
+    }
+
+    @MainActor
+    @Test func chatRowKeepsAttachmentGlyphAlongsideACaption() async throws {
+        let row = chatListRow(
+            groupIdHex: "group",
+            title: "Planning",
+            preview: "Look at this",
+            sender: "alice",
+            timelineAt: 1_700_000_000,
+            attachmentKind: .video,
+            attachmentCount: 1
+        )
+
+        let chat = ChatItem(row: row, activeAccountIdHex: "self")
+
+        // The caption is the whole preview text, so the glyph is all that marks the row as media.
+        #expect(chat.preview == "Look at this")
+        #expect(chat.previewAttachmentKind == .video)
+    }
+
+    @MainActor
+    @Test func chatRowOmitsAttachmentGlyphWithoutAttachments() async throws {
+        let textOnly = chatListRow(
+            groupIdHex: "group",
+            title: "Planning",
+            preview: "Ready when you are",
+            sender: "alice",
+            timelineAt: 1_700_000_000
+        )
+
+        #expect(ChatItem(row: textOnly, activeAccountIdHex: "self").previewAttachmentKind == nil)
+
+        let deleted = chatListRow(
+            groupIdHex: "group",
+            title: "Planning",
+            preview: "",
+            sender: "alice",
+            timelineAt: 1_700_000_000,
+            attachmentKind: .photo,
+            attachmentCount: 2,
+            deleted: true
+        )
+        let deletedChat = ChatItem(row: deleted, activeAccountIdHex: "self")
+
+        #expect(deletedChat.preview == L10n.string("Message deleted"))
+        #expect(deletedChat.previewAttachmentKind == nil)
+    }
+
+    @MainActor
+    @Test func resolvedMetadataMergeKeepsTheAttachmentGlyphWithItsPreview() async throws {
+        let mediaRow = chatListRow(
+            groupIdHex: "group",
+            title: "Planning",
+            preview: "",
+            sender: "alice",
+            timelineAt: 1_700_000_000,
+            attachmentKind: .photo,
+            attachmentCount: 1
+        )
+        let textRow = chatListRow(
+            groupIdHex: "group",
+            title: "Planning",
+            preview: "Ready when you are",
+            sender: "alice",
+            timelineAt: 1_600_000_000
+        )
+        let media = ChatItem(row: mediaRow, activeAccountIdHex: "self")
+        let text = ChatItem(row: textRow, activeAccountIdHex: "self")
+
+        // The merge takes `preview` from the incoming row, so the glyph has to travel with it in
+        // both directions — otherwise a text preview keeps a stale photo glyph.
+        #expect(ChatListOrdering.preservingResolvedMetadata(in: media, from: text).previewAttachmentKind == .photo)
+        #expect(ChatListOrdering.preservingResolvedMetadata(in: text, from: media).previewAttachmentKind == nil)
     }
 
     @MainActor
@@ -29477,7 +29581,10 @@ private func chatListRow(
     sender: String,
     timelineAt: UInt64,
     kind: UInt64 = 9,
-    selfMembership: SelfMembershipFfi = .member
+    selfMembership: SelfMembershipFfi = .member,
+    attachmentKind: ChatListAttachmentKindFfi? = nil,
+    attachmentCount: UInt32 = 0,
+    deleted: Bool = false
 ) -> ChatListRowFfi {
     ChatListRowFfi(
         groupIdHex: groupIdHex,
@@ -29495,7 +29602,10 @@ private func chatListRow(
             contentTokens: emptyMarkdownDocument(),
             kind: kind,
             timelineAt: timelineAt,
-            deleted: false
+            deleted: deleted,
+            attachmentKind: attachmentKind,
+            attachmentCount: attachmentCount,
+            deliveryState: .notApplicable
         ),
         unreadCount: 0,
         hasUnread: false,


### PR DESCRIPTION
Now when I send an image, in the chatlist appears a image icon in the last message preview. Same for audios with other icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat previews now display icons for photo, video, audio, file, and mixed attachments.
  * Attachment icons are preserved for media-only messages, captioned messages, and sender-prefixed previews.
* **Bug Fixes**
  * Attachment indicators now remain visible when chat metadata is enriched or refreshed.
  * Preview rendering correctly handles missing, deleted, and mixed attachments.
* **Tests**
  * Added coverage for attachment previews, captions, deleted messages, and metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->