### PR TITLE
Fix group name after last other member left

### DIFF
--- a/whitenoise-mac/Core/DirectPeerMemoryFileStore.swift
+++ b/whitenoise-mac/Core/DirectPeerMemoryFileStore.swift
@@ -1,0 +1,89 @@
+//
+//  DirectPeerMemoryFileStore.swift
+//  whitenoise-mac
+//
+//  Protected persistence for the peer a conversation was last a two-person chat with.
+//
+
+import Foundation
+
+/// The other party of a conversation, recorded while they were still a member.
+///
+/// MDK's roster only reports *current* members, so once the only other participant of a DM leaves,
+/// nothing is left to name the conversation with and MDK projects the shortened group id as its
+/// title. Remembering the departed peer locally is what keeps the chat recognisable — in the
+/// sidebar, the chat header, and every picker built from `ChatItem`.
+nonisolated struct RememberedDirectPeer: Codable, Hashable, Sendable {
+    let accountIdHex: String
+    /// Last published display name. Only a fallback: the peer's profile is still resolvable
+    /// through the runtime after they leave, and a fresh lookup outranks this copy.
+    let displayName: String?
+    let pictureURL: String?
+
+    init(accountIdHex: String, displayName: String?, pictureURL: String?) {
+        self.accountIdHex = accountIdHex
+        self.displayName = displayName
+        self.pictureURL = pictureURL
+    }
+}
+
+nonisolated protocol DirectPeerMemoryStoring: AnyObject {
+    func loadAll() throws -> [String: [String: RememberedDirectPeer]]
+    func write(_ peers: [String: RememberedDirectPeer], forAccountId accountId: String) throws
+    func remove(forAccountId accountId: String) throws
+    func removeAll() throws
+}
+
+nonisolated final class DirectPeerMemoryFileStore: DirectPeerMemoryStoring {
+    private struct Record: Codable {
+        let version: Int
+        let accountId: String
+        let peersByGroupId: [String: RememberedDirectPeer]
+    }
+
+    private static let directoryName = "Direct Peers"
+    private let records: ProtectedLocalMetadataFileStore<Record>
+
+    init(fileManager: FileManager = .default, directoryURL: URL? = nil) {
+        records = ProtectedLocalMetadataFileStore(
+            directoryName: Self.directoryName,
+            fileManager: fileManager,
+            directoryURL: directoryURL
+        )
+    }
+
+    convenience init(fileManager: FileManager = .default, storageRootPath: String) {
+        self.init(
+            fileManager: fileManager,
+            directoryURL: URL(fileURLWithPath: storageRootPath, isDirectory: true)
+                .appendingPathComponent(Self.directoryName, isDirectory: true)
+        )
+    }
+
+    func loadAll() throws -> [String: [String: RememberedDirectPeer]] {
+        var result: [String: [String: RememberedDirectPeer]] = [:]
+        for record in try records.loadAll() where record.version == 1 {
+            result[record.accountId, default: [:]].merge(record.peersByGroupId) { _, new in new }
+        }
+        return result
+    }
+
+    func write(_ peers: [String: RememberedDirectPeer], forAccountId accountId: String) throws {
+        guard !peers.isEmpty else {
+            try remove(forAccountId: accountId)
+            return
+        }
+        try records.write(
+            Record(version: 1, accountId: accountId, peersByGroupId: peers),
+            forKey: accountId
+        )
+    }
+
+    func remove(forAccountId accountId: String) throws {
+        try records.remove(forKey: accountId)
+    }
+
+    func removeAll() throws {
+        try records.removeAll()
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -41,9 +41,13 @@ extension WorkspaceState {
             if contactNicknameStore == nil {
                 contactNicknameStore = ContactNicknameFileStore(storageRootPath: storageRootPath)
             }
+            if directPeerMemoryStore == nil {
+                directPeerMemoryStore = DirectPeerMemoryFileStore(storageRootPath: storageRootPath)
+            }
             loadHiddenMessages()
             loadPinnedChats()
             loadContactNicknames()
+            loadRememberedDirectPeers()
             let summaries = try await runOffMain {
                 try runtime.listAccounts()
             }
@@ -403,6 +407,7 @@ extension WorkspaceState {
             purgeHiddenMessages(accountId: removedAccountId)
             purgePinnedChats(accountId: removedAccountId)
             purgeContactNicknames(ownerAccountIdHex: removedAccountIdHex)
+            purgeRememberedDirectPeers(accountId: removedAccountId)
             await mediaDiskCache.purgeAccount(removedAccountId)
             clearMediaReferenceResolutionCache(forAccountId: removedAccountId)
             accounts = try await accountItemsFromRuntime(client: client)
@@ -856,6 +861,7 @@ extension WorkspaceState {
         clearAllHiddenMessages()
         clearAllPinnedChats()
         clearAllContactNicknames()
+        clearAllRememberedDirectPeers()
         clearChatRestorationTargets()
         isRefreshing = false
         isSending = false

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -686,9 +686,34 @@ extension WorkspaceState {
             mentionNames = Self.mentionNames(from: members)
             directPeer = await directPeerProfile(
                 from: members,
+                groupIdHex: row.groupIdHex,
                 activeAccount: account,
                 client: client
             )
+            if directPeer == nil,
+                Self.otherMembers(in: members, activeAccount: account).isEmpty,
+                PeerDisplayText.sanitize(row.groupName) == nil
+            {
+                // Nobody is left to name this conversation and it never had a group name, so MDK
+                // projects the shortened group id as its title. Fall back to whoever this chat was
+                // last a one-to-one with, which is what the user recognises it by.
+                directPeer = await rememberedDirectPeerProfile(
+                    groupIdHex: row.groupIdHex,
+                    activeAccount: account,
+                    client: client
+                )
+                if directPeer == nil {
+                    // Nothing was recorded — the peer left before this device ever enriched the
+                    // chat (including every such conversation that predates this feature). Their
+                    // messages outlive their membership, so recover the identity from the
+                    // transcript and record it so this costs one lookup, not one per enrichment.
+                    directPeer = await recoveredDirectPeerProfile(
+                        from: row,
+                        activeAccount: account,
+                        client: client
+                    )
+                }
+            }
         }
         let groupImagePayload =
             row.conversationKind != .direct && directPeer == nil && groupAvatarURL == nil
@@ -756,17 +781,33 @@ extension WorkspaceState {
         ChatListOrdering.sorted(chatItems)
     }
 
+    static func otherMembers(
+        in members: [GroupMemberDetailsFfi],
+        activeAccount: AccountItem
+    ) -> [GroupMemberDetailsFfi] {
+        members.filter { member in
+            !member.isSelf && member.memberIdHex != activeAccount.accountIdHex
+        }
+    }
+
     func directPeerProfile(
         from members: [GroupMemberDetailsFfi],
+        groupIdHex: String,
         activeAccount: AccountItem,
         client: any MarmotRuntime
     ) async -> ChatPeerProfile? {
-        let otherMembers = members.filter { member in
-            !member.isSelf && member.memberIdHex != activeAccount.accountIdHex
-        }
+        let otherMembers = Self.otherMembers(in: members, activeAccount: activeAccount)
         guard otherMembers.count == 1,
             let otherMember = otherMembers.first
-        else { return nil }
+        else {
+            // Several other members means this is a real group, which no single peer describes.
+            // Drop any peer remembered from when it was a two-person chat so it cannot resurface
+            // as the title once the group empties out.
+            if otherMembers.count > 1 {
+                forgetDirectPeer(groupIdHex: groupIdHex, accountId: activeAccount.id)
+            }
+            return nil
+        }
 
         let memberId = otherMember.memberIdHex
         let resolved = await resolvedPeerFFI(
@@ -784,12 +825,141 @@ extension WorkspaceState {
         // the override reach the DM's chat-row title, and through that the forward picker,
         // compose contacts, and the sidebar filter.
         let nickname = activeContactNicknames.nickname(forContactAccountIdHex: memberId)
+        let pictureURL = resolved?.profilePicture?.nilIfBlank
+
+        // The roster is the only place this identity is available; once the peer leaves, MDK stops
+        // reporting them. Capture it while it is in hand so the chat can still name them later.
+        if activeAccountId == activeAccount.id {
+            rememberDirectPeer(
+                RememberedDirectPeer(
+                    accountIdHex: memberId,
+                    displayName: published,
+                    pictureURL: pictureURL
+                ),
+                groupIdHex: groupIdHex,
+                accountId: activeAccount.id
+            )
+        }
 
         return ChatPeerProfile(
             accountIdHex: memberId,
             displayName: nickname ?? published,
             publishedDisplayName: nickname == nil ? nil : published,
-            pictureURL: resolved?.profilePicture?.nilIfBlank
+            pictureURL: pictureURL
+        )
+    }
+
+    /// The departed other party of a conversation that no longer has one.
+    ///
+    /// Their profile outlives their membership, so prefer a fresh lookup and treat the recorded
+    /// name and picture as the offline fallback.
+    func rememberedDirectPeerProfile(
+        groupIdHex: String,
+        activeAccount: AccountItem,
+        client: any MarmotRuntime
+    ) async -> ChatPeerProfile? {
+        guard
+            let remembered = rememberedDirectPeer(
+                groupIdHex: groupIdHex,
+                accountId: activeAccount.id
+            )
+        else { return nil }
+
+        let memberId = remembered.accountIdHex
+        let resolved = await resolvedPeerFFI(
+            accountIdHex: memberId,
+            activeAccount: activeAccount,
+            client: client
+        )
+        let published = firstNonBlank([
+            resolved?.profileDisplayName,
+            resolved?.profileName,
+            resolved?.directoryDisplayName,
+            remembered.displayName,
+        ])
+        let nickname = activeContactNicknames.nickname(forContactAccountIdHex: memberId)
+
+        return ChatPeerProfile(
+            accountIdHex: memberId,
+            displayName: nickname ?? published,
+            publishedDisplayName: nickname == nil ? nil : published,
+            pictureURL: resolved?.profilePicture?.nilIfBlank ?? remembered.pictureURL?.nilIfBlank
+        )
+    }
+
+    /// Recover the other party of a conversation that has no roster peer and no recorded one, by
+    /// reading the transcript: whoever else spoke here is who this chat was with.
+    ///
+    /// A note-to-self chat has no other sender and correctly recovers nothing. That answer is
+    /// cached for the session so an empty scan is not repeated on every chat-list delta.
+    func recoveredDirectPeerProfile(
+        from row: ChatListRowFfi,
+        activeAccount: AccountItem,
+        client: any MarmotRuntime
+    ) async -> ChatPeerProfile? {
+        let groupIdHex = row.groupIdHex
+        guard !unrecoverableDirectPeerGroupIds.contains(groupIdHex) else { return nil }
+
+        let selfIdHex = activeAccount.accountIdHex
+        var memberId = row.lastMessage?.sender.nilIfBlank.flatMap { $0 == selfIdHex ? nil : $0 }
+        if memberId == nil {
+            // The newest message is this account's own (or there is none), so page back through
+            // the transcript for the newest message that is not.
+            let accountRef = activeAccount.accountRef
+            memberId = try? await runOffMain { () -> String? in
+                let page = try client.timelineMessages(
+                    accountRef: accountRef,
+                    query: TimelineMessageQueryFfi(
+                        groupIdHex: groupIdHex,
+                        search: nil,
+                        before: nil,
+                        beforeMessageId: nil,
+                        after: nil,
+                        afterMessageId: nil,
+                        limit: Self.directPeerRecoveryScanLimit
+                    )
+                )
+                return page.messages.reversed().first { $0.sender != selfIdHex }?.sender.nilIfBlank
+            }
+        }
+
+        guard activeAccountId == activeAccount.id else { return nil }
+        guard let memberId else {
+            unrecoverableDirectPeerGroupIds.insert(groupIdHex)
+            return nil
+        }
+
+        let resolved = await resolvedPeerFFI(
+            accountIdHex: memberId,
+            activeAccount: activeAccount,
+            client: client
+        )
+        let published = firstNonBlank([
+            resolved?.profileDisplayName,
+            resolved?.profileName,
+            resolved?.directoryDisplayName,
+            PeerDisplayText.sanitize(row.lastMessage?.senderDisplayName),
+        ])
+        let pictureURL = resolved?.profilePicture?.nilIfBlank
+        let nickname = activeContactNicknames.nickname(forContactAccountIdHex: memberId)
+
+        if activeAccountId == activeAccount.id {
+            rememberDirectPeer(
+                RememberedDirectPeer(
+                    accountIdHex: memberId,
+                    displayName: published,
+                    pictureURL: pictureURL
+                ),
+                groupIdHex: groupIdHex,
+                accountId: activeAccount.id
+            )
+        }
+
+        return ChatPeerProfile(
+            accountIdHex: memberId,
+            displayName: nickname ?? published,
+            publishedDisplayName: nickname == nil ? nil : published,
+            pictureURL: pictureURL
         )
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+DirectPeerMemory.swift
+++ b/whitenoise-mac/Core/WorkspaceState+DirectPeerMemory.swift
@@ -1,0 +1,95 @@
+//
+//  WorkspaceState+DirectPeerMemory.swift
+//  whitenoise-mac
+//
+//  Local, account-scoped memory of who a conversation was a one-to-one chat with, so a DM keeps
+//  naming its peer after that peer leaves and the roster has nobody left to name it with.
+//
+
+import Foundation
+import OSLog
+
+private let directPeerMemoryLogger = Logger(subsystem: "com.whitenoise.storage", category: "DirectPeers")
+
+@MainActor
+extension WorkspaceState {
+    func loadRememberedDirectPeers() {
+        guard let directPeerMemoryStore else { return }
+        do {
+            rememberedDirectPeersByAccount = try directPeerMemoryStore.loadAll()
+        } catch {
+            directPeerMemoryLogger.error(
+                "Failed to load protected direct-peer state: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    func rememberedDirectPeer(groupIdHex: String, accountId: String) -> RememberedDirectPeer? {
+        rememberedDirectPeersByAccount[accountId]?[groupIdHex]
+    }
+
+    /// Record the peer of a two-person conversation while they are still reachable in the roster.
+    ///
+    /// Re-recording an unchanged peer is a no-op, so the steady state of chat-list enrichment does
+    /// no disk writes at all — only an actual change to who the other party is costs a write.
+    func rememberDirectPeer(_ peer: RememberedDirectPeer, groupIdHex: String, accountId: String) {
+        guard !groupIdHex.isEmpty, !peer.accountIdHex.isEmpty else { return }
+        guard rememberedDirectPeersByAccount[accountId]?[groupIdHex] != peer else { return }
+        rememberedDirectPeersByAccount[accountId, default: [:]][groupIdHex] = peer
+        persistRememberedDirectPeers(forAccountId: accountId)
+    }
+
+    /// Drop the remembered peer once a conversation is no longer a two-person chat: a group with
+    /// several other members is not describable by a single peer, so a stale one must not resurface
+    /// if that group later empties out.
+    func forgetDirectPeer(groupIdHex: String, accountId: String) {
+        guard rememberedDirectPeersByAccount[accountId]?[groupIdHex] != nil else { return }
+        rememberedDirectPeersByAccount[accountId]?[groupIdHex] = nil
+        if rememberedDirectPeersByAccount[accountId]?.isEmpty == true {
+            rememberedDirectPeersByAccount[accountId] = nil
+        }
+        persistRememberedDirectPeers(forAccountId: accountId)
+    }
+
+    /// Forget every peer an account recorded. Called on account removal, where the owner is gone;
+    /// ordinary sign-out deliberately retains them, like pinned chats and hidden messages.
+    func purgeRememberedDirectPeers(accountId: String) {
+        rememberedDirectPeersByAccount[accountId] = nil
+        do {
+            try directPeerMemoryStore?.remove(forAccountId: accountId)
+        } catch {
+            directPeerMemoryLogger.error(
+                "Failed to purge direct-peer state for an account: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Forget every remembered peer on the device — part of the "Delete All Local Data" reset.
+    func clearAllRememberedDirectPeers() {
+        rememberedDirectPeersByAccount = [:]
+        unrecoverableDirectPeerGroupIds.removeAll()
+        do {
+            try directPeerMemoryStore?.removeAll()
+        } catch {
+            directPeerMemoryLogger.error(
+                "Failed to clear direct-peer state: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    private func persistRememberedDirectPeers(forAccountId accountId: String) {
+        guard let directPeerMemoryStore else { return }
+        do {
+            let peers = rememberedDirectPeersByAccount[accountId] ?? [:]
+            if peers.isEmpty {
+                try directPeerMemoryStore.remove(forAccountId: accountId)
+            } else {
+                try directPeerMemoryStore.write(peers, forAccountId: accountId)
+            }
+        } catch {
+            directPeerMemoryLogger.error(
+                "Failed to persist direct-peer state: \(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -1462,6 +1462,9 @@ extension WorkspaceState {
     }
 
     func invalidateGroupMembers(for groupIdHex: String) {
+        // A roster change can bring a new sender into a conversation that had none, so let the
+        // peer recovery scan run again for it.
+        unrecoverableDirectPeerGroupIds.remove(groupIdHex)
         groupMemberDetailsCache[groupIdHex] = nil
         mentionRosterCache[groupIdHex] = nil
         mentionNamesCache[groupIdHex] = nil
@@ -1471,6 +1474,7 @@ extension WorkspaceState {
     }
 
     func clearGroupMemberCache() {
+        unrecoverableDirectPeerGroupIds.removeAll()
         groupMemberDetailsCache.removeAll()
         mentionRosterCache.removeAll()
         mentionNamesCache.removeAll()

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -952,6 +952,14 @@ final class WorkspaceState {
     var selectedChatRevision = 0
     var archivedChatsByAccount: [String: [ChatItem]] = [:]
     var pinnedChatIdsByAccount: [String: Set<String>] = [:]
+    /// Account id → group id → the peer that conversation was last a two-person chat with. Read
+    /// only while enriching chat rows, so it does not need to drive observation on its own.
+    @ObservationIgnored var rememberedDirectPeersByAccount: [String: [String: RememberedDirectPeer]] = [:]
+    /// Conversations whose transcript held no other sender, so no peer can be recovered from it —
+    /// a note-to-self chat is the ordinary case. Session-scoped, purely to avoid rescanning.
+    @ObservationIgnored var unrecoverableDirectPeerGroupIds = Set<String>()
+    /// How far back to look for the newest message from someone other than this account.
+    static let directPeerRecoveryScanLimit: UInt32 = 200
     @ObservationIgnored var chatLookupByAccount: [String: [String: ChatItem]] = [:]
     @ObservationIgnored var chatIndexByAccount: [String: [String: Int]] = [:]
     @ObservationIgnored var chatListGenerationByAccount: [String: Int] = [:]
@@ -987,6 +995,7 @@ final class WorkspaceState {
     @ObservationIgnored var hiddenMessageStore: (any HiddenMessageStoring)?
     @ObservationIgnored var pinnedChatStore: (any PinnedChatStoring)?
     @ObservationIgnored var contactNicknameStore: (any ContactNicknameStoring)?
+    @ObservationIgnored var directPeerMemoryStore: (any DirectPeerMemoryStoring)?
     var contactNicknamesByOwner: [String: [String: String]] = [:]
     @ObservationIgnored var contactNicknameRevision: UInt64 = 0
     @ObservationIgnored var cachedContactNicknames: CachedContactNicknames?
@@ -1891,6 +1900,7 @@ final class WorkspaceState {
         hiddenMessageStore: (any HiddenMessageStoring)? = nil,
         pinnedChatStore: (any PinnedChatStoring)? = nil,
         contactNicknameStore: (any ContactNicknameStoring)? = nil,
+        directPeerMemoryStore: (any DirectPeerMemoryStoring)? = nil,
         chatRestorationStore: (any ChatRestorationStoring)? = nil,
         quickReactionStore: (any QuickReactionStoring)? = nil,
         clientFactory: @escaping @MainActor () throws -> any MarmotRuntime = { try MarmotClient() }
@@ -1915,6 +1925,7 @@ final class WorkspaceState {
         self.hiddenMessageStore = hiddenMessageStore
         self.pinnedChatStore = pinnedChatStore
         self.contactNicknameStore = contactNicknameStore
+        self.directPeerMemoryStore = directPeerMemoryStore
         let resolvedChatRestorationStore =
             chatRestorationStore ?? UserDefaultsChatRestorationStore()
         self.chatRestorationStore = resolvedChatRestorationStore

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -16961,6 +16961,390 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func directChatKeepsDepartedPeerNameAfterTheOnlyOtherMemberLeaves() async throws {
+        // MDK's roster only reports *current* members, so once the only other side of a DM leaves
+        // there is nobody left to name the conversation and MDK projects the shortened group id as
+        // its title. The chat must keep naming the peer it was a DM with — even on a fresh launch
+        // whose runtime no longer knows that peer at all.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let aliceProfile = UserProfileMetadataFfi(
+            name: "alice",
+            displayName: "Alice Actual",
+            about: nil,
+            picture: "https://example.com/alice.png",
+            nip05: nil,
+            lud16: nil
+        )
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-direct-peer-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let store = DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory)
+
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: aliceProfile
+        )
+        let state = WorkspaceState(directPeerMemoryStore: store, clientFactory: { runtime })
+
+        await state.bootstrap()
+        let didResolvePeer = await waitFor { state.activeChats.first?.title == "Alice Actual" }
+        #expect(didResolvePeer)
+        let accountId = try #require(state.activeAccountId)
+        #expect(try store.loadAll()[accountId]?["direct-group"]?.accountIdHex == aliceId)
+
+        // Alice leaves. A fresh launch sees a roster holding only this account, and this runtime
+        // cannot resolve her profile either — the recorded copy is the only thing left.
+        let departedRuntime = FakeMarmotRuntime(accounts: [account])
+        departedRuntime.installGroupDetails(
+            GroupDetailsFfi(
+                group: directGroup(),
+                members: [soleRemainingSelfMember(accountIdHex: account.accountIdHex)]
+            )
+        )
+        departedRuntime.accountIdsMissingProfiles.insert(aliceId)
+        let relaunched = WorkspaceState(directPeerMemoryStore: store, clientFactory: { departedRuntime })
+
+        await relaunched.bootstrap()
+        let didKeepDepartedPeer = await waitFor { relaunched.activeChats.first?.title == "Alice Actual" }
+
+        if !didKeepDepartedPeer {
+            Issue.record("Expected the departed peer's name. title=\(relaunched.activeChats.first?.title ?? "nil")")
+        }
+        #expect(didKeepDepartedPeer)
+        #expect(relaunched.activeChats.first?.avatarSeed == aliceId)
+        #expect(relaunched.activeChats.first?.pictureURL == "https://example.com/alice.png")
+        #expect(relaunched.activeChats.first?.isDirect == true)
+    }
+
+    @MainActor
+    @Test func departedDirectPeerIsRecoveredFromTheTranscriptWhenNothingWasRecorded() async throws {
+        // Every DM whose peer left before this device ever recorded them — including all of them
+        // on the build that introduces the record — has nothing stored. Their messages outlive
+        // their membership, so the transcript still says who this chat was with.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(
+            GroupDetailsFfi(
+                group: directGroup(),
+                members: [soleRemainingSelfMember(accountIdHex: account.accountIdHex)]
+            )
+        )
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "from-alice",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "See you around.",
+                    kind: 9,
+                    recordedAt: 1_700_000_100
+                ),
+                appMessage(
+                    id: "from-self",
+                    direction: "sent",
+                    groupIdHex: "direct-group",
+                    sender: account.accountIdHex,
+                    plaintext: "Bye!",
+                    kind: 9,
+                    recordedAt: 1_700_000_200
+                ),
+            ],
+            groupIdHex: "direct-group"
+        )
+        runtime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        // `FakeMarmotRuntime.storageRootPath` is a fixed shared path, so an injected store is what
+        // guarantees this starts with nothing recorded rather than reading another test's file.
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-direct-peer-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let state = WorkspaceState(
+            directPeerMemoryStore: DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory),
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        // The newest message is this account's own, so this only passes by paging back for the
+        // newest message that is not.
+        let didRecoverPeer = await waitFor { state.activeChats.first?.title == "Alice Actual" }
+
+        if !didRecoverPeer {
+            Issue.record(
+                "Expected the peer recovered from the transcript. title=\(state.activeChats.first?.title ?? "nil")"
+            )
+        }
+        #expect(didRecoverPeer)
+        #expect(state.activeChats.first?.avatarSeed == aliceId)
+        #expect(state.activeChats.first?.isDirect == true)
+    }
+
+    @MainActor
+    @Test func noteToSelfChatRecoversNoPeerAndScansItsTranscriptOnlyOnce() async throws {
+        // A note-to-self chat legitimately has no other member and no other sender. It must keep
+        // its own identity, and the fruitless scan must not repeat on every chat-list delta.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(
+            GroupDetailsFfi(
+                group: directGroup(),
+                members: [soleRemainingSelfMember(accountIdHex: account.accountIdHex)]
+            )
+        )
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "self-note",
+                    direction: "sent",
+                    groupIdHex: "direct-group",
+                    sender: account.accountIdHex,
+                    plaintext: "Remember the milk.",
+                    kind: 9,
+                    recordedAt: 1_700_000_100
+                )
+            ],
+            groupIdHex: "direct-group"
+        )
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-direct-peer-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let state = WorkspaceState(
+            directPeerMemoryStore: DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory),
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        let didEnrich = await waitFor { (runtime.groupDetailsCallCounts["direct-group"] ?? 0) >= 1 }
+        let didScan = await waitFor { state.unrecoverableDirectPeerGroupIds.contains("direct-group") }
+
+        #expect(didEnrich)
+        #expect(didScan)
+        #expect(state.activeChats.first?.avatarSeed == "direct-group")
+        let accountId = try #require(state.activeAccountId)
+        #expect(state.rememberedDirectPeer(groupIdHex: "direct-group", accountId: accountId) == nil)
+    }
+
+    @MainActor
+    @Test func departedDirectPeerPrefersTheirCurrentProfileOverTheRecordedCopy() async throws {
+        // A departed peer's profile outlives their membership, so a fresh lookup must still win;
+        // the recorded name is only the offline fallback.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-direct-peer-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let store = DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory)
+
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(directPeerMemoryStore: store, clientFactory: { runtime })
+        await state.bootstrap()
+        let didResolvePeer = await waitFor { state.activeChats.first?.title == "Alice Actual" }
+        #expect(didResolvePeer)
+
+        let departedRuntime = FakeMarmotRuntime(accounts: [account])
+        departedRuntime.installGroupDetails(
+            GroupDetailsFfi(
+                group: directGroup(),
+                members: [soleRemainingSelfMember(accountIdHex: account.accountIdHex)]
+            )
+        )
+        departedRuntime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Renamed",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let relaunched = WorkspaceState(directPeerMemoryStore: store, clientFactory: { departedRuntime })
+
+        await relaunched.bootstrap()
+        let didUseCurrentProfile = await waitFor { relaunched.activeChats.first?.title == "Alice Renamed" }
+
+        #expect(didUseCurrentProfile)
+    }
+
+    @MainActor
+    @Test func namedGroupKeepsItsOwnNameAfterEveryOtherMemberLeaves() async throws {
+        // A named group is not a DM. Its name is still the right title once it empties out, so the
+        // peer remembered from when it happened to hold two people must not hijack it.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-direct-peer-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let store = DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory)
+
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            messageGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(directPeerMemoryStore: store, clientFactory: { runtime })
+        await state.bootstrap()
+        let didResolvePeer = await waitFor { state.activeChats.first?.title == "Alice Actual" }
+        #expect(didResolvePeer)
+
+        let departedRuntime = FakeMarmotRuntime(accounts: [account])
+        departedRuntime.installGroupDetails(
+            GroupDetailsFfi(
+                group: messageGroup(),
+                members: [soleRemainingSelfMember(accountIdHex: account.accountIdHex)]
+            )
+        )
+        let relaunched = WorkspaceState(directPeerMemoryStore: store, clientFactory: { departedRuntime })
+
+        await relaunched.bootstrap()
+        // A correct outcome here is "nothing changes", so there is no positive witness to wait on:
+        // let enrichment run to completion and assert the remembered peer never took the title.
+        let didEnrich = await waitFor { (departedRuntime.groupDetailsCallCounts["group"] ?? 0) >= 1 }
+        let didHijackTitle = await waitFor(attempts: 30) {
+            relaunched.activeChats.first?.title == "Alice Actual"
+        }
+
+        #expect(didEnrich)
+        #expect(!didHijackTitle)
+        #expect(relaunched.activeChats.first?.title == "Test Group")
+        #expect(relaunched.activeChats.first?.subtitle == "Test Group")
+    }
+
+    @MainActor
+    @Test func directPeerMemoryIsDroppedOnceTheConversationHoldsSeveralOtherMembers() async throws {
+        // Growing past two people makes a single peer the wrong description of the conversation,
+        // so the record must go — otherwise it would resurface as the title when the group empties.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-direct-peer-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let store = DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory)
+
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            messageGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(directPeerMemoryStore: store, clientFactory: { runtime })
+        await state.bootstrap()
+        let didResolvePeer = await waitFor { state.activeChats.first?.title == "Alice Actual" }
+        #expect(didResolvePeer)
+        let accountId = try #require(state.activeAccountId)
+        #expect(try store.loadAll()[accountId]?["group"]?.accountIdHex == aliceId)
+
+        let grownRuntime = FakeMarmotRuntime(accounts: [account])
+        grownRuntime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let regrouped = WorkspaceState(directPeerMemoryStore: store, clientFactory: { grownRuntime })
+
+        await regrouped.bootstrap()
+        let didForgetPeer = await waitFor { ((try? store.loadAll())?[accountId]?["group"]) == nil }
+
+        #expect(didForgetPeer)
+        #expect(regrouped.activeChats.first?.title == "Test Group")
+    }
+
+    @Test func directPeerMemoryStoreUsesOpaqueProtectedBackupExcludedPerAccountFiles() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-direct-peer-store-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let store = DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory)
+        let alice = RememberedDirectPeer(
+            accountIdHex: "alice",
+            displayName: "Alice",
+            pictureURL: "https://example.com/alice.png"
+        )
+        let bob = RememberedDirectPeer(accountIdHex: "bob", displayName: nil, pictureURL: nil)
+
+        try store.write(["direct-group": alice], forAccountId: "account-one")
+        try store.write(["other-group": bob], forAccountId: "account-two")
+
+        #expect(
+            try store.loadAll()
+                == [
+                    "account-one": ["direct-group": alice],
+                    "account-two": ["other-group": bob],
+                ]
+        )
+        let directoryValues = try directory.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        #expect(directoryValues.isExcludedFromBackup == true)
+        let files = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isExcludedFromBackupKey],
+            options: [.skipsHiddenFiles]
+        )
+        #expect(files.count == 2)
+        for file in files {
+            #expect(file.pathExtension == "json")
+            #expect(file.deletingPathExtension().lastPathComponent.count == 64)
+            #expect(!file.lastPathComponent.contains("account-one"))
+            #expect(try file.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
+        }
+
+        try store.remove(forAccountId: "account-one")
+        #expect(try store.loadAll() == ["account-two": ["other-group": bob]])
+
+        try store.removeAll()
+        #expect(try store.loadAll().isEmpty)
+    }
+
+    @MainActor
     @Test func mentionRosterWarmUpFiresForDirectChatsWithAColdMemberCache() async throws {
         let summary = AccountSummaryFfi(
             label: "Desktop Account",
@@ -30595,6 +30979,19 @@ private func keyPackageFixture(accountRef: String, eventIdHex: String) -> Accoun
         sourceRelays: MarmotClient.seedRelays,
         local: true,
         relay: false
+    )
+}
+
+/// The roster a conversation is left with once every other participant has gone.
+private func soleRemainingSelfMember(accountIdHex: String) -> GroupMemberDetailsFfi {
+    GroupMemberDetailsFfi(
+        memberIdHex: accountIdHex,
+        account: "Desktop Account",
+        local: true,
+        isAdmin: true,
+        isSelf: true,
+        npub: "npub1self",
+        displayName: "Desktop Account"
     )
 }
 


### PR DESCRIPTION
When in a DM a member left, then the gorup ID was displayed instead of the other member name, which was super confusing. 