### PR TITLE
Add copied feedback to npub copied from settings profile

### DIFF
--- a/whitenoise-mac/Views/CopyToClipboardButton.swift
+++ b/whitenoise-mac/Views/CopyToClipboardButton.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// The transient "Copied" state behind a copy affordance.
+///
+/// Kept out of the view so the reset window is unit-testable, and so one copy action can flip
+/// several elements (glyph, title, tint) from a single source of truth.
+@Observable
+final class CopyConfirmation {
+    /// How long the confirmation stays up. Matches the iOS client's copy affordance.
+    static let defaultDuration = Duration.seconds(1.5)
+
+    private(set) var isConfirming = false
+
+    private let duration: Duration
+    private var resetTask: Task<Void, Never>?
+
+    init(duration: Duration = CopyConfirmation.defaultDuration) {
+        self.duration = duration
+    }
+
+    /// Shows the confirmation and schedules its reset. A repeated copy restarts the window rather
+    /// than letting the earlier call's pending reset clear it out from under the new copy.
+    func confirm() {
+        resetTask?.cancel()
+        withAnimation(.smooth(duration: 0.15)) { isConfirming = true }
+        resetTask = Task { [duration] in
+            try? await Task.sleep(for: duration)
+            guard !Task.isCancelled else { return }
+            withAnimation(.smooth(duration: 0.2)) { isConfirming = false }
+        }
+    }
+}
+
+/// A copy-to-clipboard button that confirms the copy in place: the glyph flips to a green
+/// checkmark for ~1.5s, matching the iOS client.
+///
+/// macOS raises no system-level confirmation when an app writes to the pasteboard, so a bare copy
+/// button leaves the user unable to tell a successful copy from a click that missed. `label`
+/// receives `true` while the confirmation is showing, so each call site keeps its own styling and
+/// decides whether to also swap its title.
+struct CopyToClipboardButton<Label: View>: View {
+    @Environment(WorkspaceState.self) private var workspace
+
+    /// The full value written to the pasteboard.
+    let value: String
+    /// Localized description of the action, e.g. "Copy npub". Used for the tooltip and the
+    /// accessibility label, both of which must stay stable while the glyph is a checkmark.
+    let actionDescription: String
+    /// Whether the value is private-messenger content; see `WorkspaceState.copyText(_:concealed:)`.
+    var concealed = true
+    @ViewBuilder var label: (Bool) -> Label
+
+    @State private var confirmation = CopyConfirmation()
+
+    var body: some View {
+        Button {
+            workspace.copyText(value, concealed: concealed)
+            confirmation.confirm()
+            // The checkmark is invisible to VoiceOver, so announce the same result it conveys.
+            AccessibilityNotification.Announcement(L10n.string("Copied")).post()
+        } label: {
+            label(confirmation.isConfirming)
+        }
+        .help(actionDescription)
+        .accessibilityLabel(actionDescription)
+    }
+}

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -559,7 +559,6 @@ struct PublicIdentityQRCodeButton: View {
 
 struct PublicIdentityQRCodeSheet: View {
     @Environment(\.dismiss) private var dismiss
-    @Environment(WorkspaceState.self) private var workspace
     let displayName: String
     let npub: String
 
@@ -606,10 +605,11 @@ struct PublicIdentityQRCodeSheet: View {
                 .frame(maxWidth: .infinity)
 
             HStack(spacing: 10) {
-                Button {
-                    workspace.copyText(npub)
-                } label: {
-                    Label(L10n.string("Copy npub"), systemImage: "doc.on.doc")
+                CopyToClipboardButton(value: npub, actionDescription: L10n.string("Copy npub")) { isConfirming in
+                    Label(
+                        isConfirming ? L10n.string("Copied") : L10n.string("Copy npub"),
+                        systemImage: isConfirming ? "checkmark" : "doc.on.doc"
+                    )
                 }
                 .nativeGlassButtonStyle()
 
@@ -980,13 +980,14 @@ struct IdentityKeysSettingsView: View {
                                 .lineLimit(3)
                                 .textSelection(.enabled)
 
-                            Button {
-                                workspace.copyText(npub)
-                            } label: {
-                                Image(systemName: "doc.on.doc")
+                            CopyToClipboardButton(
+                                value: npub,
+                                actionDescription: L10n.string("Copy npub")
+                            ) { isConfirming in
+                                Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
+                                    .foregroundStyle(isConfirming ? Color.green : Color.accentColor)
                             }
                             .buttonStyle(.borderless)
-                            .help(L10n.string("Copy npub"))
 
                             PublicIdentityQRCodeButton(
                                 accountIdHex: account.accountIdHex,
@@ -1126,13 +1127,14 @@ struct PrivateKeyBackupSheet: View {
                             .lineLimit(4)
                             .truncationMode(.middle)
                         Spacer(minLength: 8)
-                        Button {
-                            workspace.copyText(revealedSecret)
-                        } label: {
-                            Image(systemName: "doc.on.doc")
+                        CopyToClipboardButton(
+                            value: revealedSecret,
+                            actionDescription: L10n.string("Copy")
+                        ) { isConfirming in
+                            Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
+                                .foregroundStyle(isConfirming ? Color.green : Color.accentColor)
                         }
                         .buttonStyle(.borderless)
-                        .help(L10n.string("Copy"))
                     }
                 }
             }
@@ -1235,15 +1237,12 @@ struct CopyableKeyLabel: View {
                 .textSelection(.enabled)
 
             if showsCopyButton {
-                Button {
-                    workspace.copyText(npub)
-                } label: {
-                    Image(systemName: "doc.on.doc")
+                CopyToClipboardButton(value: npub, actionDescription: L10n.string("Copy npub")) { isConfirming in
+                    Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
                         .font(.system(size: 10))
+                        .foregroundStyle(isConfirming ? Color.green : Color.secondary)
                 }
                 .buttonStyle(.borderless)
-                .foregroundStyle(.secondary)
-                .help(L10n.string("Copy npub"))
             }
         }
     }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -15901,6 +15901,35 @@ struct whitenoise_macTests {
         #expect(copiedText == "public-key-value")
     }
 
+    @MainActor
+    @Test func copyConfirmationShowsThenClearsItself() async throws {
+        let confirmation = CopyConfirmation(duration: .milliseconds(30))
+
+        #expect(!confirmation.isConfirming)
+        confirmation.confirm()
+        // macOS gives no system-level copy confirmation, so the checkmark is the only signal the
+        // user gets that the click landed — it has to be up immediately, not after an await.
+        #expect(confirmation.isConfirming)
+
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(!confirmation.isConfirming)
+    }
+
+    @MainActor
+    @Test func repeatedCopyRestartsTheConfirmationWindow() async throws {
+        let confirmation = CopyConfirmation(duration: .milliseconds(200))
+
+        confirmation.confirm()
+        try await Task.sleep(for: .milliseconds(120))
+        // Second copy mid-window: the first reset must not fire and blank the confirmation while
+        // the user is still looking at the result of the newer copy.
+        confirmation.confirm()
+        try await Task.sleep(for: .milliseconds(120))
+
+        #expect(confirmation.isConfirming)
+    }
+
     @Test func globalMessageSearchTextNormalizesOrderedTokensAndBoundsSnippets() {
         let tokens = GlobalMessageSearchText.tokens(in: "  CAFÉ…shipped!  ")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable copy controls with animated confirmation feedback.
  * Copy actions now announce “Copied” for accessibility and support customizable labels.
  * Updated QR code, identity key, private key backup, and reusable key views with confirmation-aware copy controls.

* **Bug Fixes**
  * Repeated copy actions now keep confirmation visible for the full feedback period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->