### PR TITLE
Use  hybrid media send approach to avoid blocking chat input

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -22,11 +22,21 @@ private nonisolated struct MediaAttachmentDownloadTaskFailure: Error {
     let underlying: Error
 }
 
+/// One slot of a concurrently prepared batch. `index` is the position the user chose the file in,
+/// which the group's completion order does not preserve; a nil `attachment` with a nil
+/// `errorDescription` is a cancelled slot, which is silent by design.
+private nonisolated struct PreparedMediaAttachmentOutcome: Sendable {
+    let index: Int
+    let attachment: PendingMediaAttachment?
+    let errorDescription: String?
+}
+
 @MainActor
 extension WorkspaceState {
     func clearAllComposerDrafts() {
         discardAllComposerDraftPersistenceState()
         cancelAllPendingMediaUploads()
+        cancelAllPendingOutgoingMediaSends()
         draftTextByConversation.removeAll()
         composerMentionSelectionsByConversation.removeAll()
         replyDraftContextByConversation.removeAll()
@@ -94,6 +104,7 @@ extension WorkspaceState {
             let key = ComposerDraftKey(accountId: accountId, chatId: chatId)
             discardComposerDraftPersistenceState(for: key)
             cancelPendingMediaUploads(for: key)
+            cancelPendingOutgoingMediaSends(for: key)
             draftTextByConversation[key] = nil
             composerMentionSelectionsByConversation[key] = nil
             replyDraftContextByConversation[key] = nil
@@ -106,6 +117,7 @@ extension WorkspaceState {
     func clearComposerDrafts(forAccountId accountId: String) {
         discardComposerDraftPersistenceState(forAccountId: accountId)
         cancelPendingMediaUploads(forAccountId: accountId)
+        cancelPendingOutgoingMediaSends(forAccountId: accountId)
         for key in draftTextByConversation.keys.filter({ $0.accountId == accountId }) {
             draftTextByConversation[key] = nil
         }
@@ -417,22 +429,10 @@ extension WorkspaceState {
             presentMaxMediaAttachmentWarning()
         }
 
-        for url in selected {
-            let isSecurityScoped = url.startAccessingSecurityScopedResource()
-            defer {
-                if isSecurityScoped {
-                    url.stopAccessingSecurityScopedResource()
-                }
-            }
-            do {
-                let attachment = try await OutgoingMediaDraftProcessor.preparedAttachment(fromFileURL: url)
-                guard appendPendingMediaAttachmentIfSelectionUnchanged(attachment, for: draftKey) else { return }
-            } catch is CancellationError {
-                return
-            } catch {
-                lastError = error.localizedDescription
-            }
+        let prepared = await Self.preparedMediaAttachments(for: selected) { url in
+            try await Self.preparedMediaAttachment(fromFileURL: url)
         }
+        stagePreparedMediaAttachments(prepared, for: draftKey)
     }
 
     func addPastedMediaAttachments(from pasteboard: NSPasteboard = .general) async {
@@ -450,35 +450,95 @@ extension WorkspaceState {
             presentMaxMediaAttachmentWarning()
         }
 
-        for item in selected {
-            do {
-                let attachment = try await preparedPastedMediaAttachment(from: item)
-                guard appendPendingMediaAttachmentIfSelectionUnchanged(attachment, for: draftKey) else { return }
-            } catch is CancellationError {
-                return
-            } catch {
-                lastError = error.localizedDescription
+        let prepared = await Self.preparedMediaAttachments(for: selected) { item in
+            switch item.payload {
+            case .fileURL(let url):
+                return try await Self.preparedMediaAttachment(fromFileURL: url)
+            case .imageData(let data, let typeIdentifier):
+                return try await OutgoingMediaDraftProcessor.preparedAttachment(
+                    fromPastedImageData: data,
+                    typeIdentifier: typeIdentifier
+                )
             }
+        }
+        stagePreparedMediaAttachments(prepared, for: draftKey)
+    }
+
+    /// Prepares a whole selection at once, returning the outcomes in the order the user chose them.
+    ///
+    /// Preparation is the expensive half of staging — read, decode, downsample, re-encode — and an
+    /// attachment's upload cannot start until its own preparation is done. Preparing one file at a
+    /// time therefore also staggered the uploads: the last image of a ten-file drop did not begin
+    /// uploading until the other nine had been re-encoded. A failed item is reported rather than
+    /// aborting the batch, so one unsupported file no longer costs the user the rest of the drop.
+    private nonisolated static func preparedMediaAttachments<Item: Sendable>(
+        for items: [Item],
+        prepare: @Sendable @escaping (Item) async throws -> PendingMediaAttachment
+    ) async -> [PreparedMediaAttachmentOutcome] {
+        await withTaskGroup(of: PreparedMediaAttachmentOutcome.self) { group in
+            for (index, item) in items.enumerated() {
+                group.addTask {
+                    do {
+                        return PreparedMediaAttachmentOutcome(
+                            index: index,
+                            attachment: try await prepare(item),
+                            errorDescription: nil
+                        )
+                    } catch is CancellationError {
+                        return PreparedMediaAttachmentOutcome(index: index, attachment: nil, errorDescription: nil)
+                    } catch {
+                        return PreparedMediaAttachmentOutcome(
+                            index: index,
+                            attachment: nil,
+                            errorDescription: error.localizedDescription
+                        )
+                    }
+                }
+            }
+            var outcomes: [PreparedMediaAttachmentOutcome] = []
+            for await outcome in group {
+                outcomes.append(outcome)
+            }
+            return outcomes.sorted { $0.index < $1.index }
         }
     }
 
-    private func preparedPastedMediaAttachment(
-        from item: OutgoingMediaPasteboardAttachment
-    ) async throws -> PendingMediaAttachment {
-        switch item.payload {
-        case .fileURL(let url):
-            let isSecurityScoped = url.startAccessingSecurityScopedResource()
-            defer {
-                if isSecurityScoped {
-                    url.stopAccessingSecurityScopedResource()
-                }
+    private nonisolated static func preparedMediaAttachment(fromFileURL url: URL) async throws -> PendingMediaAttachment
+    {
+        let isSecurityScoped = url.startAccessingSecurityScopedResource()
+        defer {
+            if isSecurityScoped {
+                url.stopAccessingSecurityScopedResource()
             }
-            return try await OutgoingMediaDraftProcessor.preparedAttachment(fromFileURL: url)
-        case .imageData(let data, let typeIdentifier):
-            return try await OutgoingMediaDraftProcessor.preparedAttachment(
-                fromPastedImageData: data,
-                typeIdentifier: typeIdentifier
-            )
+        }
+        return try await OutgoingMediaDraftProcessor.preparedAttachment(fromFileURL: url)
+    }
+
+    /// Stages a prepared batch in selection order, surfacing at most one failure. Preparation ran
+    /// while the user could still switch chats, so every append re-checks the selection and the
+    /// first refusal ends the batch (#245).
+    private func stagePreparedMediaAttachments(
+        _ outcomes: [PreparedMediaAttachmentOutcome],
+        for draftKey: ComposerDraftKey
+    ) {
+        // Preparation ran while the composer was live, and a recording can only start from an
+        // empty one — which this batch was, right up until it landed. Yield to the recording the
+        // same way `finishVoiceRecording` yields to a meanwhile-staged file, or the batch would
+        // append itself alongside a voice message that is meant to go out on its own.
+        guard stagedVoiceMessage == nil else {
+            presentVoiceMessageIsSentAloneWarning()
+            return
+        }
+        var failure: String?
+        for outcome in outcomes {
+            guard let attachment = outcome.attachment else {
+                failure = outcome.errorDescription ?? failure
+                continue
+            }
+            guard appendPendingMediaAttachmentIfSelectionUnchanged(attachment, for: draftKey) else { return }
+        }
+        if let failure {
+            lastError = failure
         }
     }
 
@@ -497,13 +557,21 @@ extension WorkspaceState {
     /// Upload a staged attachment to Blossom without publishing it, so pressing Send later only
     /// has to hand the resulting reference to `sendMediaAttachments`. The core exposes exactly
     /// this split: `uploadMedia(send: false)` is the first half of what `send: true` does.
-    func beginPendingMediaUpload(_ attachment: PendingMediaAttachment, for draftKey: ComposerDraftKey) {
-        guard let client, let activeAccount else { return }
+    ///
+    /// The returned task resolves to the Blossom reference (or `nil` if the upload failed or was
+    /// cancelled), so a Send pressed while this is still running can await the upload already in
+    /// flight instead of starting a duplicate one.
+    @discardableResult
+    func beginPendingMediaUpload(
+        _ attachment: PendingMediaAttachment,
+        for draftKey: ComposerDraftKey
+    ) -> Task<MediaAttachmentReferenceFfi?, Never> {
+        guard let client, let activeAccount else { return Task { nil } }
         setPendingMediaUploadState(.uploading, for: attachment.id, in: draftKey)
         pendingMediaUploadTasks[attachment.id]?.cancel()
         // The finished task stays in the map until the attachment is removed or sent: clearing it
         // here would race a retry that has already installed its replacement under the same id.
-        pendingMediaUploadTasks[attachment.id] = Task { [weak self] in
+        let task = Task { [weak self] () -> MediaAttachmentReferenceFfi? in
             do {
                 let result = try await client.uploadMedia(
                     accountRef: activeAccount.accountRef,
@@ -515,23 +583,27 @@ extension WorkspaceState {
                         blossomServer: nil
                     )
                 )
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled else { return nil }
                 // A result that carries no reference is a failed upload, not a cancelled one: leaving
-                // it `.uploading` would pin the tile on a spinner with no retry, and `canSend` gates
-                // on every attachment reporting a reference, so the whole draft would wedge.
+                // it `.uploading` would pin the tile on a spinner with no retry, and an outgoing
+                // message awaiting this reference would wait for a value that never arrives.
                 guard let reference = result.attachments.first?.reference else {
                     self?.setPendingMediaUploadState(.failed, for: attachment.id, in: draftKey)
-                    return
+                    return nil
                 }
                 self?.setPendingMediaUploadState(.uploaded(reference), for: attachment.id, in: draftKey)
+                return reference
             } catch is CancellationError {
-                return
+                return nil
             } catch {
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled else { return nil }
                 self?.setPendingMediaUploadState(.failed, for: attachment.id, in: draftKey)
                 self?.lastError = error.localizedDescription
+                return nil
             }
         }
+        pendingMediaUploadTasks[attachment.id] = task
+        return task
     }
 
     func retryPendingMediaUpload(_ id: PendingMediaAttachment.ID) {
@@ -539,6 +611,15 @@ extension WorkspaceState {
             let attachment = pendingMediaAttachmentsByConversation[draftKey]?.first(where: { $0.id == id })
         else { return }
         beginPendingMediaUpload(attachment, for: draftKey)
+    }
+
+    /// The upload task already running for `id`, handed over to whoever will await it and dropped
+    /// from the composer's map *without* being cancelled.
+    ///
+    /// This is what lets Send be non-blocking: the composer clear that follows would otherwise
+    /// cancel the very upload the outgoing message is about to wait on.
+    func detachPendingMediaUpload(_ id: PendingMediaAttachment.ID) -> Task<MediaAttachmentReferenceFfi?, Never>? {
+        pendingMediaUploadTasks.removeValue(forKey: id)
     }
 
     func cancelPendingMediaUpload(_ id: PendingMediaAttachment.ID) {

--- a/whitenoise-mac/Core/WorkspaceState+PendingOutgoingMedia.swift
+++ b/whitenoise-mac/Core/WorkspaceState+PendingOutgoingMedia.swift
@@ -1,0 +1,250 @@
+//
+//  WorkspaceState+PendingOutgoingMedia.swift
+//  whitenoise-mac
+//
+//  The half of a media send that outlives the Send press: awaiting the Blossom uploads that
+//  staging started, then publishing. Send itself never waits for either — it empties the composer
+//  and parks the message here, where the transcript renders it as a loading bubble.
+//
+
+import Foundation
+import MarmotKit
+
+@MainActor
+extension WorkspaceState {
+    /// Parks a just-sent media message and starts the work that will publish it.
+    ///
+    /// `adoptedUploads` are the stage-time uploads already in flight for these attachments, handed
+    /// over by the composer so the wait continues from where staging got to instead of restarting.
+    /// Anything not covered there — an upload that failed, or one that never started — is uploaded
+    /// here, concurrently with the rest.
+    func beginPendingOutgoingMediaSend(
+        _ message: PendingOutgoingMediaMessage,
+        adoptedUploads: [PendingMediaAttachment.ID: Task<MediaAttachmentReferenceFfi?, Never>],
+        for draftKey: ComposerDraftKey,
+        account: AccountItem,
+        client: any MarmotRuntime
+    ) {
+        // Captured before the append so it is the message ahead of this one, not this one.
+        let predecessor = pendingOutgoingMediaMessagesByConversation[draftKey]?
+            .last
+            .flatMap { pendingOutgoingMediaSendTasks[$0.id] }
+        pendingOutgoingMediaMessagesByConversation[draftKey, default: []].append(message)
+
+        pendingOutgoingMediaSendTasks[message.id] = Task { [weak self] in
+            // Publish in the order Send was pressed. A failed predecessor still releases this one:
+            // its task finishes either way, it just leaves a failed bubble behind it.
+            await predecessor?.value
+            guard !Task.isCancelled else { return }
+            await self?.completePendingOutgoingMediaSend(
+                message.id,
+                adoptedUploads: adoptedUploads,
+                for: draftKey,
+                account: account,
+                client: client
+            )
+        }
+    }
+
+    /// Re-runs a failed outgoing message from wherever it got to. Uploads are not adopted — the
+    /// tasks that would have carried them are the ones that failed — so every attachment is
+    /// uploaded again, which is also what recovers a message whose blobs never landed.
+    func retryPendingOutgoingMediaMessage(_ id: PendingOutgoingMediaMessage.ID) {
+        guard let draftKey = selectedComposerDraftKey,
+            let index = pendingOutgoingMediaMessagesByConversation[draftKey]?.firstIndex(where: { $0.id == id }),
+            let account = activeAccount,
+            account.id == draftKey.accountId,
+            let client
+        else { return }
+        pendingOutgoingMediaMessagesByConversation[draftKey]?[index].state = .uploading
+        pendingOutgoingMediaSendTasks[id]?.cancel()
+        pendingOutgoingMediaSendTasks[id] = Task { [weak self] in
+            await self?.completePendingOutgoingMediaSend(
+                id,
+                adoptedUploads: [:],
+                for: draftKey,
+                account: account,
+                client: client
+            )
+        }
+    }
+
+    /// Drops a failed outgoing message. Only offered once it has failed: a message still on its way
+    /// out has no cancellation story in the core, so the affordance would be a lie.
+    func discardPendingOutgoingMediaMessage(_ id: PendingOutgoingMediaMessage.ID) {
+        guard let draftKey = selectedComposerDraftKey else { return }
+        removePendingOutgoingMediaMessage(id, in: draftKey)
+    }
+
+    func cancelAllPendingOutgoingMediaSends() {
+        for key in Array(pendingOutgoingMediaMessagesByConversation.keys) {
+            cancelPendingOutgoingMediaSends(for: key)
+        }
+        pendingOutgoingMediaMessagesByConversation.removeAll()
+    }
+
+    func cancelPendingOutgoingMediaSends(for draftKey: ComposerDraftKey) {
+        for message in pendingOutgoingMediaMessagesByConversation[draftKey] ?? [] {
+            pendingOutgoingMediaSendTasks.removeValue(forKey: message.id)?.cancel()
+            for upload in pendingOutgoingMediaUploadTasks.removeValue(forKey: message.id) ?? [] {
+                upload.cancel()
+            }
+        }
+        pendingOutgoingMediaMessagesByConversation[draftKey] = nil
+    }
+
+    func cancelPendingOutgoingMediaSends(forAccountId accountId: String) {
+        let keys = pendingOutgoingMediaMessagesByConversation.keys.filter { $0.accountId == accountId }
+        for draftKey in keys {
+            cancelPendingOutgoingMediaSends(for: draftKey)
+        }
+    }
+
+    private func completePendingOutgoingMediaSend(
+        _ id: PendingOutgoingMediaMessage.ID,
+        adoptedUploads: [PendingMediaAttachment.ID: Task<MediaAttachmentReferenceFfi?, Never>],
+        for draftKey: ComposerDraftKey,
+        account: AccountItem,
+        client: any MarmotRuntime
+    ) async {
+        guard let message = pendingOutgoingMediaMessage(id, in: draftKey) else { return }
+
+        let uploads = message.attachments.map { attachment in
+            adoptedUploads[attachment.id]
+                ?? outgoingMediaUploadTask(
+                    attachment,
+                    accountRef: account.accountRef,
+                    groupIdHex: draftKey.chatId,
+                    client: client
+                )
+        }
+        pendingOutgoingMediaUploadTasks[id] = uploads
+
+        // Every upload is already running; awaiting them in composer order only fixes the order of
+        // the references, never the order they are allowed to finish in.
+        var references: [MediaAttachmentReferenceFfi] = []
+        for upload in uploads {
+            guard let reference = await upload.value else {
+                // One failure sinks the message, so the siblings still in flight are transferring
+                // bytes nobody will publish. A retry starts them over from scratch.
+                for sibling in pendingOutgoingMediaUploadTasks.removeValue(forKey: id) ?? [] {
+                    sibling.cancel()
+                }
+                setPendingOutgoingMediaMessageState(.failed, for: id, in: draftKey)
+                return
+            }
+            references.append(reference)
+        }
+        pendingOutgoingMediaUploadTasks[id] = nil
+        guard !Task.isCancelled, pendingOutgoingMediaMessage(id, in: draftKey) != nil else { return }
+
+        setPendingOutgoingMediaMessageState(.publishing, for: id, in: draftKey)
+
+        // We are holding the plaintext that produced these references, so the sender's own bubble
+        // has no reason to fetch its own image back from Blossom and decrypt it. Seed before
+        // publishing: the real row can render the moment the send returns, and it must find a warm
+        // cache when it does.
+        await cacheOutgoingMediaPlaintext(
+            message.attachments,
+            references: references,
+            accountId: account.id,
+            groupIdHex: draftKey.chatId
+        )
+        guard !Task.isCancelled, pendingOutgoingMediaMessage(id, in: draftKey) != nil else { return }
+
+        do {
+            _ = try await client.sendMediaAttachments(
+                accountRef: account.accountRef,
+                groupIdHex: draftKey.chatId,
+                attachments: references,
+                caption: message.caption.isEmpty ? nil : message.caption
+            )
+        } catch {
+            // The blobs are on Blossom and the references stay valid, so a retry only has to
+            // re-publish — but it re-uploads anyway rather than trusting a reference whose failure
+            // mode we cannot see from here.
+            lastError = error.localizedDescription
+            setPendingOutgoingMediaMessageState(.failed, for: id, in: draftKey)
+            return
+        }
+
+        clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: draftKey.chatId)
+        // Drop the placeholder before the refresh, not after: the core commits an own send locally
+        // as part of publishing, so a subscription delta can already be carrying the real row.
+        removePendingOutgoingMediaMessage(id, in: draftKey)
+        await refreshSelectedTimelineAfterSend(
+            groupIdHex: draftKey.chatId,
+            account: account,
+            client: client
+        )
+    }
+
+    /// A Blossom upload owned by an outgoing message rather than by the composer.
+    ///
+    /// Deliberately not `beginPendingMediaUpload`: the attachment has already left the composer, so
+    /// there is no tile to report progress to and no entry in `pendingMediaUploadTasks` that anyone
+    /// would ever reclaim.
+    private func outgoingMediaUploadTask(
+        _ attachment: PendingMediaAttachment,
+        accountRef: String,
+        groupIdHex: String,
+        client: any MarmotRuntime
+    ) -> Task<MediaAttachmentReferenceFfi?, Never> {
+        Task { [weak self] () -> MediaAttachmentReferenceFfi? in
+            do {
+                let result = try await client.uploadMedia(
+                    accountRef: accountRef,
+                    groupIdHex: groupIdHex,
+                    request: MediaUploadRequestFfi(
+                        attachments: [attachment.uploadRequest],
+                        caption: nil,
+                        send: false,
+                        blossomServer: nil
+                    )
+                )
+                guard !Task.isCancelled else { return nil }
+                guard let reference = result.attachments.first?.reference else {
+                    self?.lastError = L10n.string("An attachment failed to upload")
+                    return nil
+                }
+                return reference
+            } catch is CancellationError {
+                return nil
+            } catch {
+                guard !Task.isCancelled else { return nil }
+                self?.lastError = error.localizedDescription
+                return nil
+            }
+        }
+    }
+
+    private func pendingOutgoingMediaMessage(
+        _ id: PendingOutgoingMediaMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) -> PendingOutgoingMediaMessage? {
+        pendingOutgoingMediaMessagesByConversation[draftKey]?.first { $0.id == id }
+    }
+
+    private func setPendingOutgoingMediaMessageState(
+        _ state: PendingOutgoingMediaMessageState,
+        for id: PendingOutgoingMediaMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) {
+        guard let index = pendingOutgoingMediaMessagesByConversation[draftKey]?.firstIndex(where: { $0.id == id })
+        else { return }
+        pendingOutgoingMediaMessagesByConversation[draftKey]?[index].state = state
+    }
+
+    private func removePendingOutgoingMediaMessage(
+        _ id: PendingOutgoingMediaMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) {
+        pendingOutgoingMediaSendTasks.removeValue(forKey: id)
+        for upload in pendingOutgoingMediaUploadTasks.removeValue(forKey: id) ?? [] {
+            upload.cancel()
+        }
+        var messages = pendingOutgoingMediaMessagesByConversation[draftKey] ?? []
+        messages.removeAll { $0.id == id }
+        pendingOutgoingMediaMessagesByConversation[draftKey] = messages.isEmpty ? nil : messages
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -1037,45 +1037,23 @@ extension WorkspaceState {
 
         do {
             if !mediaAttachments.isEmpty {
-                // Blossom already has every blob — staging uploaded them. Order comes from the
-                // composer, never from the order the uploads happened to finish in.
-                let uploadStates = pendingMediaUploadStatesByConversation[draftKey] ?? [:]
-                let references = mediaAttachments.compactMap { uploadStates[$0.id]?.reference }
-                guard references.count == mediaAttachments.count else { return }
-
-                // We are holding the plaintext that produced these references, so the sender's own
-                // bubble has no reason to fetch its own image back from Blossom and decrypt it.
-                // Seed before publishing: the optimistic projection can render the bubble as soon
-                // as the send returns, and it must find a warm cache when it does.
-                await cacheOutgoingMediaPlaintext(
+                // Hand the send off and return. Staging started every upload the moment the file
+                // was attached, so most of the time the blobs are already on Blossom — but when
+                // they are not, the wait belongs to the message's bubble, not to the Send button
+                // (#710 blocked the button; this is the hybrid that does not).
+                handOffMediaSend(
                     mediaAttachments,
-                    references: references,
-                    accountId: activeAccount.id,
-                    groupIdHex: selectedChat.id
+                    caption: text,
+                    draftKey: draftKey,
+                    account: activeAccount,
+                    client: client
                 )
-
-                // A recording goes out as audio and nothing else. Staging one already empties the
-                // composer and blocks every other staging path, so this is the last line of that
-                // invariant rather than a case the UI can reach.
-                let carriesVoiceMessage = mediaAttachments.contains { $0.isVoiceMessage }
-                let caption = text.isEmpty || carriesVoiceMessage ? nil : text
-
-                // The blobs are already uploaded, so publishing is a short relay round-trip rather
-                // than a transfer. Empty the composer now instead of leaving the thumbnails sitting
-                // there looking unsent; the catch below puts them back if the publish fails.
-                let restorePoint = clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
-                do {
-                    _ = try await client.sendMediaAttachments(
-                        accountRef: activeAccount.accountRef,
-                        groupIdHex: selectedChat.id,
-                        attachments: references,
-                        caption: caption
-                    )
-                } catch {
-                    restoreComposer(restorePoint, for: draftKey)
-                    throw error
-                }
-                clearMediaReferenceResolutionCache(forAccountId: activeAccount.id, groupIdHex: selectedChat.id)
+                await deletePersistedComposerDraft(
+                    for: draftKey,
+                    accountRef: activeAccount.accountRef,
+                    client: client
+                )
+                return
             } else if let replyDraftContext {
                 _ = try await client.replyToMessage(
                     accountRef: activeAccount.accountRef,
@@ -1090,8 +1068,7 @@ extension WorkspaceState {
                     text: text
                 )
             }
-            // Idempotent: the media branch already cleared optimistically before publishing.
-            _ = clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
+            clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
             await deletePersistedComposerDraft(
                 for: draftKey,
                 accountRef: activeAccount.accountRef,
@@ -1104,31 +1081,63 @@ extension WorkspaceState {
             // full re-map per delivery.
             await refreshSelectedTimelineAfterSend(groupIdHex: selectedChat.id, account: activeAccount, client: client)
         } catch {
-            // A failed *publish* leaves the blobs on Blossom and the references valid, so the
-            // restored attachments stay `.uploaded` and the user can simply press Send again.
             lastError = error.localizedDescription
         }
     }
 
-    /// Empties one conversation's composer and returns what it held, so an optimistic clear can be
-    /// undone if the publish fails.
+    /// Moves a media draft out of the composer and into a pending outgoing message, then returns.
+    ///
+    /// The uploads staging started are *detached* rather than cancelled: the composer clear that
+    /// follows would otherwise kill the very transfers the new bubble is about to wait on. An
+    /// attachment whose upload already finished contributes its reference directly, and one whose
+    /// upload failed contributes nothing — the send re-uploads it.
+    private func handOffMediaSend(
+        _ mediaAttachments: [PendingMediaAttachment],
+        caption: String,
+        draftKey: ComposerDraftKey,
+        account: AccountItem,
+        client: any MarmotRuntime
+    ) {
+        let uploadStates = pendingMediaUploadStatesByConversation[draftKey] ?? [:]
+        var adoptedUploads: [PendingMediaAttachment.ID: Task<MediaAttachmentReferenceFfi?, Never>] = [:]
+        for attachment in mediaAttachments {
+            if let reference = uploadStates[attachment.id]?.reference {
+                // Wrapping a finished reference as a task keeps the send routine on one code path
+                // instead of branching on whether staging beat the user to it.
+                adoptedUploads[attachment.id] = Task { reference }
+            } else if let inFlight = detachPendingMediaUpload(attachment.id) {
+                adoptedUploads[attachment.id] = inFlight
+            }
+        }
+        // A recording goes out as audio and nothing else. Staging one already empties the composer
+        // and blocks every other staging path, so this is the last line of that invariant rather
+        // than a case the UI can reach. Dropping the caption here rather than at publish time also
+        // keeps the pending bubble honest: it never shows a caption the message will not carry.
+        let carriesVoiceMessage = mediaAttachments.contains(where: \.isVoiceMessage)
+        clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
+        beginPendingOutgoingMediaSend(
+            PendingOutgoingMediaMessage(
+                attachments: mediaAttachments,
+                caption: carriesVoiceMessage ? "" : caption
+            ),
+            adoptedUploads: adoptedUploads,
+            for: draftKey,
+            account: account,
+            client: client
+        )
+    }
+
+    /// Empties one conversation's composer.
     ///
     /// Always clears via the captured `draftKey`, never the `draftText`/`replyDraftContext`
     /// setters — those resolve their key from the *live* selection, so if the user switched chats
     /// during a send they would wipe the newly selected conversation's composer instead of the one
-    /// we sent from.
-    @discardableResult
+    /// we sent from. Attachments staged *since* the snapshot survive: paste, drop and the importer
+    /// all still work while a send is in flight.
     private func clearComposerAfterSend(
         for draftKey: ComposerDraftKey,
         mediaAttachments: [PendingMediaAttachment]
-    ) -> ComposerSendRestorePoint {
-        let restorePoint = ComposerSendRestorePoint(
-            text: draftTextByConversation[draftKey],
-            mentionSelections: composerMentionSelectionsByConversation[draftKey],
-            replyContext: replyDraftContextByConversation[draftKey],
-            mediaAttachments: pendingMediaAttachmentsByConversation[draftKey],
-            mediaUploadStates: pendingMediaUploadStatesByConversation[draftKey]
-        )
+    ) {
         draftTextByConversation[draftKey] = nil
         composerMentionSelectionsByConversation[draftKey] = nil
         replyDraftContextByConversation[draftKey] = nil
@@ -1140,29 +1149,11 @@ extension WorkspaceState {
         var remainingUploadStates = pendingMediaUploadStatesByConversation[draftKey] ?? [:]
         sentIds.forEach { remainingUploadStates[$0] = nil }
         pendingMediaUploadStatesByConversation[draftKey] = remainingUploadStates.isEmpty ? nil : remainingUploadStates
-        return restorePoint
-    }
-
-    private func restoreComposer(_ restorePoint: ComposerSendRestorePoint, for draftKey: ComposerDraftKey) {
-        draftTextByConversation[draftKey] = restorePoint.text
-        composerMentionSelectionsByConversation[draftKey] = restorePoint.mentionSelections
-        replyDraftContextByConversation[draftKey] = restorePoint.replyContext
-        let restoredAttachments = restorePoint.mediaAttachments ?? []
-        let restoredIds = Set(restoredAttachments.map(\.id))
-        let stagedSinceSnapshot = (pendingMediaAttachmentsByConversation[draftKey] ?? [])
-            .filter { !restoredIds.contains($0.id) }
-        let mergedAttachments = restoredAttachments + stagedSinceSnapshot
-        pendingMediaAttachmentsByConversation[draftKey] = mergedAttachments.isEmpty ? nil : mergedAttachments
-        var mergedUploadStates = pendingMediaUploadStatesByConversation[draftKey] ?? [:]
-        for (id, state) in restorePoint.mediaUploadStates ?? [:] {
-            mergedUploadStates[id] = state
-        }
-        pendingMediaUploadStatesByConversation[draftKey] = mergedUploadStates.isEmpty ? nil : mergedUploadStates
     }
 
     /// Files the plaintext we just published under the same cache key the bubble will look it up
     /// by, so an outgoing attachment renders from disk instead of round-tripping through Blossom.
-    private func cacheOutgoingMediaPlaintext(
+    func cacheOutgoingMediaPlaintext(
         _ attachments: [PendingMediaAttachment],
         references: [MediaAttachmentReferenceFfi],
         accountId: String,

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1408,7 +1408,24 @@ final class WorkspaceState {
         [ComposerDraftKey: [PendingMediaAttachment.ID: PendingMediaUploadState]] = [:]
     /// In-flight stage-time Blossom uploads, so removing an attachment (or tearing the composer
     /// down) cancels the upload it started instead of letting it land on a tile that is gone.
-    @ObservationIgnored var pendingMediaUploadTasks: [PendingMediaAttachment.ID: Task<Void, Never>] = [:]
+    /// The task carries the reference it produced, so a Send pressed mid-upload can adopt the
+    /// running upload and await it rather than starting a second one.
+    @ObservationIgnored var pendingMediaUploadTasks:
+        [PendingMediaAttachment.ID: Task<MediaAttachmentReferenceFfi?, Never>] = [:]
+    /// Media messages the user has already sent whose blobs are still going up, keyed by the
+    /// composer they left. Rendered as loading bubbles at the foot of the transcript until the
+    /// publish lands and the real timeline row replaces them.
+    var pendingOutgoingMediaMessagesByConversation: [ComposerDraftKey: [PendingOutgoingMediaMessage]] = [:]
+    /// The publish task per outgoing message. Each one waits on its predecessor in the same
+    /// conversation, so two messages sent back to back publish in the order they were pressed even
+    /// when the second one's uploads finish first.
+    @ObservationIgnored var pendingOutgoingMediaSendTasks: [PendingOutgoingMediaMessage.ID: Task<Void, Never>] = [:]
+    /// The uploads one outgoing message is waiting on — adopted from the composer where staging
+    /// had already started them, freshly created where it had not. Held separately from the
+    /// publish task because they are unstructured: adopting a running upload is the whole point,
+    /// and an adopted task predates the message that now owns it.
+    @ObservationIgnored var pendingOutgoingMediaUploadTasks:
+        [PendingOutgoingMediaMessage.ID: [Task<MediaAttachmentReferenceFfi?, Never>]] = [:]
     @ObservationIgnored var composerDraftPersistenceTasks: [ComposerDraftKey: Task<Void, Never>] = [:]
     @ObservationIgnored var composerDraftMutationGenerations: [ComposerDraftKey: UInt64] = [:]
     @ObservationIgnored var dirtyComposerDraftKeys: Set<ComposerDraftKey> = []
@@ -2422,21 +2439,18 @@ final class WorkspaceState {
             && selectedChat?.canUseComposer == true
             && (!draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || !pendingMediaAttachments.isEmpty)
-            // Attachments upload as they are staged, so the composer refuses to send until every
-            // one carries a Blossom reference. Text-only drafts are unaffected.
-            && composerMediaUploadStatus == nil
+            // Deliberately *not* gated on the staged uploads. Attachments start uploading the
+            // moment they are staged, but an unfinished one only means the message spends its
+            // first moments as a loading bubble — it never means the user has to sit and wait for
+            // a button to come back (#710 made Send wait; this is the hybrid that does not).
             && !isSending
     }
 
-    /// Why the selected composer is not sendable yet, or `nil` once every staged attachment
-    /// carries a reference. Drives both the `canSend` gate and the send button's tooltip, so
-    /// "the button is off" and "here is why" can never disagree.
-    var composerMediaUploadStatus: ComposerMediaUploadStatus? {
-        let attachments = pendingMediaAttachments
-        guard !attachments.isEmpty else { return nil }
-        let states = pendingMediaUploadStates
-        if attachments.contains(where: { states[$0.id] == .failed }) { return .failed }
-        return attachments.allSatisfy { states[$0.id]?.isUploaded == true } ? nil : .uploading
+    /// Media messages sent from the selected conversation that are still uploading or publishing,
+    /// oldest first — the loading bubbles the transcript appends after its real rows.
+    var selectedPendingOutgoingMediaMessages: [PendingOutgoingMediaMessage] {
+        guard let selectedComposerDraftKey else { return [] }
+        return pendingOutgoingMediaMessagesByConversation[selectedComposerDraftKey] ?? []
     }
 
     var showsMessengerChrome: Bool {

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -52880,65 +52880,6 @@
         }
       }
     },
-    "Waiting for attachments to finish uploading": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warten, bis die Anhänge hochgeladen sind"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esperando a que terminen de subirse los adjuntos"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "En attente de la fin du téléversement des pièces jointes"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In attesa del completamento del caricamento degli allegati"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aguardando a conclusão do upload dos anexos"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ожидание завершения загрузки вложений"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eklerin yüklenmesinin bitmesi bekleniyor"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在等待附件上传完成"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在等待附件上傳完成"
-          }
-        }
-      }
-    },
     "Watch-only": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -738,8 +738,9 @@ enum MediaDownloadState: Equatable {
 }
 
 /// Blossom upload status for one composer attachment. Attachments upload as soon as they are
-/// staged, so the composer can refuse to send until every one of them carries a reference —
-/// rather than uploading at send time and failing the message after the fact.
+/// staged so the blob is usually already up by the time Send is pressed — but the upload never
+/// gates Send: an unfinished one is handed to the outgoing message and awaited there
+/// (`PendingOutgoingMediaMessage`).
 nonisolated enum PendingMediaUploadState: Hashable, Sendable {
     case uploading
     case uploaded(MediaAttachmentReferenceFfi)
@@ -755,21 +756,56 @@ nonisolated enum PendingMediaUploadState: Hashable, Sendable {
     var isUploaded: Bool { reference != nil }
 }
 
-/// What a composer held just before an optimistic clear, so a failed publish can put it back
-/// rather than losing the user's text and attachments.
-nonisolated struct ComposerSendRestorePoint: Sendable {
-    let text: String?
-    let mentionSelections: [ComposerMentionSelection]?
-    let replyContext: MessageReplyContext?
-    let mediaAttachments: [PendingMediaAttachment]?
-    let mediaUploadStates: [PendingMediaAttachment.ID: PendingMediaUploadState]?
+/// Where a sent-but-not-yet-published media message has got to.
+///
+/// Both in-flight cases render identically — one spinner over the whole bubble, never a badge per
+/// attachment — because the user pressed Send once and is waiting for one thing to happen. They
+/// stay distinct so a retry knows whether it has to re-upload or only re-publish.
+nonisolated enum PendingOutgoingMediaMessageState: Hashable, Sendable {
+    case uploading
+    case publishing
+    case failed
+
+    var isInFlight: Bool {
+        self != .failed
+    }
 }
 
-/// Why the composer's staged media is not ready to send yet. Present only while something is
-/// outstanding, so `nil` reads as "ready to send".
-nonisolated enum ComposerMediaUploadStatus: Hashable, Sendable {
-    case uploading
-    case failed
+/// A media message the user has already sent, still on its way to the relay.
+///
+/// Send does not wait for Blossom: pressing it empties the composer and parks the attachments
+/// here, where the bubble renders them from the plaintext we are still holding while the uploads
+/// finish. This is the row the transcript shows in the gap between "sent" and "published".
+nonisolated struct PendingOutgoingMediaMessage: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let attachments: [PendingMediaAttachment]
+    let caption: String
+    let createdAt: Date
+    var state: PendingOutgoingMediaMessageState
+
+    init(
+        id: UUID = UUID(),
+        attachments: [PendingMediaAttachment],
+        caption: String,
+        createdAt: Date = Date(),
+        state: PendingOutgoingMediaMessageState = .uploading
+    ) {
+        self.id = id
+        self.attachments = attachments
+        self.caption = caption
+        self.createdAt = createdAt
+        self.state = state
+    }
+
+    /// Attachments that render as grid tiles, matching `MessageItem.visualMediaAttachments` so a
+    /// pending bubble and the published one it becomes lay out the same way.
+    var visualAttachments: [PendingMediaAttachment] {
+        attachments.filter { $0.kind == .image || $0.kind == .video }
+    }
+
+    var nonvisualAttachments: [PendingMediaAttachment] {
+        attachments.filter { $0.kind == .audio || $0.kind == .file }
+    }
 }
 
 nonisolated struct PendingMediaAttachment: Identifiable, Hashable, Sendable {

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -961,9 +961,9 @@ struct VoiceMessageDraftComposerView: View {
     let uploadState: PendingMediaUploadState?
     let isSending: Bool
     let canSend: Bool
-    /// Why Send is off, worded by the shell exactly as it words it for the text composer — the
-    /// recording uploads like any other attachment, so "still uploading" and "upload failed" are
-    /// both reachable here.
+    /// Worded by the shell exactly as it words it for the text composer. An unfinished upload no
+    /// longer keeps Send off — the recording carries on uploading from its bubble — so this is the
+    /// plain Send label; the bar still offers its own retry while the recording is staged.
     let sendHelp: String
     let onDiscard: () -> Void
     let onRetryUpload: () -> Void

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -390,6 +390,7 @@ private struct ConversationView: View {
         let messageIDs = workspace.selectedMessageIDs
         let paging = workspace.selectedTimelinePaging
         let isLoadingInitialPage = workspace.selectedTimelineIsLoadingInitialPage
+        let pendingOutgoingMediaMessages = workspace.selectedPendingOutgoingMediaMessages
 
         ZStack {
             VStack(spacing: 0) {
@@ -409,7 +410,7 @@ private struct ConversationView: View {
                         // class of hang; if a large window's eager build ever costs too much, the fix
                         // is cheaper rows, not a return to lazy estimation.
                         VStack(spacing: 12) {
-                            if messageIDs.isEmpty {
+                            if messageIDs.isEmpty && pendingOutgoingMediaMessages.isEmpty {
                                 if isLoadingInitialPage {
                                     TimelineInitialLoadingView()
                                 } else {
@@ -445,6 +446,18 @@ private struct ConversationView: View {
                                 if paging.hasMoreAfter {
                                     TimelinePageLoadingRow(isLoading: paging.isLoadingAfter)
                                 }
+                            }
+
+                            // Media the user has already sent whose blobs are still going up.
+                            // Rendered after the real window rather than inside it: these rows
+                            // exist only on this client, and the published message that replaces
+                            // one arrives through the timeline store like any other.
+                            ForEach(pendingOutgoingMediaMessages) { pending in
+                                PendingOutgoingMessageBubble(
+                                    message: pending,
+                                    timestampReferenceDate: timestampReferenceDate,
+                                    timestampLocale: locale
+                                )
                             }
 
                             // Scroll-to-bottom target. Pure layout: pin/pagination state is
@@ -534,6 +547,13 @@ private struct ConversationView: View {
                         case .none:
                             return
                         }
+                    }
+                    // A pending media bubble is appended below the timeline window, so it never
+                    // moves `messageIDs.last` — without this, a message sent while the user was at
+                    // the bottom could appear just off the bottom edge.
+                    .onChange(of: pendingOutgoingMediaMessages.count) { oldCount, newCount in
+                        guard newCount > oldCount, isPinnedToBottom else { return }
+                        scrollToBottom(with: proxy)
                     }
                     .onChange(of: messageIDs.first) { _, _ in
                         guard let anchorId = pendingPrependAnchorId else { return }
@@ -769,7 +789,7 @@ private struct ConversationView: View {
                 uploadState: workspace.pendingMediaUploadStates[stagedVoiceMessage.id],
                 isSending: workspace.isSending,
                 canSend: workspace.canSend,
-                sendHelp: sendButtonHelp,
+                sendHelp: L10n.string("Send"),
                 onDiscard: workspace.discardStagedVoiceMessage,
                 onRetryUpload: {
                     workspace.retryPendingMediaUpload(stagedVoiceMessage.id)
@@ -905,7 +925,7 @@ private struct ConversationView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(!workspace.canSend)
-                .help(sendButtonHelp)
+                .help(workspace.editingMessageContext == nil ? L10n.string("Send") : L10n.string("Save edit"))
             }
         }
     }
@@ -916,20 +936,6 @@ private struct ConversationView: View {
     private var voiceRecordingButtonHelp: String {
         workspace.canRecordVoiceMessage
             ? L10n.string("Voice message") : L10n.string("A voice message is sent on its own")
-    }
-
-    /// Explains a Send that is disabled because media is still in flight. The thumbnails carry the
-    /// visible progress — a spinner while uploading, a retry button on failure — so the button
-    /// stays a plain disabled paperplane and only says why on hover.
-    private var sendButtonHelp: String {
-        switch workspace.composerMediaUploadStatus {
-        case .uploading:
-            L10n.string("Waiting for attachments to finish uploading")
-        case .failed:
-            L10n.string("An attachment failed to upload")
-        case nil:
-            workspace.editingMessageContext == nil ? L10n.string("Send") : L10n.string("Save edit")
-        }
     }
 
     private var bottomAnchorId: String {

--- a/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
+++ b/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
@@ -1,0 +1,369 @@
+//
+//  PendingOutgoingMessageViews.swift
+//  whitenoise-mac
+//
+//  The bubble a media message wears between "sent" and "published": laid out like the real
+//  outgoing row it is about to become, rendered from the plaintext still in memory, and covered by
+//  a single loading treatment for the whole message rather than a badge per attachment.
+//
+
+import AppKit
+import SwiftUI
+
+/// Matches the published bubble's tile oversample so a pending preview and the row that replaces
+/// it are decoded at the same resolution.
+private let pendingMediaThumbnailOversample: CGFloat = 1.5
+
+struct PendingOutgoingMessageBubble: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let message: PendingOutgoingMediaMessage
+    let timestampReferenceDate: Date
+    let timestampLocale: Locale
+
+    private let maxContentWidth: CGFloat = 660
+    private let bubbleGutter: CGFloat = 72
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            content
+
+            if message.state == .failed {
+                PendingOutgoingMessageFailureActions(
+                    onRetry: { workspace.retryPendingOutgoingMediaMessage(message.id) },
+                    onDiscard: { workspace.discardPendingOutgoingMediaMessage(message.id) }
+                )
+            }
+        }
+        .frame(maxWidth: maxContentWidth, alignment: .trailing)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.leading, bubbleGutter)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        message.state == .failed ? L10n.string("Not delivered") : L10n.string("Sending")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            // One dimmer and one spinner for the message, never one per file: the user pressed
+            // Send once, so there is one thing to wait for. The spinner is centered on the media
+            // alone rather than on the whole row — a caption or the timestamp footer below the
+            // grid would otherwise drag the overlay's midpoint down off the image. The dim is
+            // applied per part instead of to the stack so it does not fade the spinner with it.
+            attachments
+                .opacity(dimsForSend ? 0.55 : 1)
+                .overlay(alignment: .center) {
+                    if dimsForSend {
+                        ProgressView()
+                            .controlSize(.large)
+                            .accessibilityLabel(L10n.string("Sending"))
+                    }
+                }
+
+            if message.caption.isEmpty {
+                metadata
+                    .padding(.horizontal, 5)
+                    .opacity(dimsForSend ? 0.55 : 1)
+            } else {
+                PendingOutgoingMessageCaption(caption: message.caption) { metadata }
+                    .opacity(dimsForSend ? 0.55 : 1)
+            }
+        }
+    }
+
+    private var dimsForSend: Bool {
+        message.state.isInFlight
+    }
+
+    /// The visual body of the bubble: the grid, then any audio/document rows. Never empty — a
+    /// pending outgoing message exists only because it carries attachments.
+    @ViewBuilder
+    private var attachments: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            if !message.visualAttachments.isEmpty {
+                PendingOutgoingMediaGrid(attachments: message.visualAttachments)
+            }
+
+            ForEach(message.nonvisualAttachments) { attachment in
+                PendingOutgoingMediaAttachmentRow(attachment: attachment)
+            }
+        }
+    }
+
+    private var metadata: some View {
+        PendingOutgoingMessageMetadata(
+            createdAt: message.createdAt,
+            isFailed: message.state == .failed,
+            isOnBubbleFill: !message.caption.isEmpty,
+            timestampReferenceDate: timestampReferenceDate,
+            timestampLocale: timestampLocale
+        )
+    }
+}
+
+/// Caption surface for a pending message, matching the sent bubble's fill and corner treatment so
+/// the row does not visibly change shape when the real message replaces it.
+private struct PendingOutgoingMessageCaption<Metadata: View>: View {
+    let caption: String
+    @ViewBuilder let metadata: () -> Metadata
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text(caption)
+                .font(.system(size: 15.5))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            metadata()
+        }
+        .padding(.horizontal, 13)
+        .padding(.vertical, 8)
+        .background {
+            UnevenRoundedRectangle(
+                topLeadingRadius: 20,
+                bottomLeadingRadius: 20,
+                bottomTrailingRadius: 6,
+                topTrailingRadius: 20,
+                style: .continuous
+            )
+            .fill(MessagesPalette.sentBubble)
+        }
+        .frame(maxWidth: 540, alignment: .trailing)
+    }
+}
+
+/// Timestamp plus delivery marker, matching `MessageBubble.compactMetadata` — a pending row is a
+/// send that has not been confirmed yet, so it wears the same clock the core-committed ones do.
+private struct PendingOutgoingMessageMetadata: View {
+    let createdAt: Date
+    let isFailed: Bool
+    let isOnBubbleFill: Bool
+    let timestampReferenceDate: Date
+    let timestampLocale: Locale
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(
+                DisplayText.messageTimestamp(
+                    for: createdAt,
+                    now: timestampReferenceDate,
+                    locale: timestampLocale
+                )
+            )
+            .monospacedDigit()
+
+            Image(systemName: isFailed ? "exclamationmark.circle.fill" : "clock")
+                .foregroundStyle(isFailed ? Color.red : tint)
+        }
+        .font(.system(size: 10.5, weight: .medium))
+        .foregroundStyle(tint)
+    }
+
+    private var tint: Color {
+        isOnBubbleFill ? Color.white.opacity(0.68) : Color.secondary.opacity(0.72)
+    }
+}
+
+private struct PendingOutgoingMessageFailureActions: View {
+    let onRetry: () -> Void
+    let onDiscard: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(L10n.string("Retry"), systemImage: "arrow.clockwise", action: onRetry)
+            Button(L10n.string("Remove"), systemImage: "trash", action: onDiscard)
+        }
+        .buttonStyle(.link)
+        .font(.caption.weight(.medium))
+        .labelStyle(.titleOnly)
+    }
+}
+
+/// Grid of locally staged previews, using the published bubble's own row/tile geometry
+/// (`MessageMediaGridPresentation`) so the layout does not shift when the real row lands.
+private struct PendingOutgoingMediaGrid: View {
+    let attachments: [PendingMediaAttachment]
+
+    private let maxWidth: CGFloat = 360
+    private let spacing: CGFloat = 3
+    private let cornerRadius: CGFloat = 10
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            ForEach(rows) { row in
+                HStack(spacing: spacing) {
+                    ForEach(row.attachments) { attachment in
+                        PendingOutgoingMediaTile(
+                            attachment: attachment,
+                            sideLength: row.side,
+                            hiddenCount: attachment.id == visibleAttachments.last?.id ? hiddenCount : 0
+                        )
+                    }
+                }
+            }
+        }
+        .frame(
+            width: maxWidth,
+            height: MessageMediaGridPresentation.gridHeight(
+                totalCount: attachments.count,
+                maxWidth: maxWidth,
+                spacing: spacing
+            ),
+            alignment: .topLeading
+        )
+        .clipShape(.rect(cornerRadius: cornerRadius, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.16), lineWidth: 1)
+        }
+    }
+
+    private var visibleAttachments: [PendingMediaAttachment] {
+        Array(attachments.prefix(MessageMediaGridPresentation.visibleCount(totalCount: attachments.count)))
+    }
+
+    private var hiddenCount: Int {
+        MessageMediaGridPresentation.hiddenCount(totalCount: attachments.count)
+    }
+
+    private var rows: [PendingOutgoingMediaGridRow] {
+        let visible = visibleAttachments
+        return MessageMediaGridPresentation.rowRanges(totalCount: attachments.count)
+            .enumerated()
+            .compactMap { index, range in
+                guard !range.isEmpty, range.upperBound <= visible.count else { return nil }
+                return PendingOutgoingMediaGridRow(
+                    id: index,
+                    side: MessageMediaGridPresentation.tileSide(
+                        rowCount: range.count,
+                        maxWidth: maxWidth,
+                        spacing: spacing
+                    ),
+                    attachments: Array(visible[range])
+                )
+            }
+    }
+}
+
+private struct PendingOutgoingMediaGridRow: Identifiable {
+    let id: Int
+    let side: CGFloat
+    let attachments: [PendingMediaAttachment]
+}
+
+private struct PendingOutgoingMediaTile: View {
+    @Environment(\.displayScale) private var displayScale
+    let attachment: PendingMediaAttachment
+    let sideLength: CGFloat
+    let hiddenCount: Int
+
+    @State private var preview: NSImage?
+
+    var body: some View {
+        ZStack {
+            Color.primary.opacity(0.06)
+
+            if let preview {
+                Image(nsImage: preview)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: sideLength, height: sideLength)
+                    .clipped()
+                    .accessibilityLabel(attachment.fileName)
+            } else {
+                Image(systemName: attachment.kind.systemImageName)
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            if hiddenCount > 0 {
+                Color.black.opacity(0.46)
+                Text(verbatim: "+\(hiddenCount)")
+                    .font(.title2.bold())
+                    .foregroundStyle(.white)
+            }
+        }
+        .frame(width: sideLength, height: sideLength)
+        .clipped()
+        .task(id: attachment.id) {
+            await loadPreview()
+        }
+    }
+
+    private func loadPreview() async {
+        let data = attachment.data
+        let maxPixelSize = ceil(sideLength * max(1, displayScale) * pendingMediaThumbnailOversample)
+        preview = await Task.detached(priority: .utility) {
+            PendingMediaDraftThumbnailDecoder.image(from: data, maxPixelSize: maxPixelSize)
+        }.value
+    }
+}
+
+/// Audio and document attachments, which never enter the grid. Kept intentionally plain: the
+/// message is still going out, so there is nothing to play or reveal yet.
+private struct PendingOutgoingMediaAttachmentRow: View {
+    let attachment: PendingMediaAttachment
+
+    var body: some View {
+        Group {
+            if attachment.isVoiceMessage {
+                voiceMessageRow
+            } else {
+                fileRow
+            }
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(width: 260, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(MessagesPalette.sentBubble)
+        }
+    }
+
+    /// A recording keeps its waveform on the way out, the way the voice-draft bar showed it and
+    /// the way the delivered bubble will show it. Its file name is a generated `voice-<uuid>.m4a`
+    /// the user never chose, so naming it here would be worse than saying nothing.
+    private var voiceMessageRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "mic.fill")
+                .font(.system(size: 14, weight: .semibold))
+
+            ComposerAudioWaveformView(
+                samples: attachment.waveformSamples,
+                progress: 0,
+                barColor: Color.white.opacity(0.55),
+                playedColor: Color.white
+            )
+            .frame(height: 24)
+
+            Text(MediaDurationLabel.string(for: attachment.durationSeconds ?? 0))
+                .font(.caption2.monospacedDigit().weight(.semibold))
+                .foregroundStyle(.white.opacity(0.7))
+        }
+    }
+
+    private var fileRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: attachment.kind.systemImageName)
+                .font(.system(size: 16, weight: .semibold))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(attachment.fileName)
+                    .font(.system(size: 13, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(attachment.durationLabel ?? attachment.sizeLabel)
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+}

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -14143,6 +14143,7 @@ struct whitenoise_macTests {
 
         await Self.settleComposerMediaUploads(state)
         await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
 
         // Staging uploaded the blob; sending only published the reference it produced.
         #expect(runtime.uploadMediaCallCount == 1)
@@ -14268,9 +14269,9 @@ struct whitenoise_macTests {
 
         #expect(state.pendingMediaAttachments.count == 1)
 
-        // Staging uploads the plaintext without publishing anything, and Send stays off until
-        // that upload lands — the whole point of the stage-time upload.
-        #expect(!state.canSend)
+        // Staging uploads the plaintext without publishing anything, and Send is live from the
+        // moment the attachment is staged rather than from the moment the upload lands.
+        #expect(state.canSend)
 
         await Self.yieldUntil { runtime.uploadMediaCallCount == 1 }
         #expect(runtime.uploadMediaCallCount == 1)
@@ -14285,6 +14286,7 @@ struct whitenoise_macTests {
         #expect(state.canSend)
 
         await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
 
         // The send publishes the staged reference; it does not upload again.
         #expect(runtime.uploadMediaCallCount == 1)
@@ -14338,8 +14340,9 @@ struct whitenoise_macTests {
         #expect(attachment.kind == .image)
 
         #expect(state.pendingMediaUploadStates[attachment.id] == .uploading)
-        #expect(state.composerMediaUploadStatus == .uploading)
-        #expect(!state.canSend)
+        // An unfinished upload no longer disables Send: it only decides whether the message spends
+        // its first moments as a loading bubble.
+        #expect(state.canSend)
 
         await runtime.uploadReleaseGate.release("screenshot.png")
         await Self.settleComposerMediaUploads(state)
@@ -14350,6 +14353,8 @@ struct whitenoise_macTests {
         await state.sendDraft()
         #expect(state.pendingMediaUploadStates.isEmpty)
         #expect(state.pendingMediaAttachments.isEmpty)
+        await Self.settlePendingOutgoingMediaSends(state)
+        #expect(state.pendingOutgoingMediaMessagesByConversation.isEmpty)
     }
 
     @MainActor
@@ -14382,21 +14387,20 @@ struct whitenoise_macTests {
         #expect(runtime.uploadMediaCallCount == 2)
         #expect(runtime.uploadedMediaRequests.allSatisfy { $0.request.attachments.count == 1 })
         #expect(runtime.uploadedMediaRequests.allSatisfy { $0.request.send == false })
-        #expect(state.composerMediaUploadStatus == .uploading)
 
-        // Let the *second* attachment land first. One of the two is now uploaded, and Send is
-        // still refused because the other is not.
+        // Let the *second* attachment land first. One of the two is now uploaded, and Send stays
+        // available either way.
         await runtime.uploadReleaseGate.release("second.txt")
         await Self.yieldUntil { state.pendingMediaUploadStates.values.contains(where: \.isUploaded) }
         #expect(state.pendingMediaUploadStates.values.count(where: \.isUploaded) == 1)
-        #expect(state.composerMediaUploadStatus == .uploading)
-        #expect(!state.canSend)
+        #expect(state.canSend)
 
         await runtime.uploadReleaseGate.release("first.txt")
         await Self.settleComposerMediaUploads(state)
         #expect(state.canSend)
 
         await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
 
         #expect(runtime.sendMediaAttachmentsCallCount == 1)
         #expect(runtime.sentMediaAttachments.last?.fileNames == ["first.txt", "second.txt"])
@@ -14492,12 +14496,53 @@ struct whitenoise_macTests {
         #expect(state.canSend)
 
         await state.sendDraft()
+        // The composer is free the moment Send is pressed; the publish finishes behind it.
+        #expect(state.stagedVoiceMessage == nil)
+        #expect(state.pendingMediaAttachments.isEmpty)
+        await Self.settlePendingOutgoingMediaSends(state)
 
         #expect(runtime.sendMediaAttachmentsCallCount == 1)
         #expect(runtime.sentMediaAttachments.last?.fileNames == ["voice-note.m4a"])
         #expect(runtime.sentMediaAttachments.last?.caption == nil)
+    }
+
+    @MainActor
+    @Test func recordingSentBeforeItsUploadLandsFreesTheComposerToRecordAgain() async throws {
+        // Where "a recording is a whole message" meets the hybrid send: the recording keeps
+        // uploading from its own bubble, and because the composer empties on the press, the user
+        // can start the next recording immediately instead of waiting for Blossom.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        await runtime.uploadReleaseGate.hold("voice-note.m4a")
+        state.appendPendingMediaAttachment(recordedVoiceMessage(), for: draftKey)
+        #expect(state.pendingMediaUploadStates.values.contains(.uploading))
+        #expect(state.canSend)
+
+        await state.sendDraft()
+
+        // Composer handed back straight away — including the "record from an empty composer"
+        // gate, which the in-flight message no longer occupies.
         #expect(state.stagedVoiceMessage == nil)
-        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(state.canRecordVoiceMessage)
+        #expect(runtime.sendMediaAttachmentsCallCount == 0)
+        let pending = try #require(state.selectedPendingOutgoingMediaMessages.first)
+        #expect(pending.state == .uploading)
+        #expect(pending.attachments.first?.isVoiceMessage == true)
+        // Audio goes out on its own, so the bubble carries no caption to render either.
+        #expect(pending.caption.isEmpty)
+
+        await runtime.uploadReleaseGate.release("voice-note.m4a")
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
+        #expect(runtime.sentMediaAttachments.last?.fileNames == ["voice-note.m4a"])
+        #expect(runtime.sentMediaAttachments.last?.caption == nil)
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
     }
 
     @MainActor
@@ -14565,6 +14610,7 @@ struct whitenoise_macTests {
 
         await Self.settleComposerMediaUploads(state)
         await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
 
         #expect(runtime.replyToMessageCallCount == 0)
         #expect(runtime.sendMediaAttachmentsCallCount == 1)
@@ -14572,9 +14618,10 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func stagedVoiceNoteUploadsAndGatesSendLikeAnyOtherAttachment() async throws {
+    @Test func stagedVoiceNoteUploadsLikeAnyOtherAttachment() async throws {
         // Upload feedback used to be image-only, so a voice note or a document showed no progress
-        // at all. Gating Send on uploads only works if every attachment kind reports one.
+        // at all. Every attachment kind now reports one, which is what lets a Send pressed
+        // mid-upload know what it still has to wait for.
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroup(messageGroup())
@@ -14595,7 +14642,7 @@ struct whitenoise_macTests {
         state.appendPendingMediaAttachment(voiceNote, for: draftKey)
 
         #expect(state.pendingMediaUploadStates[voiceNote.id] == .uploading)
-        #expect(!state.canSend)
+        #expect(state.canSend)
 
         await runtime.uploadReleaseGate.release("voice.m4a")
         await Self.settleComposerMediaUploads(state)
@@ -14631,12 +14678,9 @@ struct whitenoise_macTests {
         #expect(state.pendingMediaUploadStates[attachment.id] == .failed)
         #expect(state.pendingMediaAttachments.count == 1)
         #expect(state.draftText == "Project notes")
-        #expect(state.composerMediaUploadStatus == .failed)
-        #expect(!state.canSend)
-
-        // Sending is refused outright rather than publishing a partial message.
-        await state.sendDraft()
-        #expect(runtime.sendMediaAttachmentsCallCount == 0)
+        // The failure belongs to the attachment, not to the composer: Send stays available and
+        // would re-upload it as part of sending.
+        #expect(state.canSend)
 
         state.retryPendingMediaUpload(attachment.id)
         await Self.settleComposerMediaUploads(state)
@@ -14645,6 +14689,7 @@ struct whitenoise_macTests {
         #expect(state.canSend)
 
         await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
         #expect(runtime.sentMediaAttachments.last?.fileNames == ["notes.txt"])
         #expect(state.pendingMediaAttachments.isEmpty)
     }
@@ -14652,8 +14697,8 @@ struct whitenoise_macTests {
     @MainActor
     @Test func stagedUploadWithoutAReferenceFailsInsteadOfSpinningForever() async throws {
         // A result that reports success but carries no attachment used to hit the same silent
-        // `return` as cancellation, so the tile stayed `.uploading` with no retry and `canSend`
-        // never recovered — the draft was stuck for good.
+        // `return` as cancellation, so the tile stayed `.uploading` with no retry — and a send
+        // that adopted it would now wait on a reference that never arrives.
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroup(messageGroup())
@@ -14674,8 +14719,6 @@ struct whitenoise_macTests {
         await Self.yieldUntil { state.pendingMediaUploadStates[attachment.id] == .failed }
 
         #expect(state.pendingMediaUploadStates[attachment.id] == .failed)
-        #expect(state.composerMediaUploadStatus == .failed)
-        #expect(!state.canSend)
         // The attachment and the text survive, so the failure is recoverable by retrying.
         #expect(state.pendingMediaAttachments.count == 1)
         #expect(state.draftText == "Project notes")
@@ -14738,9 +14781,9 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func failedPublishKeepsAttachmentsUploadedAndResendable() async throws {
-        // The blobs are already on Blossom and the references are still valid, so a failed publish
-        // must not force a full re-upload — pressing Send again is enough.
+    @Test func failedPublishParksTheMessageAsAFailedBubbleThatCanBeRetried() async throws {
+        // A failed publish no longer rewinds the composer: the message has left it, so the failure
+        // belongs to the bubble the user is looking at, complete with its own retry.
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroup(messageGroup())
@@ -14760,27 +14803,62 @@ struct whitenoise_macTests {
         state.draftText = "Project notes"
         runtime.sendMediaAttachmentsError = FakeMarmotRuntimeError.mediaUploadFailed
         await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
 
-        // The composer clears optimistically, so a failed publish has to put everything back —
-        // attachments, their uploaded state, and the caption the user typed.
         #expect(runtime.sendMediaAttachmentsCallCount == 1)
-        #expect(state.pendingMediaAttachments == [attachment])
-        #expect(state.pendingMediaUploadStates[attachment.id]?.isUploaded == true)
-        #expect(state.draftText == "Project notes")
-        #expect(state.canSend)
+        // The composer stays empty — the attachments and caption are held by the failed bubble.
+        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(state.draftText.isEmpty)
+        let failed = try #require(state.selectedPendingOutgoingMediaMessages.first)
+        #expect(failed.state == .failed)
+        #expect(failed.attachments == [attachment])
+        #expect(failed.caption == "Project notes")
 
         runtime.sendMediaAttachmentsError = nil
-        await state.sendDraft()
+        state.retryPendingOutgoingMediaMessage(failed.id)
+        await Self.settlePendingOutgoingMediaSends(state)
 
-        #expect(runtime.uploadMediaCallCount == 1)
+        // The retry re-uploads rather than trusting a reference whose failure it cannot see.
+        #expect(runtime.uploadMediaCallCount == 2)
         #expect(runtime.sendMediaAttachmentsCallCount == 2)
-        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+    }
+
+    @MainActor
+    @Test func failedOutgoingMediaMessageCanBeDiscarded() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(
+                fileName: "notes.txt",
+                mediaType: "text/plain",
+                data: Data("hello media".utf8),
+                dim: nil
+            ),
+            for: draftKey
+        )
+        await Self.settleComposerMediaUploads(state)
+
+        runtime.sendMediaAttachmentsError = FakeMarmotRuntimeError.mediaUploadFailed
+        await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        let failed = try #require(state.selectedPendingOutgoingMediaMessages.first)
+        state.discardPendingOutgoingMediaMessage(failed.id)
+
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+        #expect(state.pendingOutgoingMediaMessagesByConversation.isEmpty)
     }
 
     @MainActor
     @Test func composerEmptiesBeforeThePublishReturns() async throws {
-        // The upload is already done by the time Send is pressable, so the thumbnails must not sit
-        // in the composer for the length of the relay round-trip looking like nothing happened.
+        // Send hands the message off and returns, so the thumbnails must not sit in the composer
+        // for the length of the relay round-trip looking like nothing happened.
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroup(messageGroup())
@@ -14802,22 +14880,107 @@ struct whitenoise_macTests {
 
         // Arm the gate only now: staging would otherwise block on it too.
         runtime.messageActionGateEnabled = true
-        async let send: Void = state.sendDraft()
-        while !(state.isSending && runtime.didReachMessageActionGate) {
-            await Task.yield()
-        }
+        await state.sendDraft()
 
-        // Still mid-publish, and the composer is already empty.
-        #expect(runtime.sendMediaAttachmentsCallCount == 1)
+        // The composer is already empty and Send is usable again, with the publish still gated.
         #expect(state.pendingMediaAttachments.isEmpty)
         #expect(state.pendingMediaUploadStates.isEmpty)
         #expect(state.draftText.isEmpty)
+        #expect(!state.isSending)
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
+        #expect(state.selectedPendingOutgoingMediaMessages.map(\.state) == [.publishing])
 
         runtime.releaseMessageActionGate()
-        await send
+        await Self.settlePendingOutgoingMediaSends(state)
 
         #expect(state.pendingMediaAttachments.isEmpty)
         #expect(state.draftText.isEmpty)
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+    }
+
+    @MainActor
+    @Test func sendIsAvailableAgainImmediatelyWhileTheAttachmentIsStillUploading() async throws {
+        // The point of the hybrid: staging starts the upload, but a Send pressed before it lands
+        // still goes through — the composer empties, the wait moves to a loading bubble, and the
+        // user can immediately type and send the next message.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        await runtime.uploadReleaseGate.hold("slow.txt")
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(
+                fileName: "slow.txt",
+                mediaType: "text/plain",
+                data: Data("slow".utf8),
+                dim: nil
+            ),
+            for: draftKey
+        )
+        state.draftText = "Look at this"
+        #expect(state.canSend)
+
+        await state.sendDraft()
+
+        // Composer free, message parked, upload still held — and nothing published yet.
+        #expect(state.pendingMediaAttachments.isEmpty)
+        #expect(state.draftText.isEmpty)
+        #expect(state.selectedPendingOutgoingMediaMessages.map(\.state) == [.uploading])
+        #expect(runtime.sendMediaAttachmentsCallCount == 0)
+
+        // The next message does not have to wait behind it.
+        state.draftText = "And this"
+        #expect(state.canSend)
+        await state.sendDraft()
+        #expect(runtime.sendTextCallCount == 1)
+
+        // Releasing the upload lets the parked message finish on its own, carrying its caption.
+        await runtime.uploadReleaseGate.release("slow.txt")
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        #expect(runtime.uploadMediaCallCount == 1)
+        #expect(runtime.sentMediaAttachments.last?.fileNames == ["slow.txt"])
+        #expect(runtime.sentMediaAttachments.last?.caption == "Look at this")
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+    }
+
+    @MainActor
+    @Test func messagesSentBackToBackPublishInThePressedOrder() async throws {
+        // Two messages sent moments apart must arrive in that order even when the second one's
+        // upload finishes first — the publish chain, not Blossom, decides the reading order.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        await runtime.uploadReleaseGate.hold("first.txt", "second.txt")
+        for fileName in ["first.txt", "second.txt"] {
+            state.appendPendingMediaAttachment(
+                PendingMediaAttachment(
+                    fileName: fileName,
+                    mediaType: "text/plain",
+                    data: Data(fileName.utf8),
+                    dim: nil
+                ),
+                for: draftKey
+            )
+            await state.sendDraft()
+            // Send empties the composer, so the next iteration starts from a clean strip.
+            #expect(state.pendingMediaAttachments.isEmpty)
+        }
+        #expect(state.selectedPendingOutgoingMediaMessages.count == 2)
+
+        await runtime.uploadReleaseGate.release("second.txt")
+        await runtime.uploadReleaseGate.release("first.txt")
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        #expect(runtime.sentMediaAttachments.map(\.fileNames) == [["first.txt"], ["second.txt"]])
     }
 
     @MainActor
@@ -14890,10 +15053,8 @@ struct whitenoise_macTests {
 
         // Arm the gate only now: staging would otherwise block on it too.
         runtime.messageActionGateEnabled = true
-        async let send: Void = state.sendDraft()
-        while !(state.isSending && runtime.didReachMessageActionGate) {
-            await Task.yield()
-        }
+        await state.sendDraft()
+        await Self.waitUntil { runtime.didReachMessageActionGate }
         #expect(state.pendingMediaAttachments.isEmpty)
 
         let staged = PendingMediaAttachment(
@@ -14906,7 +15067,7 @@ struct whitenoise_macTests {
         #expect(state.pendingMediaAttachments.map(\.fileName) == ["staged.txt"])
 
         runtime.releaseMessageActionGate()
-        await send
+        await Self.settlePendingOutgoingMediaSends(state)
 
         // The publish carried only what Send snapshotted, and the late arrival is still staged.
         #expect(runtime.sentMediaAttachments.last?.fileNames == ["sent.txt"])
@@ -14915,9 +15076,10 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func failedSendRestoresItsAttachmentsWithoutDiscardingOnesStagedMeanwhile() async throws {
-        // The other half of the optimistic clear: the restore path put the pre-send snapshot back
-        // wholesale, so a publish that failed took a meanwhile-pasted attachment down with it.
+    @Test func failedSendDoesNotDisturbAttachmentsStagedMeanwhile() async throws {
+        // The composer moved on the moment Send was pressed, so a publish that fails afterwards
+        // must land entirely on its own bubble — never reach back into a strip the user has since
+        // refilled.
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroup(messageGroup())
@@ -14937,10 +15099,8 @@ struct whitenoise_macTests {
 
         runtime.sendMediaAttachmentsError = FakeMarmotRuntimeError.mediaUploadFailed
         runtime.messageActionGateEnabled = true
-        async let send: Void = state.sendDraft()
-        while !(state.isSending && runtime.didReachMessageActionGate) {
-            await Task.yield()
-        }
+        await state.sendDraft()
+        await Self.waitUntil { runtime.didReachMessageActionGate }
 
         let staged = PendingMediaAttachment(
             fileName: "staged.txt",
@@ -14949,15 +15109,16 @@ struct whitenoise_macTests {
             dim: nil
         )
         state.appendPendingMediaAttachment(staged, for: draftKey)
+        state.draftText = "Second draft"
 
         runtime.releaseMessageActionGate()
-        await send
+        await Self.settlePendingOutgoingMediaSends(state)
 
-        // The failed send is fully recoverable, and the late arrival is still staged behind it.
-        #expect(state.pendingMediaAttachments.map(\.fileName) == ["sent.txt", "staged.txt"])
-        #expect(state.pendingMediaUploadStates[sent.id]?.isUploaded == true)
+        #expect(state.selectedPendingOutgoingMediaMessages.map(\.state) == [.failed])
+        #expect(state.selectedPendingOutgoingMediaMessages.first?.attachments == [sent])
+        #expect(state.pendingMediaAttachments.map(\.fileName) == ["staged.txt"])
         #expect(state.pendingMediaUploadStates[staged.id] != nil)
-        #expect(state.draftText == "Project notes")
+        #expect(state.draftText == "Second draft")
     }
 
     @MainActor
@@ -15023,6 +15184,7 @@ struct whitenoise_macTests {
         state.draftText = "Project notes"
         await Self.settleComposerMediaUploads(state)
         await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
 
         let message = try #require(state.messagesByChat["direct-group"]?.first)
         let attachment = try #require(message.mediaAttachments.first)
@@ -15082,8 +15244,8 @@ struct whitenoise_macTests {
         #expect(attachment.fileName.hasPrefix("pasted-image-"))
         #expect(attachment.fileName.hasSuffix(".jpg"))
 
-        // Send only opens once the pasted image has finished uploading.
-        #expect(!state.canSend)
+        // A pasted image is sendable straight away; its upload catches up in the bubble.
+        #expect(state.canSend)
         await Self.settleComposerMediaUploads(state)
         #expect(state.canSend)
     }
@@ -15315,6 +15477,7 @@ struct whitenoise_macTests {
         state.draftText = "Project notes"
         await Self.settleComposerMediaUploads(state)
         await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
 
         #expect(runtime.uploadMediaCallCount == 1)
         #expect(runtime.sendMediaAttachmentsCallCount == 1)
@@ -22130,13 +22293,48 @@ struct whitenoise_macTests {
         return data as Data
     }
 
-    /// Attachments upload in a detached task as soon as they are staged, so tests that want to
-    /// reach a sendable composer have to let those tasks run. Yields until nothing is outstanding
-    /// (`composerMediaUploadStatus == nil`) or the budget runs out, so a hang fails the
-    /// assertion that follows rather than the whole suite.
+    /// Attachments upload in a detached task as soon as they are staged, so tests that want every
+    /// staged blob on Blossom before pressing Send have to let those tasks run. Yields until no
+    /// attachment is still `.uploading` or the budget runs out, so a hang fails the assertion that
+    /// follows rather than the whole suite.
     @MainActor
     private static func settleComposerMediaUploads(_ state: WorkspaceState, yields: Int = 1_000) async {
-        await yieldUntil(yields: yields) { state.composerMediaUploadStatus == nil }
+        await yieldUntil(yields: yields) {
+            state.pendingMediaUploadStatesByConversation.values.allSatisfy { states in
+                states.values.allSatisfy { $0 != .uploading }
+            }
+        }
+    }
+
+    /// Send never waits for media: it hands the message to a detached upload-then-publish task and
+    /// returns. Anything asserting on the runtime, the transcript, or the disk cache therefore has
+    /// to let that task finish. A failed message stays parked as a `.failed` bubble, which counts
+    /// as settled.
+    ///
+    /// Awaits the tasks themselves rather than yield-polling: the publish path does real async work
+    /// (a disk-cache store, and the Keychain read behind it) that no number of cooperative yields
+    /// will advance. `rounds` bounds a retry chain so a bug cannot hang the suite.
+    @MainActor
+    private static func settlePendingOutgoingMediaSends(_ state: WorkspaceState, rounds: Int = 20) async {
+        for _ in 0..<rounds {
+            let inFlight = state.pendingOutgoingMediaMessagesByConversation.values
+                .flatMap { $0 }
+                .filter(\.state.isInFlight)
+            guard !inFlight.isEmpty else { return }
+            for message in inFlight {
+                await state.pendingOutgoingMediaSendTasks[message.id]?.value
+            }
+        }
+    }
+
+    /// Real-time counterpart of `yieldUntil`, for conditions a detached task only reaches after
+    /// actual async work rather than after a cooperative hop.
+    @MainActor
+    private static func waitUntil(timeout: Duration = .seconds(10), _ condition: () -> Bool) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition() && ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
     }
 
     /// `beginPendingMediaUpload` marks the attachment `.uploading` synchronously but reaches the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send media messages immediately while uploads continue in the background.
  * View pending media messages with upload and publishing progress.
  * Retry or remove failed media messages without blocking the composer.
  * Preserve message order during concurrent uploads and sends.
  * Automatically display and scroll to newly pending media messages.

* **Bug Fixes**
  * Improved handling of cancelled, failed, and interrupted media uploads.
  * Prevented one failed media send from affecting other messages.
  * Ensured later drafts remain intact after media-send failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->