### PR TITLE
Improve switch account UX

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -125,11 +125,24 @@ extension WorkspaceState {
 
     func selectAccountFromSettings(_ account: AccountItem) {
         guard !account.signedOut else { return }
-        // The row for the already-active account is a no-op: it is rendered on the Accounts page
-        // the user is already reading, so switching would tear the session down and rebuild it
-        // only to land back on the same screen.
+        // The row for the already-active account is a no-op: the switcher is anchored to the
+        // settings page the user is already reading, so switching would tear the session down
+        // and rebuild it only to land back on the same screen.
         guard account.id != activeAccountId else { return }
-        switchActiveAccount(account, finalSelection: .settings(.accounts))
+        switchActiveAccount(account, finalSelection: settingsSelectionAfterAccountMutation)
+    }
+
+    /// Where to land after an account mutation hands the app a different active identity.
+    ///
+    /// The switcher lives at the top of Settings rather than on an Accounts page of its own, so
+    /// these paths stay in Settings: on the page the user was already reading (it is simply
+    /// re-answered for the new identity — `SettingsPanelView` reloads off `activeAccountId`), or
+    /// on the profile overview when the mutation came from the account rail instead.
+    var settingsSelectionAfterAccountMutation: WorkspaceSelection {
+        if case .settings(let page) = selection {
+            return .settings(page)
+        }
+        return .settings(.overview)
     }
 
     func switchActiveAccount(_ account: AccountItem, finalSelection: WorkspaceSelection?) {
@@ -452,7 +465,7 @@ extension WorkspaceState {
             // still-valid active account untouched needs no reselection.
             if needsActiveReset {
                 restoreOrSelectFirstAccount()
-                selection = .settings(.accounts)
+                selection = settingsSelectionAfterAccountMutation
                 await configureObservabilityRuntimeBestEffort()
                 await loadSettingsData()
                 await reloadChats()
@@ -569,7 +582,7 @@ extension WorkspaceState {
 
             resetActiveAccountUIState()
             if let nextActive = accounts.first(where: { !$0.signedOut }) {
-                switchActiveAccount(nextActive, finalSelection: .settings(.accounts))
+                switchActiveAccount(nextActive, finalSelection: settingsSelectionAfterAccountMutation)
                 await configureObservabilityRuntimeBestEffort()
                 await loadSettingsData()
             } else {
@@ -613,7 +626,7 @@ extension WorkspaceState {
                     && activeAccountId != preAwaitActiveAccountId
                     && currentActiveAccount?.id != account.id
                 if !userRacedToDifferentAccount {
-                    switchActiveAccount(refreshed, finalSelection: .settings(.accounts))
+                    switchActiveAccount(refreshed, finalSelection: settingsSelectionAfterAccountMutation)
                     await configureObservabilityRuntimeBestEffort()
                     await loadSettingsData()
                 }

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -40517,65 +40517,6 @@
         }
       }
     },
-    "Removing an account deletes its private key and local message history from this Mac. The identity itself is not deleted from the network.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Beim Entfernen eines Kontos werden dessen privater Schlüssel und der lokale Nachrichtenverlauf von diesem Mac gelöscht. Die Identität selbst wird nicht aus dem Netzwerk gelöscht."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Al eliminar una cuenta se borran su llave privada y el historial de mensajes local de este Mac. La identidad en sí no se elimina de la red."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer un compte efface sa clé privée et l'historique local des messages de ce Mac. L'identité elle-même n'est pas supprimée du réseau."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La rimozione di un account elimina la sua chiave privata e la cronologia locale dei messaggi da questo Mac. L'identità in sé non viene eliminata dalla rete."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remover uma conta exclui a sua chave privada e o histórico de mensagens local deste Mac. A identidade em si não é excluída da rede."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "При удалении аккаунта его закрытый ключ и локальная история сообщений удаляются с этого Mac. Сама идентичность не удаляется из сети."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bir hesabı kaldırmak, özel anahtarını ve yerel mesaj geçmişini bu Mac'ten siler. Kimliğin kendisi ağdan silinmez."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "移除账号会从此 Mac 删除其私钥和本地消息历史。身份本身不会从网络中删除。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "移除帳號會從此 Mac 刪除其私密金鑰和本機訊息記錄。身分本身不會從網路中刪除。"
-          }
-        }
-      }
-    },
     "Removing member…": {
       "extractionState": "manual",
       "localizations": {
@@ -47495,6 +47436,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "滑動聊天即可存檔；存檔的聊天記錄保持活動狀態並仍然通知您。"
+          }
+        }
+      }
+    },
+    "Switch Account": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konto wechseln"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar de cuenta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de compte"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia account"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trocar de conta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сменить аккаунт"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hesap Değiştir"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换账户"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切換帳戶"
           }
         }
       }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2437,7 +2437,6 @@ enum WorkspaceSelection: Equatable {
 enum SettingsPage: Equatable {
     case overview
     case general
-    case accounts
     case profile
     case identityKeys
     case relays
@@ -2451,7 +2450,6 @@ enum SettingsPage: Equatable {
     static let sidebarPages: [SettingsPage] = [
         .general,
         .profile,
-        .accounts,
         .identityKeys,
         .relays,
         .keyPackages,
@@ -2481,8 +2479,6 @@ enum SettingsPage: Equatable {
             "Settings"
         case .general:
             "General"
-        case .accounts:
-            "Accounts"
         case .profile:
             "Profile"
         case .identityKeys:
@@ -2510,8 +2506,6 @@ enum SettingsPage: Equatable {
             "Settings home"
         case .general:
             "Startup preferences"
-        case .accounts:
-            "Switch identities"
         case .profile:
             "Public display info"
         case .identityKeys:
@@ -2539,8 +2533,6 @@ enum SettingsPage: Equatable {
             "gearshape"
         case .general:
             "gear"
-        case .accounts:
-            "person.2"
         case .profile:
             "person.crop.circle"
         case .identityKeys:

--- a/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
@@ -1,0 +1,445 @@
+//
+//  SettingsAccountSwitcherViews.swift
+//  whitenoise-mac
+//
+//  The account switcher that sits at the top of Settings: the card naming the
+//  active identity, the popover listing every identity on this Mac, and the
+//  add-account sheet. This is where the former Accounts settings page went —
+//  the iOS and Flutter clients open Settings on the current profile with a
+//  switch control directly underneath it rather than routing identity work
+//  through a separate Accounts tab, and this mirrors that on macOS.
+//
+
+import MarmotKit
+import SwiftUI
+
+/// Top-of-Settings account card: shows who is signed in, and opens the switcher.
+///
+/// The card owns the sign-out and remove confirmations rather than the popover
+/// that raises them, because a popover dismisses as soon as the dialog takes key
+/// focus — the confirmation has to outlive it.
+struct SettingsAccountSwitcherCard: View {
+    @Environment(WorkspaceState.self) private var workspace
+    // Localizing through `\.locale` (not the stored preference) is what re-renders
+    // the card when the language changes while settings are open — see
+    // `L10n.string(_:locale:)`.
+    @Environment(\.locale) private var locale
+    @State private var isSwitcherPresented = false
+    @State private var isAddAccountPresented = false
+    @State private var accountPendingRemoval: AccountItem?
+    @State private var accountPendingSignOut: AccountItem?
+
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack(spacing: 10) {
+                if let account = workspace.activeAccount {
+                    ProfileImageAvatarView(
+                        seed: account.accountIdHex,
+                        initials: account.initials,
+                        sanitizedPictureURL: account.sanitizedPictureURL,
+                        size: 34,
+                        isSelected: false
+                    )
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(account.displayName)
+                            .font(.callout.weight(.semibold))
+                            .lineLimit(1)
+                        CopyableKeyLabel(accountIdHex: account.accountIdHex, head: 8, tail: 6, showsCopyButton: false)
+                    }
+                } else {
+                    Label(
+                        L10n.string("No account", locale: locale),
+                        systemImage: "person.crop.circle.badge.exclamationmark"
+                    )
+                    .font(.callout.weight(.semibold))
+                }
+
+                Spacer(minLength: 0)
+
+                if let account = workspace.activeAccount {
+                    PublicIdentityQRCodeButton(
+                        accountIdHex: account.accountIdHex,
+                        displayName: account.displayName
+                    )
+                }
+            }
+
+            Button {
+                isSwitcherPresented = true
+            } label: {
+                Label(
+                    L10n.string("Switch Account", locale: locale),
+                    systemImage: "arrow.up.arrow.down"
+                )
+                .font(.callout.weight(.semibold))
+                .frame(maxWidth: .infinity)
+            }
+            .nativeGlassButtonStyle()
+            .help(L10n.string("Switch Account", locale: locale))
+            .popover(isPresented: $isSwitcherPresented, arrowEdge: .bottom) {
+                AccountSwitcherPopover(
+                    onSelect: { account in
+                        isSwitcherPresented = false
+                        workspace.selectAccountFromSettings(account)
+                    },
+                    onSignIn: { account in
+                        isSwitcherPresented = false
+                        Task { await workspace.signInAccount(account) }
+                    },
+                    onAddAccount: {
+                        isSwitcherPresented = false
+                        isAddAccountPresented = true
+                    },
+                    onSignOut: { account in
+                        isSwitcherPresented = false
+                        accountPendingSignOut = account
+                    },
+                    onRemove: { account in
+                        isSwitcherPresented = false
+                        accountPendingRemoval = account
+                    }
+                )
+            }
+        }
+        .padding(10)
+        .glassCard()
+        .sheet(isPresented: $isAddAccountPresented) {
+            AddAccountSheet()
+        }
+        .removeAccountConfirmation(
+            account: accountPendingRemoval,
+            isPresented: removeConfirmationBinding,
+            isRemoveDisabled: workspace.isAccountMutationInProgress
+        ) {
+            guard let account = accountPendingRemoval else { return }
+            accountPendingRemoval = nil
+            Task { await workspace.removeAccount(account) }
+        }
+        .confirmationDialog(
+            L10n.string("Sign out of this account?", locale: locale),
+            isPresented: signOutConfirmationBinding,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.string("Sign Out", locale: locale), role: .destructive) {
+                guard let account = accountPendingSignOut else { return }
+                accountPendingSignOut = nil
+                Task { await workspace.signOutAccount(account) }
+            }
+            Button(L10n.string("Cancel", locale: locale), role: .cancel) {
+                accountPendingSignOut = nil
+            }
+        } message: {
+            Text(
+                L10n.string(
+                    "The account and its local data will stay on this Mac so you can sign in again later.",
+                    locale: locale
+                )
+            )
+        }
+    }
+
+    private var removeConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { accountPendingRemoval != nil },
+            set: { isPresented in
+                if !isPresented { accountPendingRemoval = nil }
+            }
+        )
+    }
+
+    private var signOutConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { accountPendingSignOut != nil },
+            set: { isPresented in
+                if !isPresented { accountPendingSignOut = nil }
+            }
+        )
+    }
+}
+
+/// The switcher itself: every identity stored on this Mac, with the active one
+/// marked, plus the way in for a new one. Every action is reported to the card that
+/// presents this popover: it is the view that outlives the popover, so it is the one
+/// that can close it and then raise a confirmation or a sheet.
+struct AccountSwitcherPopover: View {
+    @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.locale) private var locale
+    let onSelect: (AccountItem) -> Void
+    let onSignIn: (AccountItem) -> Void
+    let onAddAccount: () -> Void
+    let onSignOut: (AccountItem) -> Void
+    let onRemove: (AccountItem) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(L10n.string("Accounts", locale: locale))
+                    .font(.headline)
+                Text(L10n.string("Manage the identities available on this Mac.", locale: locale))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Divider()
+
+            if workspace.accounts.isEmpty {
+                Text(L10n.string("No accounts", locale: locale))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                ScrollView {
+                    VStack(spacing: 2) {
+                        ForEach(workspace.accounts) { account in
+                            AccountSwitcherRow(
+                                account: account,
+                                isActive: account.id == workspace.activeAccountId,
+                                unreadCount: workspace.unreadCount(forAccountIdHex: account.accountIdHex),
+                                isAccountMutationInProgress: workspace.isAccountMutationInProgress,
+                                onSelect: { onSelect(account) },
+                                onSignIn: { onSignIn(account) },
+                                onSignOut: { onSignOut(account) },
+                                onRemove: { onRemove(account) }
+                            )
+                        }
+                    }
+                }
+                .scrollIndicators(.hidden)
+                .frame(maxHeight: 260)
+            }
+
+            Divider()
+
+            Button(action: onAddAccount) {
+                Label(L10n.string("Add Account", locale: locale), systemImage: "plus.circle")
+                    .frame(maxWidth: .infinity)
+            }
+            .nativeGlassProminentButtonStyle()
+            .disabled(workspace.isAuthenticating || workspace.isAccountMutationInProgress)
+        }
+        .padding(14)
+        .frame(width: 320)
+    }
+}
+
+/// One identity in the switcher. Tapping switches to it (or signs it back in when
+/// it was signed out); the trailing menu carries the actions that need a
+/// confirmation.
+struct AccountSwitcherRow: View {
+    @Environment(\.locale) private var locale
+    let account: AccountItem
+    let isActive: Bool
+    let unreadCount: Int
+    let isAccountMutationInProgress: Bool
+    let onSelect: () -> Void
+    let onSignIn: () -> Void
+    let onSignOut: () -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button(action: account.signedOut ? onSignIn : onSelect) {
+                HStack(spacing: 10) {
+                    ProfileImageAvatarView(
+                        seed: account.accountIdHex,
+                        initials: account.initials,
+                        sanitizedPictureURL: account.sanitizedPictureURL,
+                        size: 32,
+                        isSelected: isActive
+                    )
+                    .opacity(account.signedOut ? 0.4 : 1)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(account.displayName)
+                            .font(.callout.weight(.semibold))
+                            .lineLimit(1)
+
+                        Text(statusText)
+                            .font(.caption)
+                            .foregroundStyle(account.signedOut ? Color.orange : .secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if unreadCount > 0 {
+                        UnreadCountBadge(count: unreadCount)
+                    }
+
+                    if isActive {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.callout)
+                            .foregroundStyle(.tint)
+                            .accessibilityLabel(Text(L10n.string("Active", locale: locale)))
+                    }
+                }
+                .padding(.vertical, 4)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(account.signedOut && isAccountMutationInProgress)
+
+            Menu {
+                Group {
+                    if account.signedOut {
+                        Button(action: onSignIn) {
+                            Label(
+                                L10n.string("Sign In", locale: locale),
+                                systemImage: "person.crop.circle.badge.checkmark"
+                            )
+                        }
+                    } else {
+                        Button(action: onSignOut) {
+                            Label(
+                                L10n.string("Sign Out", locale: locale),
+                                systemImage: "rectangle.portrait.and.arrow.right"
+                            )
+                        }
+                    }
+
+                    Divider()
+
+                    Button(role: .destructive, action: onRemove) {
+                        Label(
+                            L10n.string("Remove Account", locale: locale),
+                            systemImage: "person.crop.circle.badge.minus"
+                        )
+                    }
+                }
+                .menuLabelIcons()
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .disabled(isAccountMutationInProgress)
+            .help(L10n.string("Account actions", locale: locale))
+            .accessibilityLabel(
+                Text(String(format: L10n.string("Actions for %@", locale: locale), account.displayName))
+            )
+        }
+    }
+
+    private var statusText: String {
+        if account.signedOut {
+            return L10n.string("Signed out", locale: locale)
+        }
+        if account.localSigning {
+            return L10n.string("Local signing", locale: locale)
+        }
+        return account.externalSigning
+            ? L10n.string("External signing", locale: locale)
+            : L10n.string("Watch-only", locale: locale)
+    }
+}
+
+/// Adds an identity without leaving Settings: log in with an existing `nsec`, or
+/// create a new one. Both paths land on the new identity's profile page so the
+/// switcher card visibly reflects the account that is now active.
+struct AddAccountSheet: View {
+    @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.locale) private var locale
+    @Environment(\.dismiss) private var dismiss
+
+    /// Authentication adds an account, so it waits out any other account mutation
+    /// (sign-out, removal, wipe) rather than racing its account-list refresh.
+    private var isAuthenticationBlocked: Bool {
+        workspace.isAuthenticating || workspace.isAccountMutationInProgress
+    }
+
+    private var isLoginDisabled: Bool {
+        workspace.loginIdentity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || isAuthenticationBlocked
+    }
+
+    var body: some View {
+        @Bindable var workspace = workspace
+
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(L10n.string("Add Account", locale: locale))
+                    .font(.title3.weight(.semibold))
+
+                Spacer()
+
+                GlassCircleCloseButton {
+                    cancel()
+                }
+            }
+
+            SecureField(
+                L10n.string("nsec1...", locale: locale),
+                text: $workspace.loginIdentity,
+                prompt: Text(L10n.string("nsec1...", locale: locale))
+            )
+            .labelsHidden()
+            .textFieldStyle(.roundedBorder)
+            .disabled(workspace.isAuthenticating)
+
+            HStack(spacing: 10) {
+                Button {
+                    Task { await addAccount { await workspace.login() } }
+                } label: {
+                    Label(
+                        workspace.isAuthenticating
+                            ? L10n.string("Logging in...", locale: locale)
+                            : L10n.string("Log in with key", locale: locale),
+                        systemImage: "key"
+                    )
+                }
+                .nativeGlassProminentButtonStyle()
+                .disabled(isLoginDisabled)
+
+                Button {
+                    workspace.clearEnteredLoginIdentity()
+                    Task { await addAccount { await workspace.signUp() } }
+                } label: {
+                    Label(
+                        workspace.isAuthenticating
+                            ? L10n.string("Creating...", locale: locale)
+                            : L10n.string("Create identity", locale: locale),
+                        systemImage: "plus.circle"
+                    )
+                }
+                .nativeGlassButtonStyle()
+                .disabled(isAuthenticationBlocked)
+
+                Spacer()
+
+                Button(L10n.string("Cancel", locale: locale)) {
+                    cancel()
+                }
+                .disabled(workspace.isAuthenticating)
+            }
+
+            SettingsErrorView(error: workspace.lastError)
+        }
+        .padding(22)
+        .frame(width: 420)
+        .background {
+            LiquidGlassBackground()
+        }
+        // Esc, or the presenter going away, dismisses the sheet without running
+        // `cancel()`; the entered nsec must not survive either. See #32.
+        .onDisappear {
+            workspace.clearEnteredLoginIdentity()
+        }
+    }
+
+    /// Runs an authentication path and, when it succeeds, returns to Settings on
+    /// the new account's profile. `login`/`signUp` clear the selection on success,
+    /// so without this the window would jump to the chat list.
+    private func addAccount(_ authenticate: () async -> Void) async {
+        await authenticate()
+        guard workspace.lastError == nil else { return }
+        dismiss()
+        workspace.showSettingsPage(.overview)
+    }
+
+    /// Scrubs the entered nsec (private key) rather than letting it linger in
+    /// observable memory behind a dismissed sheet. See #32.
+    private func cancel() {
+        workspace.clearEnteredLoginIdentity()
+        dismiss()
+    }
+}

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -3,9 +3,10 @@
 //  whitenoise-mac
 //
 //  The settings surface: SettingsPanelView and every settings page/row
