### PR TITLE
Fix users metadata in invites

### DIFF
--- a/whitenoise-mac/Core/PeerProfileRefreshGate.swift
+++ b/whitenoise-mac/Core/PeerProfileRefreshGate.swift
@@ -1,0 +1,179 @@
+//
+//  PeerProfileRefreshGate.swift
+//  whitenoise-mac
+//
+//  Admission control for relay-backed peer profile (kind:0) refreshes. Pure value
+//  type: no platform state, no FFI, no clock of its own — callers pass `now` so the
+//  cache-TTL clock (`WorkspaceState.nowProvider`) drives this too.
+//
+//  Why a gate at all: `requestPeerProfileRefresh` is called from projection and
+//  render paths (timeline window applies, chat-row enrichment, reaction rows), so
+//  without admission control a scrolling transcript would issue one relay round-trip
+//  per frame per sender. Android solves this the same way (`ProfileRefreshGate.kt`).
+//
+
+import Foundation
+
+nonisolated struct PeerProfileRefreshGate: Sendable {
+    /// Cooldown after an attempt run has settled, so a render-path caller can ask on
+    /// every frame without producing relay traffic. Matches Android's
+    /// `PROFILE_REFRESH_RETRY_COOLDOWN_MILLIS`.
+    static let retryCooldown: TimeInterval = 60
+
+    /// Attempts allowed before the id falls back to `retryCooldown`. A peer with no
+    /// published kind:0 anywhere must cost a bounded number of round-trips, not a loop.
+    static let maxAttemptsPerWindow = 3
+
+    /// Delay before attempt 2 and attempt 3 of a run. Mirrors whitenoise-linux's
+    /// `resolve_display_name_async` ladder (`2u64 << (attempt - 2)` → 2s, 4s), which
+    /// exists because "a transient relay failure must not strand the caller until some
+    /// unrelated event re-asks".
+    static let backoffDelays: [TimeInterval] = [2, 4]
+
+    /// Cooldown applied after the *n*-th consecutive run that failed to name the peer, so a
+    /// pubkey with no kind:0 anywhere stops costing round-trips.
+    ///
+    /// Without this the gate is an infinite pulse: a spent run reset `attempt` to `0`, the
+    /// entry was pruned as its 60s cooldown elapsed, and the very next projection re-admitted
+    /// the id at the bottom of the 2s/4s ladder — 3 relay round-trips per peer per ~66s, for
+    /// the life of the process. The timeline and chat-list paths request every sender and
+    /// every roster member they see, so an unresolvable 50-member group sustained ~150
+    /// round-trips a minute forever, each also taking a slot on the serialized `ffiQueue`
+    /// that the transcript projection needs. Escalating instead keeps the responsive first
+    /// minute and turns the steady state into a trickle.
+    static let repeatedFailureCooldowns: [TimeInterval] = [60, 300, 1800]
+
+    private struct Entry: Sendable {
+        /// No attempt may start before this instant.
+        var retryAfter: Date
+        /// Attempts already spent in the current run. `0` means the run settled and the
+        /// id is serving out a cooldown; the counter then carries no information.
+        var attempt: Int
+        /// Consecutive runs that ended without naming the peer. Indexes
+        /// `repeatedFailureCooldowns`; reset the moment the peer resolves.
+        var failedRuns: Int = 0
+    }
+
+    /// How often the retained set is actually swept. `tryStart` runs once per unresolved
+    /// sender on every timeline window apply and every live delta, so sweeping on each call
+    /// would put an O(retained) pass on the projection hot path for a set that changes at
+    /// human speed. Admission itself never depends on the sweep — `now < retryAfter` is the
+    /// gate — so amortizing it only shifts *when* a stale entry is collected.
+    static let pruneInterval: TimeInterval = 1
+
+    private var inFlight: Set<String> = []
+    private var entries: [String: Entry] = [:]
+    private var nextPruneAt = Date.distantPast
+
+    /// Whether an attempt may start for `accountIdHex` right now.
+    mutating func tryStart(_ accountIdHex: String, now: Date) -> Bool {
+        pruneExpired(now: now)
+        guard !inFlight.contains(accountIdHex) else { return false }
+        if let entry = entries[accountIdHex], now < entry.retryAfter { return false }
+        inFlight.insert(accountIdHex)
+        return true
+    }
+
+    /// Records the outcome of an attempt. `resolved` means the lookup produced a usable
+    /// profile, which settles the run; otherwise the backoff ladder advances.
+    ///
+    /// `deferRetries` skips the urgent 2s/4s ladder and settles the run immediately. Callers
+    /// pass it for a peer the user has already nicknamed: that row reads correctly right now,
+    /// so the only thing still missing is the published name shown beneath the nickname, and
+    /// nothing about it justifies a burst of round-trips.
+    mutating func finish(_ accountIdHex: String, now: Date, resolved: Bool, deferRetries: Bool = false) {
+        inFlight.remove(accountIdHex)
+        // Prune here as well as in `tryStart`. `tryStart` is not guaranteed to run
+        // again on a gate that goes quiescent after a burst of `finish` calls — e.g. a
+        // large group whose senders are all resolved in one pass — and without this the
+        // map retains one entry per distinct pubkey for the process lifetime. Android
+        // hit exactly this (`ProfileRefreshGate.kt`, their #230).
+        pruneExpired(now: now)
+
+        let existing = entries[accountIdHex]
+
+        guard !resolved else {
+            // Resolving clears the failure history: the next time this peer goes unnameable
+            // it is a fresh problem (a changed pubkey, a rotated relay set) and deserves the
+            // responsive ladder again, not the cooldown its previous run had escalated to.
+            entries[accountIdHex] = Entry(retryAfter: now.addingTimeInterval(Self.retryCooldown), attempt: 0)
+            return
+        }
+
+        let attempt = (existing?.attempt ?? 0) + 1
+        let backoffIndex = attempt - 1
+        if !deferRetries, attempt < Self.maxAttemptsPerWindow, backoffIndex < Self.backoffDelays.count {
+            entries[accountIdHex] = Entry(
+                retryAfter: now.addingTimeInterval(Self.backoffDelays[backoffIndex]),
+                attempt: attempt,
+                failedRuns: existing?.failedRuns ?? 0
+            )
+            return
+        }
+
+        // Run spent. Reset the ladder so a later window starts fresh, but carry the run
+        // count forward so the cooldown before that window escalates.
+        let failedRuns = (existing?.failedRuns ?? 0) + 1
+        let cooldown = Self.repeatedFailureCooldowns[
+            min(failedRuns - 1, Self.repeatedFailureCooldowns.count - 1)
+        ]
+        entries[accountIdHex] = Entry(
+            retryAfter: now.addingTimeInterval(cooldown),
+            attempt: 0,
+            failedRuns: failedRuns
+        )
+    }
+
+    /// Drops one id's admission state. Used when an update arrives from outside this
+    /// gate (a profile stream, or an explicit user-driven re-resolve) and the pending
+    /// cooldown would otherwise suppress a legitimate immediate retry.
+    mutating func remove(_ accountIdHex: String) {
+        inFlight.remove(accountIdHex)
+        entries.removeValue(forKey: accountIdHex)
+    }
+
+    /// Account-switch / sign-out reset. Admission state is scoped to the active
+    /// account's directory view, exactly like `peerProfileFFICache`.
+    mutating func removeAll() {
+        inFlight.removeAll()
+        entries.removeAll()
+    }
+
+    /// Evicts entries that carry no state worth keeping, once their cooldown has elapsed.
+    ///
+    /// An entry that resolved (`attempt == 0`, `failedRuns == 0`) carries nothing beyond its
+    /// cooldown, so it can go the moment the cooldown elapses. Anything else — a mid-ladder
+    /// attempt, or a settled run that failed — must be retained *past* its `retryAfter`,
+    /// otherwise the next request drops the counter it was holding: the ladder would restart
+    /// at 2s forever instead of ever settling, and `failedRuns` would reset to 0 so the
+    /// cooldown could never escalate. Retention is still bounded: if nobody re-asked within
+    /// `retryCooldown` of the wait expiring, the run is stale and resetting it is correct.
+    private mutating func pruneExpired(now: Date) {
+        guard now >= nextPruneAt, !entries.isEmpty else { return }
+        nextPruneAt = now.addingTimeInterval(Self.pruneInterval)
+
+        // Collect then remove, rather than rebuilding the dictionary with `filter`. In the
+        // common case nothing has expired, and an empty `[String]` costs no allocation — so a
+        // sweep that finds nothing is free, instead of reallocating the whole map.
+        var expired: [String] = []
+        for (accountIdHex, entry) in entries {
+            let horizon =
+                entry.attempt == 0 && entry.failedRuns == 0
+                ? entry.retryAfter
+                : entry.retryAfter.addingTimeInterval(Self.retryCooldown)
+            if now >= horizon { expired.append(accountIdHex) }
+        }
+        for accountIdHex in expired {
+            entries.removeValue(forKey: accountIdHex)
+        }
+    }
+
+    #if DEBUG
+        /// Test-only: entries the gate is retaining. Asserts the pruning bound above.
+        var retainedEntryCountForTesting: Int { entries.count }
+        var inFlightCountForTesting: Int { inFlight.count }
+        func retryAfterForTesting(_ accountIdHex: String) -> Date? { entries[accountIdHex]?.retryAfter }
+        func attemptForTesting(_ accountIdHex: String) -> Int? { entries[accountIdHex]?.attempt }
+        func failedRunsForTesting(_ accountIdHex: String) -> Int? { entries[accountIdHex]?.failedRuns }
+    #endif
+}

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -195,6 +195,7 @@ extension WorkspaceState {
         // group membership visibility can differ per account); drop them on switch so the new
         // account does not inherit stale cross-account entries (whitenoise-mac#8/#9).
         peerProfileFFICache.removeAll()
+        clearPeerProfileRefreshState()
         clearGroupMemberCache()
         groupImagePayloadCache.removeAll()
         // Read markers are keyed by groupIdHex only; stale entries from the
@@ -495,6 +496,7 @@ extension WorkspaceState {
         mediaDownloads.removeAll()
         clearMediaReferenceResolutionCache()
         peerProfileFFICache.removeAll()
+        clearPeerProfileRefreshState()
         clearGroupMemberCache()
         groupImagePayloadCache.removeAll()
         // Active-account teardown must evict decoded peer/group avatars held in the
@@ -783,11 +785,11 @@ extension WorkspaceState {
         defer { isRefreshingAccountProfiles = false }
 
         let accountIds = accounts.map(\.accountIdHex)
+        // Seed relays alone miss an identity published only to its own NIP-65 write relays,
+        // so use the same union every peer refresh uses.
+        let relays = await peerProfileLookupRelaysForActiveAccount()
         for accountIdHex in accountIds {
-            try? await client.refreshProfile(
-                accountIdHex: accountIdHex,
-                relays: MarmotClient.seedRelays
-            )
+            try? await client.refreshProfile(accountIdHex: accountIdHex, relays: relays)
         }
 
         guard let refreshed = try? await accountItemsFromRuntime(client: client) else { return }
@@ -847,6 +849,7 @@ extension WorkspaceState {
         mediaCacheReclaimedByteCount = nil
         mediaCacheGeneration &+= 1
         peerProfileFFICache.removeAll()
+        clearPeerProfileRefreshState()
         clearGroupMemberCache()
         clearConversationMetadata()
         clearSharedMedia()

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -715,6 +715,12 @@ extension WorkspaceState {
                 }
             }
         }
+        // A group row's preview is prefixed with the last sender's name, which MDK resolves
+        // from the directory on every row read — so fetching that sender's kind:0 now makes
+        // the prefix correct on the next delta without any further client work.
+        if let sender = row.lastMessage?.sender {
+            requestPeerProfileRefresh(sender)
+        }
         let groupImagePayload =
             row.conversationKind != .direct && directPeer == nil && groupAvatarURL == nil
             ? await decryptedGroupImagePayload(from: row, account: account, client: client)
@@ -815,6 +821,9 @@ extension WorkspaceState {
             activeAccount: activeAccount,
             client: client
         )
+        // A direct chat's whole title is this one peer. When an invite arrives before the
+        // inviter's kind:0 has propagated locally, this is the request that fetches it.
+        requestPeerProfileRefresh(memberId)
         let published = firstNonBlank([
             resolved?.profileDisplayName,
             resolved?.profileName,
@@ -1012,6 +1021,17 @@ extension WorkspaceState {
             .filter { !$0.isEmpty }
         )
         guard !senderIds.isEmpty else { return [:] }
+        // Record the identities this group's labels depend on, so a later profile resolution
+        // can tell whether replaying the transcript would change anything. Built here rather
+        // than scanned from the materialized rows because `MessageItem` carries only its own
+        // sender — reply-quote authors and group-system actors are named from the record and
+        // would be invisible to such a scan.
+        //
+        // Union, never replace: the live delta path calls this with only the *changed*
+        // records, so assigning would shrink the set to one sender and then suppress the
+        // replay for everyone else in the window — the exact staleness the replay exists to
+        // fix. Erring toward a superset only ever costs one unnecessary replay.
+        timelineProjectedSenderIds[groupIdHex, default: []].formUnion(senderIds)
 
         // Resolve any senders whose cached lookup is missing, incomplete, or stale in a
         // single off-main FFI batch, then cache the raw lookups (timestamped) so repeated
@@ -1123,6 +1143,22 @@ extension WorkspaceState {
                 pictureURL: resolved?.profilePicture?.nilIfBlank
             )
         }
+
+        // Ask the relays for anyone the local directory still cannot name. This is the
+        // only thing that makes a new sender's kind:0 arrive on our schedule rather than
+        // whenever MDK's background directory sync happens to watch them. Senders whose
+        // lookup is already complete are dropped inside `requestPeerProfileRefresh`, so
+        // the all-resolved steady state issues no relay traffic from this hot path
+        // (asserted by `peerProfileRefreshRequestCount`).
+        //
+        // Reaction senders ride along here rather than being resolved above: they are not
+        // part of `senderIds`, so adding them there would put an extra local FFI pair on
+        // every window for identities no message row renders. The queue resolves them
+        // locally before touching a relay, off this path. Their rows read the cache
+        // directly (`reactionReactorDisplay`), which is observed, so no re-projection is
+        // needed to show the result.
+        requestPeerProfileRefresh(senderIds)
+        requestPeerProfileRefresh(records.lazy.flatMap { $0.reactions.userReactions }.map(\.sender))
 
         return profiles
     }

--- a/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
@@ -138,6 +138,15 @@ extension WorkspaceState {
         relabelTimelineSenders(accountIdHex: contact, nickname: nickname)
         relabelComposeContacts(accountIdHex: contact, nickname: nickname)
         relabelContactDetailsTarget(accountIdHex: contact, nickname: nickname)
+
+        if nickname == nil {
+            // Clearing a nickname hands the label back to whatever the peer published, so this
+            // is exactly when a missing kind:0 starts mattering again. The gate may be holding
+            // this id in a cooldown — possibly the long one `refreshPeerProfile` applies
+            // *because* it was nicknamed — so drop that admission state before asking.
+            peerProfileRefreshGate.remove(contact)
+            requestPeerProfileRefresh(contact)
+        }
     }
 
     // MARK: - Private

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -1476,6 +1476,12 @@ extension WorkspaceState {
         mentionRosterCache[groupIdHex] = nil
         mentionNamesCache[groupIdHex] = nil
         groupMemberDetailsCache[groupIdHex] = members
+        // Every roster the app learns about flows through here, including the one chat-list
+        // enrichment fetches for a freshly received invite. The welcoming account is always
+        // a member of the group it invited us to, so this covers the inviter too — the
+        // explicit `welcomerAccountIdHex` request in `groupDetailsSnapshot` only has to
+        // cover the details screen.
+        requestPeerProfileRefresh(members.map(\.memberIdHex))
     }
 
     func invalidateGroupMembers(for groupIdHex: String) {

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -68,7 +68,10 @@ extension WorkspaceState {
         let member = try await runOffMain {
             try client.normalizeMemberRef(memberRef: memberRef)
         }
-        try? await client.refreshProfile(accountIdHex: member.accountIdHex, relays: MarmotClient.seedRelays)
+        // Seed relays alone miss a recipient published only to their own NIP-65 write
+        // relays, so use the same union every peer refresh uses.
+        let relays = await peerProfileLookupRelaysForActiveAccount()
+        try? await client.refreshProfile(accountIdHex: member.accountIdHex, relays: relays)
         peerProfileFFICache[member.accountIdHex] = nil
         let resolved = try? await runOffMain { () -> ResolvedPeerFFI in
             let profile = try? client.userProfile(accountIdHex: member.accountIdHex)

--- a/whitenoise-mac/Core/WorkspaceState+PeerProfiles.swift
+++ b/whitenoise-mac/Core/WorkspaceState+PeerProfiles.swift
@@ -1,0 +1,517 @@
+//
+//  WorkspaceState+PeerProfiles.swift
+//  whitenoise-mac
+//
+//  Relay-backed peer profile (kind:0) refresh, and the re-projection that makes a
+//  late-arriving display name reach rows that were already rendered.
+//
+//  Two independent halves, and both are needed:
+//
+//  * **Pull.** `requestPeerProfileRefresh` asks the relays for a peer's kind:0 the
+//    first time we see them. Before this existed, `refreshProfile` was wired only to
+//    the local accounts and to a hand-typed New Chat recipient, so an inviter's or a
+//    message sender's name appeared only once MDK's background directory sync happened
+//    to watch that pubkey.
+//  * **Re-project.** `schedulePeerProfileReprojection` replays the open conversation's
+//    window and the affected sidebar rows once a name lands. `MessageItem.senderName`
+//    is baked at projection time and the live delta path deliberately re-maps only
+//    *changed* records, so without this a name resolved at T+90s never reaches a
+//    message rendered at T+0.
+//
+//  Pull without re-projection fixes nothing visible; re-projection without pull has
+//  nothing to show. iOS pairs `ProfileStore`'s fetch queue with
+//  `refreshProfileDependentTimelineProjections`; Android pairs `requestProfile` with
+//  `profileRevision`; Flutter pairs `resolve_user` with `subscribe_to_user`.
+//
+
+import Foundation
+import MarmotKit
+
+@MainActor
+extension WorkspaceState {
+    // MARK: - Pull
+
+    /// Queues a relay kind:0 fetch for any of `accountIdHexes` we cannot already name.
+    ///
+    /// Safe to call unconditionally from the projection paths: ids whose cached lookup is
+    /// already usable are dropped before the gate is consulted, using the precomputed
+    /// `CachedPeerProfile.isComplete` flag, so the all-resolved steady state does no work
+    /// beyond one dictionary lookup per id. That short-circuit is what makes the callers
+    /// (every timeline window, every live delta, every roster) affordable.
+    ///
+    /// Not for view bodies. Callers that render per-frame (`reactionReactorDisplay`) read
+    /// the observed cache instead and let a projection-path request fill it.
+    func requestPeerProfileRefresh(_ accountIdHexes: some Sequence<String>) {
+        guard client != nil, let activeAccount else { return }
+        let now = nowProvider()
+        var admitted: [String] = []
+
+        for accountIdHex in accountIdHexes {
+            guard !accountIdHex.isEmpty,
+                accountIdHex != activeAccount.accountIdHex,
+                peerProfileFFICache[accountIdHex]?.isComplete != true,
+                peerProfileRefreshGate.tryStart(accountIdHex, now: now)
+            else { continue }
+            admitted.append(accountIdHex)
+        }
+
+        guard !admitted.isEmpty else { return }
+        #if DEBUG
+            peerProfileRefreshRequestCount += admitted.count
+        #endif
+        queuedPeerProfileRefreshIds.append(contentsOf: admitted)
+        startPeerProfileRefreshQueueIfNeeded()
+    }
+
+    /// Single-id convenience for the render paths that resolve one peer at a time.
+    func requestPeerProfileRefresh(_ accountIdHex: String) {
+        requestPeerProfileRefresh(CollectionOfOne(accountIdHex))
+    }
+
+    private func startPeerProfileRefreshQueueIfNeeded() {
+        guard peerProfileRefreshTask == nil, !queuedPeerProfileRefreshIds.isEmpty else { return }
+        let taskId = UUID()
+        peerProfileRefreshTaskId = taskId
+        peerProfileRefreshTask = Task { [weak self] in
+            await self?.runPeerProfileRefreshQueue(taskId: taskId)
+        }
+    }
+
+    private func runPeerProfileRefreshQueue(taskId: UUID) async {
+        defer { finishPeerProfileRefreshQueue(taskId: taskId) }
+
+        while !Task.isCancelled {
+            guard let client, let account = activeAccount else { return }
+            let batch = nextQueuedPeerProfileRefreshIds(limit: Self.peerProfileRefreshFanout)
+            guard !batch.isEmpty else { return }
+
+            let relays = await peerProfileLookupRelays(for: account)
+            // The account can change while the relay list is being read.
+            guard !Task.isCancelled, activeAccountId == account.id else { return }
+
+            var resolvedIds: [String] = []
+            // `refreshProfile` is an async FFI call that suspends rather than blocking, so
+            // a small fan-out here does not stall the main actor. The local re-resolution
+            // it triggers still funnels through the serialized `ffiQueue`.
+            await withTaskGroup(of: (String, Bool).self) { group in
+                for accountIdHex in batch {
+                    group.addTask { @MainActor in
+                        let resolved = await self.refreshPeerProfile(
+                            accountIdHex: accountIdHex,
+                            account: account,
+                            relays: relays,
+                            client: client
+                        )
+                        return (accountIdHex, resolved)
+                    }
+                }
+                for await (accountIdHex, resolved) in group where resolved {
+                    resolvedIds.append(accountIdHex)
+                }
+            }
+
+            guard !Task.isCancelled, activeAccountId == account.id else { return }
+            if !resolvedIds.isEmpty {
+                schedulePeerProfileReprojection(ids: resolvedIds)
+            }
+        }
+    }
+
+    /// Resolves a peer, going to the relays only if the local directory cannot name them.
+    /// Returns whether the peer became nameable as a result.
+    private func refreshPeerProfile(
+        accountIdHex: String,
+        account: AccountItem,
+        relays: [String],
+        client: any MarmotRuntime
+    ) async -> Bool {
+        let wasComplete = peerProfileFFICache[accountIdHex]?.isComplete == true
+
+        // Every exit path must hand the gate's in-flight slot back. The abort paths below
+        // return without an outcome, and `tryStart` has already marked this id in flight, so
+        // without this the id stays in flight for the life of the process and the gate refuses
+        // it forever — that peer's name would never resolve again.
+        //
+        // Not hypothetical: `restoreOrSelectFirstAccount` and the preferred-account login path
+        // both move `activeAccountId` without going through `resetActiveAccountUIState`, so
+        // they never call `clearPeerProfileRefreshState`. A refresh suspended in the relay
+        // round-trip when either runs resumes straight into the account-mismatch return.
+        //
+        // `remove` rather than `finish`: no attempt outcome was observed, so this must not
+        // charge the backoff ladder for a round-trip whose result we discarded.
+        var recordedOutcome = false
+        defer {
+            if !recordedOutcome {
+                peerProfileRefreshGate.remove(accountIdHex)
+            }
+        }
+
+        // Try the local directory first. MDK may already hold this peer's kind:0 — fetched
+        // by its own background directory sync, or persisted by an earlier session — and the
+        // roster/sender call sites request every identity they see before anything has read
+        // the cache for it. Going straight to the relays would therefore put a round-trip on
+        // the first sight of an already-known contact, which is most of them.
+        let local = await resolvedPeerFFI(
+            accountIdHex: accountIdHex,
+            activeAccount: account,
+            client: client
+        )
+        guard !Task.isCancelled, activeAccountId == account.id else { return false }
+        if local?.isComplete == true {
+            peerProfileRefreshGate.finish(accountIdHex, now: nowProvider(), resolved: true)
+            recordedOutcome = true
+            return !wasComplete
+        }
+
+        try? await client.refreshProfile(accountIdHex: accountIdHex, relays: relays)
+
+        // A refresh resolving after an account switch must not write the previous
+        // account's directory view into the new account's cache — `selectAccount` /
+        // `selectAccountFromSettings` already cleared it (whitenoise-mac#8).
+        guard !Task.isCancelled, activeAccountId == account.id else { return false }
+
+        // Drop the incomplete entry so `resolvedPeerFFI` re-reads Rust instead of
+        // serving the pre-refresh miss back, exactly as `resolveNewChatRecipient` does.
+        peerProfileFFICache[accountIdHex] = nil
+        let resolved = await resolvedPeerFFI(
+            accountIdHex: accountIdHex,
+            activeAccount: account,
+            client: client
+        )
+
+        guard activeAccountId == account.id else { return false }
+        let isResolved = resolved?.isComplete == true
+        // A nicknamed peer is already labelled correctly everywhere it renders — the nickname
+        // outranks every published source. The only thing an unresolved lookup still costs
+        // them is the published name shown under the nickname, which is not worth the urgent
+        // 2s/4s ladder. Settling the run here sends them straight to the escalating cooldown.
+        // Read at finish time, not in `requestPeerProfileRefresh`: this is off the projection
+        // hot path, so the check costs nothing the timeline pays for.
+        let hasNickname =
+            !isResolved
+            && activeContactNicknames.nickname(forContactAccountIdHex: accountIdHex) != nil
+        peerProfileRefreshGate.finish(
+            accountIdHex,
+            now: nowProvider(),
+            resolved: isResolved,
+            deferRetries: hasNickname
+        )
+        recordedOutcome = true
+        return isResolved && !wasComplete
+    }
+
+    private func nextQueuedPeerProfileRefreshIds(limit: Int) -> [String] {
+        guard limit > 0, !queuedPeerProfileRefreshIds.isEmpty else { return [] }
+        let count = min(limit, queuedPeerProfileRefreshIds.count)
+        let ids = Array(queuedPeerProfileRefreshIds.prefix(count))
+        queuedPeerProfileRefreshIds.removeFirst(count)
+        return ids
+    }
+
+    private func finishPeerProfileRefreshQueue(taskId: UUID) {
+        guard peerProfileRefreshTaskId == taskId else { return }
+        peerProfileRefreshTask = nil
+        peerProfileRefreshTaskId = nil
+        // Ids appended while this drain was returning would otherwise sit unowned.
+        startPeerProfileRefreshQueueIfNeeded()
+    }
+
+    /// `peerProfileLookupRelays` for whichever account is active, falling back to the seed
+    /// relays when there is none. The callers that refresh a *named* identity — the local
+    /// account sweep, and a hand-typed New Chat recipient — all need this same choice.
+    func peerProfileLookupRelaysForActiveAccount() async -> [String] {
+        guard let activeAccount else { return MarmotClient.seedRelays }
+        return await peerProfileLookupRelays(for: activeAccount)
+    }
+
+    /// Relays to search for a peer's kind:0: the seed relays plus the active account's
+    /// own NIP-65 set, deduped. Seed relays alone miss a peer who publishes only to
+    /// their own write relays; Android composes the same union in `profileLookupRelays`.
+    func peerProfileLookupRelays(for account: AccountItem) async -> [String] {
+        if let cached = peerProfileLookupRelaysByAccountId[account.id] { return cached }
+        guard let client else { return MarmotClient.seedRelays }
+
+        let accountRelays =
+            (try? await runOffMain { try client.accountRelayLists(accountRef: account.accountRef) })?
+            .nip65.relays ?? []
+
+        var relays: [String] = []
+        var seen = Set<String>()
+        for relay in MarmotClient.seedRelays + accountRelays where seen.insert(relay).inserted {
+            relays.append(relay)
+        }
+        // Only cache under the account that is still active; a switch mid-read must not
+        // pin the previous account's relay set.
+        if activeAccountId == account.id {
+            peerProfileLookupRelaysByAccountId[account.id] = relays
+        }
+        return relays
+    }
+
+    // MARK: - Re-project
+
+    /// Coalescing entry point for "these peers became nameable — repaint what shows them".
+    ///
+    /// Deliberately not driven by observing `peerProfileGeneration`: the bump is a
+    /// notification for view-level observers, while the re-projection is scheduled
+    /// directly so a future push-based profile stream can call this same function
+    /// without a polling loop in between.
+    func schedulePeerProfileReprojection(ids: some Sequence<String>) {
+        let ids = Set(ids).subtracting([""])
+        guard !ids.isEmpty else { return }
+        pendingPeerProfileReprojectionIds.formUnion(ids)
+        peerProfileReprojectionArrivals &+= 1
+        peerProfileGeneration &+= 1
+
+        guard peerProfileReprojectionTask == nil else { return }
+        let taskId = UUID()
+        peerProfileReprojectionTaskId = taskId
+        peerProfileReprojectionTask = Task { [weak self] in
+            await self?.awaitPeerProfileReprojectionDebounce(taskId: taskId)
+        }
+    }
+
+    /// Trailing debounce: each new batch of resolutions restarts the wait, so a drain that
+    /// keeps landing ids produces one re-projection at the end instead of one per window.
+    ///
+    /// A fixed leading window is the wrong shape here. The refresh queue resolves in batches
+    /// of `peerProfileRefreshFanout`, and each batch calls this — so opening a chat with 40
+    /// unnamed senders paid a full transcript re-map every 250ms for the length of the drain,
+    /// with only the last one showing the finished state.
+    ///
+    /// Extension is counted, not clocked: `nowProvider` is a fake in tests, and a frozen
+    /// clock would spin here. `maxPeerProfileReprojectionDebounceExtensions` therefore caps
+    /// the total wait, so a long drain still repaints partway through rather than staying
+    /// blank until it finishes.
+    private func awaitPeerProfileReprojectionDebounce(taskId: UUID) async {
+        var extensions = 0
+        while true {
+            let arrivalsBeforeSleep = peerProfileReprojectionArrivals
+            try? await Task.sleep(nanoseconds: Self.peerProfileReprojectionDebounceNanoseconds)
+            guard !Task.isCancelled else {
+                // Release ownership of the slot even when the debounce is cancelled mid-sleep.
+                // Returning without this would leave `peerProfileReprojectionTask` non-nil
+                // forever, and the `== nil` guard in `schedule` would then swallow every later
+                // resolution for the life of the process.
+                finishPeerProfileReprojection(taskId: taskId)
+                return
+            }
+            guard peerProfileReprojectionArrivals != arrivalsBeforeSleep,
+                extensions < Self.maxPeerProfileReprojectionDebounceExtensions
+            else { break }
+            extensions += 1
+        }
+        await runPeerProfileReprojection(taskId: taskId)
+    }
+
+    private func runPeerProfileReprojection(taskId: UUID) async {
+        guard peerProfileReprojectionTaskId == taskId else { return }
+        let ids = pendingPeerProfileReprojectionIds
+        pendingPeerProfileReprojectionIds.removeAll()
+
+        defer { finishPeerProfileReprojection(taskId: taskId) }
+        guard !ids.isEmpty, let client, let account = activeAccount else { return }
+        #if DEBUG
+            peerProfileReprojectionCount += 1
+        #endif
+
+        await reprojectSelectedTimelineForPeerProfiles(ids: ids, account: account, client: client)
+        guard activeAccountId == account.id else { return }
+        await reprojectChatRowsForPeerProfiles(ids: ids, account: account, client: client)
+    }
+
+    private func finishPeerProfileReprojection(taskId: UUID) {
+        guard peerProfileReprojectionTaskId == taskId else { return }
+        peerProfileReprojectionTask = nil
+        peerProfileReprojectionTaskId = nil
+        // Resolutions that landed during the pass above own no task yet.
+        if !pendingPeerProfileReprojectionIds.isEmpty {
+            let pending = pendingPeerProfileReprojectionIds
+            pendingPeerProfileReprojectionIds.removeAll()
+            schedulePeerProfileReprojection(ids: pending)
+        }
+    }
+
+    /// Replays the open conversation's authoritative window so every row re-resolves its
+    /// sender name — including rows the live delta path would never revisit.
+    ///
+    /// `snapshot()` is a pure in-memory clone of the window the runtime already holds: no
+    /// store read, no relay traffic, and identical bounds, so a scrolled-back reader keeps
+    /// their position and pagination state. `loadMessages` would instead re-run the
+    /// initial-load path and re-anchor the window to the head.
+    private func reprojectSelectedTimelineForPeerProfiles(
+        ids: Set<String>,
+        account: AccountItem,
+        client: any MarmotRuntime
+    ) async {
+        guard let subscription = activeTimelineSubscription,
+            let groupIdHex = activeTimelineGroupId,
+            selectedChat?.id == groupIdHex
+        else { return }
+
+        // Replay only when a resolved id is one the open window's rows actually name. Most
+        // requests come from rosters and reaction lists — a 40-member group whose members
+        // have never posted, or reactors whose rows read `peerProfileFFICache` directly and
+        // repaint on their own. Replaying for those re-maps and re-diffs the whole transcript
+        // to produce byte-identical rows, once per debounce window for the length of a drain.
+        //
+        // `timelineProjectedSenderIds` is the exact `senderIds` set the last projection of
+        // this window resolved, so it covers reply-quote authors and group-system actors too
+        // — identities the materialized `MessageItem`s do not carry and a scan of the store
+        // would miss.
+        guard let projectedSenderIds = timelineProjectedSenderIds[groupIdHex],
+            !projectedSenderIds.isDisjoint(with: ids)
+        else { return }
+
+        guard let page = try? await runOffMain({ subscription.snapshot() }) else { return }
+        guard activeAccountId == account.id,
+            activeTimelineSubscription === subscription,
+            selectedChat?.id == groupIdHex
+        else { return }
+
+        await applyTimelineWindow(
+            page,
+            groupIdHex: groupIdHex,
+            account: account,
+            client: client,
+            owner: .subscription(subscription)
+        )
+    }
+
+    /// Re-titles direct-chat rows whose peer just became nameable.
+    ///
+    /// Scoped to direct chats on purpose: a group row's title comes from the group's own
+    /// metadata, and its preview's "Alice: " prefix is resolved by MDK on every row read
+    /// (`hydrate_chat_list_rows`), so the next chat-list delta carries the new name
+    /// without any client work. Only the direct-chat title and avatar are projected from
+    /// a peer profile this app resolved itself, and only those can go stale here.
+    private func reprojectChatRowsForPeerProfiles(
+        ids: Set<String>,
+        account: AccountItem,
+        client: any MarmotRuntime
+    ) async {
+        // Resolve which groups are affected once, from the roster cache, instead of scanning
+        // every chat's member list per chat. Chat iteration then costs a set lookup per row.
+        var affectedGroupIds = Set<String>()
+        for (groupIdHex, members) in groupMemberDetailsCache
+        where members.contains(where: { ids.contains($0.memberIdHex) }) {
+            affectedGroupIds.insert(groupIdHex)
+        }
+
+        var updated: [ChatItem] = []
+        // Walk the two stored arrays in place. Concatenating them would copy every chat row
+        // on every re-projection; the outer array here only holds two copy-on-write handles.
+        for chats in [chatsByAccount[account.id] ?? [], archivedChatsByAccount[account.id] ?? []] {
+            for chat in chats {
+                guard !Task.isCancelled, activeAccountId == account.id else { return }
+                // `avatarSeed` is the peer's account id for an enriched direct chat; the
+                // roster check also catches a row whose first enrichment ran before the
+                // roster was cached.
+                guard affectedGroupIds.contains(chat.id) || ids.contains(chat.avatarSeed),
+                    let members = groupMemberDetailsCache[chat.id]
+                else { continue }
+
+                // Test two-party membership here rather than letting `directPeerProfile` return
+                // nil for group rows. It is not a pure query: on a multi-member roster it calls
+                // `forgetDirectPeer`, and it resolves the peer over FFI before it can answer. A
+                // profile refresh has no business dropping remembered-peer state, and paying an
+                // FFI resolve per group row on every pass is the cost this guard removes.
+                guard Self.otherMembers(in: members, activeAccount: account).count == 1 else { continue }
+
+                // `readStateMetadataEnrichmentAttempts` is a permanent per-group "tried once"
+                // flag, so a group whose single enrichment pass ran before this peer's
+                // metadata landed could never re-enrich from the read-state path. Clearing it
+                // here re-arms that one retry now that the underlying data changed.
+                readStateMetadataEnrichmentAttempts.remove(chat.id)
+
+                // `directPeerProfile` already folds in any private nickname, so `displayName`
+                // is nickname-first and `publishedDisplayName` carries what the peer actually
+                // published. Re-projecting from it therefore refreshes the published name
+                // behind a nickname without ever overwriting the nickname itself.
+                guard
+                    let peer = await directPeerProfile(
+                        from: members,
+                        groupIdHex: chat.id,
+                        activeAccount: account,
+                        client: client
+                    ),
+                    let name = PeerDisplayText.sanitize(peer.displayName),
+                    !name.isEmpty
+                else { continue }
+                let publishedName = peer.publishedDisplayName.flatMap { PeerDisplayText.sanitize($0) }
+                guard
+                    name != chat.title
+                        || publishedName != chat.publishedTitle
+                        || peer.pictureURL != chat.pictureURL
+                else { continue }
+
+                updated.append(
+                    chat.replacingPeerPresentation(
+                        displayName: name,
+                        publishedDisplayName: publishedName,
+                        pictureURL: peer.pictureURL
+                    )
+                )
+            }
+        }
+
+        guard !updated.isEmpty, !Task.isCancelled, activeAccountId == account.id else { return }
+        applyChatMetadataEnrichment(updated, account: account)
+    }
+
+    // MARK: - Lifecycle
+
+    /// Drops all relay-refresh state. Called wherever `peerProfileFFICache` is cleared:
+    /// admission cooldowns, the queue, and the relay-set cache are all scoped to the
+    /// active account's directory view, and a queued id resolved after a switch would
+    /// otherwise write that account's identity into the new one's cache.
+    func clearPeerProfileRefreshState() {
+        peerProfileRefreshGate.removeAll()
+        queuedPeerProfileRefreshIds.removeAll()
+        peerProfileLookupRelaysByAccountId.removeAll()
+        pendingPeerProfileReprojectionIds.removeAll()
+        // Sender sets describe the previous account's windows; the new account's timelines
+        // record their own on first projection.
+        timelineProjectedSenderIds.removeAll()
+        let refreshTask = peerProfileRefreshTask
+        peerProfileRefreshTask = nil
+        peerProfileRefreshTaskId = nil
+        refreshTask?.cancel()
+        let reprojectionTask = peerProfileReprojectionTask
+        peerProfileReprojectionTask = nil
+        peerProfileReprojectionTaskId = nil
+        reprojectionTask?.cancel()
+    }
+
+    #if DEBUG
+        /// Test hook: settle every queued relay refresh, including a drain already in flight.
+        ///
+        /// Starting a second drain instead of awaiting the live one races it: the in-flight
+        /// pass may already have popped the ids under test and still be suspended in
+        /// `refreshProfile`, so a fresh drain finds an empty queue and returns before
+        /// anything has been fetched.
+        func settlePeerProfileRefreshQueueForTesting() async {
+            while true {
+                if let task = peerProfileRefreshTask {
+                    // `runPeerProfileRefreshQueue` finishes its bookkeeping in a `defer`, so the
+                    // task slot is already cleared (and re-armed, if ids arrived late) here.
+                    await task.value
+                    continue
+                }
+                guard !queuedPeerProfileRefreshIds.isEmpty else { return }
+                let taskId = UUID()
+                peerProfileRefreshTaskId = taskId
+                await runPeerProfileRefreshQueue(taskId: taskId)
+            }
+        }
+
+        /// Test hook: run the debounced re-projection body without the 250ms sleep.
+        func runPeerProfileReprojectionForTesting() async {
+            let taskId = UUID()
+            peerProfileReprojectionTask?.cancel()
+            peerProfileReprojectionTask = nil
+            peerProfileReprojectionTaskId = taskId
+            await runPeerProfileReprojection(taskId: taskId)
+        }
+    #endif
+}

--- a/whitenoise-mac/Core/WorkspaceState+Reactions.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Reactions.swift
@@ -29,6 +29,11 @@ extension WorkspaceState {
                 isSelf: true
             )
         }
+        // Read-only on purpose: this runs inside a SwiftUI view body, once per reactor per
+        // render pass. Reaction senders are requested from `messageSenderProfiles` on the
+        // projection path instead — once per window/delta rather than once per frame.
+        // `peerProfileFFICache` is observed, so a name resolved there reaches this row on its
+        // own with no re-projection.
         let resolved = peerProfileFFICache[accountIdHex]?.resolved
         let rosterMember = selectedChat.flatMap { chat in
             groupMemberDetailsCache[chat.id]?.first { $0.memberIdHex == accountIdHex }

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -433,6 +433,11 @@ extension WorkspaceState {
             guard activeAccountId == accountId else { return }
             relaySettings = RelaySettingsSnapshot(lists: lists)
             relayDraft = relaySettings.relays(for: selectedRelaySection)
+            // `peerProfileLookupRelays(for:)` memoizes the seed + NIP-65 union for the whole
+            // session, so without this a user who edits their relays here keeps searching the
+            // pre-edit set for peer kind:0 until they switch accounts. Drop just this
+            // account's entry; the next lookup rebuilds it from the list we were handed.
+            peerProfileLookupRelaysByAccountId[accountId] = nil
         } catch {
             guard activeAccountId == accountId else { return }
             lastError = error.localizedDescription

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1581,6 +1581,48 @@ final class WorkspaceState {
     /// and cleared on account switch.
     var peerProfileFFICache: [String: CachedPeerProfile] = [:]
 
+    // MARK: - Peer profile relay refresh (see WorkspaceState+PeerProfiles.swift)
+
+    /// Admission control for relay kind:0 refreshes: per-id in-flight dedup, a bounded
+    /// backoff ladder, and a long cooldown. Account-scoped like `peerProfileFFICache`.
+    @ObservationIgnored var peerProfileRefreshGate = PeerProfileRefreshGate()
+    /// FIFO of ids admitted by the gate and waiting for a relay refresh.
+    @ObservationIgnored var queuedPeerProfileRefreshIds: [String] = []
+    @ObservationIgnored var peerProfileRefreshTask: Task<Void, Never>?
+    @ObservationIgnored var peerProfileRefreshTaskId: UUID?
+    /// Relay set used for targeted kind:0 fetches, cached per account. Seed relays alone
+    /// miss a peer who publishes only to their own NIP-65 write relays.
+    @ObservationIgnored var peerProfileLookupRelaysByAccountId: [String: [String]] = [:]
+    /// Ids whose cached lookup became usable since the last re-projection pass. Drained
+    /// by `runPeerProfileReprojection`.
+    @ObservationIgnored var pendingPeerProfileReprojectionIds = Set<String>()
+    @ObservationIgnored var peerProfileReprojectionTask: Task<Void, Never>?
+    @ObservationIgnored var peerProfileReprojectionTaskId: UUID?
+    /// Bumped by every `schedulePeerProfileReprojection` call. The debounce compares it across
+    /// its sleep to detect "more resolutions landed", without needing a clock it can trust.
+    @ObservationIgnored var peerProfileReprojectionArrivals: UInt64 = 0
+    /// The `senderIds` set the last timeline projection of each group resolved labels for.
+    /// Lets a resolution skip replaying a window that shows none of the affected identities.
+    @ObservationIgnored var timelineProjectedSenderIds: [String: Set<String>] = [:]
+    /// Bumped when a refresh actually made a peer's profile resolvable. Views that read a
+    /// baked projection (rather than `peerProfileFFICache` directly) can observe this to
+    /// invalidate. The re-projection itself is driven by `schedulePeerProfileReprojection`,
+    /// not by polling this token, so a future push-based profile stream can share the same
+    /// entry point.
+    var peerProfileGeneration: UInt64 = 0
+
+    /// Coalescing window for profile-driven re-projection. A roster resolving one member
+    /// at a time must cost one re-projection, not one per member.
+    static let peerProfileReprojectionDebounceNanoseconds: UInt64 = 250_000_000
+    /// Concurrent relay refreshes. Android allows 6; this app also funnels the local
+    /// re-resolution through one serialized FFI queue (`ffiQueue`), so a lower ceiling
+    /// keeps the timeline hot path clear.
+    static let peerProfileRefreshFanout = 4
+    /// How many times a still-draining queue may restart the re-projection debounce. Caps the
+    /// coalescing window at roughly two seconds, so a long drain repaints on the way rather
+    /// than only at the end.
+    static let maxPeerProfileReprojectionDebounceExtensions = 7
+
     /// Per-group membership cache used by chat-list enrichment and timeline sender-name
     /// projection. Group rows already carry the latest group metadata; these call sites only
     /// need members to identify direct chats and provide member-name fallbacks, so cache just
@@ -1607,6 +1649,15 @@ final class WorkspaceState {
         /// state this must stay flat across timeline windows (whitenoise-mac#171). Not read by
         /// production code.
         var timelineSenderMemberFallbackFetchCount = 0
+
+        /// Test-only instrumentation: ids admitted by `peerProfileRefreshGate` for a relay
+        /// refresh. In the all-resolved steady state this must stay flat across timeline
+        /// windows and live deltas — the render paths call `requestPeerProfileRefresh`
+        /// unconditionally and rely on the completeness short-circuit to stay silent.
+        @ObservationIgnored var peerProfileRefreshRequestCount = 0
+        /// Test-only instrumentation: completed profile-driven re-projection passes. Asserts
+        /// that a burst of resolutions coalesces into one pass.
+        @ObservationIgnored var peerProfileReprojectionCount = 0
 
         /// Test hook for stale-result generation counter overflow hardening (issue #182).
         /// Production code only compares owner tokens for equality, so wraparound is valid.
@@ -1757,14 +1808,28 @@ final class WorkspaceState {
     /// A `ResolvedPeerFFI` plus the time it was resolved, so the cache can apply a TTL to
     /// complete lookups and always re-resolve incomplete ones (whitenoise-mac#8).
     struct CachedPeerProfile: Sendable {
-        var resolved: ResolvedPeerFFI
-        var resolvedAt: Date
+        let resolved: ResolvedPeerFFI
+        let resolvedAt: Date
+        /// Precomputed `resolved.isComplete`.
+        ///
+        /// That property trims up to four peer-controlled strings per evaluation, and the
+        /// timeline hot path reads it once per sender on every window apply *and* every live
+        /// delta (`isFresh`, plus the refresh-admission short-circuit). Computing it once at
+        /// insertion turns a repeated per-sender string-trimming cost into a stored `Bool`.
+        /// Both stored properties are `let` so the flag cannot desync from `resolved`.
+        let isComplete: Bool
+
+        init(resolved: ResolvedPeerFFI, resolvedAt: Date) {
+            self.resolved = resolved
+            self.resolvedAt = resolvedAt
+            self.isComplete = resolved.isComplete
+        }
 
         /// Whether this entry may be reused without re-resolving from the Rust store.
         /// Incomplete lookups are never reused; complete lookups are reused until the TTL
         /// elapses so later name/avatar changes are eventually picked up within a session.
         func isFresh(now: Date, ttl: TimeInterval) -> Bool {
-            resolved.isComplete && now.timeIntervalSince(resolvedAt) < ttl
+            isComplete && now.timeIntervalSince(resolvedAt) < ttl
         }
     }
 
@@ -2498,6 +2563,15 @@ final class WorkspaceState {
             uniquingKeysWith: { _, new in new }
         )
         let nicknames = activeContactNicknames
+        // The roster and the inviter are the identities an invite shows before any message
+        // exists, and MDK does not promote a welcome's members to watched directory users —
+        // so nothing else would ever fetch their kind:0. `welcomerAccountIdHex` is the
+        // account that sent the welcome for this group.
+        requestPeerProfileRefresh(
+            details.members.map(\.memberIdHex)
+                + details.group.admins
+                + [details.group.welcomerAccountIdHex].compactMap { $0 }
+        )
         let members = details.members
             .map { member in
                 let action = actionByMemberId[member.memberIdHex]

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -116,9 +116,11 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     let previewAttachmentKind: ChatPreviewAttachmentKind?
     let updatedAt: Date?
     let avatarSeed: String
-    let pictureURL: String?
+    /// `private(set)` so the only in-place writer is `replacingPeerPresentation` below, which
+    /// re-derives `sanitizedPictureURL` alongside it. The two must never disagree.
+    private(set) var pictureURL: String?
     /// Pre-sanitized avatar URL for chat rows/headers; the view still applies `loadRemoteImages`.
-    let sanitizedPictureURL: URL?
+    private(set) var sanitizedPictureURL: URL?
     /// Decrypted encrypted-Blossom group image. Direct chats leave this nil and use the peer
     /// profile picture instead. The payload id is the component's content hash, so decoded-image
     /// caching naturally invalidates when the group commits a replacement image.
@@ -178,6 +180,30 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         } else {
             copy.title = published
             copy.publishedTitle = nil
+        }
+        return copy
+    }
+
+    /// A copy whose peer-derived presentation — title, the published name a nickname is
+    /// overriding, and the avatar — reflects a profile that resolved after this row was built.
+    ///
+    /// Mutates a copy rather than re-invoking the memberwise initializer. Listing the carried
+    /// fields by hand reads as exhaustive but silently drops any field added to `ChatItem`
+    /// later, and every one of them (unread counts, mute and membership state, the preview's
+    /// attachment glyph) is row state a profile refresh has no business inventing.
+    nonisolated func replacingPeerPresentation(
+        displayName: String,
+        publishedDisplayName: String?,
+        pictureURL: String?
+    ) -> ChatItem {
+        var copy = self
+        copy.title = displayName
+        // A private nickname makes `title` the nickname and `publishedTitle` the name the peer
+        // actually publishes, so the published name has to be carried explicitly here.
+        copy.publishedTitle = publishedDisplayName
+        if let pictureURL {
+            copy.pictureURL = pictureURL
+            copy.sanitizedPictureURL = RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
         }
         return copy
     }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -3742,6 +3742,310 @@ struct PureValueTests {
         #expect(ChatRowStatus.status(for: leaving) == .leaving)
         #expect(ChatDestructiveActions.action(for: leaving) == nil)
     }
+
+    // MARK: - PeerProfileRefreshGate
+
+    @Test func peerProfileGateDedupesInFlightAttemptsForTheSameAccount() {
+        var gate = PeerProfileRefreshGate()
+        let now = Date(timeIntervalSince1970: 1_000)
+
+        let firstAttempt = gate.tryStart("alice", now: now)
+        // A second caller for the same id while the first attempt is outstanding must not
+        // start another relay round-trip: render paths ask on every frame.
+        let concurrentAttempt = gate.tryStart("alice", now: now)
+        // A different id is unaffected.
+        let otherPeer = gate.tryStart("bob", now: now)
+
+        #expect(firstAttempt)
+        #expect(!concurrentAttempt)
+        #expect(otherPeer)
+    }
+
+    @Test func peerProfileGateSuppressesRetriesUntilTheBackoffElapses() {
+        var gate = PeerProfileRefreshGate()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        _ = gate.tryStart("alice", now: start)
+        gate.finish("alice", now: start, resolved: false)
+
+        // A first failure backs off by 2s; nothing before that instant may start.
+        let duringBackoff = gate.tryStart("alice", now: start.addingTimeInterval(1.9))
+        let afterBackoff = gate.tryStart("alice", now: start.addingTimeInterval(2.0))
+
+        #expect(!duringBackoff)
+        #expect(afterBackoff)
+    }
+
+    @Test func peerProfileGateWalksTheBackoffLadderThenFallsBackToTheLongCooldown() {
+        // Attempt 1 → 2s, attempt 2 → 4s, attempt 3 spends the run → the long cooldown.
+        // Mirrors whitenoise-linux's 3-attempt 2s/4s ladder, so a peer whose kind:0 is
+        // nowhere costs a bounded number of round-trips instead of looping.
+        var gate = PeerProfileRefreshGate()
+        var now = Date(timeIntervalSince1970: 1_000)
+        var observedDelays: [TimeInterval] = []
+
+        for _ in 0..<PeerProfileRefreshGate.maxAttemptsPerWindow {
+            _ = gate.tryStart("alice", now: now)
+            gate.finish("alice", now: now, resolved: false)
+            let retryAfter = gate.retryAfterForTesting("alice")
+            observedDelays.append(retryAfter?.timeIntervalSince(now) ?? -1)
+            now = retryAfter ?? now
+        }
+
+        #expect(observedDelays == [2, 4, PeerProfileRefreshGate.retryCooldown])
+        // The ladder resets once the run is spent, so a later window starts fresh.
+        #expect(gate.attemptForTesting("alice") == 0)
+    }
+
+    @Test func peerProfileGateAppliesTheLongCooldownOnceAPeerResolves() {
+        var gate = PeerProfileRefreshGate()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        _ = gate.tryStart("alice", now: start)
+        gate.finish("alice", now: start, resolved: true)
+        // Read the ladder state before the probes below: the `tryStart` at +60 prunes this
+        // settled entry as its cooldown expires, which is the intended bound.
+        #expect(gate.attemptForTesting("alice") == 0)
+
+        let duringCooldown = gate.tryStart("alice", now: start.addingTimeInterval(59))
+        let afterCooldown = gate.tryStart("alice", now: start.addingTimeInterval(60))
+
+        #expect(!duringCooldown)
+        #expect(afterCooldown)
+    }
+
+    @Test func peerProfileGatePrunesSettledEntriesOnFinishNotOnlyOnTryStart() {
+        // Android's #230: a gate that goes quiescent after a burst of `finish` calls — a large
+        // group whose senders all resolve in one pass — must not retain one entry per distinct
+        // pubkey for the process lifetime. Pruning on `finish` too bounds the retained set to
+        // the pubkeys with a live cooldown rather than every pubkey ever seen.
+        var gate = PeerProfileRefreshGate()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        for index in 0..<50 {
+            let id = "peer-\(index)"
+            _ = gate.tryStart(id, now: start)
+            gate.finish(id, now: start, resolved: true)
+        }
+        #expect(gate.retainedEntryCountForTesting == 50)
+
+        // One later `finish`, past every cooldown, sweeps the whole settled set.
+        let later = start.addingTimeInterval(PeerProfileRefreshGate.retryCooldown + 1)
+        _ = gate.tryStart("late", now: later)
+        gate.finish("late", now: later, resolved: true)
+
+        #expect(gate.retainedEntryCountForTesting == 1)
+    }
+
+    @Test func peerProfileGateRetainsAMidLadderEntryPastItsBackoffSoTheLadderCannotRestart() {
+        // Pruning a mid-ladder entry the moment its backoff expired would drop the attempt
+        // counter, and the next request would restart at 2s forever instead of ever reaching
+        // the long cooldown. Retention is still bounded: an entry nobody re-asks about within
+        // one cooldown of its backoff expiring is stale, and does reset.
+        var gate = PeerProfileRefreshGate()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        _ = gate.tryStart("alice", now: start)
+        gate.finish("alice", now: start, resolved: false)
+
+        let secondAttemptAt = start.addingTimeInterval(2.5)
+        _ = gate.tryStart("alice", now: secondAttemptAt)
+        gate.finish("alice", now: secondAttemptAt, resolved: false)
+        // The 4s rung, i.e. attempt 2 — not attempt 1 again.
+        #expect(gate.retryAfterForTesting("alice")?.timeIntervalSince(secondAttemptAt) == 4)
+
+        let longAbandoned = secondAttemptAt.addingTimeInterval(4 + PeerProfileRefreshGate.retryCooldown + 1)
+        _ = gate.tryStart("alice", now: longAbandoned)
+        #expect(gate.attemptForTesting("alice") == nil)
+    }
+
+    @Test func peerProfileGateRemoveClearsAdmissionStateForAnExternalUpdate() {
+        // A profile that arrives from outside this gate must not be held off by the cooldown
+        // the gate set for its own earlier failed attempt.
+        var gate = PeerProfileRefreshGate()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        _ = gate.tryStart("alice", now: start)
+        gate.finish("alice", now: start, resolved: false)
+        let blockedByCooldown = gate.tryStart("alice", now: start)
+
+        gate.remove("alice")
+        let allowedAfterRemove = gate.tryStart("alice", now: start)
+
+        #expect(!blockedByCooldown)
+        #expect(allowedAfterRemove)
+    }
+
+    @Test func peerProfileGateEscalatesTheCooldownAcrossRepeatedFailedRuns() {
+        // Without escalation the gate is an infinite pulse: a spent run reset the ladder, the
+        // 60s cooldown elapsed, and the next projection re-admitted the id at 2s — three relay
+        // round-trips per peer per ~66s for the life of the process. The projection paths
+        // request every sender and roster member they see, so an unresolvable 50-member group
+        // sustained that forever. Each successive dead run must cost less than the last.
+        var gate = PeerProfileRefreshGate()
+        var now = Date(timeIntervalSince1970: 1_000)
+        var cooldowns: [TimeInterval] = []
+
+        // Four runs: one more than `repeatedFailureCooldowns` has rungs, to pin the ceiling.
+        for _ in 0..<4 {
+            var settledAt = now
+            for _ in 0..<PeerProfileRefreshGate.maxAttemptsPerWindow {
+                let admitted = gate.tryStart("alice", now: now)
+                #expect(admitted)
+                gate.finish("alice", now: now, resolved: false)
+                settledAt = now
+                now = gate.retryAfterForTesting("alice") ?? now
+            }
+            // `now` is the instant the spent run will next admit; the delta from the last
+            // `finish` is the cooldown that run actually bought.
+            cooldowns.append(now.timeIntervalSince(settledAt))
+        }
+
+        #expect(cooldowns == [60, 300, 1800, 1800])
+        #expect(gate.failedRunsForTesting("alice") == 4)
+    }
+
+    @Test func peerProfileGateHoldsAFailedRunPastItsCooldownSoEscalationSurvivesPruning() {
+        // The escalation lives in the retained entry. Pruning it the moment its cooldown
+        // elapsed would drop `failedRuns` and put the id straight back on the 2s rung — the
+        // exact pulse the escalation exists to stop.
+        var gate = PeerProfileRefreshGate()
+        var now = Date(timeIntervalSince1970: 1_000)
+
+        for _ in 0..<PeerProfileRefreshGate.maxAttemptsPerWindow {
+            _ = gate.tryStart("alice", now: now)
+            gate.finish("alice", now: now, resolved: false)
+            now = gate.retryAfterForTesting("alice") ?? now
+        }
+        #expect(gate.failedRunsForTesting("alice") == 1)
+
+        // Admitted again once the cooldown elapses, and the run count carries forward.
+        let admittedAfterCooldown = gate.tryStart("alice", now: now)
+        #expect(admittedAfterCooldown)
+        gate.finish("alice", now: now, resolved: false)
+        #expect(gate.failedRunsForTesting("alice") == 1)
+        #expect(gate.attemptForTesting("alice") == 1)
+    }
+
+    @Test func peerProfileGateClearsTheFailureHistoryOnceThePeerResolves() {
+        // A peer going unnameable again later is a fresh problem — a changed pubkey, a rotated
+        // relay set — and must get the responsive ladder back, not the escalated cooldown.
+        var gate = PeerProfileRefreshGate()
+        var now = Date(timeIntervalSince1970: 1_000)
+
+        for _ in 0..<PeerProfileRefreshGate.maxAttemptsPerWindow {
+            _ = gate.tryStart("alice", now: now)
+            gate.finish("alice", now: now, resolved: false)
+            now = gate.retryAfterForTesting("alice") ?? now
+        }
+        #expect(gate.failedRunsForTesting("alice") == 1)
+
+        _ = gate.tryStart("alice", now: now)
+        gate.finish("alice", now: now, resolved: true)
+
+        #expect(gate.failedRunsForTesting("alice") == 0)
+        now = now.addingTimeInterval(PeerProfileRefreshGate.retryCooldown)
+        _ = gate.tryStart("alice", now: now)
+        gate.finish("alice", now: now, resolved: false)
+        // Back on the first rung of the urgent ladder.
+        #expect(gate.retryAfterForTesting("alice")?.timeIntervalSince(now) == 2)
+    }
+
+    @Test func peerProfileGateDeferRetriesSkipsTheUrgentLadderAndSettlesTheRun() {
+        // A nicknamed peer already renders correctly everywhere; only the published name shown
+        // beneath the nickname is missing. That does not justify the 2s/4s burst.
+        var gate = PeerProfileRefreshGate()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        _ = gate.tryStart("alice", now: start)
+        gate.finish("alice", now: start, resolved: false, deferRetries: true)
+
+        #expect(gate.retryAfterForTesting("alice")?.timeIntervalSince(start) == 60)
+        #expect(gate.attemptForTesting("alice") == 0)
+        // One deferred run still counts, so a peer who stays unnameable keeps escalating.
+        #expect(gate.failedRunsForTesting("alice") == 1)
+    }
+
+    // MARK: - ChatItem peer presentation
+
+    @Test func replacingPeerPresentationCarriesEveryFieldItDoesNotOwn() {
+        // This copy used to re-invoke the memberwise initializer and list the carried fields by
+        // hand, which silently dropped `previewAttachmentKind` the moment that field was added:
+        // every direct row whose peer resolved late lost its media glyph. Mutating a copy makes
+        // the carry total by construction.
+        let original = ChatItem(
+            id: "group-1",
+            title: "npub1abc…",
+            subtitle: "subtitle",
+            preview: "Photo",
+            previewAttachmentKind: .photo,
+            updatedAt: Date(timeIntervalSince1970: 1_000),
+            avatarSeed: hex("a"),
+            pictureURL: "https://example.com/old.png",
+            unreadCount: 3,
+            manuallyMarkedUnread: true,
+            unreadMentionCount: 2,
+            isDirect: true,
+            hasAuthoritativeConversationKind: true,
+            muted: true,
+            mutedUntilMs: 12_345,
+            leaveRequestPending: true,
+            pendingConfirmation: true,
+            selfMembership: .left
+        )
+
+        let updated = original.replacingPeerPresentation(
+            displayName: "Ali",
+            publishedDisplayName: "Alice Cooper",
+            pictureURL: "https://example.com/new.png"
+        )
+
+        #expect(updated.title == "Ali")
+        #expect(updated.publishedTitle == "Alice Cooper")
+        #expect(updated.pictureURL == "https://example.com/new.png")
+        // Derived alongside `pictureURL`, never left pointing at the previous avatar.
+        #expect(updated.sanitizedPictureURL == URL(string: "https://example.com/new.png"))
+        // Everything else is row state a profile refresh has no business inventing.
+        #expect(updated.previewAttachmentKind == .photo)
+        #expect(updated.preview == "Photo")
+        #expect(updated.subtitle == "subtitle")
+        #expect(updated.unreadCount == 3)
+        #expect(updated.manuallyMarkedUnread)
+        #expect(updated.unreadMentionCount == 2)
+        #expect(updated.muted)
+        #expect(updated.mutedUntilMs == 12_345)
+        #expect(updated.leaveRequestPending)
+        #expect(updated.pendingConfirmation)
+        #expect(updated.selfMembership == .left)
+        #expect(updated.updatedAt == original.updatedAt)
+    }
+
+    @Test func replacingPeerPresentationKeepsTheExistingAvatarWhenNoneResolved() {
+        // A peer whose name resolved but whose picture did not must not be blanked back to no
+        // avatar; `nil` here means "nothing new", not "clear it".
+        let original = ChatItem(
+            id: "group-1",
+            title: "npub1abc…",
+            subtitle: "",
+            preview: "",
+            updatedAt: nil,
+            avatarSeed: hex("a"),
+            pictureURL: "https://example.com/old.png",
+            unreadCount: 0,
+            isDirect: true
+        )
+
+        let updated = original.replacingPeerPresentation(
+            displayName: "Alice Cooper",
+            publishedDisplayName: nil,
+            pictureURL: nil
+        )
+
+        #expect(updated.title == "Alice Cooper")
+        #expect(updated.publishedTitle == nil)
+        #expect(updated.pictureURL == "https://example.com/old.png")
+        #expect(updated.sanitizedPictureURL == original.sanitizedPictureURL)
+    }
 }
 
 /// 64-char hex built from a short seed, so tests read as `hex("a")` rather than a wall of digits.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -13581,7 +13581,12 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func timelinePagingUsesLocalProfileDataWithoutRefreshingProfiles() async throws {
+    @Test func timelinePagingRefreshesAnUnnameableSenderOncePerGateWindow() async throws {
+        // Paging must not put a relay round-trip on every page. It is no longer "no refresh
+        // at all": a sender the local directory cannot name is now fetched from the relays
+        // (otherwise their npub is all we would ever show). The guard that replaces it is
+        // `PeerProfileRefreshGate` — in-flight dedup plus a backoff ladder — so two pages
+        // covering the same unresolved sender cost one fetch, not two.
         let account = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -13600,8 +13605,8 @@ struct whitenoise_macTests {
             otherAccountIdHex: aliceId,
             otherDisplayName: "Alice",
             otherProfile: UserProfileMetadataFfi(
-                name: nil,
-                displayName: nil,
+                name: "alice",
+                displayName: "Alice",
                 about: nil,
                 picture: nil,
                 nip05: nil,
@@ -13624,12 +13629,21 @@ struct whitenoise_macTests {
         )
         let state = WorkspaceState(clientFactory: { runtime })
 
+        // Deliberately no `clearRefreshedProfileIds()` here: opening the conversation is part
+        // of bootstrap, so the fetch under test happens before this point and clearing would
+        // erase the very evidence the assertions need.
         await state.bootstrap()
-        runtime.clearRefreshedProfileIds()
         await state.loadMessages(groupIdHex: "direct-group")
         await state.loadOlderMessages(groupIdHex: "direct-group")
+        // Drain deterministically instead of racing the queue task against the assertions.
+        await state.settlePeerProfileRefreshQueueForTesting()
 
-        #expect(runtime.refreshedProfileIds.isEmpty)
+        // Bob has no published profile, so he is fetched — once in total, across the initial
+        // open and both page loads, because the gate dedupes and then backs off.
+        #expect(runtime.refreshedProfileIds.filter { $0 == bobId }.count == 1)
+        // Alice is already nameable from the local directory, so she costs no relay hop at
+        // all: the queue resolves locally first and only falls through on a miss.
+        #expect(!runtime.refreshedProfileIds.contains(aliceId))
         #expect(state.messagesByChat["direct-group"]?.first?.id == "message-000")
     }
 
@@ -13709,6 +13723,569 @@ struct whitenoise_macTests {
 
         let secondPass = state.messagesByChat["direct-group"] ?? []
         #expect(secondPass.first?.senderName == "Alice Cooper")
+    }
+
+    @MainActor
+    @Test func lateArrivingPeerMetadataRelabelsAlreadyRenderedMessages() async throws {
+        // The headline fix. `MessageItem.senderName` is baked at projection time and the live
+        // delta path re-maps only *changed* records, so before this a name that landed after a
+        // message was rendered could never reach it — the npub stayed on every old message for
+        // the life of the conversation. A resolved profile now replays the open window through
+        // the authoritative snapshot, so every row re-resolves its sender.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        // Blank roster name and no profile: the npub fallback is the only name available.
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "",
+            otherProfile: UserProfileMetadataFfi(
+                name: nil,
+                displayName: nil,
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.accountIdsMissingProfiles.insert(aliceId)
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<40).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let clock = MutableClock(now: Date(timeIntervalSince1970: 2_000_000_000))
+        let state = WorkspaceState(nowProvider: { clock.now }, clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        // Nothing was published yet, so the whole transcript is stuck on the npub fallback.
+        let beforeMetadata = state.messagesByChat["direct-group"] ?? []
+        #expect(beforeMetadata.count == 40)
+        #expect(beforeMetadata.allSatisfy { $0.senderName == DisplayText.short(aliceId) })
+        // The relays were asked, which is what eventually makes the metadata available.
+        #expect(runtime.refreshedProfileIds.contains(aliceId))
+
+        // Alice's kind:0 lands. Advance past the gate's first backoff rung so the peer is
+        // admitted again, exactly as it would be on any later projection pass.
+        runtime.accountIdsMissingProfiles.remove(aliceId)
+        runtime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Cooper",
+                about: nil,
+                picture: "https://example.com/alice.png",
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        clock.now = clock.now.addingTimeInterval(PeerProfileRefreshGate.retryCooldown + 1)
+        state.requestPeerProfileRefresh([aliceId])
+        await state.settlePeerProfileRefreshQueueForTesting()
+        await state.runPeerProfileReprojectionForTesting()
+
+        // Every message relabels in place — including the oldest, which no delta would revisit.
+        let afterMetadata = state.messagesByChat["direct-group"] ?? []
+        #expect(afterMetadata.allSatisfy { $0.senderName == "Alice Cooper" })
+        #expect(afterMetadata.first?.senderName == "Alice Cooper")
+        // The window is replayed, not reloaded: same rows, same order, same bounds.
+        #expect(afterMetadata.map(\.id) == beforeMetadata.map(\.id))
+        // The sidebar row for the direct chat picks the peer up too.
+        #expect(state.activeChats.first?.title == "Alice Cooper")
+        #expect(state.activeChats.first?.pictureURL == "https://example.com/alice.png")
+    }
+
+    @MainActor
+    @Test func steadyStatePeerProfileRefreshMakesNoRequestsAcrossWindowsAndDeltas() async throws {
+        // The render/projection paths call `requestPeerProfileRefresh` unconditionally, so the
+        // completeness short-circuit is what keeps them affordable. With every sender already
+        // nameable, repeated windows and live deltas must admit nothing at all.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Cooper",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<30).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        let settledRequestCount = state.peerProfileRefreshRequestCount
+        await state.loadOlderMessages(groupIdHex: "direct-group")
+        await state.loadMessages(groupIdHex: "direct-group")
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        #expect(state.peerProfileRefreshRequestCount == settledRequestCount)
+        #expect(!runtime.refreshedProfileIds.contains(aliceId))
+        #expect(state.messagesByChat["direct-group"]?.first?.senderName == "Alice Cooper")
+    }
+
+    @MainActor
+    @Test func reactionAuthorProfilesAreRequestedFromTheProjectionNotTheRenderPath() async throws {
+        // `reactionReactorDisplay` runs inside a SwiftUI view body, once per reactor per render
+        // pass, so it must stay a pure read. The request for a reactor who never sent a message
+        // is issued from `messageSenderProfiles` instead — once per window/delta.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let reactorId = "carol1234567890carol1234567890carol1234567890carol1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        // Carol only ever reacts — she is not in `senderIds`, so before this she was never
+        // resolved at all and her row was stuck on the npub no matter how long you waited.
+        runtime.accountIdsMissingProfiles.insert(reactorId)
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "message-000",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Hello",
+                    kind: 9,
+                    recordedAt: baseTime
+                ),
+                appMessage(
+                    id: "reaction-000",
+                    groupIdHex: "direct-group",
+                    sender: reactorId,
+                    plaintext: "👍",
+                    kind: 7,
+                    tags: [MessageTagFfi(values: ["e", "message-000"])],
+                    recordedAt: baseTime + 1
+                ),
+            ],
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        // The projection path asked for the reactor.
+        #expect(runtime.refreshedProfileIds.contains(reactorId))
+
+        // Rendering her row asks for nothing: no admission, no queue, no relay hop.
+        let requestsBeforeRender = state.peerProfileRefreshRequestCount
+        let reactor = state.reactionReactorDisplay(accountIdHex: reactorId)
+        #expect(state.peerProfileRefreshRequestCount == requestsBeforeRender)
+        #expect(state.queuedPeerProfileRefreshIds.isEmpty)
+        #expect(reactor.accountIdHex == reactorId)
+    }
+
+    @MainActor
+    @Test func peerProfileResolutionsWithinTheDebounceWindowCostOneReprojection() async throws {
+        // A roster resolving one member at a time must repaint once, not once per member.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let baseline = state.peerProfileReprojectionCount
+        state.schedulePeerProfileReprojection(ids: ["peer-a"])
+        state.schedulePeerProfileReprojection(ids: ["peer-b"])
+        state.schedulePeerProfileReprojection(ids: ["peer-c"])
+        // Three bumps, one coalesced pass — and the generation still moves once per resolution
+        // so view-level observers see each change.
+        #expect(state.peerProfileGeneration >= 3)
+
+        await state.runPeerProfileReprojectionForTesting()
+        #expect(state.peerProfileReprojectionCount == baseline + 1)
+        #expect(state.pendingPeerProfileReprojectionIds.isEmpty)
+    }
+
+    @MainActor
+    @Test func resolvingAPeerTheOpenWindowNeverNamesSkipsTheTranscriptReplay() async throws {
+        // Most refresh requests come from rosters and reaction lists, not from anyone the open
+        // transcript labels: a 40-member group whose members have never posted, or reactors
+        // whose rows read `peerProfileFFICache` directly and repaint on their own. Replaying
+        // the window for those re-maps and re-diffs every row to produce identical output —
+        // once per debounce window for the whole length of a drain.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cooper",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Cooper",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.installMessages(
+            (0..<10).map { index in
+                appMessage(
+                    id: String(format: "message-%03d", index),
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "Message \(index)",
+                    kind: 9,
+                    recordedAt: 1_700_000_000 + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        // `snapshot()` is the first thing the transcript replay does, so counting it is a
+        // direct witness for whether the window was replayed at all.
+        let replaysBefore = runtime.syncCallThreadRecord("timelineMessagesSubscription.snapshot").count
+
+        // A peer nobody in this window is labelled from.
+        state.schedulePeerProfileReprojection(ids: ["bob12345678901234567890bob12345678901234567890bob1234567890"])
+        await state.runPeerProfileReprojectionForTesting()
+        let replaysAfterUnrelatedPeer =
+            runtime.syncCallThreadRecord("timelineMessagesSubscription.snapshot").count
+        #expect(replaysAfterUnrelatedPeer == replaysBefore)
+
+        // The sender the window *does* name still replays — the guard scopes the work, it
+        // does not withhold the fix.
+        state.schedulePeerProfileReprojection(ids: [aliceId])
+        await state.runPeerProfileReprojectionForTesting()
+        let replaysAfterWindowSender =
+            runtime.syncCallThreadRecord("timelineMessagesSubscription.snapshot").count
+        #expect(replaysAfterWindowSender > replaysAfterUnrelatedPeer)
+    }
+
+    @MainActor
+    @Test func clearingANicknameReArmsTheMetadataFetchTheCooldownWasHoldingOff() async throws {
+        // Clearing a nickname hands the label back to whatever the peer published, so a missing
+        // kind:0 starts mattering again at exactly that moment. The gate may be sitting on a
+        // cooldown for this id — possibly the long one applied *because* it was nicknamed — and
+        // without dropping that admission state the row keeps the npub until the cooldown ends.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "",
+            otherProfile: UserProfileMetadataFfi(
+                name: nil,
+                displayName: nil,
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        runtime.accountIdsMissingProfiles.insert(aliceId)
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        state.setContactNickname("Ali", forContactAccountIdHex: aliceId)
+        #expect(state.activeChats.first?.title == "Ali")
+
+        // Alice publishes while the nickname is in place, and the gate is holding a cooldown
+        // from the run that already failed for her.
+        runtime.accountIdsMissingProfiles.remove(aliceId)
+        runtime.installProfile(
+            accountIdHex: aliceId,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Cooper",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let requestsBefore = state.peerProfileRefreshRequestCount
+        state.setContactNickname(nil, forContactAccountIdHex: aliceId)
+        #expect(state.peerProfileRefreshRequestCount > requestsBefore)
+
+        await state.settlePeerProfileRefreshQueueForTesting()
+        await state.runPeerProfileReprojectionForTesting()
+
+        // The row lands on the published name rather than sitting on the fallback.
+        #expect(state.activeChats.first?.title == "Alice Cooper")
+    }
+
+    @MainActor
+    @Test func peerProfileRefreshFetchesFromSeedAndAccountNip65Relays() async throws {
+        // Seed relays alone miss a peer who publishes only to their own NIP-65 write relays.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installAccountNip65Relays(["wss://alice.relay.example"])
+        runtime.accountIdsMissingProfiles.insert(bobId)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.requestPeerProfileRefresh([bobId])
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        let relays = runtime.lastProfileRefreshRelays
+        #expect(relays.contains("wss://alice.relay.example"))
+        #expect(MarmotClient.seedRelays.allSatisfy { relays.contains($0) })
+        // Deduped: the seed relays also appear in the account's bootstrap list.
+        #expect(relays.count == Set(relays).count)
+    }
+
+    @MainActor
+    @Test func savingRelaySettingsRebuildsThePeerProfileLookupUnion() async throws {
+        // `peerProfileLookupRelays(for:)` memoizes the seed + NIP-65 union for the session, so
+        // editing relays in Settings would otherwise keep searching the pre-edit set for peer
+        // kind:0 until the next account switch.
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1"
+        let carolId = "caro1234567890caro1234567890caro1234567890caro1234567890caro"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installAccountNip65Relays(["wss://old.relay.example"])
+        runtime.accountIdsMissingProfiles.insert(bobId)
+        runtime.accountIdsMissingProfiles.insert(carolId)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.requestPeerProfileRefresh([bobId])
+        await state.settlePeerProfileRefreshQueueForTesting()
+        #expect(runtime.lastProfileRefreshRelays.contains("wss://old.relay.example"))
+
+        // The user edits their NIP-65 set in Settings.
+        state.selectedRelaySection = .nip65
+        state.relayDraft = ["wss://new.relay.example"]
+        await state.saveRelaySettings()
+
+        state.requestPeerProfileRefresh([carolId])
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        let relays = runtime.lastProfileRefreshRelays
+        #expect(relays.contains("wss://new.relay.example"))
+        #expect(!relays.contains("wss://old.relay.example"))
+        // The seed relays are still folded in, and the union is still deduped.
+        #expect(MarmotClient.seedRelays.allSatisfy { relays.contains($0) })
+        #expect(relays.count == Set(relays).count)
+    }
+
+    @MainActor
+    @Test func anAbortedRefreshHandsBackItsGateSlotInsteadOfStrandingThePeer() async throws {
+        // `tryStart` marks the id in flight, and the abort paths in `refreshPeerProfile` return
+        // without recording an outcome. Leaving the slot held would make the gate refuse that
+        // id for the life of the process — the peer's name could never resolve again.
+        //
+        // Reachable: `restoreOrSelectFirstAccount` and the preferred-account login path both
+        // move `activeAccountId` without going through `resetActiveAccountUIState`, so they
+        // never call `clearPeerProfileRefreshState` to sweep the slot on their way past.
+        let first = AccountSummaryFfi(
+            label: "First Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let second = AccountSummaryFfi(
+            label: "Second Account",
+            accountIdHex: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1"
+        let runtime = FakeMarmotRuntime(accounts: [first, second])
+        runtime.accountIdsMissingProfiles.insert(bobId)
+        // Hold the attempt inside the relay round-trip so the account can move underneath it.
+        runtime.profileRefreshDelaysByAccountId[bobId] = 400_000_000
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let startingAccountId = try #require(state.activeAccountId)
+        state.requestPeerProfileRefresh([bobId])
+        // Let the queue task get as far as the suspended `refreshProfile`.
+        try await Task.sleep(nanoseconds: 80_000_000)
+        #expect(state.peerProfileRefreshGate.inFlightCountForTesting == 1)
+
+        // Exactly what `restoreOrSelectFirstAccount` does — move the active account without
+        // going anywhere near `clearPeerProfileRefreshState`.
+        let otherAccountId = try #require(state.accounts.first { $0.id != startingAccountId }?.id)
+        state.activeAccountId = otherAccountId
+
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        // The aborted attempt handed its slot back rather than stranding the peer.
+        #expect(state.peerProfileRefreshGate.inFlightCountForTesting == 0)
+
+        // Proof that it is really usable again: with the account restored, the same peer is
+        // admitted and actually fetched instead of being refused for the rest of the session.
+        state.activeAccountId = startingAccountId
+        runtime.clearRefreshedProfileIds()
+        runtime.profileRefreshDelaysByAccountId[bobId] = nil
+        state.requestPeerProfileRefresh([bobId])
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        #expect(runtime.refreshedProfileIds.contains(bobId))
+    }
+
+    @MainActor
+    @Test func peerProfileRefreshStateIsDroppedOnAccountSwitch() async throws {
+        // Admission cooldowns, the queue, and the relay-set cache are all scoped to the active
+        // account's directory view, exactly like `peerProfileFFICache` (#8/#9).
+        let first = AccountSummaryFfi(
+            label: "First Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let second = AccountSummaryFfi(
+            label: "Second Account",
+            accountIdHex: "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1"
+        let runtime = FakeMarmotRuntime(accounts: [first, second])
+        runtime.accountIdsMissingProfiles.insert(bobId)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.requestPeerProfileRefresh([bobId])
+        #expect(!state.queuedPeerProfileRefreshIds.isEmpty || state.peerProfileRefreshTask != nil)
+
+        guard let secondAccount = state.accounts.first(where: { $0.accountIdHex == second.accountIdHex }) else {
+            Issue.record("second account missing")
+            return
+        }
+        state.prepareForActiveAccountSwitch(to: secondAccount, preservingMessageCacheFor: nil)
+
+        #expect(state.queuedPeerProfileRefreshIds.isEmpty)
+        #expect(state.peerProfileRefreshTask == nil)
+        #expect(state.peerProfileFFICache.isEmpty)
+        // The cooldown from the previous account must not suppress the new account's first ask.
+        var gate = state.peerProfileRefreshGate
+        let admittedUnderNewAccount = gate.tryStart(bobId, now: Date(timeIntervalSince1970: 1_000))
+        #expect(admittedUnderNewAccount)
+
+        // The switch cancels any in-flight re-projection debounce. Releasing that slot on
+        // cancellation is what keeps re-projection alive: a wedged slot would make the
+        // `peerProfileReprojectionTask == nil` guard swallow every later resolution.
+        state.schedulePeerProfileReprojection(ids: ["peer-after-switch"])
+        #expect(state.peerProfileReprojectionTask != nil)
     }
 
     @MainActor
@@ -28211,6 +28788,19 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         nip05: nil,
         lud16: nil
     )
+    /// Overrides the account's published NIP-65 write relays, so a test can prove a peer
+    /// profile refresh searches them alongside the seed relays.
+    func installAccountNip65Relays(_ relays: [String]) {
+        relayLists = AccountRelayListsFfi(
+            complete: relayLists.complete,
+            missing: relayLists.missing,
+            defaultRelays: relayLists.defaultRelays,
+            bootstrapRelays: relayLists.bootstrapRelays,
+            nip65: RelayListFfi(kind: 10002, relays: relays),
+            inbox: relayLists.inbox
+        )
+    }
+
     private var relayLists = AccountRelayListsFfi(
         complete: true,
         missing: [],
@@ -28402,6 +28992,11 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         recordedStateLock.withLock { _refreshedProfileIds }
     }
     private var _refreshedProfileIds: [String] = []
+    /// Relay set the most recent `refreshProfile` searched.
+    var lastProfileRefreshRelays: [String] {
+        recordedStateLock.withLock { _lastProfileRefreshRelays }
+    }
+    private var _lastProfileRefreshRelays: [String] = []
     private(set) var markedReadMessageIds: [String] = []
     private(set) var accountKeyPackagesCallCount = 0
     /// Number of times `userProfile` was queried — used to assert settings-load coalescing
@@ -28829,7 +29424,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func refreshProfile(accountIdHex: String, relays: [String]) async throws {
-        recordedStateLock.withLock { _refreshedProfileIds.append(accountIdHex) }
+        recordedStateLock.withLock {
+            _refreshedProfileIds.append(accountIdHex)
+            _lastProfileRefreshRelays = relays
+        }
         if let delay = profileRefreshDelaysByAccountId[accountIdHex] {
             try await Task.sleep(nanoseconds: delay)
         }


### PR DESCRIPTION
Before this PR, when receiving a new invite, the npub was shown. And after the metadata was loaded, the old message sstill had the npub instead of the name. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Peer profiles now refresh automatically across chats, messages, reactions, groups, and contact updates.
  - Updated names, published names, and avatars appear in already-loaded conversations without requiring a full reload.
  - Profile lookups use local data and the active account’s available relay settings when applicable.

- **Bug Fixes**
  - Reduced duplicate profile requests and improved retry handling during temporary failures.
  - Profile refresh state now resets correctly when switching, removing, or resetting an account.
  - Clearing a contact nickname now refreshes the contact’s profile data.
  - Profile updates now recover more reliably after temporary failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->