### PR TITLE
Exclude current group from groups in common

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -110,7 +110,10 @@ extension WorkspaceState {
         isGroupDetailsPresented = true
         if chat.isDirect {
             async let details: Void = loadGroupDetails(groupIdHex: chat.id)
-            async let commonGroups: Void = loadCommonGroups(forContactIdHex: chat.avatarSeed)
+            async let commonGroups: Void = loadCommonGroups(
+                forContactIdHex: chat.avatarSeed,
+                excludingGroupIdHex: chat.id
+            )
             // Chat info doubles as the peer's profile for a 1:1 conversation, so it carries the
             // follow control and needs the relationship resolved alongside everything else.
             async let followStatus: Void = refreshDirectPeerFollowStatus(for: chat)
@@ -142,7 +145,8 @@ extension WorkspaceState {
         accountIdHex: String,
         npub: String = "",
         displayName: String?,
-        pictureURL: String?
+        pictureURL: String?,
+        excludingGroupIdHex: String? = nil
     ) async {
         let accountIdHex = accountIdHex.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !accountIdHex.isEmpty, let client, let activeAccount else { return }
@@ -164,7 +168,10 @@ extension WorkspaceState {
         lastError = nil
 
         async let followStatus: Void = refreshFollowStatus(forContactIdHex: accountIdHex)
-        async let commonGroups: Void = loadCommonGroups(forContactIdHex: accountIdHex)
+        async let commonGroups: Void = loadCommonGroups(
+            forContactIdHex: accountIdHex,
+            excludingGroupIdHex: excludingGroupIdHex
+        )
         let resolved = await resolvedPeerFFI(
             accountIdHex: accountIdHex,
             activeAccount: activeAccount,
@@ -208,7 +215,10 @@ extension WorkspaceState {
             accountIdHex: member.id,
             npub: member.npub,
             displayName: member.publishedDisplayName ?? member.displayName,
-            pictureURL: nil
+            pictureURL: nil,
+            // A member row is only reachable from the open conversation's details, so that
+            // conversation is the one group the viewer already knows they share.
+            excludingGroupIdHex: groupDetailsSnapshot?.groupIdHex
         )
     }
 
@@ -216,7 +226,8 @@ extension WorkspaceState {
         await showContactDetails(
             accountIdHex: message.senderAccountIdHex,
             displayName: message.publishedSenderName ?? message.senderName,
-            pictureURL: message.senderPictureURL
+            pictureURL: message.senderPictureURL,
+            excludingGroupIdHex: message.groupIdHex
         )
     }
 
@@ -237,7 +248,11 @@ extension WorkspaceState {
         await startDirectChat(with: contact)
     }
 
-    func loadCommonGroups(forContactIdHex contactIdHex: String) async {
+    /// Collect the groups the viewer shares with a contact.
+    ///
+    /// `excludingGroupIdHex` drops the conversation the contact was opened from: the group whose
+    /// details are already on screen is not a group "in common", it is the group you are in.
+    func loadCommonGroups(forContactIdHex contactIdHex: String, excludingGroupIdHex: String? = nil) async {
         guard let client, let activeAccount, let accountId = activeAccountId else {
             clearCommonGroups()
             return
@@ -255,11 +270,13 @@ extension WorkspaceState {
         }
 
         let normalizedContactId = contactIdHex.lowercased()
+        let excludedGroupId = excludingGroupIdHex?.nilIfBlank?.lowercased()
         let chats =
             ((chatsByAccount[accountId] ?? []) + (archivedChatsByAccount[accountId] ?? []))
             .filter {
                 !$0.pendingConfirmation
                     && $0.selfMembership == .member
+                    && $0.id.lowercased() != excludedGroupId
             }
             .sorted {
                 let lhsDate = $0.updatedAt ?? .distantPast

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -18835,18 +18835,15 @@ struct whitenoise_macTests {
         state.selectChat(directChat)
         await state.showGroupDetails(for: directChat)
 
-        #expect(Set(state.commonGroupsForContact.map(\.id)) == ["direct-group", "group"])
+        // The direct chat whose details are open is the conversation the viewer is already in,
+        // so it must not be listed back to them as a group in common.
+        #expect(state.commonGroupsForContact.map(\.id) == ["group"])
         #expect(!state.isLoadingCommonGroups)
         #expect(!state.commonGroupsLoadHadFailures)
 
-        let directMessageGroup = try #require(
-            state.commonGroupsForContact.first { $0.id == "direct-group" }
-        )
-        #expect(directMessageGroup.isDirect)
-        #expect(directMessageGroup.subtitle == "Direct message")
-
-        state.openCommonGroup(directMessageGroup)
-        #expect(state.selection == .chat("direct-group"))
+        let sharedGroup = try #require(state.commonGroupsForContact.first { $0.id == "group" })
+        state.openCommonGroup(sharedGroup)
+        #expect(state.selection == .chat("group"))
         #expect(!state.isGroupDetailsPresented)
         #expect(state.commonGroupsForContact.isEmpty)
     }
@@ -18883,7 +18880,9 @@ struct whitenoise_macTests {
         #expect(state.contactDetailsTarget?.accountIdHex == aliceIdHex)
         #expect(state.contactDetailsTarget?.title == "Alice Cooper")
         #expect(state.contactDetailsTarget?.pictureURL == "https://example.com/alice.png")
-        #expect(state.commonGroupsForContact.map(\.id) == ["group"])
+        // "group" is the group whose details are open, so the only shared conversation is
+        // filtered out and the section reads empty.
+        #expect(state.commonGroupsForContact.isEmpty)
         #expect(!state.isLoadingContactDetails)
         #expect(state.isGroupDetailsPresented)
 
@@ -18891,6 +18890,90 @@ struct whitenoise_macTests {
         #expect(state.contactDetailsTarget == nil)
         #expect(state.isGroupDetailsPresented)
         #expect(state.commonGroupsForContact.isEmpty)
+    }
+
+    @MainActor
+    @Test func groupMemberContactDetailsListDirectChatButNotTheOpenGroup() async throws {
+        let account = desktopAccount()
+        let aliceIdHex = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            alongside: [messageGroup()],
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceIdHex,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installGroupDetailsRecord(
+            groupDetailsFixture(selfAccountIdHex: account.accountIdHex)
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let groupChat = try #require(state.activeChats.first { $0.id == "group" })
+        state.selectChat(groupChat)
+        await state.showGroupDetails(for: groupChat)
+        let alice = try #require(state.groupDetailsSnapshot?.members.first { $0.id == aliceIdHex })
+
+        await state.showContactDetails(for: alice)
+
+        // The open group is dropped; the direct chat the viewer shares with Alice still shows.
+        #expect(state.commonGroupsForContact.map(\.id) == ["direct-group"])
+        let directMessageGroup = try #require(state.commonGroupsForContact.first)
+        #expect(directMessageGroup.isDirect)
+        #expect(!state.commonGroupsLoadHadFailures)
+    }
+
+    @MainActor
+    @Test func messageSenderContactDetailsExcludeTheHostingGroup() async throws {
+        let account = desktopAccount()
+        let aliceIdHex = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            alongside: [messageGroup()],
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceIdHex,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installGroupDetailsRecord(
+            groupDetailsFixture(selfAccountIdHex: account.accountIdHex)
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let message = MessageItem(
+            id: "m1",
+            groupIdHex: "group",
+            senderAccountIdHex: aliceIdHex,
+            senderName: "Alice",
+            body: "Hello",
+            sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+            timelineAt: 1_700_000_000,
+            isOutgoing: false
+        )
+        await state.showContactDetails(for: message)
+
+        // Tapping a sender inside "group" opens their card from that group, so it is not
+        // reported back as a group in common.
+        #expect(state.contactDetailsTarget?.accountIdHex == aliceIdHex)
+        #expect(state.commonGroupsForContact.map(\.id) == ["direct-group"])
     }
 
     @MainActor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Common-group results no longer include the conversation currently being viewed.
  * Contact details now show only other shared groups, with consistent filtering across direct chats, group conversations, and message-based views.
  * Pending memberships and group sorting continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->