### PR TITLE
Fix audio player visibility in light mode

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -584,6 +584,9 @@ private extension View {
         }
     }
 
+    /// Chrome shared by every non-visual attachment presentation: the audio player, the
+    /// download/failed status rows, and the document row. See `AttachmentRowPalette` for why the
+    /// outgoing fill is the opaque accent rather than a wash over whatever sits behind the row.
     func attachmentRowChrome(isOutgoing: Bool) -> some View {
         foregroundStyle(isOutgoing ? Color.white : Color.primary)
             .padding(.horizontal, 10)
@@ -591,7 +594,7 @@ private extension View {
             .frame(width: 260, alignment: .leading)
             .background {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(isOutgoing ? Color.white.opacity(0.12) : Color.primary.opacity(0.06))
+                    .fill(AttachmentRowPalette.fill(isOutgoing: isOutgoing))
             }
     }
 

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -90,6 +90,30 @@ enum MessagesPalette {
     static let sentBubble = Color(nsColor: .systemBlue)
 }
 
+/// Surface for the non-visual attachment rows: the audio player, the download/failed status rows,
+/// and the document row.
+///
+/// Unlike the reply quote, these rows sit *beside* the bubble in `MessageBubble`'s stack rather than
+/// inside it, so they never inherit `BubbleBackground`'s fill and have to bring their own.
+nonisolated enum AttachmentRowPalette {
+    /// The accent itself — the same fill the sent bubble uses, which is what the row's white content
+    /// (play button, waveform, detail text) is drawn for.
+    ///
+    /// It has to stay **opaque**. A translucent white wash composites against whatever is behind the
+    /// row, and what is behind it is the window background: dark in dark appearance, light in light
+    /// appearance. That is how sent voice notes and documents came to render white-on-white and
+    /// vanish in light mode while looking correct in dark.
+    static let outgoingFill = MessagesPalette.sentBubble
+
+    /// Received rows stay on a wash, which is safe here because `.primary` flips with the
+    /// appearance — it darkens the light backdrop and lightens the dark one.
+    static let incomingFill = Color.primary.opacity(0.06)
+
+    static func fill(isOutgoing: Bool) -> Color {
+        isOutgoing ? outgoingFill : incomingFill
+    }
+}
+
 /// The background chip drawn behind an `@mention`'s glyphs, Signal's treatment: the mention keeps
 /// the body font, weight, and inherited foreground, and is set off by its fill alone. Each chip is
 /// the bubble's own fill pushed a step further, never a different hue — a mention should look like

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5754,6 +5754,47 @@ struct whitenoise_macTests {
         #expect(chip(isOutgoing: false) == MentionChipPalette.onNeutralFill)
     }
 
+    /// The audio player, the download/failed status rows, and the document row draw white content
+    /// keyed off `isOutgoing`, but they sit *beside* the bubble rather than inside it, so they never
+    /// inherit `BubbleBackground`'s fill. The outgoing fill was `white.opacity(0.12)`, which
+    /// composited against the window background instead of covering it — white-on-white in light
+    /// appearance, so sent voice notes and documents took up their space and rendered nothing.
+    /// Dark appearance hid it, because there the wash happened to land on a dark backdrop.
+    ///
+    /// Opacity in *both* appearances is the property that matters: an alpha < 1 here means the row
+    /// is at the mercy of whatever is behind it, which is exactly the bug.
+    @Test func outgoingAttachmentRowFillCoversTheWindowBackgroundInBothAppearances() throws {
+        #expect(AttachmentRowPalette.fill(isOutgoing: true) == AttachmentRowPalette.outgoingFill)
+        #expect(AttachmentRowPalette.fill(isOutgoing: false) == AttachmentRowPalette.incomingFill)
+
+        for appearanceName in [NSAppearance.Name.aqua, .darkAqua] {
+            let appearance = try #require(NSAppearance(named: appearanceName))
+            var outgoing: NSColor?
+            var windowBackground: NSColor?
+            appearance.performAsCurrentDrawingAppearance {
+                outgoing = NSColor(AttachmentRowPalette.outgoingFill).usingColorSpace(.sRGB)
+                windowBackground = NSColor.windowBackgroundColor.usingColorSpace(.sRGB)
+            }
+            let fill = try #require(outgoing)
+            let backdrop = try #require(windowBackground)
+
+            #expect(
+                fill.alphaComponent == 1,
+                "Outgoing attachment row fill must be opaque in \(appearanceName.rawValue), got alpha \(fill.alphaComponent)"
+            )
+            // And it must actually read as a different surface than the backdrop it covers — an
+            // opaque fill that matches the window background would be just as invisible.
+            let distance =
+                abs(fill.redComponent - backdrop.redComponent)
+                + abs(fill.greenComponent - backdrop.greenComponent)
+                + abs(fill.blueComponent - backdrop.blueComponent)
+            #expect(
+                distance > 0.2,
+                "Outgoing attachment row fill matches the window background in \(appearanceName.rawValue) (channel distance \(distance))"
+            )
+        }
+    }
+
     @Test func singleEmojiMessagesAreClassifiedForStickerPresentation() {
         let singleEmoji = [
             "😀",


### PR DESCRIPTION
In light mode, audios sent by me weren't visible. Now they are
<img width="452" height="97" alt="Screenshot 2026-08-05 at 12 50 29 PM" src="https://github.com/user-attachments/assets/3b04f406-fb16-4b6e-a36b-2a1027039d08" />