-//  (accounts, profile, identity keys, appearance, privacy/security, audit
-//  logs, notifications, developer mode, relays, key packages). Extracted
-//  verbatim from MessengerShellView.swift (no behavior change).
+//  (profile, identity keys, appearance, privacy/security, audit logs,
+//  notifications, developer mode, relays, key packages). Switching between
+//  identities is not a page here — it lives in the switcher at the top of the
+//  settings drawer, in SettingsAccountSwitcherViews.swift.
 //
 
 import AppKit
@@ -29,8 +30,6 @@ struct SettingsPanelView: View {
                 ProfileSettingsView()
             case .general:
                 GeneralSettingsView()
-            case .accounts:
-                AccountsSettingsView()
             case .profile:
                 ProfileSettingsView()
             case .identityKeys:
@@ -253,26 +252,26 @@ struct SettingsScaffold<Content: View>: View {
     }
 }
 
-private var removeAccountConfirmationMessage: String {
-    L10n.string(
-        "This deletes the private key and local message history for this identity from this Mac. This cannot be undone."
-    )
-}
-
-private func removeAccountConfirmationTitle(for account: AccountItem?) -> String {
-    guard let account else { return L10n.string("Remove account?") }
-    return String(format: L10n.string("Remove %@?"), account.displayName)
-}
-
-private struct RemoveAccountConfirmationModifier: ViewModifier {
+struct RemoveAccountConfirmationModifier: ViewModifier {
     let account: AccountItem?
     @Binding var isPresented: Bool
     let isRemoveDisabled: Bool
     let onRemove: () -> Void
 
+    private static var message: String {
+        L10n.string(
+            "This deletes the private key and local message history for this identity from this Mac. This cannot be undone."
+        )
+    }
+
+    private static func title(for account: AccountItem?) -> String {
+        guard let account else { return L10n.string("Remove account?") }
+        return String(format: L10n.string("Remove %@?"), account.displayName)
+    }
+
     func body(content: Content) -> some View {
         content.confirmationDialog(
-            removeAccountConfirmationTitle(for: account),
+            Self.title(for: account),
             isPresented: $isPresented,
             titleVisibility: .visible
         ) {
@@ -282,12 +281,12 @@ private struct RemoveAccountConfirmationModifier: ViewModifier {
             .disabled(isRemoveDisabled)
             Button(L10n.string("Cancel"), role: .cancel) {}
         } message: {
-            Text(removeAccountConfirmationMessage)
+            Text(Self.message)
         }
     }
 }
 
-private extension View {
+extension View {
     func removeAccountConfirmation(
         account: AccountItem?,
         isPresented: Binding<Bool>,
@@ -302,231 +301,6 @@ private extension View {
                 onRemove: onRemove
             )
         )
-    }
-}
-
-struct AccountsSettingsView: View {
-    @Environment(WorkspaceState.self) private var workspace
-    @State private var accountPendingRemoval: AccountItem?
-    @State private var accountPendingSignOut: AccountItem?
-
-    var body: some View {
-        @Bindable var workspace = workspace
-
-        SettingsScaffold(
-            title: L10n.string("Accounts"),
-            subtitle: L10n.string("Manage the identities available on this Mac."),
-            errorSectionTitle: L10n.string("Status")
-        ) {
-            Section {
-                ForEach(workspace.accounts) { account in
-                    AccountSettingsRow(
-                        account: account,
-                        isActive: account.id == workspace.activeAccountId,
-                        isRemoving: workspace.isRemovingAccount,
-                        isAccountMutationInProgress: workspace.isAccountMutationInProgress,
-                        onSelect: {
-                            workspace.selectAccountFromSettings(account)
-                        },
-                        onRemove: {
-                            accountPendingRemoval = account
-                        },
-                        onSignOut: {
-                            accountPendingSignOut = account
-                        },
-                        onSignIn: {
-                            Task { await workspace.signInAccount(account) }
-                        }
-                    )
-                }
-            } header: {
-                Text(L10n.string("Accounts"))
-            } footer: {
-                Text(
-                    L10n.string(
-                        "Removing an account deletes its private key and local message history from this Mac. The identity itself is not deleted from the network."
-                    )
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-
-            Section(L10n.string("Add Account")) {
-                SecureField(L10n.string(""), text: $workspace.loginIdentity, prompt: Text(L10n.string("nsec1...")))
-                    .labelsHidden()
-                    .textFieldStyle(.roundedBorder)
-                    .disabled(workspace.isAuthenticating)
-
-                HStack(spacing: 10) {
-                    Button {
-                        Task {
-                            await workspace.login()
-                            workspace.showSettingsPage(.accounts)
-                        }
-                    } label: {
-                        Label(
-                            workspace.isAuthenticating ? L10n.string("Logging in...") : L10n.string("Log in with key"),
-                            systemImage: "key")
-                    }
-                    .nativeGlassProminentButtonStyle()
-                    .disabled(
-                        workspace.loginIdentity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                            || workspace.isAuthenticating)
-
-                    Button {
-                        workspace.loginIdentity = ""
-                        Task {
-                            await workspace.signUp()
-                            workspace.showSettingsPage(.accounts)
-                        }
-                    } label: {
-                        Label(
-                            workspace.isAuthenticating ? L10n.string("Creating...") : L10n.string("Create identity"),
-                            systemImage: "plus.circle")
-                    }
-                    .nativeGlassButtonStyle()
-                    .disabled(workspace.isAuthenticating)
-
-                    Spacer()
-                }
-            }
-
-        }
-        .removeAccountConfirmation(
-            account: accountPendingRemoval,
-            isPresented: removeConfirmationBinding,
-            isRemoveDisabled: workspace.isAccountMutationInProgress
-        ) {
-            guard let account = accountPendingRemoval else { return }
-            accountPendingRemoval = nil
-            Task { await workspace.removeAccount(account) }
-        }
-        .confirmationDialog(
-            L10n.string("Sign out of this account?"),
-            isPresented: signOutConfirmationBinding,
-            titleVisibility: .visible
-        ) {
-            Button(L10n.string("Sign Out"), role: .destructive) {
-                guard let account = accountPendingSignOut else { return }
-                accountPendingSignOut = nil
-                Task { await workspace.signOutAccount(account) }
-            }
-            Button(L10n.string("Cancel"), role: .cancel) {
-                accountPendingSignOut = nil
-            }
-        } message: {
-            Text(L10n.string("The account and its local data will stay on this Mac so you can sign in again later."))
-        }
-    }
-
-    private var removeConfirmationBinding: Binding<Bool> {
-        Binding(
-            get: { accountPendingRemoval != nil },
-            set: { isPresented in
-                if !isPresented { accountPendingRemoval = nil }
-            }
-        )
-    }
-
-    private var signOutConfirmationBinding: Binding<Bool> {
-        Binding(
-            get: { accountPendingSignOut != nil },
-            set: { isPresented in
-                if !isPresented { accountPendingSignOut = nil }
-            }
-        )
-    }
-}
-
-struct AccountSettingsRow: View {
-    let account: AccountItem
-    let isActive: Bool
-    let isRemoving: Bool
-    let isAccountMutationInProgress: Bool
-    let onSelect: () -> Void
-    let onRemove: () -> Void
-    let onSignOut: () -> Void
-    let onSignIn: () -> Void
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Button(action: account.signedOut ? onSignIn : onSelect) {
-                HStack(spacing: 12) {
-                    ProfileImageAvatarView(
-                        seed: account.accountIdHex,
-                        initials: account.initials,
-                        sanitizedPictureURL: account.sanitizedPictureURL,
-                        size: 44,
-                        isSelected: false
-                    )
-                    .opacity(account.signedOut ? 0.4 : 1)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(account.displayName)
-                            .font(.callout.weight(.semibold))
-                            .lineLimit(1)
-
-                        HStack(spacing: 8) {
-                            CopyableKeyLabel(accountIdHex: account.accountIdHex, showsCopyButton: false)
-
-                            Text(statusText)
-                                .font(.caption)
-                                .foregroundStyle(account.signedOut ? Color.orange : .secondary)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    if isActive {
-                        Label(L10n.string("Active"), systemImage: "checkmark.circle.fill")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.tint)
-                    }
-                }
-                .padding(.vertical, 4)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .disabled(isRemoving || (account.signedOut && isAccountMutationInProgress))
-
-            PublicIdentityQRCodeButton(
-                accountIdHex: account.accountIdHex,
-                displayName: account.displayName
-            )
-            .disabled(isRemoving)
-
-            Menu {
-                if account.signedOut {
-                    Button(action: onSignIn) {
-                        Label(L10n.string("Sign In"), systemImage: "person.crop.circle.badge.checkmark")
-                    }
-                } else {
-                    Button(action: onSignOut) {
-                        Label(L10n.string("Sign Out"), systemImage: "rectangle.portrait.and.arrow.right")
-                    }
-                }
-                Divider()
-                Button(role: .destructive, action: onRemove) {
-                    Label(L10n.string("Remove Account"), systemImage: "person.crop.circle.badge.minus")
-                }
-            } label: {
-                Image(systemName: "ellipsis.circle")
-            }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
-            .disabled(isRemoving || isAccountMutationInProgress)
-            .help(L10n.string("Account actions"))
-            .accessibilityLabel(Text(String(format: L10n.string("Actions for %@"), account.displayName)))
-        }
-    }
-
-    private var statusText: String {
-        if account.signedOut {
-            return L10n.string("Signed out")
-        }
-        if account.localSigning {
-            return L10n.string("Local signing")
-        }
-        return account.externalSigning ? L10n.string("External signing") : L10n.string("Watch-only")
     }
 }
 

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -3,14 +3,15 @@
 //  whitenoise-mac
 //
 //  Left-hand navigation: the account rail, chat-list and settings-list
-//  drawers, their rows, and the pending-invite badge. Extracted verbatim
-//  from MessengerShellView.swift (no behavior change).
+//  drawers, their rows, and the pending-invite badge. The settings drawer
+//  opens with the account switcher card (SettingsAccountSwitcherViews.swift)
+//  above the page list.
 //
 
 import AppKit
 import SwiftUI
 
-private struct UnreadCountBadge: View {
+struct UnreadCountBadge: View {
     let count: Int
     var font: Font = .caption2.weight(.bold)
 
@@ -545,7 +546,7 @@ struct SettingsListDrawerView: View {
                 Text(L10n.string("Settings", locale: locale))
                     .font(.title2.weight(.semibold))
 
-                activeAccountSummary
+                SettingsAccountSwitcherCard()
             }
             .padding(.horizontal, 14)
             .padding(.top, MessagesLayout.sidebarTitlebarTopPadding)
@@ -574,43 +575,6 @@ struct SettingsListDrawerView: View {
         }
     }
 
-    private var activeAccountSummary: some View {
-        HStack(spacing: 10) {
-            if let account = workspace.activeAccount {
-                ProfileImageAvatarView(
-                    seed: account.accountIdHex,
-                    initials: account.initials,
-                    sanitizedPictureURL: account.sanitizedPictureURL,
-                    size: 34,
-                    isSelected: false
-                )
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(account.displayName)
-                        .font(.callout.weight(.semibold))
-                        .lineLimit(1)
-                    CopyableKeyLabel(accountIdHex: account.accountIdHex, head: 8, tail: 6, showsCopyButton: false)
-                }
-            } else {
-                Label(
-                    L10n.string("No account", locale: locale),
-                    systemImage: "person.crop.circle.badge.exclamationmark"
-                )
-                .font(.callout.weight(.semibold))
-            }
-
-            Spacer(minLength: 0)
-
-            if let account = workspace.activeAccount {
-                PublicIdentityQRCodeButton(
-                    accountIdHex: account.accountIdHex,
-                    displayName: account.displayName
-                )
-            }
-        }
-        .padding(10)
-        .glassCard()
-    }
 }
 
 struct SettingsSidebarRow: View {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -827,7 +827,7 @@ struct whitenoise_macTests {
         #expect(UserDefaults.standard.string(forKey: WorkspaceState.activeAccountKey) == "Primary Account")
 
         // Simulate the user sitting on a Settings page for the current account.
-        state.selection = .settings(.accounts)
+        state.selection = .settings(.overview)
 
         // Add a second account, but make the runtime fail to come online.
         let secondary = AccountSummaryFfi(
@@ -850,7 +850,7 @@ struct whitenoise_macTests {
         #expect(runtime.startCallCount == 2)
         #expect(state.activeAccountId == "Primary Account")
         #expect(UserDefaults.standard.string(forKey: WorkspaceState.activeAccountKey) == "Primary Account")
-        #expect(state.selection == .settings(.accounts))
+        #expect(state.selection == .settings(.overview))
         #expect(state.phase == .ready)
     }
 
@@ -875,7 +875,7 @@ struct whitenoise_macTests {
         await state.bootstrap()
         #expect(state.phase == .ready)
         #expect(state.activeAccountId == "Primary Account")
-        state.selection = .settings(.accounts)
+        state.selection = .settings(.overview)
 
         let secondary = AccountSummaryFfi(
             label: "Second Identity",
@@ -893,7 +893,7 @@ struct whitenoise_macTests {
         #expect(runtime.startCallCount == 2)
         #expect(state.activeAccountId == "Primary Account")
         #expect(UserDefaults.standard.string(forKey: WorkspaceState.activeAccountKey) == "Primary Account")
-        #expect(state.selection == .settings(.accounts))
+        #expect(state.selection == .settings(.overview))
         #expect(state.phase == .ready)
     }
 
@@ -955,7 +955,7 @@ struct whitenoise_macTests {
         // Simulate a typed-but-unsubmitted key in the Add Account field.
         state.loginIdentity = "nsec1faketestkeyfaketestkeyfaketestkeyfaketestkeyfaketest"
 
-        state.showSettings(.accounts)
+        state.showSettings(.overview)
         #expect(state.loginIdentity == "")
 
         // And again when leaving for a chat.
@@ -964,6 +964,27 @@ struct whitenoise_macTests {
             state.selectChat(chat)
             #expect(state.loginIdentity == "")
         }
+    }
+
+    /// #32 one layer up: the Add Account sheet's own teardown has to scrub the key, because Esc
+    /// and a disappearing presenter both dismiss it without running its cancel affordance. Only
+    /// the source can hold that contract — once the sheet is gone there is nothing left to observe.
+    @MainActor
+    @Test func addAccountSheetScrubsEnteredNsecWhenItDisappears() throws {
+        let sourceURL =
+            URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "whitenoise-mac")
+            .appending(path: "Views")
+            .appending(path: "SettingsAccountSwitcherViews.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        let sheetStart = try #require(source.range(of: "struct AddAccountSheet: View {"))
+        let sheetSource = String(source[sheetStart.lowerBound...])
+        let normalized = sheetSource.components(separatedBy: .whitespacesAndNewlines).joined()
+
+        #expect(normalized.contains(".onDisappear{workspace.clearEnteredLoginIdentity()}"))
     }
 
     @MainActor
@@ -994,7 +1015,7 @@ struct whitenoise_macTests {
         #expect(runtime.removedAccountRefs == ["Desktop Account"])
         #expect(state.accounts.map(\.id) == ["Backup Account"])
         #expect(state.activeAccountId == "Backup Account")
-        #expect(state.selection == .settings(.accounts))
+        #expect(state.selection == .settings(.overview))
     }
 
     @MainActor
@@ -11026,7 +11047,7 @@ struct whitenoise_macTests {
         let didReachReadMarker = await waitFor { runtime.didReachMarkTimelineMessageReadGate }
         #expect(didReachReadMarker)
 
-        state.selection = .settings(.accounts)
+        state.selection = .settings(.overview)
         runtime.releaseMarkTimelineMessageReadGate()
         _ = await firstMark
 
@@ -11095,7 +11116,7 @@ struct whitenoise_macTests {
         let didReachReadMarker = await waitFor { runtime.didReachMarkTimelineMessageReadGate }
         #expect(didReachReadMarker)
 
-        state.selection = .settings(.accounts)
+        state.selection = .settings(.overview)
         runtime.releaseMarkTimelineMessageReadGate()
         _ = await firstMark
 
@@ -21588,9 +21609,6 @@ struct whitenoise_macTests {
         state.showSettings(.general)
         #expect(state.selection == .settings(.general))
 
-        state.showSettings(.accounts)
-        #expect(state.selection == .settings(.accounts))
-
         state.showSettings(.profile)
         #expect(state.selection == .settings(.profile))
 
@@ -21626,6 +21644,77 @@ struct whitenoise_macTests {
         #expect(SettingsPage.sidebarPages.contains(.privacySecurity))
         #expect(SettingsPage.sidebarPages.contains(.storage))
         #expect(SettingsPage.sidebarPages.last == .developerMode)
+    }
+
+    /// Switching identities is chrome at the top of Settings (`SettingsAccountSwitcherCard`),
+    /// not a page in the sidebar: like the iOS and Flutter clients, Settings shows the current
+    /// account with a switch control under it instead of routing through an Accounts tab.
+    @MainActor
+    @Test func settingsSidebarHasNoAccountsPage() async throws {
+        #expect(
+            SettingsPage.sidebarPages == [
+                .general,
+                .profile,
+                .identityKeys,
+                .relays,
+                .keyPackages,
+                .appearance,
+                .privacySecurity,
+                .notifications,
+                .storage,
+                .developerMode,
+            ]
+        )
+    }
+
+    /// Account mutations that hand the app a different active identity stay on the settings page
+    /// the switcher was opened from, and fall back to the profile overview the switcher card sits
+    /// above when they were started from the account rail instead.
+    @MainActor
+    @Test func accountMutationLandingKeepsTheOpenSettingsPageOtherwiseTheOverview() async throws {
+        let state = WorkspaceState.preview()
+
+        state.showSettings(.keyPackages)
+        #expect(state.settingsSelectionAfterAccountMutation == .settings(.keyPackages))
+
+        state.selection = nil
+        #expect(state.settingsSelectionAfterAccountMutation == .settings(.overview))
+
+        let chat = try #require(state.activeChats.first)
+        state.selectChat(chat)
+        #expect(state.settingsSelectionAfterAccountMutation == .settings(.overview))
+    }
+
+    /// The rail's sign-out lands in Settings on the overview, because the identity that owned the
+    /// open chat is gone and the switcher card there is what names the one that took over.
+    @MainActor
+    @Test func signingOutTheActiveAccountFromAChatLandsOnTheSettingsOverview() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+
+        let primary = desktopAccount()
+        let secondary = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, secondary])
+        runtime.installGroup(messageGroup())
+        UserDefaults.standard.set(primary.label, forKey: WorkspaceState.activeAccountKey)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let chat = try #require(state.activeChats.first { $0.id == "group" })
+        state.selectChat(chat)
+        let active = try #require(state.accounts.first { $0.id == primary.label })
+
+        await state.signOutAccount(active)
+
+        #expect(state.activeAccountId == secondary.label)
+        #expect(state.selection == .settings(.overview))
     }
 
     @MainActor
@@ -22275,16 +22364,16 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func settingsAccountSwitchStaysOnAccountsPage() async throws {
+    @Test func settingsAccountSwitchStaysOnTheSettingsPageItWasStartedFrom() async throws {
         let state = WorkspaceState.preview()
-        state.showSettings(.accounts)
+        state.showSettings(.relays)
         state.searchText = "relay"
         state.draftText = "half-written"
 
         state.selectAccountFromSettings(AccountItem.samples[1])
 
         #expect(state.activeAccountId == AccountItem.samples[1].id)
-        #expect(state.selection == .settings(.accounts))
+        #expect(state.selection == .settings(.relays))
         #expect(state.searchText.isEmpty)
         #expect(state.draftText.isEmpty)
     }
@@ -22421,7 +22510,7 @@ struct whitenoise_macTests {
         // account-switch teardown.
         let state = WorkspaceState.preview()
         let active = try #require(state.activeAccount)
-        state.showSettings(.accounts)
+        state.showSettings(.overview)
         #expect(state.isShowingSettings)
 
         state.selectAccount(active)
@@ -22450,17 +22539,17 @@ struct whitenoise_macTests {
 
     @MainActor
     @Test func reselectingTheActiveAccountRowInSettingsKeepsTheSessionLoaded() async throws {
-        // Settings ▸ Accounts marks the active row "Active"; tapping it would otherwise tear the
-        // session down and rebuild it only to land back on the page already on screen.
+        // The settings account switcher marks the active row "Active"; tapping it would otherwise
+        // tear the session down and rebuild it only to land back on the page already on screen.
         let state = WorkspaceState.preview()
         let active = try #require(state.activeAccount)
-        state.showSettings(.accounts)
+        state.showSettings(.relays)
         let cachedChatIdsBefore = state.cachedMessageChatIds
         let reloadGenerationBefore = state.reloadChatsGeneration
 
         state.selectAccountFromSettings(active)
 
-        #expect(state.selection == .settings(.accounts))
+        #expect(state.selection == .settings(.relays))
         #expect(state.activeAccountId == active.id)
         #expect(state.cachedMessageChatIds == cachedChatIdsBefore)
         #expect(state.reloadChatsGeneration == reloadGenerationBefore)
@@ -25490,7 +25579,7 @@ struct whitenoise_macTests {
         // but the current chat-list snapshot has not learned about yet. The tap path must
         // select first and let the reload discover it, not reject it as unavailable.
         state.setChats([], forAccountId: account.label)
-        state.selection = .settings(.accounts)
+        state.selection = .settings(.overview)
         runtime.clearTimelineMessageQueries()
 
         state.handleNotificationResponse([
@@ -26080,9 +26169,9 @@ struct whitenoise_macTests {
         state.showSettingsPage(.notifications)
         state.lastError = WorkspaceState.notificationPermissionGuidance
 
-        state.showSettingsPage(.accounts)
+        state.showSettingsPage(.storage)
 
-        #expect(state.selection == .settings(.accounts))
+        #expect(state.selection == .settings(.storage))
         #expect(state.lastError == nil)
     }
 


### PR DESCRIPTION
Make UX to switch account similar to the old flutter app and to the current ios app with a switch account button in the top of settings instead of an accounts tab 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account switcher to the Settings drawer.
  * Switch accounts, sign in or out, remove accounts, and add new accounts without leaving the current Settings page.
  * Added identity details, QR codes, unread counts, and account actions.
  * Added localized “Switch Account” text in multiple languages.

* **Updates**
  * Removed the separate Accounts settings page; account management is now available through the Settings drawer.
  * Account changes made elsewhere now return to Settings Overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->