### PR TITLE
Change color palette to dark and white colors

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -48,7 +48,18 @@ struct ContentView: View {
                     workspace.handleMessageLinkOpen(url)
                 }
             )
-            .tint(Color(nsColor: .systemBlue))
+            // The app-wide tint is `fillPrimary`, the primary action's fill on every White Noise
+            // client: near-black in light appearance, white in dark. It is deliberately not a hue —
+            // the palette's only blue is `intentionInfoContent`, reserved for links and search
+            // hits, and the twelve accent sets are reserved for identifying people.
+            .tint(WNColor.fillPrimary)
+            // The default foreground for anything that does not name a color: text and glyphs that
+            // inherit rather than choose. Without this they fall back to AppKit's `labelColor`,
+            // which is close to `backgroundContentPrimary` but is not part of the palette — so an
+            // unstyled glyph on a `fillSecondary` control would be right only by coincidence.
+            // `fillContentSecondary` happens to be the same value, which is why those controls read
+            // correctly by inheritance.
+            .foregroundStyle(WNColor.backgroundContentPrimary)
             .nativeWindowGlassBackground()
             .onOpenURL { url in
                 workspace.handleDeepLinkURL(url)

--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -7,17 +7,6 @@ import SwiftUI
 /// Injected through the builder so the transformation stays pure and off-main.
 typealias MarkdownMentionNames = [String: String]
 
-/// Which fill the rendered text will be drawn on top of, so a mention chip can be picked to
-/// contrast with it. Threaded through the builder rather than resolved in the view: the
-/// attributed string is built once, off-main, when the message is mapped, and body/layout
-/// passes must not rewrite it (see `MarkdownMessageView`, whitenoise-mac#205).
-nonisolated enum MarkdownMentionFill {
-    /// A neutral surface — received bubbles, agent rows, anything not filled with the accent.
-    case neutral
-    /// The accent-filled sent bubble.
-    case sentBubble
-}
-
 // Pure FFI → display-model transformation (built off-main while mapping a timeline window,
 // read on the main actor by the views). Marked `nonisolated` so it does not inherit the
 // module's default main-actor isolation — otherwise constructing it from `MessageItem.init`
@@ -55,8 +44,7 @@ nonisolated struct MarkdownDisplayDocument {
 
     init(
         document: MarkdownDocumentFfi,
-        mentionNames: MarkdownMentionNames = [:],
-        mentionFill: MarkdownMentionFill = .neutral
+        mentionNames: MarkdownMentionNames = [:]
     ) {
         var swiftTruncated = false
         var budget = MarkdownDisplayBudget(limit: Self.maxDisplayNodes)
@@ -64,7 +52,6 @@ nonisolated struct MarkdownDisplayDocument {
             from: document.blocks,
             remainingDepth: Self.maxDepth,
             mentionNames: mentionNames,
-            mentionFill: mentionFill,
             budget: &budget,
             truncated: &swiftTruncated
         )
@@ -75,7 +62,6 @@ nonisolated struct MarkdownDisplayDocument {
         from blocks: [MarkdownBlockFfi],
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
-        mentionFill: MarkdownMentionFill,
         budget: inout MarkdownDisplayBudget,
         truncated: inout Bool
     ) -> [MarkdownDisplayBlockNode] {
@@ -93,7 +79,6 @@ nonisolated struct MarkdownDisplayDocument {
                         block,
                         remainingDepth: remainingDepth,
                         mentionNames: mentionNames,
-                        mentionFill: mentionFill,
                         budget: &budget,
                         truncated: &truncated
                     )
@@ -151,7 +136,6 @@ nonisolated enum MarkdownDisplayBlock {
         _ block: MarkdownBlockFfi,
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
-        mentionFill: MarkdownMentionFill,
         budget: inout MarkdownDisplayBudget,
         truncated: inout Bool
     ) {
@@ -162,7 +146,6 @@ nonisolated enum MarkdownDisplayBlock {
                     from: inlines,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -173,7 +156,6 @@ nonisolated enum MarkdownDisplayBlock {
                     from: inlines,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -187,7 +169,6 @@ nonisolated enum MarkdownDisplayBlock {
                     from: blocks,
                     remainingDepth: remainingDepth - 1,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     budget: &budget,
                     truncated: &truncated
                 )
@@ -199,7 +180,6 @@ nonisolated enum MarkdownDisplayBlock {
                     items: items,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     budget: &budget,
                     truncated: &truncated
                 )
@@ -210,7 +190,6 @@ nonisolated enum MarkdownDisplayBlock {
                 from: Array(header.prefix(headerCount)),
                 remainingDepth: remainingDepth,
                 mentionNames: mentionNames,
-                mentionFill: mentionFill,
                 truncated: &truncated
             )
             var displayRows: [MarkdownDisplayTableRow] = []
@@ -221,7 +200,6 @@ nonisolated enum MarkdownDisplayBlock {
                     from: Array(row.prefix(cellCount)),
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
                 guard row.isEmpty || !cells.isEmpty else { break }
@@ -240,7 +218,6 @@ nonisolated enum MarkdownDisplayBlock {
         items: [MarkdownListItemFfi],
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
-        mentionFill: MarkdownMentionFill,
         budget: inout MarkdownDisplayBudget,
         truncated: inout Bool
     ) -> [MarkdownDisplayListItem] {
@@ -251,7 +228,6 @@ nonisolated enum MarkdownDisplayBlock {
                 from: item.blocks,
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
-                mentionFill: mentionFill,
                 budget: &budget,
                 truncated: &truncated
             )
@@ -289,7 +265,6 @@ nonisolated enum MarkdownDisplayBlock {
         from cells: [MarkdownTableCellFfi],
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
-        mentionFill: MarkdownMentionFill,
         truncated: inout Bool
     ) -> [MarkdownDisplayTableCell] {
         cells.enumerated().map { index, cell in
@@ -299,7 +274,6 @@ nonisolated enum MarkdownDisplayBlock {
                     from: cell.inlines,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -342,15 +316,13 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     static func attributedString(
         from inlines: [MarkdownInlineFfi],
         remainingDepth: Int,
-        mentionNames: MarkdownMentionNames = [:],
-        mentionFill: MarkdownMentionFill = .neutral
+        mentionNames: MarkdownMentionNames = [:]
     ) -> AttributedString {
         var truncated = false
         return attributedString(
             from: inlines,
             remainingDepth: remainingDepth,
             mentionNames: mentionNames,
-            mentionFill: mentionFill,
             truncated: &truncated
         )
     }
@@ -359,7 +331,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         from inlines: [MarkdownInlineFfi],
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
-        mentionFill: MarkdownMentionFill,
         truncated: inout Bool
     ) -> AttributedString {
         guard remainingDepth > 0 else {
@@ -375,7 +346,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     link: nil,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -389,7 +359,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         link: MarkdownDisplayLink?,
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
-        mentionFill: MarkdownMentionFill,
         truncated: inout Bool
     ) -> AttributedString {
         switch inline {
@@ -408,7 +377,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 link: link,
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
-                mentionFill: mentionFill,
                 truncated: &truncated
             )
         case .strong(let children):
@@ -418,7 +386,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 link: link,
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
-                mentionFill: mentionFill,
                 truncated: &truncated
             )
         case .strikethrough(let children):
@@ -428,7 +395,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 link: link,
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
-                mentionFill: mentionFill,
                 truncated: &truncated
             )
         case .link(let dest, _, let children, let classification):
@@ -438,7 +404,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 link: actionableURL(from: dest, classification: classification),
                 remainingDepth: remainingDepth - 1,
                 mentionNames: mentionNames,
-                mentionFill: mentionFill,
                 truncated: &truncated
             )
         case .image(_, let title, let alt, _):
@@ -449,7 +414,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     link: link,
                     remainingDepth: remainingDepth - 1,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             }
@@ -459,7 +423,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         case .math(let content):
             return styled(content, intent: intent.union(.code), link: link)
         case .nostrMention(let entity), .nostrUri(let entity):
-            return nostrEntity(entity, intent: intent, mentionNames: mentionNames, mentionFill: mentionFill)
+            return nostrEntity(entity, intent: intent, mentionNames: mentionNames)
         @unknown default:
             return AttributedString()
         }
@@ -486,7 +450,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         link: MarkdownDisplayLink?,
         remainingDepth: Int,
         mentionNames: MarkdownMentionNames,
-        mentionFill: MarkdownMentionFill,
         truncated: inout Bool
     ) -> AttributedString {
         guard remainingDepth > 0 else {
@@ -502,7 +465,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                     link: link,
                     remainingDepth: remainingDepth,
                     mentionNames: mentionNames,
-                    mentionFill: mentionFill,
                     truncated: &truncated
                 )
             )
@@ -539,8 +501,7 @@ nonisolated enum MarkdownDisplayInlineBuilder {
     private static func nostrEntity(
         _ entity: MarkdownNostrEntityFfi,
         intent: InlinePresentationIntent,
-        mentionNames: MarkdownMentionNames,
-        mentionFill: MarkdownMentionFill
+        mentionNames: MarkdownMentionNames
     ) -> AttributedString {
         let shortReference = shortBech32(entity.bech32)
         let displayText: String
@@ -562,11 +523,6 @@ nonisolated enum MarkdownDisplayInlineBuilder {
             displayText = shortReference
             presentation = .underlined
         }
-        // No baked foreground color: the bubble owns `.tint` so the linked reference stays visible
-        // on both sent and received, and the chip is picked to keep that inherited text legible.
-        // A mention is set off by a background chip (Signal's treatment) rather than bold weight,
-        // a foreground color, or a decoration — see `MentionChipPalette` for why the chip has to
-        // know its fill instead of being one translucent wash over all of them.
         var attributed = styled(
             displayText,
             intent: intent,
@@ -574,8 +530,18 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 MarkdownDisplayLink(url: $0, presentation: presentation)
             }
         )
+        // A mention is set off by weight plus the mentioned person's own accent — the same
+        // treatment the other clients give it, and the reason it needs no knowledge of the fill
+        // it lands on. See `MentionTextPalette`.
+        //
+        // The accent is only applied when it can be derived honestly; where it cannot, the
+        // mention stays bold and inherits the bubble's foreground, which also keeps a linked
+        // `nprofile` reference visible on both sent and received.
         if presentation == .mention {
-            attributed.backgroundColor = MentionChipPalette.color(on: mentionFill)
+            attributed.inlinePresentationIntent = intent.union(.stronglyEmphasized)
+            if let accent = MentionTextPalette.foreground(forNpub: entity.bech32) {
+                attributed.foregroundColor = accent
+            }
         }
         return attributed
     }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2138,15 +2138,11 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         self.senderPictureURL = senderPictureURL
         self.body = body
         self.wireBody = wireBody ?? body
-        // The mention chip has to contrast with the bubble it lands in, and the attributed string
-        // is built here — once, off-main — rather than during a body pass, so the fill is decided
-        // here too, from the direction this row already knows.
+        // Built here — once, off-main — rather than during a body pass, so a layout pass never
+        // rewrites it (whitenoise-mac#205). It no longer needs to know which bubble it will land
+        // in: a mention takes the mentioned person's accent, which reads on either one.
         self.contentMarkdown = contentMarkdown.map {
-            MarkdownDisplayDocument(
-                document: $0,
-                mentionNames: mentionNames,
-                mentionFill: isOutgoing ? .sentBubble : .neutral
-            )
+            MarkdownDisplayDocument(document: $0, mentionNames: mentionNames)
         }
         self.mentionNames = mentionNames
         self.trimmedBody = trimmedBody

--- a/whitenoise-mac/Views/ComposeFlowViews.swift
+++ b/whitenoise-mac/Views/ComposeFlowViews.swift
@@ -86,7 +86,7 @@ struct NewChatPanelView: View {
                     if let lastError = workspace.lastError {
                         Text(lastError)
                             .font(.caption)
-                            .foregroundStyle(.red)
+                            .foregroundStyle(WNColor.backgroundContentDestructive)
                             .padding(.horizontal, 12)
                             .padding(.top, 6)
                     }
@@ -143,7 +143,7 @@ struct NewChatPanelView: View {
                     .controlSize(.small)
                 Text(L10n.string("Finding people from your groups..."))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             .padding(12)
         }
@@ -243,7 +243,7 @@ struct ChooseMembersPanelView: View {
             HStack {
                 Text(L10n.plural("%lld members", Int64(workspace.newChatRecipients.count)))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                 Spacer()
                 Button(L10n.string("Next")) {
                     workspace.composeShowNameGroup()
@@ -331,7 +331,12 @@ struct NameGroupPanelView: View {
                         .glassCard()
                         .overlay {
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .stroke(isNameFocused ? Color.accentColor : Color.clear, lineWidth: 1)
+                                // `borderTertiary` at rest, not `fillTertiary`: a border takes a
+                                // border token, and `fillTertiary` is the ghost control's
+                                // transparent resting fill — it drew nothing at all here.
+                                .stroke(
+                                    isNameFocused ? WNColor.borderPrimary : WNColor.borderTertiary,
+                                    lineWidth: 1)
                         }
                         .accessibilityIdentifier("compose.groupName")
 
@@ -340,7 +345,7 @@ struct NameGroupPanelView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(L10n.plural("%lld members", Int64(workspace.newChatRecipients.count)))
                             .font(MessagesType.sectionHeader)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                         ForEach(workspace.newChatRecipients, id: \.accountIdHex) { member in
                             memberRow(member)
                         }
@@ -350,7 +355,7 @@ struct NameGroupPanelView: View {
                     if let lastError = workspace.lastError {
                         Text(lastError)
                             .font(.caption)
-                            .foregroundStyle(.red)
+                            .foregroundStyle(WNColor.backgroundContentDestructive)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
@@ -393,9 +398,10 @@ struct NameGroupPanelView: View {
         if trimmedName.isEmpty {
             Image(systemName: "person.2.fill")
                 .font(.system(size: 30, weight: .semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .frame(width: 84, height: 84)
-                .background(Circle().fill(.quaternary))
+                .background(Circle().fill(WNColor.fillSecondary))
+                .overlay(Circle().strokeBorder(WNColor.borderTertiary, lineWidth: 1))
         } else {
             AvatarView(seed: trimmedName, initials: trimmedName, size: 84, isSelected: false)
         }
@@ -444,7 +450,7 @@ struct NameGroupPanelView: View {
                     .lineLimit(1)
                 Text(shortKey(npub: member.npub, hex: member.accountIdHex))
                     .font(MessagesType.meta)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
@@ -571,7 +577,7 @@ private struct ComposeSectionHeader: View {
     var body: some View {
         Text(title)
             .font(MessagesType.sectionHeader)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(WNColor.backgroundContentSecondary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 12)
             .padding(.top, 10)
@@ -590,7 +596,8 @@ private struct ComposeActionRow: View {
                 Image(systemName: symbol)
                     .font(.system(size: 13, weight: .semibold))
                     .frame(width: 32, height: 32)
-                    .background(Circle().fill(.quaternary))
+                    .background(Circle().fill(WNColor.fillSecondary))
+                    .overlay(Circle().strokeBorder(WNColor.borderTertiary, lineWidth: 1))
                 Text(title)
                     .font(MessagesType.rowLabel)
                 Spacer(minLength: 0)
@@ -631,13 +638,13 @@ private struct ComposeContactRow: View {
                         .lineLimit(1)
                     Text(subtitle)
                         .font(MessagesType.meta)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                     if let provenance {
                         Text(provenance)
                             .font(MessagesType.meta)
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(WNColor.backgroundContentTertiary)
                             .lineLimit(1)
                     }
                 }
@@ -648,7 +655,9 @@ private struct ComposeContactRow: View {
                 } else if let selection {
                     Image(systemName: selection ? "checkmark.circle.fill" : "circle")
                         .font(.system(size: 19))
-                        .foregroundStyle(selection ? Color.accentColor : Color.secondary)
+                        .foregroundStyle(
+                            selection
+                                ? WNColor.backgroundContentPrimary : WNColor.backgroundContentSecondary)
                 }
             }
             .padding(.horizontal, 10)
@@ -697,16 +706,16 @@ private struct ComposeDiscoveryStatusRow: View {
                     .controlSize(.small)
                 Text(L10n.string("Searching your network..."))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             .padding(12)
         case .failed:
             HStack(spacing: 8) {
                 Image(systemName: "exclamationmark.triangle")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                 Text(L10n.string("Search couldn't be completed."))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                 Button(L10n.string("Retry")) {
                     workspace.scheduleUserDiscovery()
                 }
@@ -716,10 +725,10 @@ private struct ComposeDiscoveryStatusRow: View {
         case .partial:
             HStack(spacing: 8) {
                 Image(systemName: "exclamationmark.triangle")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                 Text(L10n.string("Some results may be missing."))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             .padding(12)
         }
@@ -733,7 +742,7 @@ private struct ComposeResolvingRow: View {
                 .controlSize(.small)
             Text(L10n.string("Resolving..."))
                 .font(.callout)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
         }
         .padding(12)
     }
@@ -746,10 +755,10 @@ private struct ComposeNoMatchesView: View {
         VStack(spacing: 10) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 30))
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(WNColor.backgroundContentTertiary)
             Text(L10n.string("No matches"))
                 .font(.callout)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             if let onPaste {
                 Button(L10n.string("Paste npub"), action: onPaste)
                     .buttonStyle(.link)
@@ -779,12 +788,12 @@ private struct MemberChip: View {
                     .lineLimit(1)
                 Image(systemName: "xmark")
                     .font(.system(size: 8, weight: .bold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             .padding(.leading, 4)
             .padding(.trailing, 7)
             .padding(.vertical, 4)
-            .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(.quaternary))
+            .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(WNColor.fillSecondary))
             .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
         .buttonStyle(.plain)

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -86,7 +86,7 @@ struct ComposerMessageInputView: View {
             if text.isEmpty {
                 Text(placeholder)
                     .font(.body)
-                    .foregroundStyle(Color(nsColor: .placeholderTextColor))
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
                     .padding(.top, 1)
                     .allowsHitTesting(false)
             }
@@ -121,9 +121,9 @@ struct ComposerMentionPicker: View {
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                .strokeBorder(WNColor.borderTertiary, lineWidth: 1)
         }
-        .shadow(color: .black.opacity(0.14), radius: 12, y: 4)
+        .shadow(color: WNColor.shadow.opacity(0.1), radius: 12, y: 4)
         .accessibilityIdentifier("composer.mentionPicker")
     }
 }
@@ -147,12 +147,12 @@ private struct ComposerMentionRow: View {
                 VStack(alignment: .leading, spacing: 1) {
                     Text(candidate.displayName)
                         .font(.callout.weight(.medium))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(WNColor.backgroundContentPrimary)
                         .lineLimit(1)
                     if !candidate.npub.isEmpty {
                         Text(DisplayText.short(candidate.npub))
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                             .lineLimit(1)
                     }
                 }
@@ -164,7 +164,7 @@ private struct ComposerMentionRow: View {
             .background {
                 if isHovered {
                     RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .fill(Color.accentColor.opacity(0.14))
+                        .fill(WNColor.fillTertiaryHover)
                         .padding(.horizontal, 4)
                 }
             }
@@ -214,7 +214,7 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
     static var plainTypingAttributes: [NSAttributedString.Key: Any] {
         [
             .font: NSFont.preferredFont(forTextStyle: .body),
-            .foregroundColor: NSColor.labelColor,
+            .foregroundColor: WNNSColor.backgroundContentPrimary,
         ]
     }
 
@@ -246,8 +246,8 @@ struct ComposerMessageTextViewRepresentable: NSViewRepresentable {
         textView.importsGraphics = false
         textView.allowsUndo = true
         textView.font = .preferredFont(forTextStyle: .body)
-        textView.textColor = .labelColor
-        textView.insertionPointColor = .labelColor
+        textView.textColor = WNNSColor.backgroundContentPrimary
+        textView.insertionPointColor = WNNSColor.backgroundContentPrimary
         // Plain text is the baseline; only a mention marker adds attributes on top of it.
         textView.typingAttributes = Self.plainTypingAttributes
         textView.textContainerInset = NSSize(width: 0, height: 1)
@@ -505,27 +505,23 @@ enum ComposerMentionMarkerStore {
         let selection: ComposerMentionSelection
     }
 
-    /// Identity markers plus the visible chip. The chip is never maintained on its own: it is
-    /// written only by `add` and dropped wherever the markers are dropped, so styling cannot drift
-    /// from identity — a marker that later fails validation reverts to plain text with no separate
-    /// cleanup path. Sweeping `.backgroundColor` is safe over any range because the composer text
-    /// view is plain text (`isRichText = false`), so the chip is the only background in play.
-    private static let markerAttributes: [NSAttributedString.Key] = [
-        .composerMentionNpub,
-        .composerMentionDisplayText,
-        .backgroundColor,
-    ]
-
     static func add(_ selection: ComposerMentionSelection, to textView: NSTextView) {
         guard isExact(selection, in: textView.string), let storage = textView.textStorage else { return }
         storage.addAttribute(.composerMentionNpub, value: selection.npub, range: selection.range)
         storage.addAttribute(.composerMentionDisplayText, value: selection.displayText, range: selection.range)
-        // Same chip a received bubble draws: the draft token sits on the same neutral surface, so
-        // it reads as the same kind of object even though the sent bubble's accent fill needs a
-        // darker one.
+        // The same treatment a rendered mention gets — bold, in the mentioned person's accent — so
+        // a token looks the same while you are typing it as it will once it is sent. See
+        // `MentionTextPalette`; where the accent cannot be derived the token stays bold on the
+        // field's own content color.
         storage.addAttribute(
-            .backgroundColor,
-            value: MentionChipPalette.neutralFillTextBackground,
+            .foregroundColor,
+            value: MentionTextPalette.nsForeground(forNpub: selection.npub)
+                ?? MentionTextPalette.composerFallbackForeground,
+            range: selection.range
+        )
+        storage.addAttribute(
+            .font,
+            value: NSFont.boldSystemFont(ofSize: NSFont.preferredFont(forTextStyle: .body).pointSize),
             range: selection.range
         )
     }
@@ -539,10 +535,25 @@ enum ComposerMentionMarkerStore {
         }
     }
 
+    /// Reverts a range to plain typed text: the identity markers come off, and the styling `add`
+    /// laid over them is *restored to the plain values* rather than removed.
+    ///
+    /// Restoring rather than removing is the whole point. With no `.foregroundColor` attribute at
+    /// all, TextKit draws the run in opaque black — it does not fall back to the text view's
+    /// `textColor` — which is invisible on the composer's `backgroundPrimary` field in dark
+    /// appearance and fine in light, so the damage only shows in one of the two. `replaceAll`
+    /// sweeps the *entire* storage before re-adding tokens, so one mention anywhere in a draft was
+    /// enough to blank every character of it.
+    ///
+    /// The styling is still never maintained on its own: it is written only by `add` and reset
+    /// wherever the markers are dropped, so it cannot drift from identity. Resetting these keys is
+    /// safe over any range because the composer text view is plain text (`isRichText = false`), so
+    /// the plain attributes are what every unstyled character already carries.
     private static func removeMarkers(in range: NSRange, from storage: NSTextStorage) {
-        for key in markerAttributes {
-            storage.removeAttribute(key, range: range)
-        }
+        storage.removeAttribute(.composerMentionNpub, range: range)
+        storage.removeAttribute(.composerMentionDisplayText, range: range)
+        guard range.length > 0 else { return }
+        storage.addAttributes(ComposerMessageTextViewRepresentable.plainTypingAttributes, range: range)
     }
 
     static func selections(in textView: NSTextView) -> [ComposerMentionSelection] {
@@ -703,8 +714,10 @@ struct PendingMediaDraftStrip: View {
                                 Image(systemName: "xmark.circle.fill")
                                     .font(.system(size: 18, weight: .semibold))
                                     .symbolRenderingMode(.palette)
+                                    // Two-layer glyph: the inner disc is the surface it is
+                                    // punched out of, the ring is content on that surface.
                                     .foregroundStyle(
-                                        Color(nsColor: .windowBackgroundColor), Color.primary.opacity(0.82))
+                                        WNColor.backgroundPrimary, WNColor.backgroundContentSecondary)
                             }
                             .buttonStyle(.plain)
                             .help(L10n.string("Remove attachment"))
@@ -746,11 +759,11 @@ struct PendingMediaDraftTile: View {
         .frame(width: tileSize.width, height: tileSize.height)
         .background {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.primary.opacity(0.06))
+                .fill(WNColor.fillSecondary)
         }
         .overlay {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 1)
+                .strokeBorder(WNColor.borderTertiary, lineWidth: 1)
         }
         .overlay(alignment: .bottomTrailing) {
             if let uploadState {
@@ -809,21 +822,21 @@ struct PendingMediaDraftTile: View {
         HStack(spacing: 8) {
             Image(systemName: "mic.fill")
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(WNColor.backgroundContentPrimary)
                 .frame(width: 20)
 
             VStack(alignment: .leading, spacing: 5) {
                 ComposerAudioWaveformView(
                     samples: attachment.waveformSamples,
                     progress: 0,
-                    barColor: Color.accentColor.opacity(0.82),
-                    playedColor: Color.accentColor
+                    barColor: WNColor.backgroundContentTertiary,
+                    playedColor: WNColor.backgroundContentPrimary
                 )
                 .frame(height: 24)
 
                 Text(attachment.durationLabel ?? attachment.sizeLabel)
                     .font(.caption2.monospacedDigit().weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(1)
             }
         }
@@ -839,14 +852,14 @@ struct PendingMediaDraftTile: View {
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
         }
-        .foregroundStyle(.secondary)
+        .foregroundStyle(WNColor.backgroundContentSecondary)
         .padding(.horizontal, 8)
     }
 
     private func iconPreview(systemName: String) -> some View {
         Image(systemName: systemName)
             .font(.system(size: 20, weight: .semibold))
-            .foregroundStyle(.secondary)
+            .foregroundStyle(WNColor.backgroundContentSecondary)
     }
 }
 
@@ -863,21 +876,21 @@ private struct PendingMediaUploadStatusBadge: View {
         case .uploading:
             ProgressView()
                 .controlSize(.small)
-                .tint(.accentColor)
+                .tint(WNColor.backgroundContentPrimary)
                 .scaleEffect(0.62)
                 .frame(width: 24, height: 24)
                 .background(.regularMaterial, in: .circle)
-                .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
+                .shadow(color: WNColor.shadow.opacity(0.1), radius: 4, y: 1)
         case .uploaded:
             EmptyView()
         case .failed:
             Button(L10n.string("Retry upload"), systemImage: "arrow.clockwise", action: onRetry)
                 .labelStyle(.iconOnly)
                 .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(.white)
+                .foregroundStyle(WNColor.fillContentQuaternary)
                 .buttonStyle(.plain)
                 .frame(width: 24, height: 24)
-                .background(.red, in: .circle)
+                .background(WNColor.fillDestructive, in: .circle)
                 .shadow(color: .black.opacity(0.12), radius: 4, y: 1)
                 .help(L10n.string("Retry upload"))
         }
@@ -917,23 +930,33 @@ struct VoiceRecordingComposerView: View {
             ComposerAudioWaveformView(
                 samples: samples,
                 progress: 0,
-                barColor: Color.accentColor.opacity(0.70),
-                playedColor: Color.accentColor,
+                // Recording, so every bar is "live" rather than played — one token at full
+                // strength. `backgroundContent*` rather than a fill token because the bars are
+                // drawn straight onto the bar's own surface, and primary rather than the
+                // destructive red this used to be: a recording in progress is the composer doing
+                // what it was asked to, not an error. The voice-draft bar below uses the same two
+                // tokens at two weights, so the two waveforms read as one control.
+                barColor: WNColor.backgroundContentPrimary,
+                playedColor: WNColor.backgroundContentPrimary,
                 mode: .liveRecording
             )
             .frame(height: 30)
 
             Text(Self.durationLabel(durationSeconds))
                 .font(.caption.monospacedDigit().weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .frame(minWidth: 44, alignment: .trailing)
 
+            // Stop is the only thing this bar asks for, so it wears the primary action's pair
+            // (`fillPrimary` + `fillContentPrimary`) rather than the destructive one. Finishing a
+            // recording keeps it — the trash can that throws it away lives in the voice-draft bar
+            // this hands off to, and that is where the destructive color belongs.
             Button(action: onStop) {
                 Image(systemName: "stop.fill")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(WNColor.fillContentPrimary)
                     .frame(width: 30, height: 30)
-                    .background(Color.accentColor, in: Circle())
+                    .background(WNColor.fillPrimary, in: .circle)
             }
             .buttonStyle(.plain)
             .help(L10n.string("Finish recording"))
@@ -944,7 +967,7 @@ struct VoiceRecordingComposerView: View {
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.10), lineWidth: 1)
+                .strokeBorder(WNColor.borderTertiary, lineWidth: 1)
         }
     }
 
@@ -1004,19 +1027,20 @@ struct VoiceMessageDraftComposerView: View {
             .accessibilityLabel(playbackActionLabel)
             .accessibilityIdentifier("composer.voiceDraft.playback")
 
-            // Unplayed bars are neutral, played bars accent — the same reading the transcript's
-            // audio rows use, so progress is legible rather than two shades of the same blue.
+            // Unplayed bars are de-emphasized, played bars are full-strength content — the same
+            // reading the transcript's audio rows use, so progress is legible as one hue at two
+            // weights rather than two competing colors.
             ComposerAudioWaveformView(
                 samples: attachment.waveformSamples,
                 progress: playbackProgress,
-                barColor: Color.secondary.opacity(0.55),
-                playedColor: Color.accentColor
+                barColor: WNColor.backgroundContentTertiary,
+                playedColor: WNColor.backgroundContentPrimary
             )
             .frame(height: 30)
 
             Text(MediaDurationLabel.string(for: isPlaying ? elapsedSeconds : (attachment.durationSeconds ?? 0)))
                 .font(.caption.monospacedDigit().weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .frame(minWidth: 44, alignment: .trailing)
 
             // Discard sits with Send rather than at the far left: the two decisions the bar asks
@@ -1024,7 +1048,7 @@ struct VoiceMessageDraftComposerView: View {
             Button(action: discard) {
                 Image(systemName: "trash")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(.red)
+                    .foregroundStyle(WNColor.backgroundContentDestructive)
                     .frame(width: 30, height: 30)
                     .background {
                         MessagesCircleControlBackground()
@@ -1039,29 +1063,19 @@ struct VoiceMessageDraftComposerView: View {
                 Button(L10n.string("Retry upload"), systemImage: "arrow.clockwise", action: onRetryUpload)
                     .labelStyle(.iconOnly)
                     .font(.system(size: 13, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(WNColor.fillContentQuaternary)
                     .buttonStyle(.plain)
                     .frame(width: 30, height: 30)
-                    .background(.red, in: .circle)
+                    .background(WNColor.fillDestructive, in: .circle)
                     .help(L10n.string("Retry upload"))
             }
 
             Button(action: send) {
-                Group {
-                    if isSending {
-                        ProgressView()
-                            .controlSize(.small)
-                            .tint(.white)
-                            .scaleEffect(0.72)
-                    } else {
-                        Image(systemName: "paperplane.fill")
-                            .font(.system(size: 14, weight: .semibold))
-                    }
-                }
-                .frame(width: 32, height: 32)
-                .background {
-                    MessagesSendButtonBackground(isEnabled: canSend || isSending)
-                }
+                MessagesSendButtonLabel(
+                    systemImage: "paperplane.fill",
+                    isEnabled: canSend,
+                    isSending: isSending
+                )
             }
             .buttonStyle(.plain)
             .disabled(!canSend)
@@ -1074,7 +1088,7 @@ struct VoiceMessageDraftComposerView: View {
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.10), lineWidth: 1)
+                .strokeBorder(WNColor.borderTertiary, lineWidth: 1)
         }
         // The player is built from one recording's bytes: if this view's identity outlives a
         // re-recording, drop it so playback cannot replay the discarded take.
@@ -1308,7 +1322,7 @@ struct TimelineInitialLoadingView: View {
                 .controlSize(.regular)
             Text(L10n.string("Loading messages..."))
                 .font(.callout)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 48)
@@ -1351,7 +1365,7 @@ struct ReplyComposerContextView: View {
 
                 Text(context.body)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
             }
@@ -1390,7 +1404,7 @@ struct EditComposerContextView: View {
                     .font(.caption.weight(.semibold))
                 Text(context.originalBody)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(1)
             }
 
@@ -1412,7 +1426,7 @@ struct MembershipEndedComposerNotice: View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
             Image(systemName: membership.endedSymbolName ?? "")
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(membership.endedDescription ?? "")
@@ -1420,7 +1434,7 @@ struct MembershipEndedComposerNotice: View {
 
                 Text(ChatSelfMembership.endedHistoryExplanation)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
 
             Spacer(minLength: 0)
@@ -1442,7 +1456,7 @@ struct PendingGroupInviteComposerNotice: View {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
                 Image(systemName: "lock.shield.fill")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(WNColor.intentionInfoContent)
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text(inviteMessage)
@@ -1451,7 +1465,7 @@ struct PendingGroupInviteComposerNotice: View {
 
                     Text(L10n.string("If you decline, this chat will be removed from your chat list."))
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
@@ -1650,7 +1664,7 @@ struct ConversationHeader: View {
                             Text(chat.title)
                                 .font(.system(size: 15, weight: .semibold))
                                 .lineLimit(1)
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(WNColor.backgroundContentPrimary)
 
                             headerSubtitle
                         }
@@ -1781,7 +1795,7 @@ struct MessageInfoSheet: View {
     private func infoRow(title: String, value: String) -> some View {
         GridRow {
             Text(title)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             Text(value)
                 .textSelection(.enabled)
         }
@@ -1815,13 +1829,13 @@ struct MessageForwardSheet: View {
 
             HStack(spacing: 8) {
                 Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                 TextField(L10n.string("Search chats"), text: $query)
                     .textFieldStyle(.plain)
             }
             .padding(.horizontal, 12)
             .frame(height: 36)
-            .background(Color.primary.opacity(0.07), in: RoundedRectangle(cornerRadius: 10))
+            .background(WNColor.fillSecondary, in: RoundedRectangle(cornerRadius: 10))
             .padding(.horizontal, 16)
             .padding(.bottom, 10)
 
@@ -1849,7 +1863,7 @@ struct MessageForwardSheet: View {
                                     ProgressView().controlSize(.small)
                                 } else {
                                     Image(systemName: "arrowshape.turn.up.right")
-                                        .foregroundStyle(.secondary)
+                                        .foregroundStyle(WNColor.backgroundContentSecondary)
                                 }
                             }
                             .padding(.horizontal, 16)

--- a/whitenoise-mac/Views/ContactNicknameViews.swift
+++ b/whitenoise-mac/Views/ContactNicknameViews.swift
@@ -36,7 +36,7 @@ struct ContactNicknameRow: View {
                                 .truncationMode(.middle)
                         } else {
                             Text(L10n.string("None"))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(WNColor.backgroundContentSecondary)
                         }
 
                         Spacer()
@@ -64,13 +64,13 @@ struct ContactNicknameRow: View {
                         )
                     )
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(2)
                 }
 
                 Text(L10n.string("Only you see this on this device. It is never published."))
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
             }
             .alert(
                 nickname == nil ? L10n.string("Set Nickname") : L10n.string("Edit Nickname"),

--- a/whitenoise-mac/Views/DisappearingMessageViews.swift
+++ b/whitenoise-mac/Views/DisappearingMessageViews.swift
@@ -133,6 +133,6 @@ struct DisappearingMessageHeaderSubtitle: View {
                 Text(fallback)
             }
         }
-        .foregroundStyle(.secondary)
+        .foregroundStyle(WNColor.backgroundContentSecondary)
     }
 }

--- a/whitenoise-mac/Views/EmojiPicker.swift
+++ b/whitenoise-mac/Views/EmojiPicker.swift
@@ -231,7 +231,7 @@ struct ChatEmojiPicker: View {
     private var searchField: some View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             TextField(L10n.string("Search emoji"), text: $query)
                 .textFieldStyle(.plain)
             if !query.isEmpty {
@@ -239,7 +239,7 @@ struct ChatEmojiPicker: View {
                     query = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(L10n.string("Clear search"))
@@ -247,7 +247,7 @@ struct ChatEmojiPicker: View {
         }
         .padding(.horizontal, 11)
         .frame(height: 34)
-        .background(Color(nsColor: .controlBackgroundColor), in: Capsule())
+        .background(WNColor.fillSecondary, in: Capsule())
         .padding(10)
     }
 
@@ -308,7 +308,7 @@ struct ChatEmojiPicker: View {
         } header: {
             Text(title)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 6)
                 .background(.bar)
@@ -338,7 +338,7 @@ struct ChatEmojiPicker: View {
         }
         .padding(.horizontal, 7)
         .padding(.vertical, 6)
-        .background(Color(nsColor: .windowBackgroundColor).opacity(0.92))
+        .background(WNColor.backgroundSecondary.opacity(0.92))
     }
 
     private func railButton(
@@ -350,9 +350,13 @@ struct ChatEmojiPicker: View {
         Button(action: action) {
             Image(systemName: systemImage)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(selected ? Color.primary : Color.secondary)
+                .foregroundStyle(
+                    selected ? WNColor.fillContentSecondary : WNColor.fillContentTertiary
+                )
                 .frame(width: 34, height: 28)
-                .background(selected ? Color.primary.opacity(0.10) : .clear, in: RoundedRectangle(cornerRadius: 7))
+                .background(
+                    selected ? WNColor.fillTertiaryHover : WNColor.fillTertiary,
+                    in: RoundedRectangle(cornerRadius: 7))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(label)

--- a/whitenoise-mac/Views/GlobalMessageSearchView.swift
+++ b/whitenoise-mac/Views/GlobalMessageSearchView.swift
@@ -18,7 +18,7 @@ struct GlobalMessageSearchView: View {
                         .font(.title2.weight(.semibold))
                     Text(L10n.string("Search across your visible chats"))
                         .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
                 Spacer()
                 Button {
@@ -71,7 +71,7 @@ struct GlobalMessageSearchView: View {
                 ProgressView()
                 Text(L10n.string("Searching message history…"))
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let error = workspace.globalMessageSearchError {
@@ -115,20 +115,20 @@ private struct GlobalMessageSearchResultRow: View {
                         .font(.callout.weight(.semibold))
                         .lineLimit(1)
                     Text("·")
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(WNColor.backgroundContentTertiary)
                     Text(result.senderName)
                         .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .lineLimit(1)
                     Spacer(minLength: 8)
                     Text(timestamp)
                         .font(.caption)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(WNColor.backgroundContentTertiary)
                 }
 
                 highlightedSnippet
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(2)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -136,7 +136,7 @@ private struct GlobalMessageSearchResultRow: View {
             .padding(.vertical, 10)
             .background {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .fill(Color.primary.opacity(0.045))
+                    .fill(WNColor.fillSecondary)
             }
             .contentShape(Rectangle())
         }
@@ -146,7 +146,9 @@ private struct GlobalMessageSearchResultRow: View {
 
     private var highlightedSnippet: Text {
         Text(result.snippet.leading)
-            + Text(result.snippet.match).bold().foregroundColor(.primary)
+            // The matched run takes `intentionInfoContent`, the same token the other clients
+            // highlight a search hit with.
+            + Text(result.snippet.match).bold().foregroundColor(WNColor.intentionInfoContent)
             + Text(result.snippet.trailing)
     }
 

--- a/whitenoise-mac/Views/GroupAddMembersSheet.swift
+++ b/whitenoise-mac/Views/GroupAddMembersSheet.swift
@@ -27,7 +27,7 @@ struct GroupAddMembersSheet: View {
             if let resolveError {
                 Text(resolveError)
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(WNColor.backgroundContentDestructive)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 16)
                     .padding(.bottom, 6)
@@ -77,10 +77,10 @@ struct GroupAddMembersSheet: View {
             VStack(spacing: 6) {
                 Image(systemName: "person.2")
                     .font(.title)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
                 Text(L10n.string("No one added yet"))
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
@@ -113,7 +113,7 @@ struct GroupAddMembersSheet: View {
                     .lineLimit(1)
                 Text(DisplayText.short(recipient.npub))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(1)
             }
             Spacer(minLength: 8)
@@ -121,7 +121,7 @@ struct GroupAddMembersSheet: View {
                 staged.removeAll { $0.accountIdHex == recipient.accountIdHex }
             } label: {
                 Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             .buttonStyle(.plain)
         }

--- a/whitenoise-mac/Views/GroupSharedMediaViews.swift
+++ b/whitenoise-mac/Views/GroupSharedMediaViews.swift
@@ -102,10 +102,10 @@ struct GroupSharedMediaSection: View {
     private func errorRow(_ error: String) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Label(L10n.string("Shared media unavailable"), systemImage: "exclamationmark.triangle")
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             Text(error)
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             Button(L10n.string("Retry")) {
                 Task { await workspace.loadSharedMedia(groupIdHex: groupIdHex) }
             }
@@ -119,10 +119,10 @@ struct GroupSharedMediaSection: View {
             VStack(spacing: 6) {
                 Image(systemName: systemImage)
                     .font(.title2)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
                 Text(title)
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             Spacer()
         }
@@ -172,24 +172,24 @@ private struct SharedMediaThumbnail: View {
     private var tileContent: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(Color.secondary.opacity(0.12))
+                .fill(WNColor.fillSecondary)
             if let image {
                 image.resizable()
                     .scaledToFill()
             } else if isVideo {
                 // Static placeholder — videos aren't frame-extracted here, so never spin.
                 Image(systemName: "film")
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
             } else if didFail {
                 Image(systemName: "photo")
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
             } else {
                 ProgressView().controlSize(.small)
             }
             if isVideo {
                 Image(systemName: "play.circle.fill")
                     .font(.title2)
-                    .foregroundStyle(.white.opacity(0.9))
+                    .foregroundStyle(WNColor.fillContentQuaternary.opacity(0.9))
                     .shadow(radius: 2)
             }
         }
@@ -299,14 +299,14 @@ private struct SharedMediaImagePreviewView: View {
             .frame(width: proxy.size.width, height: proxy.size.height)
         }
         .frame(minWidth: 480, minHeight: 360)
-        .background(Color.black.opacity(0.85))
+        .background(WNColor.shadow.opacity(0.85))
         .overlay(alignment: .topTrailing) {
             Button {
                 dismiss()
             } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.title2)
-                    .foregroundStyle(.white.opacity(0.9))
+                    .foregroundStyle(WNColor.fillContentQuaternary.opacity(0.9))
             }
             .buttonStyle(.plain)
             .padding(12)
@@ -325,14 +325,14 @@ private struct SharedMediaFileRow: View {
         HStack(spacing: 10) {
             Image(systemName: item.attachment.kind.systemImageName)
                 .font(.title3)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .frame(width: 28)
             VStack(alignment: .leading, spacing: 1) {
                 Text(item.attachment.fileName)
                     .lineLimit(1)
                 Text(item.attachment.mediaType)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(1)
             }
             Spacer(minLength: 8)

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -199,7 +199,7 @@ struct GroupDetailsSheet: View {
                                     )
                                 )
                                 .font(.callout)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(WNColor.backgroundContentSecondary)
                                 .fixedSize(horizontal: false, vertical: true)
 
                                 HStack(spacing: 10) {
@@ -241,12 +241,12 @@ struct GroupDetailsSheet: View {
 
                                     Text(ChatSelfMembership.endedHistoryExplanation)
                                         .font(.callout)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundStyle(WNColor.backgroundContentSecondary)
                                         .fixedSize(horizontal: false, vertical: true)
                                 }
                             } icon: {
                                 Image(systemName: snapshot.selfMembership.endedSymbolName ?? "")
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(WNColor.backgroundContentSecondary)
                             }
                         }
                     }
@@ -317,11 +317,11 @@ struct GroupDetailsSheet: View {
                                     ProgressView()
                                         .controlSize(.small)
                                     Text(L10n.string("Checking shared groups…"))
-                                        .foregroundStyle(.secondary)
+                                        .foregroundStyle(WNColor.backgroundContentSecondary)
                                 }
                             } else if workspace.commonGroupsForContact.isEmpty {
                                 Label(L10n.string("No groups in common"), systemImage: "person.2.slash")
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(WNColor.backgroundContentSecondary)
                             } else {
                                 ForEach(workspace.commonGroupsForContact) { commonGroup in
                                     Button {
@@ -340,18 +340,18 @@ struct GroupDetailsSheet: View {
                                             VStack(alignment: .leading, spacing: 2) {
                                                 Text(commonGroup.title)
                                                     .font(.callout.weight(.semibold))
-                                                    .foregroundStyle(.primary)
+                                                    .foregroundStyle(WNColor.backgroundContentPrimary)
                                                     .lineLimit(1)
                                                 Text(commonGroup.subtitle)
                                                     .font(.caption)
-                                                    .foregroundStyle(.secondary)
+                                                    .foregroundStyle(WNColor.backgroundContentSecondary)
                                                     .lineLimit(1)
                                             }
 
                                             Spacer()
                                             Image(systemName: "chevron.right")
                                                 .font(.caption.weight(.semibold))
-                                                .foregroundStyle(.tertiary)
+                                                .foregroundStyle(WNColor.backgroundContentTertiary)
                                         }
                                         .contentShape(Rectangle())
                                     }
@@ -362,7 +362,7 @@ struct GroupDetailsSheet: View {
                             if workspace.commonGroupsLoadHadFailures {
                                 Text(L10n.string("Some groups could not be checked."))
                                     .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(WNColor.backgroundContentSecondary)
                             }
                         }
                     }
@@ -510,7 +510,7 @@ struct GroupDetailsSheet: View {
                         if let blocker = snapshot.leaveBlocker {
                             Text(blocker.message)
                                 .font(.callout)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(WNColor.backgroundContentSecondary)
                         }
                     }
 
@@ -538,7 +538,7 @@ struct GroupDetailsSheet: View {
                                 } else if let status = workspace.groupTranscriptExportStatus {
                                     Label(status, systemImage: "checkmark.circle")
                                         .font(.callout)
-                                        .foregroundStyle(.green)
+                                        .foregroundStyle(WNColor.intentionSuccessContent)
                                 }
                             }
 
@@ -690,7 +690,7 @@ struct GroupDiagnosticsValueRow: View {
 
                 Text(displayValue)
                     .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(lineLimit)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -748,13 +748,13 @@ struct GroupMemberRow: View {
                             if member.isSelf {
                                 Text(L10n.string("You"))
                                     .font(.caption2.weight(.semibold))
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(WNColor.backgroundContentSecondary)
                             }
                         }
 
                         Text(member.detailLabel)
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                             .lineLimit(1)
                     }
 
@@ -861,7 +861,7 @@ struct ContactDetailsView: View {
                         .lineLimit(1)
                     Text(isSelf ? L10n.string("You") : L10n.string("Contact"))
                         .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
 
                 Spacer()
@@ -920,11 +920,11 @@ struct ContactDetailsView: View {
                             ProgressView()
                                 .controlSize(.small)
                             Text(L10n.string("Checking shared groups…"))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(WNColor.backgroundContentSecondary)
                         }
                     } else if workspace.commonGroupsForContact.isEmpty {
                         Label(L10n.string("No groups in common"), systemImage: "person.2.slash")
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     } else {
                         ForEach(workspace.commonGroupsForContact) { commonGroup in
                             Button {
@@ -942,17 +942,17 @@ struct ContactDetailsView: View {
                                     VStack(alignment: .leading, spacing: 2) {
                                         Text(commonGroup.title)
                                             .font(.callout.weight(.semibold))
-                                            .foregroundStyle(.primary)
+                                            .foregroundStyle(WNColor.backgroundContentPrimary)
                                             .lineLimit(1)
                                         Text(commonGroup.subtitle)
                                             .font(.caption)
-                                            .foregroundStyle(.secondary)
+                                            .foregroundStyle(WNColor.backgroundContentSecondary)
                                             .lineLimit(1)
                                     }
                                     Spacer()
                                     Image(systemName: "chevron.right")
                                         .font(.caption.weight(.semibold))
-                                        .foregroundStyle(.tertiary)
+                                        .foregroundStyle(WNColor.backgroundContentTertiary)
                                 }
                                 .contentShape(Rectangle())
                             }
@@ -963,7 +963,7 @@ struct ContactDetailsView: View {
                     if workspace.commonGroupsLoadHadFailures {
                         Text(L10n.string("Some groups could not be checked."))
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
                 }
             }
@@ -1025,7 +1025,7 @@ private struct ContactFollowControl: View {
                     ProgressView()
                         .controlSize(.small)
                     Text(L10n.string("Checking…"))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
                 .frame(maxWidth: .infinity)
                 .accessibilityIdentifier("contact.details.follow.loading")
@@ -1093,7 +1093,7 @@ struct GroupImagePickerSheet: View {
                             .lineLimit(1)
                         Text(L10n.string("Group image"))
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
 
                     Spacer()
@@ -1118,7 +1118,7 @@ struct GroupImagePickerSheet: View {
 
                         Text(L10n.string("or search the web"))
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
 
                         Spacer()
                     }
@@ -1150,7 +1150,7 @@ struct GroupImagePickerSheet: View {
 
                     Text(L10n.string("Search terms are sent to Openverse."))
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     HStack {
@@ -1174,13 +1174,13 @@ struct GroupImagePickerSheet: View {
                             VStack(spacing: 10) {
                                 Image(systemName: "photo.on.rectangle.angled")
                                     .font(.system(size: 28, weight: .light))
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(WNColor.backgroundContentSecondary)
                                 Text(
                                     workspace.isSearchingGroupImages
                                         ? L10n.string("Searching") : L10n.string("No images")
                                 )
                                 .font(.callout.weight(.medium))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(WNColor.backgroundContentSecondary)
                             }
                             .frame(maxWidth: .infinity, minHeight: 300)
                         } else {
@@ -1239,12 +1239,12 @@ struct GroupImageResultTile: View {
                     } placeholder: {
                         Image(systemName: "photo")
                             .font(.system(size: 24, weight: .light))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
                 } else {
                     Image(systemName: "photo")
                         .font(.system(size: 24, weight: .light))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
             }
             .aspectRatio(1.18, contentMode: .fit)
@@ -1258,7 +1258,7 @@ struct GroupImageResultTile: View {
 
             Text(result.creditLine)
                 .font(.caption2)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .lineLimit(1)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/whitenoise-mac/Views/MarkdownMessageView.swift
+++ b/whitenoise-mac/Views/MarkdownMessageView.swift
@@ -31,7 +31,7 @@ struct MarkdownMessageView: View {
                 if document.truncated {
                     Text(L10n.string("… (message truncated)"))
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
             }
             .fixedSize(horizontal: false, vertical: true)
@@ -79,14 +79,14 @@ private struct MarkdownBlockView: View {
         case .blockQuote(let blocks):
             HStack(spacing: 8) {
                 RoundedRectangle(cornerRadius: 1.5)
-                    .fill(Color.secondary.opacity(0.5))
+                    .fill(WNColor.borderTertiary)
                     .frame(width: 3)
                 VStack(alignment: .leading, spacing: 6) {
                     ForEach(blocks) { inner in
                         MarkdownBlockView(block: inner.block)
                     }
                 }
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             }
 
         case .list(let items):
@@ -121,6 +121,31 @@ private struct MarkdownInlineText: View {
     }
 }
 
+/// The fenced-code and math-block pair, named so the contrast between the two can be asserted
+/// against the same values the view draws.
+nonisolated enum MarkdownCodeBlockPalette {
+    /// `backgroundContentSecondary` as a *fill* looks odd written down, but it is what the other
+    /// clients set behind code: the neutral `500`/`400` step is the one mid-gray that reads as a
+    /// distinct block against the sent bubble and the received bubble alike, in both appearances. A
+    /// wash keyed off `.primary` cannot, because it changes direction between them while the sent
+    /// bubble does too.
+    static let fill = WNColor.backgroundContentSecondary
+
+    /// Named rather than inherited, for two reasons. A code block nested in a block quote inherits
+    /// the quote's `backgroundContentSecondary` — the block's own fill — so its text was drawn in
+    /// exactly the color behind it and disappeared. And the app-wide `backgroundContentPrimary` it
+    /// inherits everywhere else only clears 2.52:1 on this mid-gray in dark appearance, where
+    /// `fillContentPrimary` clears 7.85:1 (4.74:1 in light). One named token fixes both: the block
+    /// reads the same whatever it is nested in.
+    static let content = WNColor.fillContentPrimary
+
+    /// The AppKit twins of the two above, so the contrast between them can be asserted on the
+    /// dynamic colors themselves rather than on a snapshot frozen by `NSColor(someSwiftUIColor)` —
+    /// see the note on that conversion in `WNNSColor`.
+    static let nsFill = WNNSColor.backgroundContentSecondary
+    static let nsContent = WNNSColor.fillContentPrimary
+}
+
 private struct MarkdownCodeBlock: View {
     let content: String
 
@@ -128,9 +153,12 @@ private struct MarkdownCodeBlock: View {
         // No `.textSelection(.enabled)` — see the note in MarkdownMessageView.body.
         Text(content)
             .font(.system(.callout, design: .monospaced))
+            .foregroundStyle(MarkdownCodeBlockPalette.content)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(8)
-            .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .background(
+                MarkdownCodeBlockPalette.fill,
+                in: RoundedRectangle(cornerRadius: 6, style: .continuous))
     }
 }
 
@@ -158,10 +186,12 @@ private struct MarkdownListView: View {
         switch marker {
         case .checkbox(let checked):
             Image(systemName: checked ? "checkmark.square.fill" : "square")
-                .foregroundStyle(checked ? Color.accentColor : .secondary)
+                .foregroundStyle(
+                    checked ? WNColor.intentionSuccessContent : WNColor.backgroundContentSecondary
+                )
                 .font(.callout)
         case .text(let text):
-            Text(text).foregroundStyle(.secondary)
+            Text(text).foregroundStyle(WNColor.backgroundContentSecondary)
         }
     }
 }
@@ -187,6 +217,9 @@ private struct MarkdownTableView: View {
             }
         }
         .padding(8)
-        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(WNColor.borderTertiary, lineWidth: 1)
+        }
     }
 }

--- a/whitenoise-mac/Views/MessageEditHistorySheet.swift
+++ b/whitenoise-mac/Views/MessageEditHistorySheet.swift
@@ -56,7 +56,7 @@ private struct MessageEditHistoryView: View {
                     if versions.isEmpty {
                         Text(L10n.string("No earlier versions."))
                             .font(.callout)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                             .padding(.top, 8)
                     }
                     ForEach(versions, id: \.version.id) { entry in
@@ -79,11 +79,12 @@ private struct MessageEditHistoryView: View {
                         : (isLatest ? L10n.string("Current") : L10n.string("Edited"))
                 )
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(isLatest ? Color.accentColor : Color.secondary)
+                .foregroundStyle(
+                    isLatest ? WNColor.backgroundContentPrimary : WNColor.backgroundContentSecondary)
                 Spacer()
                 Text(DisplayText.messageTimestamp(for: version.date))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
             Text(version.text)
                 .font(.body)

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -93,13 +93,15 @@ struct ConversationMessageRow: View {
             HStack(alignment: .center, spacing: 8) {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .font(.system(size: 20, weight: .medium))
-                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .foregroundStyle(
+                        isSelected ? WNColor.backgroundContentPrimary : WNColor.backgroundContentTertiary
+                    )
                     .frame(width: 24)
                     .padding(.leading, 14)
                 content
             }
             .padding(.vertical, 1)
-            .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+            .background(isSelected ? WNColor.fillTertiaryHover : WNColor.fillTertiary)
             .contentShape(Rectangle())
             .onTapGesture { workspace.toggleMessageSelection(message) }
             .accessibilityElement(children: .combine)
@@ -158,14 +160,14 @@ struct TimelineNoticeRow: View {
 
                     Text(message.timeLabel(at: timestampReferenceDate, locale: timestampLocale))
                         .font(.caption2.monospacedDigit())
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(WNColor.backgroundContentTertiary)
                 }
 
                 if showsDebugMetadata {
                     MessageDebugMetadataView(message: message, isOutgoing: false)
                 }
             }
-            .foregroundStyle(.secondary)
+            .foregroundStyle(WNColor.backgroundContentSecondary)
             .padding(.horizontal, 12)
             .padding(.vertical, 7)
             .background {
@@ -220,7 +222,7 @@ struct MessageBubble: View {
                     } label: {
                         Text(message.senderName)
                             .font(.caption.weight(.medium))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                             .padding(.horizontal, 4)
                     }
                     .buttonStyle(.plain)
@@ -230,7 +232,7 @@ struct MessageBubble: View {
                 } else {
                     Text(message.senderName)
                         .font(.caption.weight(.medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .padding(.horizontal, 4)
                 }
             }
@@ -263,7 +265,7 @@ struct MessageBubble: View {
             }
 
             if message.supportsChatActions && !message.reactions.isEmpty {
-                MessageReactionChips(reactions: message.reactions) { emoji in
+                MessageReactionChips(reactions: message.reactions, isOutgoing: message.isOutgoing) { emoji in
                     reactionViewerEmoji = emoji
                     isReactionViewerPresented = true
                 }
@@ -448,8 +450,12 @@ struct MessageBubble: View {
                     trailingMetadata: showsInlineMetadata ? inlineMetadataSpacer : nil
                 )
                 .font(.system(size: 15.5))
-                .foregroundStyle(message.isOutgoing ? .white : .primary)
-                .tint(message.isOutgoing ? .white : .accentColor)
+                .foregroundStyle(MessagesPalette.bubbleContent(isOutgoing: message.isOutgoing))
+                // Links take `intentionInfoContent` — the palette's one blue outside the accent
+                // sets, and the same token the other clients use for a link inside a bubble. Its
+                // `600`/`500` step clears both bubble fills, so it needs no per-direction variant.
+                // Mentions carry the mentioned person's accent and override this per run.
+                .tint(WNColor.intentionInfoContent)
                 .multilineTextAlignment(.leading)
             }
 
@@ -536,9 +542,11 @@ struct MessageBubble: View {
         message.deliveryIndicator(at: deliveryClock)
     }
 
+    /// The timestamp/delivery footer. One token in both directions, as on the other clients:
+    /// `backgroundContentTertiary` is the neutral `400`/`500` step, which is the only rung that
+    /// clears the sent bubble and the received bubble in both appearances.
     private var metadataColor: Color {
-        message.isOutgoing && message.hasBubbleContent && !usesStickerStyle
-            ? Color.white.opacity(0.68) : Color.secondary.opacity(0.72)
+        WNColor.backgroundContentTertiary
     }
 
     private var compactMetadata: some View {
@@ -554,7 +562,9 @@ struct MessageBubble: View {
                 Image(systemName: systemImage)
                     // Only a real failure earns the alarm color; an in-flight send stays in the
                     // metadata's own tint next to the timestamp.
-                    .foregroundStyle(deliveryIndicator == .failed ? Color.red : metadataColor)
+                    .foregroundStyle(
+                        deliveryIndicator == .failed
+                            ? WNColor.backgroundContentDestructiveSecondary : metadataColor)
             }
         }
         .font(.system(size: 10.5, weight: .medium))
@@ -588,7 +598,7 @@ private extension View {
     /// download/failed status rows, and the document row. See `AttachmentRowPalette` for why the
     /// outgoing fill is the opaque accent rather than a wash over whatever sits behind the row.
     func attachmentRowChrome(isOutgoing: Bool) -> some View {
-        foregroundStyle(isOutgoing ? Color.white : Color.primary)
+        foregroundStyle(AttachmentRowPalette.content(isOutgoing: isOutgoing))
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .frame(width: 260, alignment: .leading)
@@ -680,30 +690,24 @@ private struct AutomaticMediaDownloadModifier: ViewModifier {
 }
 
 /// The chat-bubble shape: a rounded rectangle with the trailing/leading bottom corner
-/// tucked in on the sender's side. Outgoing bubbles use the accent fill; incoming bubbles
-/// use a scheme-aware translucent fill with a hairline stroke.
+/// tucked in on the sender's side.
+///
+/// Both fills are opaque palette tokens — `fillPrimary` for sent, `backgroundMessageIncoming` for
+/// received — and neither carries a stroke, matching the other clients. The received bubble used to
+/// be a translucent wash, which meant its apparent color depended on whatever it happened to be
+/// scrolled over.
 private struct BubbleBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
     let isOutgoing: Bool
 
     var body: some View {
-        let shape = UnevenRoundedRectangle(
+        UnevenRoundedRectangle(
             topLeadingRadius: 20,
             bottomLeadingRadius: isOutgoing ? 20 : 6,
             bottomTrailingRadius: isOutgoing ? 6 : 20,
             topTrailingRadius: 20,
             style: .continuous
         )
-
-        if isOutgoing {
-            shape.fill(MessagesPalette.sentBubble)
-        } else {
-            shape
-                .fill(colorScheme == .dark ? Color.white.opacity(0.12) : Color.black.opacity(0.08))
-                .overlay {
-                    shape.stroke(Color.white.opacity(colorScheme == .dark ? 0.08 : 0.24), lineWidth: 1)
-                }
-        }
+        .fill(MessagesPalette.bubbleFill(isOutgoing: isOutgoing))
     }
 }
 
@@ -817,7 +821,7 @@ struct MessageVisualMediaGrid: View {
         .clipShape(.rect(cornerRadius: cornerRadius, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .strokeBorder(Color.primary.opacity(isOutgoing ? 0.16 : 0.1), lineWidth: 1)
+                .strokeBorder(WNColor.borderTertiary, lineWidth: 1)
         }
     }
 
@@ -878,10 +882,13 @@ struct MessageVisualMediaTile: View {
             content
 
             if hiddenCount > 0 {
-                Color.black.opacity(0.46)
+                // Chrome over media: `overlayTertiary` is the palette's scrim, and content on it
+                // takes `fillContentQuaternary` — white in both appearances, because the scrim is
+                // dark in both.
+                WNColor.overlayTertiary
                 Text(verbatim: "+\(hiddenCount)")
                     .font(.title2.weight(.bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(WNColor.fillContentQuaternary)
             }
         }
         .frame(width: sideLength, height: sideLength)
@@ -951,14 +958,14 @@ struct MessageVisualMediaTile: View {
 
     private func placeholder(systemImage: String, isLoading: Bool) -> some View {
         ZStack {
-            Color.primary.opacity(0.06)
+            WNColor.backgroundTertiary
             if isLoading {
                 ProgressView()
                     .controlSize(.small)
             } else {
                 Image(systemName: systemImage)
                     .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
             }
         }
     }
@@ -1115,12 +1122,12 @@ struct MessageAttachmentStatusRow: View {
         HStack(spacing: 10) {
             ZStack {
                 Circle()
-                    .fill(iconBackground)
+                    .fill(AttachmentRowPalette.controlFill(isOutgoing: isOutgoing))
                     .frame(width: 30, height: 30)
                 if isLoading {
                     ProgressView()
                         .controlSize(.small)
-                        .tint(isOutgoing ? Color.white : Color.primary)
+                        .tint(AttachmentRowPalette.content(isOutgoing: isOutgoing))
                 } else {
                     Image(systemName: systemImage)
                         .font(.system(size: 14, weight: .semibold))
@@ -1133,7 +1140,7 @@ struct MessageAttachmentStatusRow: View {
                     .lineLimit(1)
                 Text(detail)
                     .font(.caption2)
-                    .foregroundStyle(isOutgoing ? Color.white.opacity(0.72) : Color.secondary)
+                    .foregroundStyle(AttachmentRowPalette.detailContent)
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1148,10 +1155,6 @@ struct MessageAttachmentStatusRow: View {
             }
         }
         .attachmentRowChrome(isOutgoing: isOutgoing)
-    }
-
-    private var iconBackground: Color {
-        isOutgoing ? Color.white.opacity(0.18) : Color.primary.opacity(0.08)
     }
 }
 
@@ -1197,7 +1200,7 @@ struct MessageAudioAttachmentPlayer: View {
                     .frame(width: 30, height: 30)
                     .background {
                         Circle()
-                            .fill(isOutgoing ? Color.white.opacity(0.18) : Color.primary.opacity(0.08))
+                            .fill(AttachmentRowPalette.controlFill(isOutgoing: isOutgoing))
                     }
             }
             .buttonStyle(.plain)
@@ -1212,14 +1215,14 @@ struct MessageAudioAttachmentPlayer: View {
                     ComposerAudioWaveformView(
                         bars: visibleWaveformBars,
                         progress: playbackProgress,
-                        barColor: isOutgoing ? Color.white.opacity(0.42) : Color.secondary.opacity(0.55),
-                        playedColor: isOutgoing ? Color.white.opacity(0.9) : Color.accentColor
+                        barColor: AttachmentRowPalette.waveformBar(isOutgoing: isOutgoing),
+                        playedColor: AttachmentRowPalette.waveformPlayedBar(isOutgoing: isOutgoing)
                     )
                     .frame(height: 24)
 
                     Text(durationLabel)
                         .font(.caption2.monospacedDigit())
-                        .foregroundStyle(isOutgoing ? Color.white.opacity(0.72) : Color.secondary)
+                        .foregroundStyle(AttachmentRowPalette.detailContent)
                         .lineLimit(1)
                 }
             }
@@ -1381,7 +1384,7 @@ struct MessageVideoAttachmentPlayer: View {
             if let player {
                 VideoPlayer(player: player)
                     .frame(width: sideLength, height: sideLength)
-                    .background(Color.black)
+                    .background(WNColor.shadow)
             } else {
                 Button(action: activatePlayback) {
                     playbackPlaceholder
@@ -1419,20 +1422,24 @@ struct MessageVideoAttachmentPlayer: View {
         }
     }
 
+    // Chrome that sits over a video frame, so it follows the other clients' media pairing rather
+    // than the app surface's: `overlayTertiary` for the scrim (black at 50% in both appearances,
+    // since a video frame is not light or dark in a way the palette can know) and
+    // `fillContentQuaternary` for everything drawn on it.
     private var playbackPlaceholder: some View {
         ZStack {
-            Color.black.opacity(0.86)
+            WNColor.overlayTertiary
             Image(systemName: didFail ? "arrow.clockwise" : "play.fill")
                 .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(.white)
+                .foregroundStyle(WNColor.fillContentQuaternary)
                 .frame(width: 48, height: 48)
-                .background(Color.black.opacity(0.45), in: Circle())
+                .background(WNColor.overlayTertiary, in: Circle())
 
             VStack {
                 Spacer()
                 Text(download.fileName.nilIfBlank ?? attachment.fileName)
                     .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.white.opacity(0.86))
+                    .foregroundStyle(WNColor.fillContentQuaternary.opacity(0.86))
                     .lineLimit(1)
                     .padding(.horizontal, 8)
                     .padding(.bottom, 8)
@@ -1441,9 +1448,9 @@ struct MessageVideoAttachmentPlayer: View {
             if isLoading {
                 ProgressView()
                     .controlSize(.small)
-                    .tint(.white)
+                    .tint(WNColor.fillContentQuaternary)
                     .frame(width: 42, height: 42)
-                    .background(Color.black.opacity(0.45), in: Circle())
+                    .background(WNColor.overlayTertiary, in: Circle())
             }
         }
         .frame(width: sideLength, height: sideLength)
@@ -1619,7 +1626,11 @@ struct MessageImageGalleryOverlay: View {
         let _ = workspace.mediaCacheGeneration
         GeometryReader { geometry in
             ZStack {
-                Color.black.opacity(0.92)
+                // The full-bleed viewer backdrop. `shadow` is the palette's black — the only pure
+                // black it defines, and black in both appearances — held at viewer strength rather
+                // than `overlayTertiary`'s 50%, which would leave the transcript legible behind the
+                // photo.
+                WNColor.shadow.opacity(0.92)
                     .onTapGesture(perform: onClose)
 
                 imageContent
@@ -1632,7 +1643,7 @@ struct MessageImageGalleryOverlay: View {
                     HStack(spacing: 12) {
                         Text(selectedAttachment.fileName)
                             .font(.callout.weight(.semibold))
-                            .foregroundStyle(.white)
+                            .foregroundStyle(WNColor.fillContentQuaternary)
                             .lineLimit(1)
 
                         Spacer()
@@ -1640,17 +1651,18 @@ struct MessageImageGalleryOverlay: View {
                         if canNavigate {
                             Text(verbatim: "\(selectedIndex + 1) / \(presentation.imageAttachments.count)")
                                 .font(.caption.monospacedDigit().weight(.semibold))
-                                .foregroundStyle(.white.opacity(0.72))
+                                .foregroundStyle(WNColor.fillContentQuaternary.opacity(0.72))
                         }
 
                         Button(action: onClose) {
                             Image(systemName: "xmark")
                                 .font(.system(size: 15, weight: .bold))
                                 .frame(width: 34, height: 34)
-                                .background(Color.white.opacity(0.14), in: Circle())
+                                .background(
+                                    WNColor.fillContentQuaternary.opacity(0.14), in: Circle())
                         }
                         .buttonStyle(.plain)
-                        .foregroundStyle(.white)
+                        .foregroundStyle(WNColor.fillContentQuaternary)
                         .help(L10n.string("Close"))
                         .accessibilityLabel(L10n.string("Close"))
                     }
@@ -1708,10 +1720,11 @@ struct MessageImageGalleryOverlay: View {
             Image(systemName: systemName)
                 .font(.system(size: 26, weight: .bold))
                 .frame(width: 54, height: 54)
-                .background(Color.white.opacity(isEnabled ? 0.16 : 0.06), in: Circle())
+                .background(
+                    WNColor.fillContentQuaternary.opacity(isEnabled ? 0.16 : 0.06), in: Circle())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(.white.opacity(isEnabled ? 0.96 : 0.28))
+        .foregroundStyle(WNColor.fillContentQuaternary.opacity(isEnabled ? 0.96 : 0.28))
         .disabled(!isEnabled)
         .help(accessibilityLabel)
         .accessibilityLabel(accessibilityLabel)
@@ -1730,7 +1743,7 @@ struct MessageImageGalleryContent: View {
             case .idle, .loading:
                 ProgressView()
                     .controlSize(.regular)
-                    .tint(.white)
+                    .tint(WNColor.fillContentQuaternary)
             case .failed:
                 VStack(spacing: 10) {
                     Image(systemName: "exclamationmark.triangle")
@@ -1743,7 +1756,7 @@ struct MessageImageGalleryContent: View {
                         Label(L10n.string("Retry"), systemImage: "arrow.clockwise")
                     }
                 }
-                .foregroundStyle(.white)
+                .foregroundStyle(WNColor.fillContentQuaternary)
             case .loaded(let download):
                 DownsampledMessageGalleryImage(download: download, attachment: attachment)
             }
@@ -1779,7 +1792,7 @@ struct DownsampledMessageGalleryImage: View {
             } placeholder: {
                 Text(L10n.string("Image unavailable"))
                     .font(.callout.weight(.semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(WNColor.fillContentQuaternary)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .frame(width: proxy.size.width, height: proxy.size.height)
@@ -1799,7 +1812,7 @@ struct MessageDebugMetadataView: View {
                 .font(.caption2.monospaced())
                 .lineLimit(1)
         }
-        .foregroundStyle(isOutgoing ? Color.white.opacity(0.74) : Color.primary.opacity(0.52))
+        .foregroundStyle(WNColor.backgroundContentTertiary)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
@@ -1880,11 +1893,13 @@ struct MessageInlineActionIcon: View {
         Image(systemName: systemName)
             .font(.system(size: 18, weight: .medium))
             .symbolRenderingMode(.monochrome)
-            .foregroundStyle(isHovering ? Color.primary : Color.secondary.opacity(0.9))
+            .foregroundStyle(
+                isHovering ? WNColor.backgroundContentPrimary : WNColor.backgroundContentSecondary
+            )
             .frame(width: 40, height: 40)
             .background {
                 Circle()
-                    .fill(isHovering ? Color.primary.opacity(0.07) : .clear)
+                    .fill(isHovering ? WNColor.fillTertiaryHover : WNColor.fillTertiary)
                     .frame(width: 32, height: 32)
             }
             .contentShape(Rectangle())
@@ -1941,9 +1956,9 @@ struct MessageEmojiPickerPopover: View {
             } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 14, weight: .bold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.fillContentTertiary)
                     .frame(width: 32, height: 32)
-                    .background(Color.primary.opacity(0.08), in: Circle())
+                    .background(WNColor.fillSecondary, in: Circle())
                     .frame(width: 40, height: 40)
             }
             .buttonStyle(.plain)
@@ -2072,7 +2087,9 @@ struct MessageOverflowPopover: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(action.role == .destructive ? Color.red : Color.primary)
+        .foregroundStyle(
+            action.role == .destructive
+                ? WNColor.backgroundContentDestructive : WNColor.backgroundContentPrimary)
     }
 }
 
@@ -2121,18 +2138,18 @@ struct MessageReplyContextView: View {
         Button(action: onOpen) {
             HStack(spacing: 8) {
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .fill(isOutgoing ? Color.white.opacity(0.72) : MessagesPalette.sentBubble.opacity(0.68))
+                    .fill(WNColor.borderTertiary)
                     .frame(width: 3)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(context.senderName)
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(isOutgoing ? Color.white.opacity(0.9) : MessagesPalette.sentBubble)
+                        .foregroundStyle(WNColor.backgroundContentTertiary)
                         .lineLimit(1)
 
                     Text(context.body)
                         .font(.caption)
-                        .foregroundStyle(isOutgoing ? Color.white.opacity(0.78) : Color.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                 }
@@ -2143,13 +2160,18 @@ struct MessageReplyContextView: View {
         .help(L10n.string("Show replied-to message"))
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
+        // The quote is its own card on `backgroundPrimary`, identically in both directions, as on
+        // the other clients — which is what lets its content take `background*` tokens instead of
+        // having to be picked per bubble fill. It cannot inherit a translucent material here: it
+        // sits *inside* the bubble, so a material would composite against `fillPrimary` and leave
+        // the quote's text colors undefined.
         .background {
-            if isOutgoing {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.white.opacity(0.13))
-            } else {
-                GlassRoundedBackground(cornerRadius: 8)
-            }
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(WNColor.backgroundPrimary)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(WNColor.borderTertiary, lineWidth: 1)
+                }
         }
     }
 }
@@ -2162,7 +2184,7 @@ struct TimelineDayHeaderView: View {
             Spacer(minLength: 24)
             Text(title)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
                 .background { GlassCapsuleBackground() }

--- a/whitenoise-mac/Views/MessageReactionViews.swift
+++ b/whitenoise-mac/Views/MessageReactionViews.swift
@@ -8,11 +8,18 @@
 
 import SwiftUI
 
-/// A tight, clustered row of reaction chips (emoji + count). Own reactions get a gentle accent
-/// fill. Tapping a chip opens the viewer filtered to that emoji; the overflow chip opens it on
-/// "All". Chips are view-only — adding/removing is done from the hover React control.
+/// A tight, clustered row of reaction chips (emoji + count). Tapping a chip opens the viewer
+/// filtered to that emoji; the overflow chip opens it on "All". Chips are view-only —
+/// adding/removing is done from the hover React control.
+///
+/// Colors come from `WNReactionColors`, which is keyed by direction because a chip hangs off the
+/// bubble's edge and therefore sits against `fillPrimary` or `backgroundMessageIncoming` — fills
+/// that run in opposite directions. A chip for a reaction the local account added takes the
+/// `selected` state.
 struct MessageReactionChips: View {
     let reactions: [MessageReaction]
+    /// Which bubble these chips hang off, which decides the whole chip color set.
+    let isOutgoing: Bool
     /// emoji to focus the viewer on, or nil for the "All" tab.
     let onOpenViewer: (String?) -> Void
 
@@ -32,7 +39,12 @@ struct MessageReactionChips: View {
         reactions.contains { $0.isOwn }
     }
 
+    private var colors: WNReactionColorSet {
+        WNReactionColors.set(isOutgoing: isOutgoing)
+    }
+
     var body: some View {
+        let colors = colors
         Button {
             onOpenViewer(nil)
         } label: {
@@ -41,7 +53,7 @@ struct MessageReactionChips: View {
                 if totalCount > 1 {
                     Text(verbatim: "\(totalCount)")
                         .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(isOwn ? colors.contentSelected : colors.content)
                 }
             }
             .font(.footnote)
@@ -49,14 +61,7 @@ struct MessageReactionChips: View {
             .padding(.vertical, 3)
             .background(
                 Capsule(style: .continuous)
-                    .fill(isOwn ? Color.accentColor.opacity(0.20) : Color(nsColor: .controlBackgroundColor))
-            )
-            .overlay(
-                Capsule(style: .continuous)
-                    .strokeBorder(
-                        isOwn ? Color.accentColor.opacity(0.45) : Color.primary.opacity(0.12),
-                        lineWidth: 1
-                    )
+                    .fill(isOwn ? colors.fillSelected : colors.fill)
             )
         }
         .buttonStyle(.plain)
@@ -128,10 +133,12 @@ struct MessageReactionDetailsView: View {
                     .font(.caption.weight(.semibold))
             }
             .font(.subheadline.weight(.semibold))
-            .foregroundStyle(isSelected ? Color.white : Color.primary)
+            // The viewer's filter pills are buttons on a `background*` surface, so they take the
+            // fill/fill-content pairs: `fillPrimary` when active, `fillSecondary` at rest.
+            .foregroundStyle(isSelected ? WNColor.fillContentPrimary : WNColor.fillContentSecondary)
             .padding(.horizontal, 12)
             .frame(minHeight: 30)
-            .background(isSelected ? Color.accentColor : Color.secondary.opacity(0.16), in: Capsule())
+            .background(isSelected ? WNColor.fillPrimary : WNColor.fillSecondary, in: Capsule())
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -208,7 +215,7 @@ struct MessageReactionDetailsView: View {
                 if canRemove {
                     Text(L10n.string("Tap to remove"))
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
             }
             Spacer(minLength: 8)

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -38,16 +38,26 @@ struct AvatarView: View {
 /// Applies the shared avatar ring + drop shadow. Centralized so `AvatarView` and
 /// `ProfileImageAvatarView` stay visually identical and only one of them draws it.
 struct AvatarChromeModifier: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
     let isSelected: Bool
     var isEnabled = true
     /// The unselected ring. Initials avatars pass their accent's border token, which is what makes
-    /// a pale fill read as an object against a light window; photo avatars keep
-    /// `neutralRing`, the same split the Flutter client draws between its image and initials
-    /// avatars. Selection still wins over both — the ring is a focus affordance first.
+    /// a pale fill read as an object against a light window; photo avatars keep `neutralRing`, the
+    /// same split the other clients draw between their image and initials avatars.
     var ringColor: Color = neutralRing
 
-    /// Hairline for avatars that are showing a picture rather than initials.
-    static let neutralRing = Color.white.opacity(0.2)
+    /// Hairline for avatars that are showing a picture rather than initials. `borderTertiary`, the
+    /// palette's resting border, rather than the white wash this used to be: a wash lightens
+    /// whatever is behind it, so it only read as a hairline in one of the two appearances.
+    static let neutralRing = WNColor.borderTertiary
+
+    /// How much the selected avatar grows. Size is the affordance that reads in both appearances,
+    /// so it carries selection on its own where the ring cannot. Kept small enough that the account
+    /// rail's avatar still fits inside its frame (`accountRailAvatarSize` inside
+    /// `accountRailAvatarFrameSize`), and applied as a scale so no neighbour is pushed around when
+    /// the selection moves.
+    static let selectedScale: CGFloat = 1.15
 
     @ViewBuilder
     func body(content: Content) -> some View {
@@ -55,14 +65,25 @@ struct AvatarChromeModifier: ViewModifier {
             content
                 .overlay {
                     Circle()
-                        .strokeBorder(
-                            isSelected ? MessagesPalette.sentBubble : ringColor,
-                            lineWidth: isSelected ? 3 : 1)
+                        .strokeBorder(strokeColor, lineWidth: isSelected ? 3 : 1)
                 }
-                .shadow(color: .black.opacity(0.12), radius: 2, y: 1)
+                .shadow(color: WNColor.shadow.opacity(0.1), radius: 2, y: 1)
+                .scaleEffect(isSelected ? Self.selectedScale : 1)
         } else {
             content
         }
+    }
+
+    /// The one place in the app that reads the appearance to pick a token, and it is deliberate:
+    /// what the selection ring has to contrast with is the avatar's own accent fill, and that fill
+    /// is itself inverted between appearances (the ramp's `950` step in dark, `50` in light). In
+    /// dark, `borderPrimary` is white and a white ring on a deep fill is the clearest selection
+    /// mark in the app. In light the same token is near-black, and a heavy near-black ring around a
+    /// pale disc reads as an outlined object rather than a selected one — so light keeps the
+    /// avatar's own ring and lets `selectedScale` say which one is active.
+    private var strokeColor: Color {
+        guard isSelected, colorScheme == .dark else { return ringColor }
+        return WNColor.borderPrimary
     }
 }
 
@@ -93,107 +114,149 @@ struct AvatarChromeModifier: ViewModifier {
 /// 2. **This appearance-dependence is designed, unlike an opacity flip.** Two full token sets are
 ///    specified per ramp, so contrast is preserved by construction rather than by luck. That is the
 ///    opposite of resolving one translucent color against two different backdrops, the trap
-///    documented on `MentionChipPalette` below.
-/// 3. **The disc is deliberately soft in Aqua, and softer here than in Flutter.** The Flutter
-///    client draws these on pure white/black; `windowBackgroundColor` is `#ECECEC`/`#323232`. In
-///    Dark Aqua the `200` ring sits 8.6:1–11:1 against the window, a crisp outline. In Aqua both
-///    fill and ring land within 1.01–1.26 of the window, so the edge is carried by hue plus the
-///    drop shadow in `AvatarChromeModifier` rather than by luminance. That shadow, which Flutter
-///    has no equivalent of, is doing real work on the gray macOS window — do not drop it.
+///    documented on the pairing rule in `WNNSColor`.
+/// 3. **The disc is deliberately soft in Aqua.** These are drawn on the palette's own surfaces
+///    now — `backgroundPrimary`/`Secondary`/`Tertiary` rather than AppKit's `#ECECEC`/`#323232`
+///    window gray — so the app matches what the other clients draw them on. In Dark Aqua the `200`
+///    ring is a crisp outline against those surfaces. In Aqua both fill and ring land close to
+///    them, so the edge is carried by hue plus the drop shadow in `AvatarChromeModifier` rather
+///    than by luminance. That shadow, which the other clients have no equivalent of, is doing real
+///    work here — do not drop it.
 ///
 /// `AvatarChromeModifier` therefore takes the `200` step as its `ringColor` for initials avatars,
 /// keeping the neutral hairline for the ones showing a picture.
-enum AvatarPalette {
-    /// The twelve accents in the Flutter client's `AvatarColor` declaration order. `accentIndex(for:)`
-    /// indexes into this array with that client's arithmetic, so reordering these silently recolors
-    /// every avatar on one platform.
-    private static let accents: [AvatarColorSet] = [
-        accent("blue", step50: 0xEFF6FF, step200: 0xBFDBFE, step900: 0x1E3A8A, step950: 0x172554),
-        accent("cyan", step50: 0xECFEFF, step200: 0xA5F3FC, step900: 0x164E63, step950: 0x083344),
-        accent("emerald", step50: 0xECFDF5, step200: 0xA7F3D0, step900: 0x064E3B, step950: 0x022C22),
-        accent("fuchsia", step50: 0xFDF4FF, step200: 0xF5D0FE, step900: 0x701A75, step950: 0x4A044E),
-        accent("indigo", step50: 0xEEF2FF, step200: 0xC7D2FE, step900: 0x312E81, step950: 0x1E1B4B),
-        accent("lime", step50: 0xF7FEE7, step200: 0xD9F99D, step900: 0x365314, step950: 0x1A2E05),
-        accent("orange", step50: 0xFFF7ED, step200: 0xFED7AA, step900: 0x7C2D12, step950: 0x431407),
-        accent("rose", step50: 0xFFF1F2, step200: 0xFECDD3, step900: 0x881337, step950: 0x4C0519),
-        accent("sky", step50: 0xF0F9FF, step200: 0xBAE6FD, step900: 0x0C4A6E, step950: 0x082F49),
-        accent("teal", step50: 0xF0FDFA, step200: 0x99F6E4, step900: 0x134E4A, step950: 0x042F2E),
-        accent("violet", step50: 0xF5F3FF, step200: 0xDDD6FE, step900: 0x4C1D95, step950: 0x2E1065),
-        accent("amber", step50: 0xFFFBEB, step200: 0xFDE68A, step900: 0x78350F, step950: 0x451A03),
+nonisolated enum AvatarPalette {
+    /// The twelve accents in the other clients' `AvatarColor` declaration order.
+    /// `accentIndex(for:)` indexes into this array with that client's arithmetic, so reordering
+    /// these silently recolors every avatar on one platform.
+    ///
+    /// The ramp values themselves live once, in `WNAccentColors` — these are the same sets the
+    /// palette hands to mentions and anything else that identifies a person, viewed through the
+    /// three tokens an avatar needs.
+    private static let accents: [WNAccentColorSet] = [
+        WNAccentColors.blue,
+        WNAccentColors.cyan,
+        WNAccentColors.emerald,
+        WNAccentColors.fuchsia,
+        WNAccentColors.indigo,
+        WNAccentColors.lime,
+        WNAccentColors.orange,
+        WNAccentColors.rose,
+        WNAccentColors.sky,
+        WNAccentColors.teal,
+        WNAccentColors.violet,
+        WNAccentColors.amber,
     ]
 
-    /// For seeds that do not start with a hex digit. The Flutter client logs and falls back here
-    /// too; the only such seed in this app is the still-unnamed group in the compose flow, which is
+    /// For seeds that do not start with a hex digit. The other clients log and fall back here too;
+    /// the only such seed in this app is the still-unnamed group in the compose flow, which is
     /// keyed on its typed title because it has no group id yet.
+    ///
+    /// Neutral is the one set drawn from the semantic fills rather than an accent, which is what
+    /// `WnAvatar` does with `AvatarColor.neutral`.
     static let neutral = AvatarColorSet(
-        // neutral100 / neutral800, neutral500 / neutral400, neutral950 / white.
-        fill: dynamic("avatarFill.neutral", light: 0xF5F5F5, dark: 0x262626),
-        border: dynamic("avatarBorder.neutral", light: 0x737373, dark: 0xA3A3A3),
-        content: dynamic("avatarContent.neutral", light: 0x0A0A0A, dark: 0xFFFFFF))
+        fill: WNColor.fillSecondary,
+        border: WNColor.borderSecondary,
+        content: WNColor.fillContentSecondary)
 
     static var accentCount: Int { accents.count }
 
     static func colors(for seed: String) -> AvatarColorSet {
         guard let index = accentIndex(for: seed) else { return neutral }
-        return accents[index]
+        return AvatarColorSet(accents[index])
     }
 
-    /// The Flutter client's mapping: the value of the seed's **first hex digit**, modulo the accent
+    /// The whole accent set at `index`, for the callers that need a token the three avatar ones do
+    /// not carry. A mention takes `contentSecondary`; see `MentionTextPalette`.
+    static func accent(at index: Int) -> WNAccentColorSet {
+        accents[index]
+    }
+
+    /// The other clients' mapping: the value of the seed's **first hex digit**, modulo the accent
     /// count, or `nil` when that character is not one. Only the first character participates — two
-    /// pubkeys sharing a leading nibble share a color, by design on both platforms.
+    /// pubkeys sharing a leading nibble share a color, by design on every platform.
     ///
     /// Note the inherited skew: a nibble spans 0...15 but there are twelve accents, so `c`-`f` wrap
     /// onto blue, cyan, emerald, and fuchsia, leaving those four twice as likely as the other
-    /// eight. Kept as-is deliberately — matching the other client's assignment is the point, and
-    /// `% accents.count` is exactly what it computes.
+    /// eight. Kept as-is deliberately — matching the other clients' assignment is the point, and
+    /// `% accents.count` is exactly what they compute.
     static func accentIndex(for seed: String) -> Int? {
         guard let first = seed.first, first.isASCII, let nibble = first.hexDigitValue else { return nil }
         return nibble % accents.count
     }
 
-    private static func accent(
-        _ name: String, step50: UInt32, step200: UInt32, step900: UInt32, step950: UInt32
-    ) -> AvatarColorSet {
-        AvatarColorSet(
-            fill: dynamic("avatarFill.\(name)", light: step50, dark: step950),
-            // The one token the design system holds constant across appearances.
-            border: Color(nsColor: NSColor(rgb: step200)),
-            content: dynamic("avatarContent.\(name)", light: step900, dark: step50))
+    /// The same mapping for an `npub1…`, without decoding it.
+    ///
+    /// Message bodies carry mentions as bech32, and the accent has to be chosen while the body's
+    /// attributed string is built — off the main actor, with no `Marmot` client in reach, so
+    /// `hexPubkeyFromNpub` (which the other clients call here) is not available.
+    ///
+    /// It is not needed. `accentIndex(for:)` reads exactly one hex digit, and that digit is
+    /// recoverable from the bech32 directly: a bech32 payload is the byte string regrouped into
+    /// 5-bit characters, most significant bits first, so the first data character holds the top
+    /// *five* bits of byte 0 while the first hex digit is its top *four*. Dropping the low bit
+    /// converts between them.
+    ///
+    /// Returns `nil` for anything that is not a plain `npub1…`. `nprofile` in particular is
+    /// TLV-encoded rather than a bare key, so its first data character is a record tag and means
+    /// nothing here — the other clients also restrict the per-user color to `npub` for this reason.
+    static func accentIndex(forNpub npub: String) -> Int? {
+        let prefix = "npub1"
+        guard npub.hasPrefix(prefix),
+            let firstDataCharacter = npub.dropFirst(prefix.count).first,
+            let fiveBitValue = bech32Alphabet.firstIndex(of: firstDataCharacter)
+        else { return nil }
+        return (fiveBitValue >> 1) % accents.count
     }
 
-    /// A single token that resolves per appearance at draw time. `NSColor(name:)` rather than an
-    /// `@Environment(\.colorScheme)` read so that `AvatarPalette` stays a plain static API that
-    /// non-`View` callers and tests can ask for colors without building a view hierarchy.
-    private static func dynamic(_ name: String, light: UInt32, dark: UInt32) -> Color {
-        Color(
-            nsColor: NSColor(name: name) { appearance in
-                appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-                    ? NSColor(rgb: dark) : NSColor(rgb: light)
-            })
-    }
+    /// The BIP-173 bech32 character set, where a character's index *is* its 5-bit value.
+    private static let bech32Alphabet = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
 }
 
-/// The three tokens an avatar needs from its accent ramp. Mirrors the Flutter client's
-/// `AvatarColorSet` minus `contentSecondary`, which only feeds widgets this app does not have.
-struct AvatarColorSet {
+/// The three tokens an avatar needs from its accent ramp. Mirrors the other clients'
+/// `AvatarColorSet` minus `contentSecondary`, which feeds mentions rather than avatars — reach for
+/// `WNAccentColors` directly if you need that one.
+nonisolated struct AvatarColorSet {
     let fill: Color
     let border: Color
     let content: Color
-}
 
-extension NSColor {
-    /// `0xRRGGBB` in sRGB, so the ramp tables above read as the hex the design system publishes.
-    fileprivate convenience init(rgb: UInt32) {
-        self.init(
-            srgbRed: CGFloat((rgb >> 16) & 0xFF) / 255,
-            green: CGFloat((rgb >> 8) & 0xFF) / 255,
-            blue: CGFloat(rgb & 0xFF) / 255,
-            alpha: 1)
+    init(fill: Color, border: Color, content: Color) {
+        self.fill = fill
+        self.border = border
+        self.content = content
+    }
+
+    fileprivate init(_ accent: WNAccentColorSet) {
+        self.init(fill: accent.fill, border: accent.border, content: accent.contentPrimary)
     }
 }
 
-enum MessagesPalette {
-    static let sentBubble = Color(nsColor: .systemBlue)
+/// `nonisolated` for the same reason `AttachmentRowPalette` below is: the bubble fills are read
+/// while a message's display content is built off the main actor.
+nonisolated enum MessagesPalette {
+    /// The sent bubble's fill: `fillPrimary`, the same token the primary button takes.
+    /// It is inverted against the surface rather than an accent hue, which is why a sent
+    /// bubble is near-black in light appearance and white in dark — White Noise has no
+    /// blue "my messages" color, on any client.
+    static let sentBubble = WNColor.fillPrimary
+
+    /// Content on the sent bubble. Pairs with `sentBubble` and crosses over with it, so it
+    /// is white on the light appearance's dark bubble and near-black on the dark
+    /// appearance's white one. Never substitute a literal `.white` here.
+    static let sentBubbleContent = WNColor.fillContentPrimary
+
+    /// The received bubble's fill, and the content that goes on it.
+    static let receivedBubble = WNColor.backgroundMessageIncoming
+    static let receivedBubbleContent = WNColor.backgroundContentPrimary
+
+    static func bubbleFill(isOutgoing: Bool) -> Color {
+        isOutgoing ? sentBubble : receivedBubble
+    }
+
+    static func bubbleContent(isOutgoing: Bool) -> Color {
+        isOutgoing ? sentBubbleContent : receivedBubbleContent
+    }
 }
 
 /// Surface for the non-visual attachment rows: the audio player, the download/failed status rows,
@@ -202,78 +265,93 @@ enum MessagesPalette {
 /// Unlike the reply quote, these rows sit *beside* the bubble in `MessageBubble`'s stack rather than
 /// inside it, so they never inherit `BubbleBackground`'s fill and have to bring their own.
 nonisolated enum AttachmentRowPalette {
-    /// The accent itself — the same fill the sent bubble uses, which is what the row's white content
-    /// (play button, waveform, detail text) is drawn for.
+    /// The same fill the sent bubble uses, which is what `outgoingContent` is drawn for.
     ///
-    /// It has to stay **opaque**. A translucent white wash composites against whatever is behind the
+    /// It has to stay **opaque**. A translucent wash composites against whatever is behind the
     /// row, and what is behind it is the window background: dark in dark appearance, light in light
     /// appearance. That is how sent voice notes and documents came to render white-on-white and
     /// vanish in light mode while looking correct in dark.
     static let outgoingFill = MessagesPalette.sentBubble
 
-    /// Received rows stay on a wash, which is safe here because `.primary` flips with the
-    /// appearance — it darkens the light backdrop and lightens the dark one.
-    static let incomingFill = Color.primary.opacity(0.06)
+    /// Received rows take the received bubble's fill, so an attachment row reads as part of the
+    /// same message as the bubble above it.
+    static let incomingFill = MessagesPalette.receivedBubble
+
+    /// The row's content — play button, waveform, detail text. Paired with the fill above, which
+    /// matters more here than anywhere else in the app: both fills invert between appearances, so a
+    /// literal `.white` (what these rows used to draw) is correct in exactly one of the four
+    /// combinations.
+    static let outgoingContent = MessagesPalette.sentBubbleContent
+    static let incomingContent = MessagesPalette.receivedBubbleContent
 
     static func fill(isOutgoing: Bool) -> Color {
         isOutgoing ? outgoingFill : incomingFill
     }
+
+    static func content(isOutgoing: Bool) -> Color {
+        isOutgoing ? outgoingContent : incomingContent
+    }
+
+    /// The disc behind a play/status glyph, and the unplayed waveform. Derived from the row's own
+    /// content color so it steps away from the fill in whichever direction that fill has room —
+    /// the alternative, a fixed white or black wash, is only correct in one of the four
+    /// fill × appearance combinations.
+    static func controlFill(isOutgoing: Bool) -> Color {
+        content(isOutgoing: isOutgoing).opacity(0.14)
+    }
+
+    static func waveformBar(isOutgoing: Bool) -> Color {
+        content(isOutgoing: isOutgoing).opacity(0.42)
+    }
+
+    static func waveformPlayedBar(isOutgoing: Bool) -> Color {
+        content(isOutgoing: isOutgoing).opacity(0.9)
+    }
+
+    /// Detail text inside an attachment row — file size, duration. `backgroundContentTertiary` is
+    /// what the other clients use for de-emphasized text inside a bubble, in *both* directions:
+    /// the `400`/`500` neutral step is the one that clears both bubble fills.
+    static let detailContent = WNColor.backgroundContentTertiary
 }
 
-/// The background chip drawn behind an `@mention`'s glyphs, Signal's treatment: the mention keeps
-/// the body font, weight, and inherited foreground, and is set off by its fill alone. Each chip is
-/// the bubble's own fill pushed a step further, never a different hue — a mention should look like
-/// part of the bubble, not like something pasted into it.
+/// How an `@mention` is set off from the text around it: **bold, in the mentioned person's own
+/// accent**, with no background chip and no decoration — the same treatment the other clients give
+/// it.
 ///
-/// The chip has to hold up over four different fills — the accent-filled sent bubble, plus the light
-/// and dark neutral fills shared by received bubbles, agent rows, and the composer. No single
-/// translucent wash does that, which is why the previous `primary.opacity(0.14)` read as smudged
-/// text everywhere: `.primary` flips direction between the appearances, so it darkened one neutral
-/// fill and lightened the other, too faintly to register either way.
+/// The color is `accent.contentSecondary`, the `500` step of that person's accent ramp, and the
+/// choice of step is the whole trick. `500` is the one rung of each ramp that is neither the light
+/// surface (`50`) nor the dark one (`950`), so a single value stays legible on every fill a mention
+/// can land on — the sent bubble, the received bubble, an agent row, the composer — in both
+/// appearances, without the mention having to know which of them it is on. That is why this replaced
+/// a background chip: a chip has to be picked per fill, and there is no fill-independent chip.
 ///
-/// Direction is per fill, and it is not a free choice. The sent bubble and the light neutral fill
-/// both take a darker chip. The dark neutral fill cannot: it is already close to black, so even a
-/// 45%-black wash only reaches 1.43 contrast against it, while a light step of the same gray reaches
-/// 1.86. There it steps lighter instead — same achromatic family, just the only direction with room.
-///
-/// Measured against the fill behind it (WCAG contrast, chip vs. bubble), every combination lands at
-/// 1.84–1.87 where the old chip managed 1.19–1.55, and the inherited body text keeps 6.1:1 or
-/// better against the chip:
-///
-/// | fill | chip | chip ÷ fill | was | text ÷ chip |
-/// | --- | --- | --- | --- | --- |
-/// | sent, light | `#0053AD` | 1.84 | 1.29 | 7.39 |
-/// | sent, dark | `#075AAD` | 1.87 | 1.19 | 6.83 |
-/// | received, light | `#AEAEAE` | 1.86 | 1.37 | 9.47 |
-/// | received, dark | `#616161` | 1.86 | 1.55 | 6.19 |
+/// A mention whose accent cannot be determined (an `nprofile`, which is TLV-encoded rather than a
+/// bare key) stays bold and keeps the surrounding foreground, so it is still marked as a mention but
+/// does not claim to identify a specific person with a color that would be wrong.
 ///
 /// `nonisolated` because a message's attributed string is built off-main while mapping a timeline
-/// window (whitenoise-mac#285), so these must be reachable from outside the main actor.
-nonisolated enum MentionChipPalette {
-    /// Over the accent-filled sent bubble: the same blue, pushed distinctly darker. One value for
-    /// both appearances, because that fill is blue in either.
-    static let onSentBubble = Color.black.opacity(0.32)
-
-    /// Over a neutral fill: the same gray, one step away. Which way depends on the appearance — the
-    /// light fill has room to go darker, the dark fill only has room to go lighter — so this is a
-    /// dynamic color resolved at draw time rather than a fixed overlay.
-    static let neutralFillTextBackground = NSColor(name: "mentionChipOnNeutralFill") { appearance in
-        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
-            ? NSColor(white: 1.0, alpha: 0.20)
-            : NSColor(white: 0.0, alpha: 0.26)
+/// window (whitenoise-mac#285), so this must be reachable from outside the main actor.
+nonisolated enum MentionTextPalette {
+    /// The accent color for a mention written as `npub1…`, or `nil` when the reference is not a
+    /// bare public key and no person-specific color can honestly be applied.
+    static func foreground(forNpub npub: String) -> Color? {
+        AvatarPalette.accentIndex(forNpub: npub).map { AvatarPalette.accent(at: $0).contentSecondary }
     }
 
-    /// SwiftUI twin of `neutralFillTextBackground`. The composer's `NSTextView` draft token takes
-    /// the AppKit one; both are the same chip, because the draft sits on the same neutral surface a
-    /// received bubble does.
-    static let onNeutralFill = Color(nsColor: neutralFillTextBackground)
-
-    static func color(on fill: MarkdownMentionFill) -> Color {
-        switch fill {
-        case .neutral: onNeutralFill
-        case .sentBubble: onSentBubble
+    /// AppKit twin, for the composer's `NSTextView` draft tokens. Reads the accent's own
+    /// dynamic `NSColor` rather than converting the SwiftUI one back: `NSColor(someColor)` can
+    /// bake in whichever appearance was current when it ran, which would freeze a draft token's
+    /// color at the appearance the composer first drew under.
+    static func nsForeground(forNpub npub: String) -> NSColor? {
+        AvatarPalette.accentIndex(forNpub: npub).map {
+            AvatarPalette.accent(at: $0).nsContentSecondary
         }
     }
+
+    /// The composer draft's fallback for a token whose accent is unknown. The draft sits on
+    /// `backgroundPrimary`, so it takes that surface's primary content color; a rendered message
+    /// body instead inherits whatever its bubble already set.
+    static let composerFallbackForeground = WNNSColor.backgroundContentPrimary
 }
 
 enum MessagesLayout {
@@ -308,11 +386,12 @@ struct MessagesSearchField: View {
         HStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentTertiary)
 
             TextField(placeholder, text: $text)
                 .textFieldStyle(.plain)
                 .font(.callout)
+                .foregroundStyle(WNColor.backgroundContentPrimary)
                 .focused($isFocused)
                 .accessibilityIdentifier(accessibilityIdentifier ?? "search.field")
 
@@ -323,7 +402,7 @@ struct MessagesSearchField: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentTertiary)
                 }
                 .buttonStyle(.plain)
                 .help(L10n.string("Clear search"))
@@ -342,88 +421,106 @@ struct MessagesSearchField: View {
     }
 }
 
+/// The round icon controls in the composer, the account rail, and the conversation header.
+///
+/// These are the other clients' `WnIconButton` in its `outline` form: a `fillSecondary` disc inside a
+/// `borderTertiary` ring, stepping to the active fill when selected. There is no destructive form:
+/// a live microphone replaces the whole composer with `VoiceRecordingComposerView` rather than
+/// recoloring this control, and nothing else here is destructive.
 struct MessagesCircleControlBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
     var isSelected = false
-    var isActive = false
 
     var body: some View {
         Circle()
-            .fill(fillColor)
+            .fill(isSelected ? WNColor.fillSecondaryActive : WNColor.fillSecondary)
             .overlay {
                 Circle()
-                    .stroke(strokeColor, lineWidth: 1)
+                    .stroke(WNColor.borderTertiary, lineWidth: 1)
             }
             .nativeBackgroundExtensionEffect()
     }
-
-    private var fillColor: Color {
-        if isActive {
-            return Color.red.opacity(colorScheme == .dark ? 0.28 : 0.18)
-        }
-        if isSelected {
-            return Color.white.opacity(colorScheme == .dark ? 0.16 : 0.34)
-        }
-        return Color.white.opacity(colorScheme == .dark ? 0.06 : 0.18)
-    }
-
-    private var strokeColor: Color {
-        if isActive {
-            return Color.red.opacity(colorScheme == .dark ? 0.42 : 0.30)
-        }
-        return Color.white.opacity(colorScheme == .dark ? 0.08 : 0.32)
-    }
 }
 
+/// The selected chat row in the sidebar. `fillTertiaryHover` is the ghost control's pointed-at
+/// fill — one neutral step off the surface — which is what the other clients highlight a selected
+/// list row with. An unselected row draws nothing at all, since `fillTertiary` is transparent.
 struct MessagesSidebarRowBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
     let isSelected: Bool
 
     var body: some View {
         RoundedRectangle(cornerRadius: 9, style: .continuous)
-            .fill(
-                isSelected
-                    ? Color.white.opacity(colorScheme == .dark ? 0.13 : 0.28)
-                    : Color.clear
-            )
+            .fill(isSelected ? WNColor.fillTertiaryHover : WNColor.fillTertiary)
     }
 }
 
 struct MessagesSearchFieldBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
         Capsule(style: .continuous)
-            .fill(Color.white.opacity(colorScheme == .dark ? 0.08 : 0.28))
+            .fill(WNColor.backgroundPrimary)
             .overlay {
                 Capsule(style: .continuous)
-                    .stroke(Color.white.opacity(colorScheme == .dark ? 0.08 : 0.28), lineWidth: 1)
+                    .stroke(WNColor.borderTertiary, lineWidth: 1)
             }
     }
 }
 
+/// The send button. `fillPrimary` when it can send, `fillDisabled` when it cannot — the same pair
+/// `WnButton.primary` uses, so the send control and a primary push button are the same button.
 struct MessagesSendButtonBackground: View {
     let isEnabled: Bool
 
     var body: some View {
         Circle()
-            .fill(isEnabled ? MessagesPalette.sentBubble : Color.white.opacity(0.08))
-            .overlay {
-                Circle()
-                    .stroke(Color.white.opacity(isEnabled ? 0.18 : 0.08), lineWidth: 1)
-            }
+            .fill(isEnabled ? WNColor.fillPrimary : WNColor.fillDisabled)
     }
 }
 
-struct MessagesComposerFieldBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
+/// The send control, disc and glyph together, because the two are a pairing rather than two
+/// choices: the glyph on `fillPrimary` is `fillContentPrimary`, and the glyph on `fillDisabled` is
+/// `fillContentDisabled`. Naming the glyph's color is what the two call sites were missing — an
+/// unstyled one inherits the app-wide `backgroundContentPrimary`, which is near-black in light
+/// appearance and disappears into the near-black `fillPrimary` disc under it.
+struct MessagesSendButtonLabel: View {
+    let systemImage: String
+    /// Whether the composer can send right now. The disc stays filled while a send is in flight, so
+    /// the spinner is never drawn on the disabled gray.
+    let isEnabled: Bool
+    let isSending: Bool
+
+    private var isFilled: Bool { isEnabled || isSending }
 
     var body: some View {
+        Group {
+            if isSending {
+                ProgressView()
+                    .controlSize(.small)
+                    // Spins inside the send button, so it takes the send button's content color
+                    // rather than a literal white.
+                    .tint(WNColor.fillContentPrimary)
+                    .scaleEffect(0.72)
+            } else {
+                Image(systemName: systemImage)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(isFilled ? WNColor.fillContentPrimary : WNColor.fillContentDisabled)
+            }
+        }
+        .frame(width: 32, height: 32)
+        .background {
+            MessagesSendButtonBackground(isEnabled: isFilled)
+        }
+    }
+}
+
+/// The composer's text field: `backgroundPrimary` inside a `borderSecondary` hairline, matching
+/// `WnChatMessageInput` on the other clients. `borderSecondary` rather than `borderTertiary` because
+/// this is an editable field at rest, not a divider.
+struct MessagesComposerFieldBackground: View {
+    var body: some View {
         RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(Color.white.opacity(colorScheme == .dark ? 0.06 : 0.22))
+            .fill(WNColor.backgroundPrimary)
             .overlay {
                 RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .stroke(Color.white.opacity(colorScheme == .dark ? 0.12 : 0.32), lineWidth: 1)
+                    .stroke(WNColor.borderSecondary, lineWidth: 1)
             }
     }
 }
@@ -438,46 +535,47 @@ struct GlassFill: View {
     var material: Material = .regularMaterial
     var darkOpacity: Double
     var lightOpacity: Double
-    var lightTint: NSColor = .windowBackgroundColor
+    /// The wash laid over the material. `backgroundPrimary` already inverts between
+    /// appearances — white over the light material, black over the dark one — so only the
+    /// strength of the wash still has to be chosen per appearance.
+    var tint: Color = WNColor.backgroundPrimary
 
     var body: some View {
         ZStack {
             Rectangle()
                 .fill(material)
-            Color(nsColor: colorScheme == .dark ? .black : lightTint)
+            tint
                 .opacity(colorScheme == .dark ? darkOpacity : lightOpacity)
         }
     }
 }
 
+/// The window's base surface, behind every pane.
+///
+/// This and the three below were the app's hardcoded grays — `#0E0E0F` / `#F9F9F6` and friends,
+/// values that existed nowhere else in White Noise. They are the neutral ramp now, which is what
+/// makes the mac app's chrome the same set of surfaces the other clients use rather than a
+/// look-alike.
 struct MessagesWindowBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
         Rectangle()
-            .fill(
-                colorScheme == .dark
-                    ? Color(red: 0.055, green: 0.055, blue: 0.058)
-                    : Color(red: 0.975, green: 0.975, blue: 0.965)
-            )
+            .fill(WNColor.backgroundSecondary)
             .ignoresSafeArea()
     }
 }
 
+/// The transcript, the detail panes, and the settings pages: the app's primary reading surface.
 struct MessagesTranscriptBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
         Rectangle()
-            .fill(
-                colorScheme == .dark
-                    ? Color(red: 0.055, green: 0.055, blue: 0.058)
-                    : Color(nsColor: .textBackgroundColor)
-            )
+            .fill(WNColor.backgroundPrimary)
             .ignoresSafeArea()
     }
 }
 
+/// The two sidebar columns. Both sit *off* the primary surface, one step further than the
+/// transcript, which is how the other clients separate navigation from content — the account
+/// rail takes the deeper of the two.
 struct MessagesSidebarBackground: View {
     enum Level {
         case rail
@@ -485,7 +583,6 @@ struct MessagesSidebarBackground: View {
     }
 
     let level: Level
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         Rectangle()
@@ -494,34 +591,18 @@ struct MessagesSidebarBackground: View {
     }
 
     private var backgroundColor: Color {
-        if colorScheme == .dark {
-            switch level {
-            case .rail:
-                return Color(red: 0.18, green: 0.18, blue: 0.18)
-            case .drawer:
-                return Color(red: 0.145, green: 0.145, blue: 0.145)
-            }
-        } else {
-            switch level {
-            case .rail:
-                return Color(red: 0.84, green: 0.84, blue: 0.82)
-            case .drawer:
-                return Color(red: 0.90, green: 0.90, blue: 0.88)
-            }
+        switch level {
+        case .rail: WNColor.backgroundTertiary
+        case .drawer: WNColor.backgroundSecondary
         }
     }
 }
 
+/// The conversation header, which reads as part of the transcript below it.
 struct MessagesHeaderBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
         Rectangle()
-            .fill(
-                colorScheme == .dark
-                    ? Color(red: 0.055, green: 0.055, blue: 0.058)
-                    : Color(nsColor: .textBackgroundColor)
-            )
+            .fill(WNColor.backgroundPrimary)
     }
 }
 
@@ -532,9 +613,10 @@ struct MessagesComposerBarBackground: View {
     }
 }
 
+/// The app's hairline. `borderTertiary` is the resting border on every other client — by a wide
+/// margin the most-used border token there — and a separator is exactly that: a border with nothing
+/// on either side of it.
 struct GlassSeparator: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     enum Axis {
         case horizontal
         case vertical
@@ -544,15 +626,11 @@ struct GlassSeparator: View {
 
     var body: some View {
         Rectangle()
-            .fill(Color.primary.opacity(colorScheme == .dark ? 0.11 : 0.08))
+            .fill(WNColor.borderTertiary)
             .frame(
                 width: axis == .vertical ? 1 : nil,
                 height: axis == .horizontal ? 1 : nil
             )
-            .overlay {
-                Rectangle()
-                    .fill(Color.white.opacity(colorScheme == .dark ? 0.05 : 0.18))
-            }
     }
 }
 
@@ -582,7 +660,6 @@ struct LiquidGlassBackground: View {
 }
 
 struct GlassRoundedBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
     var cornerRadius: CGFloat = 8
     var material: Material = .ultraThinMaterial
     var borderColor: Color?
@@ -592,7 +669,7 @@ struct GlassRoundedBackground: View {
             .fill(material)
             .overlay {
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .stroke(borderColor ?? Color.white.opacity(colorScheme == .dark ? 0.16 : 0.34), lineWidth: 1)
+                    .stroke(borderColor ?? WNColor.borderTertiary, lineWidth: 1)
             }
             .nativeBackgroundExtensionEffect()
     }
@@ -616,21 +693,22 @@ struct GlassCardModifier: ViewModifier {
 }
 
 struct GlassCapsuleBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
     var borderColor: Color?
 
     var body: some View {
-        // Flat translucent fill instead of `.ultraThinMaterial`. A material capsule renders a
+        // Flat fill instead of `.ultraThinMaterial`. A material capsule renders a
         // `CABackdropLayer` blur per instance — fine once, but these are per-row chrome
-        // (reactions, system notices), and rendering every visible one was a measurable slice
+        // (day headers, system notices), and rendering every visible one was a measurable slice
         // of initial-render / scroll cost (Instruments: CA::Render::copy_image / -[CAFilter
-        // CA_copyRenderValue]). `.quaternary` is a solid, adaptive hierarchical fill that reads
-        // almost identically without the backdrop pass. See the #205 scroll-performance work.
+        // CA_copyRenderValue]). See the #205 scroll-performance work. `fillSecondary` keeps that
+        // property — it is a plain opaque color, so there is no backdrop pass at all — and it is
+        // the token the other clients put behind a pill, where `.quaternary` was the system's
+        // hierarchical gray and belonged to no palette.
         Capsule(style: .continuous)
-            .fill(.quaternary)
+            .fill(WNColor.fillSecondary)
             .overlay {
                 Capsule(style: .continuous)
-                    .stroke(borderColor ?? Color.white.opacity(colorScheme == .dark ? 0.14 : 0.3), lineWidth: 1)
+                    .stroke(borderColor ?? WNColor.borderTertiary, lineWidth: 1)
             }
     }
 }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -64,10 +64,10 @@ private struct BackgroundStatusBanner: View {
         if let status = workspace.backgroundStatus {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
                 Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(WNColor.intentionWarningContent)
                 Text(status)
                     .font(.callout)
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(WNColor.backgroundContentPrimary)
                     .multilineTextAlignment(.leading)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: 8)
@@ -105,7 +105,7 @@ private struct WelcomeAuthView: View {
                 .interpolation(.high)
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 104, height: 104)
-                .shadow(color: Color.black.opacity(0.12), radius: 18, y: 10)
+                .shadow(color: WNColor.shadow.opacity(0.1), radius: 18, y: 10)
 
             // Standard primary/secondary pattern: hierarchy comes from the button style,
             // and the system owns the label/fill colors (adapts to accent, contrast, and
@@ -169,7 +169,7 @@ private struct WelcomeAuthView: View {
             if let lastError = workspace.lastError {
                 Text(lastError)
                     .font(.callout)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(WNColor.backgroundContentDestructive)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 460)
                     .padding(.top, 2)
@@ -179,9 +179,11 @@ private struct WelcomeAuthView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background {
-            // Matches the app-logo tile grey (#202020) so the mark sits on a seamless field.
-            Color(red: 32.0 / 255.0, green: 32.0 / 255.0, blue: 32.0 / 255.0)
-                .ignoresSafeArea()
+            // `backgroundPrimary`, as on the other clients' sign-in screen. It used to be a fixed
+            // #202020 chosen to bleed into the logo tile, which made this the one pane in the app
+            // whose surface belonged to no palette and did not follow the appearance at all. The
+            // logo now reads as the app icon it is, sitting on the app's own surface.
+            MessagesTranscriptBackground()
         }
     }
 }
@@ -239,7 +241,7 @@ private struct SignedOutAccountsView: View {
                 Text(L10n.string("Choose an account"))
                     .font(.title2.weight(.semibold))
                 Text(L10n.string("Sign in to continue with an account stored on this Mac."))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
 
             VStack(spacing: 10) {
@@ -260,7 +262,7 @@ private struct SignedOutAccountsView: View {
                                     .font(.headline)
                                 Text(DisplayText.short(account.npub ?? account.accountIdHex))
                                     .font(.caption.monospaced())
-                                    .foregroundStyle(.secondary)
+                                    .foregroundStyle(WNColor.backgroundContentSecondary)
                             }
                             Spacer(minLength: 20)
                             Text(L10n.string("Sign In"))
@@ -286,7 +288,7 @@ private struct SignedOutAccountsView: View {
             if let lastError = workspace.lastError {
                 Text(lastError)
                     .font(.callout)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(WNColor.backgroundContentDestructive)
                     .multilineTextAlignment(.center)
             }
         }
@@ -602,9 +604,9 @@ private struct ConversationView: View {
                                     .frame(width: 40, height: 40)
                                     .background(.regularMaterial, in: Circle())
                                     .overlay {
-                                        Circle().strokeBorder(Color.primary.opacity(0.10), lineWidth: 1)
+                                        Circle().strokeBorder(WNColor.borderTertiary, lineWidth: 1)
                                     }
-                                    .shadow(color: .black.opacity(0.16), radius: 8, y: 3)
+                                    .shadow(color: WNColor.shadow.opacity(0.1), radius: 8, y: 3)
                             }
                             .buttonStyle(.plain)
                             .help(L10n.string("Jump to latest message"))
@@ -675,7 +677,7 @@ private struct ConversationView: View {
             .overlay {
                 if isFileDropTargeted {
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(Color.accentColor.opacity(0.75), lineWidth: 2)
+                        .strokeBorder(WNColor.borderPrimary, lineWidth: 2)
                         .padding(10)
                         .allowsHitTesting(false)
                 }
@@ -907,21 +909,11 @@ private struct ConversationView: View {
                 Button {
                     Task { await workspace.sendDraft() }
                 } label: {
-                    Group {
-                        if workspace.isSending {
-                            ProgressView()
-                                .controlSize(.small)
-                                .tint(.white)
-                                .scaleEffect(0.72)
-                        } else {
-                            Image(systemName: workspace.editingMessageContext == nil ? "paperplane.fill" : "checkmark")
-                                .font(.system(size: 14, weight: .semibold))
-                        }
-                    }
-                    .frame(width: 32, height: 32)
-                    .background {
-                        MessagesSendButtonBackground(isEnabled: workspace.canSend || workspace.isSending)
-                    }
+                    MessagesSendButtonLabel(
+                        systemImage: workspace.editingMessageContext == nil ? "paperplane.fill" : "checkmark",
+                        isEnabled: workspace.canSend,
+                        isSending: workspace.isSending
+                    )
                 }
                 .buttonStyle(.plain)
                 .disabled(!workspace.canSend)
@@ -1045,7 +1037,7 @@ private struct StartupView: View {
             ProgressView()
             Text(L10n.string("Starting Marmot"))
                 .font(.callout)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/whitenoise-mac/Views/Palette/NSColor+WNDynamic.swift
+++ b/whitenoise-mac/Views/Palette/NSColor+WNDynamic.swift
@@ -1,0 +1,28 @@
+//
+//  NSColor+WNDynamic.swift
+//  whitenoise-mac
+//
+//  Light/dark pairing for the semantic palette.
+//
+
+import AppKit
+
+extension NSColor {
+    /// A single semantic token that resolves to `light` in Aqua and `dark` in
+    /// Dark Aqua.
+    ///
+    /// The other clients express this as two `SemanticColors` constants
+    /// (`.light` / `.dark`) that Flutter swaps wholesale. AppKit has no
+    /// equivalent swap, so each token carries both values and lets the drawing
+    /// appearance pick — which is also what makes `Color(nsColor:)` follow the
+    /// window's appearance without any view having to read `\.colorScheme`.
+    ///
+    /// `name` is only used for archiving and debug descriptions, but it is worth
+    /// setting: an unnamed dynamic color prints as `<dynamic>` in the view
+    /// debugger, which makes a mis-paired token very hard to spot.
+    nonisolated static func wnDynamic(_ name: String, light: NSColor, dark: NSColor) -> NSColor {
+        NSColor(name: name) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+        }
+    }
+}

--- a/whitenoise-mac/Views/Palette/WNAccentColorSet.swift
+++ b/whitenoise-mac/Views/Palette/WNAccentColorSet.swift
@@ -1,0 +1,135 @@
+//
+//  WNAccentColorSet.swift
+//  whitenoise-mac
+//
+//  The twelve accent sets, ported from `_lightAccentColors` / `_darkAccentColors`
+//  in the sibling repository's `lib/theme/semantic_colors.dart`.
+//
+//  Accents are not a second palette to decorate with — they exist so that one
+//  person is consistently one color. Everything else in the app stays neutral.
+//
+
+import SwiftUI
+
+/// One accent, as the four roles it plays together. Never mix roles across sets:
+/// `contentPrimary` is legible on its own set's `fill` and on no other.
+///
+/// Each role is stored as the dynamic `NSColor` with the SwiftUI twin alongside it,
+/// rather than converting on demand. `NSColor(someSwiftUIColor)` is not a
+/// round-trip — it can bake in the appearance that happened to be current when it
+/// was called — and one of these roles is handed to AppKit for the composer's
+/// mention tokens.
+nonisolated struct WNAccentColorSet {
+    /// The surface. `X50` in light appearance, `X950` in dark.
+    let nsFill: NSColor
+    /// Primary content on `fill`. `X900` in light, `X50` in dark — it crosses over
+    /// with `fill` so the pair keeps its contrast in both appearances.
+    let nsContentPrimary: NSColor
+    /// Supporting content on `fill`, and the color a mention of this person is
+    /// written in. `X500` in both appearances: the one step of each ramp that is
+    /// neither the light surface nor the dark one, and therefore the only one that
+    /// stays legible without knowing which fill it landed on.
+    let nsContentSecondary: NSColor
+    /// The outline around `fill`. `X200` in both appearances.
+    let nsBorder: NSColor
+
+    let fill: Color
+    let contentPrimary: Color
+    let contentSecondary: Color
+    let border: Color
+
+    fileprivate init(
+        _ name: String,
+        lightFill: NSColor,
+        darkFill: NSColor,
+        lightContent: NSColor,
+        darkContent: NSColor,
+        contentSecondary: NSColor,
+        border: NSColor
+    ) {
+        self.nsFill = .wnDynamic("wn.accent.\(name).fill", light: lightFill, dark: darkFill)
+        self.nsContentPrimary = .wnDynamic(
+            "wn.accent.\(name).contentPrimary", light: lightContent, dark: darkContent)
+        self.nsContentSecondary = contentSecondary
+        self.nsBorder = border
+
+        self.fill = Color(nsColor: nsFill)
+        self.contentPrimary = Color(nsColor: nsContentPrimary)
+        self.contentSecondary = Color(nsColor: nsContentSecondary)
+        self.border = Color(nsColor: nsBorder)
+    }
+}
+
+nonisolated enum WNAccentColors {
+    static let blue = WNAccentColorSet(
+        "blue",
+        lightFill: WNColorRamp.blue50, darkFill: WNColorRamp.blue950,
+        lightContent: WNColorRamp.blue900, darkContent: WNColorRamp.blue50,
+        contentSecondary: WNColorRamp.blue500, border: WNColorRamp.blue200)
+
+    static let cyan = WNAccentColorSet(
+        "cyan",
+        lightFill: WNColorRamp.cyan50, darkFill: WNColorRamp.cyan950,
+        lightContent: WNColorRamp.cyan900, darkContent: WNColorRamp.cyan50,
+        contentSecondary: WNColorRamp.cyan500, border: WNColorRamp.cyan200)
+
+    static let emerald = WNAccentColorSet(
+        "emerald",
+        lightFill: WNColorRamp.emerald50, darkFill: WNColorRamp.emerald950,
+        lightContent: WNColorRamp.emerald900, darkContent: WNColorRamp.emerald50,
+        contentSecondary: WNColorRamp.emerald500, border: WNColorRamp.emerald200)
+
+    static let fuchsia = WNAccentColorSet(
+        "fuchsia",
+        lightFill: WNColorRamp.fuchsia50, darkFill: WNColorRamp.fuchsia950,
+        lightContent: WNColorRamp.fuchsia900, darkContent: WNColorRamp.fuchsia50,
+        contentSecondary: WNColorRamp.fuchsia500, border: WNColorRamp.fuchsia200)
+
+    static let indigo = WNAccentColorSet(
+        "indigo",
+        lightFill: WNColorRamp.indigo50, darkFill: WNColorRamp.indigo950,
+        lightContent: WNColorRamp.indigo900, darkContent: WNColorRamp.indigo50,
+        contentSecondary: WNColorRamp.indigo500, border: WNColorRamp.indigo200)
+
+    static let lime = WNAccentColorSet(
+        "lime",
+        lightFill: WNColorRamp.lime50, darkFill: WNColorRamp.lime950,
+        lightContent: WNColorRamp.lime900, darkContent: WNColorRamp.lime50,
+        contentSecondary: WNColorRamp.lime500, border: WNColorRamp.lime200)
+
+    static let orange = WNAccentColorSet(
+        "orange",
+        lightFill: WNColorRamp.orange50, darkFill: WNColorRamp.orange950,
+        lightContent: WNColorRamp.orange900, darkContent: WNColorRamp.orange50,
+        contentSecondary: WNColorRamp.orange500, border: WNColorRamp.orange200)
+
+    static let rose = WNAccentColorSet(
+        "rose",
+        lightFill: WNColorRamp.rose50, darkFill: WNColorRamp.rose950,
+        lightContent: WNColorRamp.rose900, darkContent: WNColorRamp.rose50,
+        contentSecondary: WNColorRamp.rose500, border: WNColorRamp.rose200)
+
+    static let sky = WNAccentColorSet(
+        "sky",
+        lightFill: WNColorRamp.sky50, darkFill: WNColorRamp.sky950,
+        lightContent: WNColorRamp.sky900, darkContent: WNColorRamp.sky50,
+        contentSecondary: WNColorRamp.sky500, border: WNColorRamp.sky200)
+
+    static let teal = WNAccentColorSet(
+        "teal",
+        lightFill: WNColorRamp.teal50, darkFill: WNColorRamp.teal950,
+        lightContent: WNColorRamp.teal900, darkContent: WNColorRamp.teal50,
+        contentSecondary: WNColorRamp.teal500, border: WNColorRamp.teal200)
+
+    static let violet = WNAccentColorSet(
+        "violet",
+        lightFill: WNColorRamp.violet50, darkFill: WNColorRamp.violet950,
+        lightContent: WNColorRamp.violet900, darkContent: WNColorRamp.violet50,
+        contentSecondary: WNColorRamp.violet500, border: WNColorRamp.violet200)
+
+    static let amber = WNAccentColorSet(
+        "amber",
+        lightFill: WNColorRamp.amber50, darkFill: WNColorRamp.amber950,
+        lightContent: WNColorRamp.amber900, darkContent: WNColorRamp.amber50,
+        contentSecondary: WNColorRamp.amber500, border: WNColorRamp.amber200)
+}

--- a/whitenoise-mac/Views/Palette/WNColor.swift
+++ b/whitenoise-mac/Views/Palette/WNColor.swift
@@ -1,0 +1,95 @@
+//
+//  WNColor.swift
+//  whitenoise-mac
+//
+//  The SwiftUI face of the semantic palette. Every token is the `Color` twin of
+//  the `WNNSColor` of the same name, so there is one set of values and one set of
+//  names across both frameworks; see `WNNSColor` for what each token means and
+//  for the background/content pairing rule.
+//
+//  Each of these wraps a dynamic `NSColor`, so it resolves against the drawing
+//  appearance on its own. A view does not need to read `\.colorScheme` to pick
+//  between a light and a dark value — if you find yourself doing that, the token
+//  is missing, not the branch.
+//
+
+import SwiftUI
+
+nonisolated enum WNColor {
+    // MARK: - Backgrounds
+
+    static let backgroundPrimary = Color(nsColor: WNNSColor.backgroundPrimary)
+    static let backgroundSecondary = Color(nsColor: WNNSColor.backgroundSecondary)
+    static let backgroundTertiary = Color(nsColor: WNNSColor.backgroundTertiary)
+    static let backgroundSlate = Color(nsColor: WNNSColor.backgroundSlate)
+    static let backgroundMessageIncoming = Color(nsColor: WNNSColor.backgroundMessageIncoming)
+
+    // MARK: - Background content
+
+    static let backgroundContentPrimary = Color(nsColor: WNNSColor.backgroundContentPrimary)
+    static let backgroundContentSecondary = Color(nsColor: WNNSColor.backgroundContentSecondary)
+    static let backgroundContentTertiary = Color(nsColor: WNNSColor.backgroundContentTertiary)
+    static let backgroundContentQuaternary = Color(nsColor: WNNSColor.backgroundContentQuaternary)
+    static let backgroundContentDestructive = Color(nsColor: WNNSColor.backgroundContentDestructive)
+    static let backgroundContentDestructiveSecondary = Color(
+        nsColor: WNNSColor.backgroundContentDestructiveSecondary)
+
+    // MARK: - Fills
+
+    static let fillPrimary = Color(nsColor: WNNSColor.fillPrimary)
+    static let fillPrimaryHover = Color(nsColor: WNNSColor.fillPrimaryHover)
+    static let fillPrimaryActive = Color(nsColor: WNNSColor.fillPrimaryActive)
+
+    static let fillSecondary = Color(nsColor: WNNSColor.fillSecondary)
+    static let fillSecondaryHover = Color(nsColor: WNNSColor.fillSecondaryHover)
+    static let fillSecondaryActive = Color(nsColor: WNNSColor.fillSecondaryActive)
+
+    static let fillTertiary = Color(nsColor: WNNSColor.fillTertiary)
+    static let fillTertiaryHover = Color(nsColor: WNNSColor.fillTertiaryHover)
+    static let fillTertiaryActive = Color(nsColor: WNNSColor.fillTertiaryActive)
+
+    static let fillQuaternary = Color(nsColor: WNNSColor.fillQuaternary)
+    static let fillQuaternaryHover = Color(nsColor: WNNSColor.fillQuaternaryHover)
+    static let fillQuaternaryActive = Color(nsColor: WNNSColor.fillQuaternaryActive)
+
+    static let fillDestructive = Color(nsColor: WNNSColor.fillDestructive)
+    static let fillDestructiveHover = Color(nsColor: WNNSColor.fillDestructiveHover)
+    static let fillDestructiveActive = Color(nsColor: WNNSColor.fillDestructiveActive)
+
+    static let fillDisabled = Color(nsColor: WNNSColor.fillDisabled)
+    static let fillContentDisabled = Color(nsColor: WNNSColor.fillContentDisabled)
+
+    // MARK: - Fill content
+
+    static let fillContentPrimary = Color(nsColor: WNNSColor.fillContentPrimary)
+    static let fillContentSecondary = Color(nsColor: WNNSColor.fillContentSecondary)
+    static let fillContentTertiary = Color(nsColor: WNNSColor.fillContentTertiary)
+    static let fillContentQuaternary = Color(nsColor: WNNSColor.fillContentQuaternary)
+
+    // MARK: - Borders
+
+    static let borderPrimary = Color(nsColor: WNNSColor.borderPrimary)
+    static let borderSecondary = Color(nsColor: WNNSColor.borderSecondary)
+    static let borderTertiary = Color(nsColor: WNNSColor.borderTertiary)
+    static let borderDestructivePrimary = Color(nsColor: WNNSColor.borderDestructivePrimary)
+    static let borderDestructiveSecondary = Color(nsColor: WNNSColor.borderDestructiveSecondary)
+
+    // MARK: - Intentions
+
+    static let intentionInfoBackground = Color(nsColor: WNNSColor.intentionInfoBackground)
+    static let intentionInfoContent = Color(nsColor: WNNSColor.intentionInfoContent)
+    static let intentionSuccessBackground = Color(nsColor: WNNSColor.intentionSuccessBackground)
+    static let intentionSuccessContent = Color(nsColor: WNNSColor.intentionSuccessContent)
+    static let intentionWarningBackground = Color(nsColor: WNNSColor.intentionWarningBackground)
+    static let intentionWarningContent = Color(nsColor: WNNSColor.intentionWarningContent)
+    static let intentionErrorBackground = Color(nsColor: WNNSColor.intentionErrorBackground)
+    static let intentionErrorContent = Color(nsColor: WNNSColor.intentionErrorContent)
+
+    // MARK: - Overlays and effects
+
+    static let shadow = Color(nsColor: WNNSColor.shadow)
+    static let overlayPrimary = Color(nsColor: WNNSColor.overlayPrimary)
+    static let overlaySecondary = Color(nsColor: WNNSColor.overlaySecondary)
+    static let overlayTertiary = Color(nsColor: WNNSColor.overlayTertiary)
+    static let qrCode = Color(nsColor: WNNSColor.qrCode)
+}

--- a/whitenoise-mac/Views/Palette/WNColorRamp.swift
+++ b/whitenoise-mac/Views/Palette/WNColorRamp.swift
@@ -1,0 +1,186 @@
+//
+//  WNColorRamp.swift
+//  whitenoise-mac
+//
+//  The raw color ramp shared with the other White Noise clients. Ported
+//  value-for-value from `lib/theme/semantic_colors.dart` in the sibling
+//  repository, where these live as the private `_NeutralColors`,
+//  `_BlueColors`, … classes.
+//
+//  Nothing outside the palette should reference these directly: a view picks a
+//  *semantic* token (`WNColor.backgroundPrimary`), never a ramp step. The ramp
+//  exists only so the semantic layer can be read side by side with the Dart
+//  file and checked for drift.
+//
+
+import AppKit
+
+/// `nonisolated` because message bodies are styled off the main actor while a timeline
+/// window is mapped (whitenoise-mac#285), so the palette has to be reachable from there.
+nonisolated enum WNColorRamp {
+    // MARK: - Base
+
+    static let white = srgb(0xFF_FFFF)
+    static let black = srgb(0x00_0000)
+    /// Dart's `_BaseColors.transparent` is `0x00FFFFFF` — transparent *white*,
+    /// not transparent black, which matters when it is interpolated.
+    static let transparent = srgb(0xFF_FFFF, alpha: 0)
+
+    // MARK: - Black alpha
+
+    static let blackAlpha50 = srgb(0x00_0000, alpha: 0x0D / 255)
+    static let blackAlpha200 = srgb(0x00_0000, alpha: 0x33 / 255)
+    static let blackAlpha300 = srgb(0x00_0000, alpha: 0x4D / 255)
+    static let blackAlpha500 = srgb(0x00_0000, alpha: 0x80 / 255)
+    static let blackAlpha600 = srgb(0x00_0000, alpha: 0x99 / 255)
+
+    // MARK: - White alpha
+
+    static let whiteAlpha500 = srgb(0xFF_FFFF, alpha: 0x80 / 255)
+    static let whiteAlpha600 = srgb(0xFF_FFFF, alpha: 0x99 / 255)
+    static let whiteAlpha800 = srgb(0xFF_FFFF, alpha: 0xCC / 255)
+    static let whiteAlpha900 = srgb(0xFF_FFFF, alpha: 0xE6 / 255)
+
+    // MARK: - Neutral
+
+    static let neutral50 = srgb(0xFA_FAFA)
+    static let neutral100 = srgb(0xF5_F5F5)
+    static let neutral150 = srgb(0xED_EDEE)
+    static let neutral200 = srgb(0xE5_E5E5)
+    static let neutral250 = srgb(0xDC_DCDD)
+    static let neutral300 = srgb(0xD4_D4D4)
+    static let neutral400 = srgb(0xA3_A3A3)
+    static let neutral450 = srgb(0x8B_8B8B)
+    static let neutral500 = srgb(0x73_7373)
+    static let neutral650 = srgb(0x49_4949)
+    static let neutral700 = srgb(0x40_4040)
+    static let neutral750 = srgb(0x33_3333)
+    static let neutral800 = srgb(0x26_2626)
+    static let neutral850 = srgb(0x1E_1E1F)
+    static let neutral900 = srgb(0x17_1717)
+    static let neutral950 = srgb(0x0A_0A0A)
+
+    // MARK: - Red
+
+    static let red50 = srgb(0xFE_F2F2)
+    static let red500 = srgb(0xEF_4444)
+    static let red600 = srgb(0xDC_2626)
+    static let red950 = srgb(0x45_0A0A)
+
+    // MARK: - Orange
+
+    static let orange50 = srgb(0xFF_F7ED)
+    static let orange200 = srgb(0xFE_D7AA)
+    static let orange500 = srgb(0xF9_7316)
+    static let orange600 = srgb(0xEA_580C)
+    static let orange900 = srgb(0x7C_2D12)
+    static let orange950 = srgb(0x43_1407)
+
+    // MARK: - Amber
+
+    static let amber50 = srgb(0xFF_FBEB)
+    static let amber200 = srgb(0xFD_E68A)
+    static let amber500 = srgb(0xF5_9E0B)
+    static let amber900 = srgb(0x78_350F)
+    static let amber950 = srgb(0x45_1A03)
+
+    // MARK: - Lime
+
+    static let lime50 = srgb(0xF7_FEE7)
+    static let lime200 = srgb(0xD9_F99D)
+    static let lime500 = srgb(0x84_CC16)
+    static let lime900 = srgb(0x36_5314)
+    static let lime950 = srgb(0x1A_2E05)
+
+    // MARK: - Green
+
+    static let green50 = srgb(0xF0_FDF4)
+    static let green500 = srgb(0x22_C55E)
+    static let green600 = srgb(0x16_A34A)
+    static let green950 = srgb(0x05_2E16)
+
+    // MARK: - Emerald
+
+    static let emerald50 = srgb(0xEC_FDF5)
+    static let emerald200 = srgb(0xA7_F3D0)
+    static let emerald500 = srgb(0x10_B981)
+    static let emerald900 = srgb(0x06_4E3B)
+    static let emerald950 = srgb(0x02_2C22)
+
+    // MARK: - Teal
+
+    static let teal50 = srgb(0xF0_FDFA)
+    static let teal200 = srgb(0x99_F6E4)
+    static let teal500 = srgb(0x14_B8A6)
+    static let teal900 = srgb(0x13_4E4A)
+    static let teal950 = srgb(0x04_2F2E)
+
+    // MARK: - Cyan
+
+    static let cyan50 = srgb(0xEC_FEFF)
+    static let cyan200 = srgb(0xA5_F3FC)
+    static let cyan500 = srgb(0x06_B6D4)
+    static let cyan900 = srgb(0x16_4E63)
+    static let cyan950 = srgb(0x08_3344)
+
+    // MARK: - Sky
+
+    static let sky50 = srgb(0xF0_F9FF)
+    static let sky200 = srgb(0xBA_E6FD)
+    static let sky500 = srgb(0x0E_A5E9)
+    static let sky900 = srgb(0x0C_4A6E)
+    static let sky950 = srgb(0x08_2F49)
+
+    // MARK: - Blue
+
+    static let blue50 = srgb(0xEF_F6FF)
+    static let blue200 = srgb(0xBF_DBFE)
+    static let blue500 = srgb(0x3B_82F6)
+    static let blue600 = srgb(0x25_63EB)
+    static let blue900 = srgb(0x1E_3A8A)
+    static let blue950 = srgb(0x17_2554)
+
+    // MARK: - Indigo
+
+    static let indigo50 = srgb(0xEE_F2FF)
+    static let indigo200 = srgb(0xC7_D2FE)
+    static let indigo500 = srgb(0x63_66F1)
+    static let indigo900 = srgb(0x31_2E81)
+    static let indigo950 = srgb(0x1E_1B4B)
+
+    // MARK: - Violet
+
+    static let violet50 = srgb(0xF5_F3FF)
+    static let violet200 = srgb(0xDD_D6FE)
+    static let violet500 = srgb(0x8B_5CF6)
+    static let violet900 = srgb(0x4C_1D95)
+    static let violet950 = srgb(0x2E_1065)
+
+    // MARK: - Fuchsia
+
+    static let fuchsia50 = srgb(0xFD_F4FF)
+    static let fuchsia200 = srgb(0xF5_D0FE)
+    static let fuchsia500 = srgb(0xD9_46EF)
+    static let fuchsia900 = srgb(0x70_1A75)
+    static let fuchsia950 = srgb(0x4A_044E)
+
+    // MARK: - Rose
+
+    static let rose50 = srgb(0xFF_F1F2)
+    static let rose200 = srgb(0xFE_CDD3)
+    static let rose500 = srgb(0xF4_3F5E)
+    static let rose900 = srgb(0x88_1337)
+    static let rose950 = srgb(0x4C_0519)
+
+    /// Flutter's `Color(0xAARRGGBB)` is sRGB, so the ramp is pinned to the sRGB
+    /// space rather than the display's — otherwise the same hex renders as a
+    /// different color here than it does on the other clients.
+    private static func srgb(_ rgb: Int, alpha: CGFloat = 1) -> NSColor {
+        NSColor(
+            srgbRed: CGFloat((rgb >> 16) & 0xFF) / 255,
+            green: CGFloat((rgb >> 8) & 0xFF) / 255,
+            blue: CGFloat(rgb & 0xFF) / 255,
+            alpha: alpha
+        )
+    }
+}

--- a/whitenoise-mac/Views/Palette/WNNSColor.swift
+++ b/whitenoise-mac/Views/Palette/WNNSColor.swift
@@ -1,0 +1,196 @@
+//
+//  WNNSColor.swift
+//  whitenoise-mac
+//
+//  The semantic palette, in AppKit form. Ported token-for-token from
+//  `SemanticColors.light` / `SemanticColors.dark` in the sibling repository's
+//  `lib/theme/semantic_colors.dart`, keeping the Dart names so the two files can
+//  be diffed by eye.
+//
+//  SwiftUI code wants `WNColor` (the `Color` twin of this enum) — this one exists
+//  for the handful of places that hand colors to AppKit: the composer's
+//  `NSTextView`, and the attributed strings built for message bodies.
+//
+//  ## Pairing rule
+//
+//  Tokens come in background/content and fill/fill-content pairs, and the pairs
+//  are not interchangeable. Content drawn on `backgroundPrimary` takes
+//  `backgroundContent*`; content drawn on `fillSecondary` takes
+//  `fillContentSecondary`. Reaching across the two families is how you get white
+//  text on a white button — the reason `fillContentPrimary` is white in light
+//  appearance but near-black in dark is that it is only ever drawn on
+//  `fillPrimary`, which runs the other way.
+//
+
+import AppKit
+
+nonisolated enum WNNSColor {
+    // MARK: - Backgrounds
+
+    /// The app's base surface: the transcript, the chat list, a settings pane.
+    static let backgroundPrimary = NSColor.wnDynamic(
+        "wn.backgroundPrimary", light: WNColorRamp.white, dark: WNColorRamp.black)
+    /// One step off the base surface — the sidebar columns, avatar placeholders.
+    static let backgroundSecondary = NSColor.wnDynamic(
+        "wn.backgroundSecondary", light: WNColorRamp.neutral50, dark: WNColorRamp.neutral950)
+    /// Two steps off the base surface.
+    static let backgroundTertiary = NSColor.wnDynamic(
+        "wn.backgroundTertiary", light: WNColorRamp.neutral100, dark: WNColorRamp.neutral900)
+    /// The surface of a sheet or popover lifted above the app ("slate").
+    static let backgroundSlate = NSColor.wnDynamic(
+        "wn.backgroundSlate", light: WNColorRamp.neutral50, dark: WNColorRamp.neutral900)
+    /// The received message bubble.
+    static let backgroundMessageIncoming = NSColor.wnDynamic(
+        "wn.backgroundMessageIncoming", light: WNColorRamp.neutral100, dark: WNColorRamp.neutral800)
+
+    // MARK: - Background content
+
+    /// Primary text and glyphs on any `background*` surface.
+    static let backgroundContentPrimary = NSColor.wnDynamic(
+        "wn.backgroundContentPrimary", light: WNColorRamp.neutral950, dark: WNColorRamp.white)
+    /// Supporting text: message previews, subtitles, field labels.
+    static let backgroundContentSecondary = NSColor.wnDynamic(
+        "wn.backgroundContentSecondary", light: WNColorRamp.neutral500, dark: WNColorRamp.neutral400)
+    /// De-emphasized text: timestamps, placeholders, disabled glyphs.
+    static let backgroundContentTertiary = NSColor.wnDynamic(
+        "wn.backgroundContentTertiary", light: WNColorRamp.neutral400, dark: WNColorRamp.neutral500)
+    /// Content that has to hold up over an unknown backdrop (media, blur), which
+    /// is why it is an alpha of the opposite extreme rather than a ramp step.
+    static let backgroundContentQuaternary = NSColor.wnDynamic(
+        "wn.backgroundContentQuaternary",
+        light: WNColorRamp.blackAlpha600,
+        dark: WNColorRamp.whiteAlpha600)
+    /// Destructive text and glyphs on a `background*` surface.
+    static let backgroundContentDestructive = NSColor.wnDynamic(
+        "wn.backgroundContentDestructive", light: WNColorRamp.red600, dark: WNColorRamp.red600)
+    static let backgroundContentDestructiveSecondary = NSColor.wnDynamic(
+        "wn.backgroundContentDestructiveSecondary",
+        light: WNColorRamp.red500,
+        dark: WNColorRamp.red500)
+
+    // MARK: - Fills
+
+    /// The primary action: the send button, a confirming push button, and the
+    /// sent message bubble. Inverted against the surface — near-black on white,
+    /// white on black — which is why White Noise has no accent hue here.
+    static let fillPrimary = NSColor.wnDynamic(
+        "wn.fillPrimary", light: WNColorRamp.neutral950, dark: WNColorRamp.white)
+    static let fillPrimaryHover = NSColor.wnDynamic(
+        "wn.fillPrimaryHover", light: WNColorRamp.neutral800, dark: WNColorRamp.neutral200)
+    static let fillPrimaryActive = NSColor.wnDynamic(
+        "wn.fillPrimaryActive", light: WNColorRamp.neutral800, dark: WNColorRamp.neutral200)
+
+    /// The secondary action: a bordered button, a pill, a circular icon control.
+    static let fillSecondary = NSColor.wnDynamic(
+        "wn.fillSecondary", light: WNColorRamp.neutral100, dark: WNColorRamp.neutral800)
+    static let fillSecondaryHover = NSColor.wnDynamic(
+        "wn.fillSecondaryHover", light: WNColorRamp.neutral150, dark: WNColorRamp.neutral750)
+    static let fillSecondaryActive = NSColor.wnDynamic(
+        "wn.fillSecondaryActive", light: WNColorRamp.neutral150, dark: WNColorRamp.neutral750)
+
+    /// The ghost action: no fill at rest, a wash once pointed at. Note that
+    /// `fillTertiary` is deliberately *transparent*, so the hover/active steps
+    /// are the only ones that draw.
+    static let fillTertiary = NSColor.wnDynamic(
+        "wn.fillTertiary", light: WNColorRamp.transparent, dark: WNColorRamp.transparent)
+    static let fillTertiaryHover = NSColor.wnDynamic(
+        "wn.fillTertiaryHover", light: WNColorRamp.neutral150, dark: WNColorRamp.neutral850)
+    static let fillTertiaryActive = NSColor.wnDynamic(
+        "wn.fillTertiaryActive", light: WNColorRamp.neutral150, dark: WNColorRamp.neutral850)
+
+    /// Chrome floating over media, where the backdrop is a photo rather than a
+    /// surface — hence an alpha wash instead of a ramp step.
+    static let fillQuaternary = NSColor.wnDynamic(
+        "wn.fillQuaternary", light: WNColorRamp.whiteAlpha900, dark: WNColorRamp.blackAlpha300)
+    static let fillQuaternaryHover = NSColor.wnDynamic(
+        "wn.fillQuaternaryHover", light: WNColorRamp.whiteAlpha800, dark: WNColorRamp.blackAlpha200)
+    static let fillQuaternaryActive = NSColor.wnDynamic(
+        "wn.fillQuaternaryActive", light: WNColorRamp.whiteAlpha800, dark: WNColorRamp.blackAlpha200)
+
+    /// A destructive action's fill. Same in both appearances.
+    static let fillDestructive = NSColor.wnDynamic(
+        "wn.fillDestructive", light: WNColorRamp.red600, dark: WNColorRamp.red600)
+    static let fillDestructiveHover = NSColor.wnDynamic(
+        "wn.fillDestructiveHover", light: WNColorRamp.red500, dark: WNColorRamp.red500)
+    static let fillDestructiveActive = NSColor.wnDynamic(
+        "wn.fillDestructiveActive", light: WNColorRamp.red500, dark: WNColorRamp.red500)
+
+    static let fillDisabled = NSColor.wnDynamic(
+        "wn.fillDisabled", light: WNColorRamp.neutral300, dark: WNColorRamp.neutral650)
+    static let fillContentDisabled = NSColor.wnDynamic(
+        "wn.fillContentDisabled", light: WNColorRamp.neutral450, dark: WNColorRamp.neutral400)
+
+    // MARK: - Fill content
+
+    /// Content on `fillPrimary` — and therefore on the sent bubble.
+    static let fillContentPrimary = NSColor.wnDynamic(
+        "wn.fillContentPrimary", light: WNColorRamp.white, dark: WNColorRamp.neutral950)
+    /// Content on `fillSecondary`.
+    static let fillContentSecondary = NSColor.wnDynamic(
+        "wn.fillContentSecondary", light: WNColorRamp.neutral950, dark: WNColorRamp.white)
+    /// Content on `fillTertiary` — the ghost action's label.
+    static let fillContentTertiary = NSColor.wnDynamic(
+        "wn.fillContentTertiary", light: WNColorRamp.neutral500, dark: WNColorRamp.neutral400)
+    /// Content on `fillDestructive`, and on `fillQuaternary` over media. White in
+    /// both appearances, because both of those fills are dark in both.
+    static let fillContentQuaternary = NSColor.wnDynamic(
+        "wn.fillContentQuaternary", light: WNColorRamp.white, dark: WNColorRamp.white)
+
+    // MARK: - Borders
+
+    /// A focused or selected outline.
+    static let borderPrimary = NSColor.wnDynamic(
+        "wn.borderPrimary", light: WNColorRamp.neutral950, dark: WNColorRamp.white)
+    /// A hovered outline, and the resting outline of an editable field.
+    static let borderSecondary = NSColor.wnDynamic(
+        "wn.borderSecondary", light: WNColorRamp.neutral500, dark: WNColorRamp.neutral400)
+    /// The resting hairline: separators, card outlines, list dividers. By far the
+    /// most-used border token on the other clients.
+    static let borderTertiary = NSColor.wnDynamic(
+        "wn.borderTertiary", light: WNColorRamp.neutral200, dark: WNColorRamp.neutral800)
+    static let borderDestructivePrimary = NSColor.wnDynamic(
+        "wn.borderDestructivePrimary", light: WNColorRamp.red600, dark: WNColorRamp.red600)
+    static let borderDestructiveSecondary = NSColor.wnDynamic(
+        "wn.borderDestructiveSecondary", light: WNColorRamp.red500, dark: WNColorRamp.red500)
+
+    // MARK: - Intentions
+
+    /// Informational: also the color of a link and of a search-hit highlight.
+    /// This is the palette's only blue outside the accent sets.
+    static let intentionInfoBackground = NSColor.wnDynamic(
+        "wn.intentionInfoBackground", light: WNColorRamp.blue50, dark: WNColorRamp.blue950)
+    static let intentionInfoContent = NSColor.wnDynamic(
+        "wn.intentionInfoContent", light: WNColorRamp.blue600, dark: WNColorRamp.blue500)
+
+    static let intentionSuccessBackground = NSColor.wnDynamic(
+        "wn.intentionSuccessBackground", light: WNColorRamp.green50, dark: WNColorRamp.green950)
+    static let intentionSuccessContent = NSColor.wnDynamic(
+        "wn.intentionSuccessContent", light: WNColorRamp.green600, dark: WNColorRamp.green500)
+
+    static let intentionWarningBackground = NSColor.wnDynamic(
+        "wn.intentionWarningBackground", light: WNColorRamp.orange50, dark: WNColorRamp.orange950)
+    static let intentionWarningContent = NSColor.wnDynamic(
+        "wn.intentionWarningContent", light: WNColorRamp.orange600, dark: WNColorRamp.orange500)
+
+    static let intentionErrorBackground = NSColor.wnDynamic(
+        "wn.intentionErrorBackground", light: WNColorRamp.red50, dark: WNColorRamp.red950)
+    static let intentionErrorContent = NSColor.wnDynamic(
+        "wn.intentionErrorContent", light: WNColorRamp.red600, dark: WNColorRamp.red500)
+
+    // MARK: - Overlays and effects
+
+    /// Drop shadows are drawn from this at low alpha in both appearances.
+    static let shadow = NSColor.wnDynamic(
+        "wn.shadow", light: WNColorRamp.black, dark: WNColorRamp.black)
+    static let overlayPrimary = NSColor.wnDynamic(
+        "wn.overlayPrimary", light: WNColorRamp.whiteAlpha500, dark: WNColorRamp.blackAlpha50)
+    static let overlaySecondary = NSColor.wnDynamic(
+        "wn.overlaySecondary", light: WNColorRamp.whiteAlpha500, dark: WNColorRamp.blackAlpha500)
+    /// The scrim behind a full-screen media viewer.
+    static let overlayTertiary = NSColor.wnDynamic(
+        "wn.overlayTertiary", light: WNColorRamp.blackAlpha500, dark: WNColorRamp.blackAlpha500)
+    /// QR modules. Always the opposite of the surface they are drawn on, and
+    /// never tinted — a tinted QR code scans poorly.
+    static let qrCode = NSColor.wnDynamic(
+        "wn.qrCode", light: WNColorRamp.neutral950, dark: WNColorRamp.white)
+}

--- a/whitenoise-mac/Views/Palette/WNReactionColorSet.swift
+++ b/whitenoise-mac/Views/Palette/WNReactionColorSet.swift
@@ -1,0 +1,95 @@
+//
+//  WNReactionColorSet.swift
+//  whitenoise-mac
+//
+//  Reaction chip colors, ported from `_lightReactionColors` /
+//  `_darkReactionColors` in the sibling repository's
+//  `lib/theme/semantic_colors.dart`.
+//
+//  Reactions get their own sets rather than reusing `fill*` because a chip sits
+//  *against a bubble*, not against the app surface, and the two bubbles run in
+//  opposite directions: the sent bubble is `fillPrimary` (inverted), the received
+//  one is `backgroundMessageIncoming` (a neutral step). A chip that used one fill
+//  token for both would disappear into one of them.
+//
+//  Which is also why the two sets cross over between appearances — the light
+//  `outgoing` set and the dark `incoming` set are the same values, because in both
+//  of those cases the chip is sitting on a dark bubble.
+//
+
+import SwiftUI
+
+/// A chip's three states, each with its matching content color.
+///
+/// Stored as dynamic `NSColor`s with their SwiftUI twins alongside, for the same
+/// reason `WNAccentColorSet` does it: converting a `SwiftUI.Color` back to an
+/// `NSColor` is not a round-trip and can bake in whichever appearance was current.
+nonisolated struct WNReactionColorSet {
+    let nsFill: NSColor
+    let nsFillHover: NSColor
+    /// The state for a reaction the local account has added.
+    let nsFillSelected: NSColor
+    let nsContent: NSColor
+    let nsContentSelected: NSColor
+
+    let fill: Color
+    let fillHover: Color
+    let fillSelected: Color
+    let content: Color
+    let contentHover: Color
+    let contentSelected: Color
+
+    fileprivate init(
+        _ name: String,
+        lightFill: NSColor, darkFill: NSColor,
+        lightFillHover: NSColor, darkFillHover: NSColor,
+        lightFillSelected: NSColor, darkFillSelected: NSColor,
+        lightContent: NSColor, darkContent: NSColor,
+        lightContentSelected: NSColor, darkContentSelected: NSColor
+    ) {
+        self.nsFill = .wnDynamic("wn.reaction.\(name).fill", light: lightFill, dark: darkFill)
+        self.nsFillHover = .wnDynamic(
+            "wn.reaction.\(name).fillHover", light: lightFillHover, dark: darkFillHover)
+        self.nsFillSelected = .wnDynamic(
+            "wn.reaction.\(name).fillSelected", light: lightFillSelected, dark: darkFillSelected)
+        self.nsContent = .wnDynamic(
+            "wn.reaction.\(name).content", light: lightContent, dark: darkContent)
+        self.nsContentSelected = .wnDynamic(
+            "wn.reaction.\(name).contentSelected",
+            light: lightContentSelected,
+            dark: darkContentSelected)
+
+        self.fill = Color(nsColor: nsFill)
+        self.fillHover = Color(nsColor: nsFillHover)
+        self.fillSelected = Color(nsColor: nsFillSelected)
+        // `content` and `contentHover` are the same value in every set the other
+        // clients define, so one dynamic color backs both.
+        self.content = Color(nsColor: nsContent)
+        self.contentHover = Color(nsColor: nsContent)
+        self.contentSelected = Color(nsColor: nsContentSelected)
+    }
+}
+
+nonisolated enum WNReactionColors {
+    /// Chips on a received bubble.
+    static let incoming = WNReactionColorSet(
+        "incoming",
+        lightFill: WNColorRamp.white, darkFill: WNColorRamp.neutral800,
+        lightFillHover: WNColorRamp.neutral200, darkFillHover: WNColorRamp.neutral700,
+        lightFillSelected: WNColorRamp.neutral800, darkFillSelected: WNColorRamp.neutral50,
+        lightContent: WNColorRamp.neutral500, darkContent: WNColorRamp.neutral250,
+        lightContentSelected: WNColorRamp.white, darkContentSelected: WNColorRamp.neutral950)
+
+    /// Chips on a sent bubble.
+    static let outgoing = WNReactionColorSet(
+        "outgoing",
+        lightFill: WNColorRamp.neutral800, darkFill: WNColorRamp.neutral100,
+        lightFillHover: WNColorRamp.neutral700, darkFillHover: WNColorRamp.neutral150,
+        lightFillSelected: WNColorRamp.neutral50, darkFillSelected: WNColorRamp.neutral800,
+        lightContent: WNColorRamp.neutral250, darkContent: WNColorRamp.neutral500,
+        lightContentSelected: WNColorRamp.neutral950, darkContentSelected: WNColorRamp.white)
+
+    static func set(isOutgoing: Bool) -> WNReactionColorSet {
+        isOutgoing ? outgoing : incoming
+    }
+}

--- a/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
+++ b/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
@@ -97,7 +97,6 @@ struct PendingOutgoingMessageBubble: View {
         PendingOutgoingMessageMetadata(
             createdAt: message.createdAt,
             isFailed: message.state == .failed,
-            isOnBubbleFill: !message.caption.isEmpty,
             timestampReferenceDate: timestampReferenceDate,
             timestampLocale: timestampLocale
         )
@@ -114,7 +113,7 @@ private struct PendingOutgoingMessageCaption<Metadata: View>: View {
         VStack(alignment: .trailing, spacing: 2) {
             Text(caption)
                 .font(.system(size: 15.5))
-                .foregroundStyle(.white)
+                .foregroundStyle(MessagesPalette.sentBubbleContent)
                 .multilineTextAlignment(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -141,7 +140,6 @@ private struct PendingOutgoingMessageCaption<Metadata: View>: View {
 private struct PendingOutgoingMessageMetadata: View {
     let createdAt: Date
     let isFailed: Bool
-    let isOnBubbleFill: Bool
     let timestampReferenceDate: Date
     let timestampLocale: Locale
 
@@ -157,14 +155,18 @@ private struct PendingOutgoingMessageMetadata: View {
             .monospacedDigit()
 
             Image(systemName: isFailed ? "exclamationmark.circle.fill" : "clock")
-                .foregroundStyle(isFailed ? Color.red : tint)
+                .foregroundStyle(isFailed ? WNColor.backgroundContentDestructiveSecondary : tint)
         }
         .font(.system(size: 10.5, weight: .medium))
         .foregroundStyle(tint)
     }
 
+    /// The same token `MessageBubble.compactMetadata` uses, and for the same reason: the neutral
+    /// `400`/`500` step is the one rung that clears the sent bubble and the transcript surface
+    /// alike, so a pending row and the delivered row that replaces it read identically. That is
+    /// what retired the `isOnBubbleFill` flag this used to branch on.
     private var tint: Color {
-        isOnBubbleFill ? Color.white.opacity(0.68) : Color.secondary.opacity(0.72)
+        WNColor.backgroundContentTertiary
     }
 }
 
@@ -218,7 +220,7 @@ private struct PendingOutgoingMediaGrid: View {
         .clipShape(.rect(cornerRadius: cornerRadius, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .strokeBorder(Color.primary.opacity(0.16), lineWidth: 1)
+                .strokeBorder(WNColor.borderTertiary, lineWidth: 1)
         }
     }
 
@@ -265,7 +267,7 @@ private struct PendingOutgoingMediaTile: View {
 
     var body: some View {
         ZStack {
-            Color.primary.opacity(0.06)
+            WNColor.backgroundTertiary
 
             if let preview {
                 Image(nsImage: preview)
@@ -277,14 +279,14 @@ private struct PendingOutgoingMediaTile: View {
             } else {
                 Image(systemName: attachment.kind.systemImageName)
                     .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
             }
 
             if hiddenCount > 0 {
-                Color.black.opacity(0.46)
+                WNColor.overlayTertiary
                 Text(verbatim: "+\(hiddenCount)")
                     .font(.title2.bold())
-                    .foregroundStyle(.white)
+                    .foregroundStyle(WNColor.fillContentQuaternary)
             }
         }
         .frame(width: sideLength, height: sideLength)
@@ -316,7 +318,7 @@ private struct PendingOutgoingMediaAttachmentRow: View {
                 fileRow
             }
         }
-        .foregroundStyle(.white)
+        .foregroundStyle(AttachmentRowPalette.outgoingContent)
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .frame(width: 260, alignment: .leading)
@@ -337,14 +339,14 @@ private struct PendingOutgoingMediaAttachmentRow: View {
             ComposerAudioWaveformView(
                 samples: attachment.waveformSamples,
                 progress: 0,
-                barColor: Color.white.opacity(0.55),
-                playedColor: Color.white
+                barColor: AttachmentRowPalette.waveformBar(isOutgoing: true),
+                playedColor: AttachmentRowPalette.waveformPlayedBar(isOutgoing: true)
             )
             .frame(height: 24)
 
             Text(MediaDurationLabel.string(for: attachment.durationSeconds ?? 0))
                 .font(.caption2.monospacedDigit().weight(.semibold))
-                .foregroundStyle(.white.opacity(0.7))
+                .foregroundStyle(AttachmentRowPalette.detailContent)
         }
     }
 
@@ -360,7 +362,7 @@ private struct PendingOutgoingMediaAttachmentRow: View {
                     .truncationMode(.middle)
                 Text(attachment.durationLabel ?? attachment.sizeLabel)
                     .font(.caption2.monospacedDigit())
-                    .foregroundStyle(.white.opacity(0.7))
+                    .foregroundStyle(AttachmentRowPalette.detailContent)
             }
 
             Spacer(minLength: 0)

--- a/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
@@ -178,7 +178,7 @@ struct AccountSwitcherPopover: View {
                     .font(.headline)
                 Text(L10n.string("Manage the identities available on this Mac.", locale: locale))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -187,7 +187,7 @@ struct AccountSwitcherPopover: View {
             if workspace.accounts.isEmpty {
                 Text(L10n.string("No accounts", locale: locale))
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 ScrollView {
@@ -258,7 +258,10 @@ struct AccountSwitcherRow: View {
 
                         Text(statusText)
                             .font(.caption)
-                            .foregroundStyle(account.signedOut ? Color.orange : .secondary)
+                            .foregroundStyle(
+                                account.signedOut
+                                    ? WNColor.intentionWarningContent
+                                    : WNColor.backgroundContentSecondary)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -269,7 +272,7 @@ struct AccountSwitcherRow: View {
                     if isActive {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.callout)
-                            .foregroundStyle(.tint)
+                            .foregroundStyle(WNColor.intentionSuccessContent)
                             .accessibilityLabel(Text(L10n.string("Active", locale: locale)))
                     }
                 }

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -50,8 +50,15 @@ struct SettingsPanelView: View {
                 DeveloperModeSettingsView()
             }
         }
+        // The same surface the transcript and the group/contact detail panes draw on, rather than
+        // the glass wash this used to be. A settings page is a reading surface in the content
+        // column, so it takes the reading surface: `backgroundPrimary`. The glass wash never
+        // reached that value in light appearance — a material over `backgroundSecondary` with a
+        // partial white tint lands visibly grayer than the chat beside it, which is the whole
+        // complaint. Glass stays where it belongs in settings: the header (`GlassToolbarBackground`)
+        // and the sheets that lift off this pane.
         .background {
-            LiquidGlassBackground()
+            MessagesTranscriptBackground()
         }
         .task(id: workspace.activeAccountId) {
             await workspace.loadSettingsData()
@@ -79,7 +86,7 @@ struct GeneralSettingsView: View {
 
                 Text(L10n.string("Open the White Noise window automatically when you log in to your Mac."))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
 
                 launchAtLoginStatus
 
@@ -98,7 +105,7 @@ struct GeneralSettingsView: View {
                         "Return to the last conversation selected for this account after White Noise finishes loading.")
                 )
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             }
         }
         .onAppear {
@@ -129,7 +136,7 @@ struct GeneralSettingsView: View {
                     systemImage: "exclamationmark.triangle"
                 )
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
 
                 Button(L10n.string("Open Login Items Settings")) {
                     launchAtLogin.openSystemSettings()
@@ -141,7 +148,7 @@ struct GeneralSettingsView: View {
                 systemImage: "exclamationmark.triangle"
             )
             .font(.caption)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(WNColor.backgroundContentSecondary)
         case .notRegistered, .enabled:
             EmptyView()
         }
@@ -175,7 +182,7 @@ struct SettingsHeader: View {
             if let subtitle {
                 Text(subtitle)
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
         }
         .padding(.horizontal, 28)
@@ -345,7 +352,7 @@ struct PublicIdentityQRCodeSheet: View {
                         .lineLimit(1)
                     Text(L10n.string("Public identity"))
                         .font(.callout)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
 
                 Spacer()
@@ -356,7 +363,9 @@ struct PublicIdentityQRCodeSheet: View {
             }
 
             ZStack {
-                Color.white
+                // The same surface the code's own quiet zone is rendered in, so the padding around
+                // it is continuous with it rather than a border. See `QRCodePalette`.
+                WNColor.backgroundPrimary
                 // Encode the marmot:// profile link form so scanners can route the
                 // scheme; the visible text and Copy button keep the bare npub.
                 QRCodeImageView(payload: MarmotProfileLink.qrPayload(npub: npub))
@@ -366,12 +375,12 @@ struct PublicIdentityQRCodeSheet: View {
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                    .stroke(WNColor.borderTertiary, lineWidth: 1)
             }
 
             Text(DisplayText.short(npub, head: 24, tail: 24))
                 .font(.system(.callout, design: .monospaced))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .multilineTextAlignment(.center)
                 .textSelection(.enabled)
                 .lineLimit(2)
@@ -409,39 +418,96 @@ private nonisolated struct RenderedQRCodeImage: @unchecked Sendable {
     let nsImage: NSImage
 }
 
+/// One appearance's resolved QR colors, flattened to components so the Core Image work can happen
+/// off the main actor. Resolved rather than carried as a dynamic `NSColor` deliberately: a QR code
+/// is rasterized once into a bitmap that has no appearance of its own, so the two colors have to be
+/// pinned at render time and the bitmap re-rendered when the appearance changes.
+struct QRCodeInk: Equatable, Sendable {
+    let red: Double
+    let green: Double
+    let blue: Double
+
+    init(_ color: NSColor) {
+        let resolved = color.usingColorSpace(.sRGB) ?? .black
+        red = resolved.redComponent
+        green = resolved.greenComponent
+        blue = resolved.blueComponent
+    }
+
+    var ciColor: CIColor { CIColor(red: red, green: green, blue: blue) }
+
+    /// The resolved color as AppKit sees it — a static color, since the whole point of this type is
+    /// that the appearance has already been chosen.
+    var nsColor: NSColor { NSColor(srgbRed: red, green: green, blue: blue, alpha: 1) }
+}
+
+/// The palette's own QR pair: `qrCode` modules on `backgroundPrimary`. Both invert with the
+/// appearance, which is the point — a code pinned to black-on-white sits as a lit card in a dark
+/// window. A conforming decoder reads either polarity (asserted in `SemanticPaletteTests`); what it
+/// cannot read is a tinted or low-contrast code, which is why neither of these is an accent.
+struct QRCodePalette: Equatable, Sendable {
+    let modules: QRCodeInk
+    let background: QRCodeInk
+
+    @MainActor
+    static func resolved(for colorScheme: ColorScheme) -> QRCodePalette {
+        let name: NSAppearance.Name = colorScheme == .dark ? .darkAqua : .aqua
+        var modules = QRCodeInk(WNNSColor.qrCode)
+        var background = QRCodeInk(WNNSColor.backgroundPrimary)
+        // Resolving under the *view's* scheme rather than the drawing appearance already current:
+        // the two can disagree while an appearance override is settling, and a code rendered under
+        // the wrong one would sit inverted against the sheet until the payload changed.
+        NSAppearance(named: name)?.performAsCurrentDrawingAppearance {
+            modules = QRCodeInk(WNNSColor.qrCode)
+            background = QRCodeInk(WNNSColor.backgroundPrimary)
+        }
+        return QRCodePalette(modules: modules, background: background)
+    }
+}
+
 struct QRCodeImageView: View {
     let payload: String
 
+    @Environment(\.colorScheme) private var colorScheme
     @State private var renderedPayload: String?
+    @State private var renderedPalette: QRCodePalette?
     @State private var renderedImage: NSImage?
+
+    private var isRendered: Bool {
+        renderedPayload == payload && renderedPalette == QRCodePalette.resolved(for: colorScheme)
+    }
 
     var body: some View {
         Group {
-            if renderedPayload == payload, let renderedImage {
+            if isRendered, let renderedImage {
                 Image(nsImage: renderedImage)
                     .interpolation(.none)
                     .resizable()
                     .scaledToFit()
-            } else if renderedPayload == payload {
+            } else if isRendered {
                 ContentUnavailableView("QR code unavailable", systemImage: "qrcode")
-                    .foregroundStyle(.black)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             } else {
                 ProgressView()
                     .controlSize(.small)
-                    .foregroundStyle(.black)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
         }
-        .task(id: payload) {
+        // Keyed on the appearance as well as the payload: the rasterized code carries no appearance
+        // of its own, so switching Aqua and Dark Aqua has to re-render it rather than re-resolve it.
+        .task(id: QRCodeRenderKey(payload: payload, palette: QRCodePalette.resolved(for: colorScheme))) {
+            let palette = QRCodePalette.resolved(for: colorScheme)
             let image = await Task.detached(priority: .utility) {
-                Self.image(for: payload)
+                Self.image(for: payload, palette: palette)
             }.value
             guard !Task.isCancelled else { return }
             renderedImage = image?.nsImage
             renderedPayload = payload
+            renderedPalette = palette
         }
     }
 
-    nonisolated private static func image(for payload: String) -> RenderedQRCodeImage? {
+    nonisolated static func ciImage(for payload: String, palette: QRCodePalette) -> CIImage? {
         guard !payload.isEmpty,
             let filter = CIFilter(name: "CIQRCodeGenerator")
         else { return nil }
@@ -451,11 +517,28 @@ struct QRCodeImageView: View {
         guard let outputImage = filter.outputImage else { return nil }
 
         let scaledImage = outputImage.transformed(by: CGAffineTransform(scaleX: 12, y: 12))
-        let representation = NSCIImageRep(ciImage: scaledImage)
+        // `CIQRCodeGenerator` hands back opaque black modules on an opaque white quiet zone, so the
+        // `backgroundPrimary` behind this view never showed through — recoloring is what actually
+        // puts the code on the app's surface instead of on a white card.
+        guard let falseColor = CIFilter(name: "CIFalseColor") else { return scaledImage }
+        falseColor.setValue(scaledImage, forKey: kCIInputImageKey)
+        falseColor.setValue(palette.modules.ciColor, forKey: "inputColor0")
+        falseColor.setValue(palette.background.ciColor, forKey: "inputColor1")
+        return falseColor.outputImage ?? scaledImage
+    }
+
+    nonisolated private static func image(for payload: String, palette: QRCodePalette) -> RenderedQRCodeImage? {
+        guard let ciImage = ciImage(for: payload, palette: palette) else { return nil }
+        let representation = NSCIImageRep(ciImage: ciImage)
         let image = NSImage(size: representation.size)
         image.addRepresentation(representation)
         return RenderedQRCodeImage(nsImage: image)
     }
+}
+
+private struct QRCodeRenderKey: Equatable {
+    let payload: String
+    let palette: QRCodePalette
 }
 
 struct SettingsErrorView: View {
@@ -465,7 +548,7 @@ struct SettingsErrorView: View {
         if let error {
             Text(error)
                 .font(.callout)
-                .foregroundStyle(.red)
+                .foregroundStyle(WNColor.backgroundContentDestructive)
                 .textSelection(.enabled)
         }
     }
@@ -499,9 +582,9 @@ struct ProfileSettingsView: View {
 
                                 Image(systemName: "camera.fill")
                                     .font(.system(size: 9, weight: .semibold))
-                                    .foregroundStyle(.white)
+                                    .foregroundStyle(WNColor.fillContentQuaternary)
                                     .frame(width: 20, height: 20)
-                                    .background(.black.opacity(0.68), in: Circle())
+                                    .background(WNColor.overlayTertiary, in: Circle())
                             }
                             .contentShape(Circle())
                         }
@@ -600,7 +683,7 @@ struct ProfileImagePickerSheet: View {
                         .font(.headline)
                     Text(L10n.string("Choose from your Mac or search the web"))
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
 
                 Spacer()
@@ -655,7 +738,7 @@ struct ProfileImagePickerSheet: View {
                     L10n.string("Search terms are sent to Openverse. Selected images are copied to Blossom before use.")
                 )
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 SettingsErrorView(error: workspace.lastError)
@@ -666,12 +749,12 @@ struct ProfileImagePickerSheet: View {
                         VStack(spacing: 10) {
                             Image(systemName: "person.crop.circle.badge.plus")
                                 .font(.system(size: 28, weight: .light))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(WNColor.backgroundContentSecondary)
                             Text(
                                 workspace.isSearchingProfileImages ? L10n.string("Searching") : L10n.string("No images")
                             )
                             .font(.callout.weight(.medium))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                         }
                         .frame(maxWidth: .infinity, minHeight: 300)
                     } else {
@@ -739,7 +822,7 @@ struct IdentityKeysSettingsView: View {
                                 .lineLimit(1)
                             Text(accountSigningDescription(for: account))
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(WNColor.backgroundContentSecondary)
                         }
                     }
                 }
@@ -750,7 +833,7 @@ struct IdentityKeysSettingsView: View {
                         HStack(alignment: .firstTextBaseline, spacing: 8) {
                             Text(npub)
                                 .font(.system(.callout, design: .monospaced))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(WNColor.backgroundContentSecondary)
                                 .lineLimit(3)
                                 .textSelection(.enabled)
 
@@ -759,7 +842,10 @@ struct IdentityKeysSettingsView: View {
                                 actionDescription: L10n.string("Copy npub")
                             ) { isConfirming in
                                 Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
-                                    .foregroundStyle(isConfirming ? Color.green : Color.accentColor)
+                                    .foregroundStyle(
+                                        isConfirming
+                                            ? WNColor.intentionSuccessContent
+                                            : WNColor.backgroundContentPrimary)
                             }
                             .buttonStyle(.borderless)
 
@@ -778,7 +864,7 @@ struct IdentityKeysSettingsView: View {
                                 ? L10n.string("Stored in Keychain")
                                 : L10n.string("Not stored on this Mac")
                         )
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
 
                     Button {
@@ -799,7 +885,7 @@ struct IdentityKeysSettingsView: View {
                             "Remove this identity from this Mac. Messages and keys managed by Marmot for this account will no longer be available locally."
                         )
                     )
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
 
                     Button(role: .destructive) {
@@ -876,7 +962,7 @@ struct PrivateKeyBackupSheet: View {
             case .encrypted:
                 Text(L10n.string("Protect your key with a passphrase. You'll need it to restore the backup."))
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
                 SecureField(L10n.string("Passphrase"), text: $passphrase)
                     .textFieldStyle(.roundedBorder)
@@ -888,7 +974,7 @@ struct PrivateKeyBackupSheet: View {
                     systemImage: "exclamationmark.triangle.fill"
                 )
                 .font(.callout)
-                .foregroundStyle(.orange)
+                .foregroundStyle(WNColor.intentionWarningContent)
                 .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -906,7 +992,10 @@ struct PrivateKeyBackupSheet: View {
                             actionDescription: L10n.string("Copy")
                         ) { isConfirming in
                             Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
-                                .foregroundStyle(isConfirming ? Color.green : Color.accentColor)
+                                .foregroundStyle(
+                                    isConfirming
+                                        ? WNColor.intentionSuccessContent
+                                        : WNColor.backgroundContentPrimary)
                         }
                         .buttonStyle(.borderless)
                     }
@@ -931,7 +1020,7 @@ struct PrivateKeyBackupSheet: View {
             if let error = workspace.lastError {
                 Text(error)
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(WNColor.backgroundContentDestructive)
             }
         }
         .padding(20)
@@ -947,7 +1036,7 @@ struct PrivateKeyBackupSheet: View {
         .frame(maxWidth: .infinity)
         .background {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.primary.opacity(0.10))
+                .fill(WNColor.fillSecondary)
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(L10n.string("Backup type"))
@@ -964,13 +1053,15 @@ struct PrivateKeyBackupSheet: View {
                 .font(.callout.weight(.semibold))
                 .lineLimit(1)
                 .minimumScaleFactor(0.85)
-                .foregroundStyle(isSelected ? Color.white : Color.secondary)
+                .foregroundStyle(
+                    isSelected ? WNColor.fillContentPrimary : WNColor.fillContentTertiary
+                )
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 7)
                 .background {
                     if isSelected {
                         RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(Color.accentColor)
+                            .fill(WNColor.fillPrimary)
                     }
                 }
         }
@@ -1005,7 +1096,7 @@ struct CopyableKeyLabel: View {
         HStack(spacing: 6) {
             Text(DisplayText.short(npub, head: head, tail: tail))
                 .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .textSelection(.enabled)
@@ -1014,7 +1105,8 @@ struct CopyableKeyLabel: View {
                 CopyToClipboardButton(value: npub, actionDescription: L10n.string("Copy npub")) { isConfirming in
                     Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
                         .font(.system(size: 10))
-                        .foregroundStyle(isConfirming ? Color.green : Color.secondary)
+                        .foregroundStyle(
+                            isConfirming ? WNColor.intentionSuccessContent : WNColor.backgroundContentSecondary)
                 }
                 .buttonStyle(.borderless)
             }
@@ -1047,14 +1139,14 @@ struct AppearanceSettingsView: View {
                 }
 
                 Text(L10n.string("System follows your Mac language. Other choices update White Noise immediately."))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Section(L10n.string("Quick reactions")) {
                 Text(L10n.string("Choose and order the six reactions shown in message actions."))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
 
                 ForEach(Array(workspace.quickReactions.enumerated()), id: \.offset) { index, emoji in
                     HStack(spacing: 12) {
@@ -1064,7 +1156,7 @@ struct AppearanceSettingsView: View {
                             Text(emoji)
                                 .font(.system(size: 24))
                                 .frame(width: 38, height: 32)
-                                .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 8))
+                                .background(WNColor.fillSecondary, in: RoundedRectangle(cornerRadius: 8))
                         }
                         .buttonStyle(.plain)
                         .accessibilityLabel(
@@ -1082,7 +1174,7 @@ struct AppearanceSettingsView: View {
                         }
 
                         Text(String(format: L10n.string("Quick reaction %d"), index + 1))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
 
                         Spacer()
 
@@ -1162,7 +1254,7 @@ struct PrivacySecuritySettingsView: View {
                     )
                 )
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             }
 
             Section(L10n.string("Data Sharing")) {
@@ -1205,7 +1297,7 @@ struct PrivacySecuritySettingsView: View {
                                 + L10n.string("Leave off to keep sensitive data obfuscated.")
                         )
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
                 }
                 .disabled(workspace.isSavingPrivacySecurity || !workspace.privacySecuritySettings.auditLoggingEnabled)
@@ -1215,7 +1307,7 @@ struct PrivacySecuritySettingsView: View {
                         ProgressView()
                             .controlSize(.small)
                         Text(L10n.string("Saving..."))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
                 }
             }
@@ -1277,7 +1369,7 @@ struct PrivacySecuritySettingsView: View {
 
                 if let auditLogUploadStatus = workspace.auditLogUploadStatus {
                     Label(auditLogUploadStatus, systemImage: "checkmark.seal")
-                        .foregroundStyle(.green)
+                        .foregroundStyle(WNColor.intentionSuccessContent)
                 }
             }
 
@@ -1291,11 +1383,11 @@ struct PrivacySecuritySettingsView: View {
                     )
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(.red)
+                .tint(WNColor.fillDestructive)
                 .disabled(workspace.isAccountMutationInProgress)
 
                 Text(L10n.string("Reset White Noise to a newly installed state on this Mac."))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -1343,17 +1435,17 @@ struct AuditLogFileRow: View {
                 Spacer()
                 Text(byteCount(file.sizeBytes))
                     .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
 
             Text(details)
                 .font(.caption2)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .lineLimit(1)
 
             Text(file.path)
                 .font(.caption2.monospaced())
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(WNColor.backgroundContentTertiary)
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .textSelection(.enabled)
@@ -1407,7 +1499,7 @@ struct NotificationsSettingsView: View {
                 LabeledContent(L10n.string("Permission")) {
                     HStack(spacing: 8) {
                         Text(workspace.notificationAuthorizationStatus.label)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                         if workspace.isSavingNotifications {
                             ProgressView()
                                 .controlSize(.small)
@@ -1439,7 +1531,7 @@ struct NotificationsSettingsView: View {
                 .disabled(!workspace.notificationSettings.localNotificationsEnabled)
 
                 Text(workspace.notificationPreviewMode.detail)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
@@ -1477,7 +1569,7 @@ struct StorageSettingsView: View {
                     } else {
                         Text(byteCount(workspace.mediaCacheFootprint.byteCount))
                             .monospacedDigit()
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
                 }
 
@@ -1486,7 +1578,7 @@ struct StorageSettingsView: View {
                         "White Noise encrypts cached attachment data on this Mac. Clearing it does not remove accounts, messages, drafts, or settings."
                     )
                 )
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .fixedSize(horizontal: false, vertical: true)
 
                 Button(role: .destructive) {
@@ -1517,7 +1609,7 @@ struct StorageSettingsView: View {
                         ),
                         systemImage: "checkmark.circle"
                     )
-                    .foregroundStyle(.green)
+                    .foregroundStyle(WNColor.intentionSuccessContent)
                 }
             }
         }
@@ -1576,7 +1668,7 @@ struct DeveloperModeSettingsView: View {
                     Text(L10n.string("Location"))
 
                     Text(workspace.storageRootPath)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -1592,7 +1684,7 @@ struct DeveloperModeSettingsView: View {
                 ForEach(workspace.diagnosticsInfo) { item in
                     LabeledContent(item.title) {
                         Text(item.value)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                             .textSelection(.enabled)
                     }
                 }
@@ -1707,7 +1799,7 @@ struct RelayDiagnosticsView: View {
                 Spacer()
                 Text(settings.isComplete ? L10n.string("Complete") : L10n.string("Missing"))
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             }
 
             RelayDiagnosticsRow(
@@ -1718,7 +1810,7 @@ struct RelayDiagnosticsView: View {
             if !settings.missing.isEmpty {
                 Text(String(format: L10n.string("Missing: %@"), settings.missing.joined(separator: ", ")))
                     .font(.caption)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(WNColor.intentionWarningContent)
             }
         }
         .padding(.vertical, 4)
@@ -1735,12 +1827,12 @@ struct RelayDiagnosticsRow: View {
             if relays.isEmpty {
                 Text(L10n.string("Not published"))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
             } else {
                 ForEach(relays, id: \.self) { relay in
                     Text(relay)
                         .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -1749,16 +1841,21 @@ struct RelayDiagnosticsRow: View {
             HStack(spacing: 8) {
                 Image(systemName: systemImage)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .frame(width: 18)
                 Text(title)
                 Spacer()
+                // Drawn on `fillSecondary`, so it takes a `fillContent*` token rather than a
+                // `backgroundContent*` one. `fillContentTertiary` is the de-emphasized step of that
+                // family — the right weight for a count beside its own row title, and the same
+                // `500`/`400` ramp steps this already rendered at.
                 Text(verbatim: "\(relays.count)")
                     .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.fillContentTertiary)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 2)
-                    .background(.quaternary, in: Capsule())
+                    .background(WNColor.fillSecondary, in: Capsule())
+                    .overlay(Capsule().strokeBorder(WNColor.borderTertiary, lineWidth: 1))
             }
             .font(.callout)
         }
@@ -1835,10 +1932,10 @@ struct KeyPackageRow: View {
             HStack(alignment: .top, spacing: 12) {
                 Image(systemName: "key.fill")
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(WNColor.fillContentPrimary)
                     .frame(width: 30, height: 30)
                     .background {
-                        Circle().fill(MessagesPalette.sentBubble)
+                        Circle().fill(WNColor.fillPrimary)
                     }
 
                 VStack(alignment: .leading, spacing: 5) {
@@ -1866,7 +1963,7 @@ struct KeyPackageRow: View {
                         }
                         Text(package.publishedLabel)
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
 
                     keyValue(L10n.string("Event"), package.eventIdHex)
@@ -1876,7 +1973,7 @@ struct KeyPackageRow: View {
                         keyValue(L10n.string("Slot"), package.keyPackageId)
                         Text(L10n.plural("%llu bytes", package.keyPackageBytes))
                             .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
                 }
 
@@ -1886,7 +1983,7 @@ struct KeyPackageRow: View {
                     Image(systemName: "trash")
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(.red)
+                .foregroundStyle(WNColor.backgroundContentDestructive)
                 .help(L10n.string("Delete key package"))
                 .disabled(package.eventIdHex.isEmpty || workspace.deletingKeyPackageId != nil)
             }
@@ -1895,11 +1992,11 @@ struct KeyPackageRow: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(L10n.string("Source relays"))
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                     ForEach(package.sourceRelays, id: \.self) { relay in
                         Text(relay)
                             .font(.system(.caption, design: .monospaced))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                             .textSelection(.enabled)
                     }
                 }
@@ -1924,10 +2021,10 @@ struct KeyPackageRow: View {
         HStack(spacing: 6) {
             Text(title)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
             Text(value.isEmpty ? L10n.string("Unknown") : DisplayText.short(value, head: 12, tail: 10))
                 .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .textSelection(.enabled)
         }
     }
@@ -1961,7 +2058,7 @@ struct RelayRow: View {
                             : "Insecure — cleartext ws:// (public host)"
                     )
                     .font(.caption2)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(WNColor.intentionWarningContent)
                 }
             }
 
@@ -1971,7 +2068,7 @@ struct RelayRow: View {
                 Image(systemName: "minus.circle")
             }
             .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(WNColor.backgroundContentSecondary)
             .help(L10n.string("Remove relay"))
         }
         .padding(.vertical, 4)

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -18,10 +18,13 @@ struct UnreadCountBadge: View {
     var body: some View {
         Text(verbatim: count > 99 ? "99+" : "\(count)")
             .font(font)
-            .foregroundStyle(.white)
+            // `fillPrimary` + `fillContentPrimary`, the pair the other clients give the unread
+            // count. Both invert between appearances, so the count is white on a near-black pill in
+            // light and near-black on a white pill in dark.
+            .foregroundStyle(WNColor.fillContentPrimary)
             .padding(.horizontal, 5)
             .frame(minWidth: 18, minHeight: 18)
-            .background(Capsule().fill(MessagesPalette.sentBubble))
+            .background(Capsule().fill(WNColor.fillPrimary))
     }
 }
 
@@ -70,7 +73,9 @@ struct AccountRailView: View {
                     }
             }
             .buttonStyle(.plain)
-            .foregroundStyle(isSettingsSelected ? Color.primary : Color.secondary)
+            .foregroundStyle(
+                isSettingsSelected ? WNColor.fillContentSecondary : WNColor.fillContentTertiary
+            )
             .help(L10n.string("Settings"))
         }
         .padding(.top, MessagesLayout.sidebarTitlebarTopPadding)
@@ -144,11 +149,13 @@ private struct AccountRailAvatar: View {
         if account.signedOut {
             Image(systemName: "pause.circle.fill")
                 .font(.system(size: 15))
-                .foregroundStyle(.secondary)
-                .background(Circle().fill(Color(nsColor: .windowBackgroundColor)))
+                .foregroundStyle(WNColor.backgroundContentSecondary)
+                // Punched out of the rail behind it, so it takes the rail's own surface rather
+                // than the system window color.
+                .background(Circle().fill(WNColor.backgroundTertiary))
         } else if unread > 0 {
             UnreadCountBadge(count: unread)
-                .overlay(Capsule().strokeBorder(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
+                .overlay(Capsule().strokeBorder(WNColor.backgroundTertiary, lineWidth: 1.5))
         }
     }
 }
@@ -359,7 +366,7 @@ private struct ChatListFilterMenu: View {
         .background {
             if workspace.chatListFilter == filter {
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color.accentColor.opacity(0.14))
+                    .fill(WNColor.fillTertiaryHover)
             }
         }
     }
@@ -592,16 +599,19 @@ struct SettingsSidebarRow: View {
         HStack(spacing: 10) {
             Image(systemName: page.systemImage)
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(isSelected ? Color.primary : Color.secondary)
+                .foregroundStyle(
+                    isSelected
+                        ? WNColor.backgroundContentPrimary : WNColor.backgroundContentSecondary
+                )
                 .frame(width: 28, height: 28)
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(page.title(in: locale))
                     .font(.callout.weight(.semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(WNColor.backgroundContentPrimary)
                 Text(page.sidebarSubtitle(in: locale))
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -654,13 +664,13 @@ struct ChatRowContent: View {
                     if isPinned {
                         Image(systemName: "pin.fill")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                             .accessibilityLabel(L10n.string("Pinned"))
                     }
                     if chat.muted {
                         Image(systemName: "bell.slash.fill")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                             .accessibilityLabel(L10n.string("Muted"))
                     }
                     Spacer(minLength: 8)
@@ -672,12 +682,12 @@ struct ChatRowContent: View {
                     )
                     .equatable()
                     .font(MessagesType.meta)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
                 HStack(alignment: .top, spacing: 4) {
                     previewText
                         .font(MessagesType.preview)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                         .lineLimit(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     if searchResult == nil {
@@ -687,16 +697,16 @@ struct ChatRowContent: View {
                         if chat.hasMention {
                             Image(systemName: "at")
                                 .font(.caption2.weight(.bold))
-                                .foregroundStyle(.white)
+                                .foregroundStyle(WNColor.fillContentPrimary)
                                 .frame(width: 18, height: 18)
-                                .background(Circle().fill(Color.accentColor))
+                                .background(Circle().fill(WNColor.fillPrimary))
                                 .help(L10n.string("You were mentioned"))
                         }
                         if chat.unreadCount > 0 {
                             UnreadCountBadge(count: chat.unreadCount, font: MessagesType.badge)
                         } else {
                             Circle()
-                                .fill(Color.accentColor)
+                                .fill(WNColor.fillPrimary)
                                 .frame(width: 9, height: 9)
                                 .accessibilityLabel(L10n.string("Marked unread"))
                         }
@@ -723,7 +733,8 @@ struct ChatRowContent: View {
         }
         return Text(verbatim: "\(searchResult.senderName): ").bold()
             + Text(searchResult.snippet.leading)
-            + Text(searchResult.snippet.match).bold().foregroundColor(.primary)
+            + Text(searchResult.snippet.match).bold()
+            .foregroundColor(WNColor.intentionInfoContent)
             + Text(searchResult.snippet.trailing)
     }
 }
@@ -737,15 +748,15 @@ private struct ChatDeliveryStateIcon: View {
             EmptyView()
         case .pending:
             Image(systemName: "clock")
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .help(L10n.string("Sending"))
         case .delivered:
             Image(systemName: "checkmark")
-                .foregroundStyle(.secondary)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
                 .help(L10n.string("Delivered"))
         case .failed:
             Image(systemName: "exclamationmark.circle.fill")
-                .foregroundStyle(.red)
+                .foregroundStyle(WNColor.intentionErrorContent)
                 .help(L10n.string("Not delivered"))
         }
     }
@@ -774,6 +785,14 @@ private struct ChatTimestampText: View, Equatable {
     }
 }
 
+/// An invitation waiting on an answer. This is the other clients' `ChatStatusType.request`, which
+/// is the one chat-row status they draw in the info intention rather than in neutral gray — it is
+/// the only one that is asking the reader for something. Taking the intention's own background and
+/// content tokens (`intentionInfoBackground` + `intentionInfoContent`) is how the reference styles
+/// every info surface, and it is also why this capsule has no hairline: the intention pair is
+/// self-contained, and a neutral `borderTertiary` ring drawn around a blue wash belongs to neither
+/// family. The neutral capsule stays on `LeavingGroupBadge` and `MembershipEndedBadge`, which
+/// report a state rather than ask for a decision.
 struct PendingInviteBadge: View {
     var body: some View {
         Label(L10n.string("Invite"), systemImage: "envelope.badge")
@@ -781,8 +800,8 @@ struct PendingInviteBadge: View {
             .labelStyle(.titleAndIcon)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .foregroundStyle(.secondary)
-            .background(.quaternary, in: Capsule())
+            .foregroundStyle(WNColor.intentionInfoContent)
+            .background(WNColor.intentionInfoBackground, in: Capsule())
             .help(L10n.string("Group invite pending"))
     }
 }
@@ -794,8 +813,9 @@ struct LeavingGroupBadge: View {
             .labelStyle(.titleAndIcon)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .foregroundStyle(.secondary)
-            .background(.quaternary, in: Capsule())
+            .foregroundStyle(WNColor.fillContentTertiary)
+            .background(WNColor.fillSecondary, in: Capsule())
+            .overlay(Capsule().strokeBorder(WNColor.borderTertiary, lineWidth: 1))
             .help(L10n.string("Leave request pending"))
     }
 }
@@ -814,8 +834,9 @@ struct MembershipEndedBadge: View {
         .labelStyle(.titleAndIcon)
         .padding(.horizontal, 6)
         .padding(.vertical, 2)
-        .foregroundStyle(.secondary)
-        .background(.quaternary, in: Capsule())
+        .foregroundStyle(WNColor.fillContentTertiary)
+        .background(WNColor.fillSecondary, in: Capsule())
+        .overlay(Capsule().strokeBorder(WNColor.borderTertiary, lineWidth: 1))
         .help(membership.endedDescription ?? "")
     }
 }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -198,12 +198,12 @@ struct PureValueTests {
         #expect(ComposerMentionMarkerStore.selections(in: editedMentionView).isEmpty)
     }
 
-    /// The composer chip is derived from the identity markers rather than tracked on its own, so
-    /// the styled range must follow a repaired marker and vanish with an invalidated one. Drift
-    /// either way would leave a chip on text that is no longer a mention, or a mention with no
-    /// visible affordance.
+    /// A composer token's styling is derived from the identity markers rather than tracked on its
+    /// own, so the styled range must follow a repaired marker and vanish with an invalidated one.
+    /// Drift either way would leave a mention's styling on text that is no longer a mention, or a
+    /// mention with no visible affordance.
     @MainActor
-    @Test func mentionChipTracksTheIdentityRangeAndDisappearsWithTheMarker() throws {
+    @Test func mentionStylingTracksTheIdentityRangeAndDisappearsWithTheMarker() throws {
         let candidate = mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq")
         let selection = ComposerMentionSelection(
             range: NSRange(location: 0, length: 5),
@@ -215,29 +215,64 @@ struct PureValueTests {
         textView.isRichText = false
         textView.string = "@Alex "
         ComposerMentionMarkerStore.replaceAll(with: [selection], in: textView)
-        #expect(chipRanges(in: textView) == [NSRange(location: 0, length: 5)])
+        #expect(mentionStyledRanges(in: textView) == [NSRange(location: 0, length: 5)])
 
-        // Boundary edit: the marker is repaired to the shifted range, and so is the chip.
+        // Boundary edit: the marker is repaired to the shifted range, and so is the styling.
         textView.insertText("Hi ", replacementRange: NSRange(location: 0, length: 0))
         let repaired = ComposerMentionMarkerStore.selections(in: textView)
         #expect(repaired.map(\.range) == [NSRange(location: 3, length: 5)])
-        #expect(chipRanges(in: textView) == repaired.map(\.range))
+        #expect(mentionStyledRanges(in: textView) == repaired.map(\.range))
 
-        // Internal edit: the marker is dropped, and the chip goes with it.
+        // Internal edit: the marker is dropped, and the styling goes with it.
         let editedMentionView = NSTextView()
         editedMentionView.isRichText = false
         editedMentionView.string = "@Alex "
         ComposerMentionMarkerStore.replaceAll(with: [selection], in: editedMentionView)
         editedMentionView.insertText("x", replacementRange: NSRange(location: 3, length: 0))
         #expect(ComposerMentionMarkerStore.selections(in: editedMentionView).isEmpty)
-        #expect(chipRanges(in: editedMentionView).isEmpty)
+        #expect(mentionStyledRanges(in: editedMentionView).isEmpty)
 
-        // A draft with no picked mention is never chipped.
+        // A draft with no picked mention is never styled.
         let plainView = NSTextView()
         plainView.isRichText = false
         plainView.string = "@Alex "
         ComposerMentionMarkerStore.replaceAll(with: [], in: plainView)
-        #expect(chipRanges(in: plainView).isEmpty)
+        #expect(mentionStyledRanges(in: plainView).isEmpty)
+    }
+
+    /// Dropping a token has to leave *plain typed text* behind, not text with no foreground color
+    /// at all: TextKit draws an uncolored run in opaque black rather than falling back to the text
+    /// view's `textColor`, so a swept draft is invisible on the composer's dark field and perfectly
+    /// legible on its light one. `replaceAll` sweeps the whole storage before re-adding tokens, so
+    /// this covers every character of the draft and not just the former token.
+    @MainActor
+    @Test func draftKeepsTheComposerContentColorAfterItsMentionsAreDropped() throws {
+        let selection = ComposerMentionSelection(
+            range: NSRange(location: 3, length: 5),
+            displayText: "@Alex",
+            npub: "npub1qqqq"
+        )
+        let textView = NSTextView()
+        textView.isRichText = false
+        textView.string = "Hi @Alex there"
+        ComposerMentionMarkerStore.replaceAll(with: [selection], in: textView)
+
+        // The token is dropped the way an invalidating edit drops it: markers gone, no styled run
+        // left anywhere.
+        ComposerMentionMarkerStore.replaceAll(with: [], in: textView)
+        #expect(ComposerMentionMarkerStore.selections(in: textView).isEmpty)
+        #expect(mentionStyledRanges(in: textView).isEmpty)
+
+        let storage = try #require(textView.textStorage)
+        let plainForeground =
+            ComposerMessageTextViewRepresentable.plainTypingAttributes[.foregroundColor] as? NSColor
+        for location in 0..<(textView.string as NSString).length {
+            let foreground = storage.attribute(.foregroundColor, at: location, effectiveRange: nil) as? NSColor
+            #expect(
+                foreground == plainForeground,
+                "character \(location) lost the composer's content color"
+            )
+        }
     }
 
     @MainActor
@@ -2755,20 +2790,29 @@ struct PureValueTests {
             remainingDepth: 32
         )
         #expect(links(in: mention).map(\.absoluteString) == ["nostr:\(npub)"])
-        #expect(mention.runs.allSatisfy { $0.backgroundColor != nil })
         #expect(underlineStyles(in: mention) == [nil])
 
-        // The chip has to contrast with the fill it is drawn on, so the sent bubble's accent fill
-        // gets a different one from a neutral surface. Collapsing the two back into a single
-        // translucent wash is the regression this guards.
-        let sentMention = MarkdownDisplayInlineBuilder.attributedString(
-            from: [.nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: npub))],
-            remainingDepth: 32,
-            mentionFill: .sentBubble
+        // A mention is bold, in the mentioned person's accent, and carries no background chip.
+        // Asserted against `MentionTextPalette` rather than "it differs from the body" so a
+        // mention that quietly stopped identifying anyone fails here.
+        #expect(mention.runs.allSatisfy { $0.backgroundColor == nil })
+        #expect(
+            mention.runs.first?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
+        #expect(mention.runs.first?.foregroundColor == MentionTextPalette.foreground(forNpub: npub))
+
+        // An `nprofile` is TLV-encoded rather than a bare key, so no accent can be derived from
+        // it. It stays bold but inherits the surrounding foreground instead of claiming to
+        // identify someone with a color that would be wrong.
+        let nprofile = "nprofile1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+        let nprofileMention = MarkdownDisplayInlineBuilder.attributedString(
+            from: [.nostrMention(entity: MarkdownNostrEntityFfi(hrp: .nprofile, bech32: nprofile))],
+            remainingDepth: 32
         )
-        #expect(mention.runs.first?.backgroundColor == MentionChipPalette.onNeutralFill)
-        #expect(sentMention.runs.first?.backgroundColor == MentionChipPalette.onSentBubble)
-        #expect(String(sentMention.characters) == String(mention.characters))
+        #expect(MentionTextPalette.foreground(forNpub: nprofile) == nil)
+        #expect(nprofileMention.runs.first?.foregroundColor == nil)
+        #expect(
+            nprofileMention.runs.first?.inlinePresentationIntent?.contains(.stronglyEmphasized)
+                == true)
 
         let note = "note1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
         let noteReference = MarkdownDisplayInlineBuilder.attributedString(
@@ -3156,20 +3200,28 @@ struct PureValueTests {
         attributed.runs.map(\.underlineStyle)
     }
 
-    /// Ranges carrying the mention chip, read back from a composer text view's storage. The
-    /// identity markers use private attribute keys, so the chip is what a test can observe
-    /// directly; identity is observed through `ComposerMentionMarkerStore.selections(in:)`.
+    /// Ranges carrying a mention token's visible styling, read back from a composer text view's
+    /// storage. The identity markers use private attribute keys, so the styling is what a test can
+    /// observe directly; identity is observed through
+    /// `ComposerMentionMarkerStore.selections(in:)`.
+    ///
+    /// A token is styled by weight and by the mentioned person's accent, matching a rendered
+    /// mention, rather than by a background chip. The **weight** is what is enumerated here: the
+    /// composer's typing attributes carry a foreground color for every character, so enumerating
+    /// color alone would match the entire draft, while only a mention is bold.
     @MainActor
-    private func chipRanges(in textView: NSTextView) -> [NSRange] {
+    private func mentionStyledRanges(in textView: NSTextView) -> [NSRange] {
         guard let storage = textView.textStorage else { return [] }
+        let plainWeight = NSFontManager.shared.weight(of: .preferredFont(forTextStyle: .body))
         var result: [NSRange] = []
         storage.enumerateAttribute(
-            .backgroundColor,
+            .font,
             in: NSRange(location: 0, length: (textView.string as NSString).length)
         ) { value, range, _ in
-            if value != nil {
-                result.append(range)
-            }
+            guard let font = value as? NSFont,
+                NSFontManager.shared.weight(of: font) > plainWeight
+            else { return }
+            result.append(range)
         }
         return result
     }

--- a/whitenoise-macTests/SemanticPaletteTests.swift
+++ b/whitenoise-macTests/SemanticPaletteTests.swift
@@ -1,0 +1,449 @@
+//
+//  SemanticPaletteTests.swift
+//  whitenoise-macTests
+//
+//  Guards on the semantic palette ported from the sibling clients'
+//  `lib/theme/semantic_colors.dart`.
+//
+//  The mistake these exist to catch is a *pairing* one, not a wrong hex: reaching
+//  across the background/content and fill/fill-content families, so that content
+//  is drawn on a surface it was never meant for. It is invisible in one appearance
+//  and unreadable in the other, which is exactly how it survives a visual check —
+//  `fillContentPrimary` is white in light appearance, so putting it on
+//  `backgroundPrimary` (also white) looks fine in dark and vanishes in light.
+//
+//  `.serialized` and `@MainActor`: these resolve colors through
+//  `performAsCurrentDrawingAppearance`, which tears down the test host when it runs
+//  off the main actor and reports the failure against whatever suite happens to be
+//  running at the time.
+//
+
+import AppKit
+import CoreImage
+import SwiftUI
+import Testing
+
+@testable import whitenoise_mac
+
+@MainActor
+@Suite(.serialized)
+struct SemanticPaletteTests {
+    // MARK: - Ramp fidelity
+
+    /// Spot-checks the ramp against the Dart source. Not exhaustive — the point is to
+    /// catch a transcription slip in the steps the semantic layer leans on hardest.
+    @Test func colorRampMatchesTheSharedPaletteValues() throws {
+        let expected: [(NSColor, String)] = [
+            (WNColorRamp.white, "FFFFFF"),
+            (WNColorRamp.black, "000000"),
+            (WNColorRamp.neutral50, "FAFAFA"),
+            (WNColorRamp.neutral100, "F5F5F5"),
+            (WNColorRamp.neutral150, "EDEDEE"),
+            (WNColorRamp.neutral200, "E5E5E5"),
+            (WNColorRamp.neutral400, "A3A3A3"),
+            (WNColorRamp.neutral500, "737373"),
+            (WNColorRamp.neutral800, "262626"),
+            (WNColorRamp.neutral950, "0A0A0A"),
+            (WNColorRamp.red600, "DC2626"),
+            (WNColorRamp.green600, "16A34A"),
+            (WNColorRamp.orange600, "EA580C"),
+            (WNColorRamp.blue600, "2563EB"),
+            (WNColorRamp.blue500, "3B82F6"),
+        ]
+
+        for (color, hex) in expected {
+            #expect(Self.hexString(of: try #require(color.usingColorSpace(.sRGB))) == hex)
+        }
+
+        // The Dart `transparent` is `0x00FFFFFF` — transparent *white*, not transparent
+        // black, which is what an interpolation through it produces.
+        let transparent = try #require(WNColorRamp.transparent.usingColorSpace(.sRGB))
+        #expect(transparent.alphaComponent == 0)
+        #expect(Self.hexString(of: transparent) == "FFFFFF")
+    }
+
+    // MARK: - Pairing
+
+    /// Every background/content and fill/fill-content pair the app draws, checked in both
+    /// appearances. A swapped or crossed pair collapses the contrast here.
+    @Test func semanticPairsStayLegibleInBothAppearances() throws {
+        // Thresholds are per emphasis level, not one number: the palette deliberately runs
+        // `backgroundContentTertiary` close to its surface, because that token is for
+        // timestamps and placeholders that are *meant* to recede. Primary content is held to
+        // WCAG AA for body text.
+        let pairs: [(name: String, surface: NSColor, content: NSColor, minimum: Double)] = [
+            ("primary/primary", WNNSColor.backgroundPrimary, WNNSColor.backgroundContentPrimary, 4.5),
+            ("primary/secondary", WNNSColor.backgroundPrimary, WNNSColor.backgroundContentSecondary, 3.0),
+            ("primary/tertiary", WNNSColor.backgroundPrimary, WNNSColor.backgroundContentTertiary, 2.0),
+            ("secondary/primary", WNNSColor.backgroundSecondary, WNNSColor.backgroundContentPrimary, 4.5),
+            ("secondary/secondary", WNNSColor.backgroundSecondary, WNNSColor.backgroundContentSecondary, 3.0),
+            ("tertiary/primary", WNNSColor.backgroundTertiary, WNNSColor.backgroundContentPrimary, 4.5),
+            ("tertiary/secondary", WNNSColor.backgroundTertiary, WNNSColor.backgroundContentSecondary, 3.0),
+            ("tertiary/tertiary", WNNSColor.backgroundTertiary, WNNSColor.backgroundContentTertiary, 2.0),
+            ("slate/primary", WNNSColor.backgroundSlate, WNNSColor.backgroundContentPrimary, 4.5),
+            ("slate/secondary", WNNSColor.backgroundSlate, WNNSColor.backgroundContentSecondary, 3.0),
+            // The received bubble, and the de-emphasized metadata drawn inside it.
+            ("incoming/primary", WNNSColor.backgroundMessageIncoming, WNNSColor.backgroundContentPrimary, 4.5),
+            ("incoming/secondary", WNNSColor.backgroundMessageIncoming, WNNSColor.backgroundContentSecondary, 3.0),
+            ("incoming/tertiary", WNNSColor.backgroundMessageIncoming, WNNSColor.backgroundContentTertiary, 2.0),
+            // The sent bubble and the primary button are the same pair.
+            ("fillPrimary", WNNSColor.fillPrimary, WNNSColor.fillContentPrimary, 4.5),
+            ("fillPrimaryHover", WNNSColor.fillPrimaryHover, WNNSColor.fillContentPrimary, 4.5),
+            ("fillSecondary", WNNSColor.fillSecondary, WNNSColor.fillContentSecondary, 4.5),
+            ("fillSecondaryHover", WNNSColor.fillSecondaryHover, WNNSColor.fillContentSecondary, 4.5),
+            ("fillSecondary/tertiary", WNNSColor.fillSecondary, WNNSColor.fillContentTertiary, 2.0),
+            ("fillDestructive", WNNSColor.fillDestructive, WNNSColor.fillContentQuaternary, 4.5),
+            ("fillDisabled", WNNSColor.fillDisabled, WNNSColor.fillContentDisabled, 1.4),
+            // The intentions are background/content pairs like any other, and are used as pairs:
+            // the pending-invite badge draws `intentionInfoContent` on `intentionInfoBackground`,
+            // the way the other clients style every info surface. Held to the large-text bar rather
+            // than the body-text one, because that is where the reference palette actually sits —
+            // a `600` step on a `50` wash of the same hue measures 3.15 (success, Aqua) to 5.6, and
+            // these surfaces carry short bold labels and glyphs, never running text. The bar still
+            // catches the mistake worth catching: an intention's content drawn on another
+            // intention's background, or on a neutral surface it was not built for.
+            ("intentionInfo", WNNSColor.intentionInfoBackground, WNNSColor.intentionInfoContent, 3.0),
+            ("intentionSuccess", WNNSColor.intentionSuccessBackground, WNNSColor.intentionSuccessContent, 3.0),
+            ("intentionWarning", WNNSColor.intentionWarningBackground, WNNSColor.intentionWarningContent, 3.0),
+            ("intentionError", WNNSColor.intentionErrorBackground, WNNSColor.intentionErrorContent, 3.0),
+            // An intention wash is laid over the app's own surfaces, so it has to be told apart
+            // from them too — a badge whose capsule matches the row behind it is not a badge.
+            ("intentionInfo/onPrimary", WNNSColor.backgroundPrimary, WNNSColor.intentionInfoContent, 4.5),
+            // The scrim over media, and the chrome drawn on it.
+            ("overlayTertiary", WNNSColor.overlayTertiary, WNNSColor.fillContentQuaternary, 4.5),
+        ]
+
+        for appearance in try Self.appearances() {
+            for pair in pairs {
+                let ratio = try Self.contrast(pair.surface, pair.content, in: appearance)
+                #expect(
+                    ratio >= pair.minimum,
+                    """
+                    \(pair.name) contrast \(ratio) < \(pair.minimum) \
+                    in \(appearance.name.rawValue)
+                    """
+                )
+            }
+        }
+    }
+
+    /// `fillPrimary` and `backgroundPrimary` run in opposite directions, and so do their
+    /// content tokens. That inversion is the reason the two families cannot be mixed, so it
+    /// is asserted directly rather than left implicit in the contrast table.
+    @Test func fillAndBackgroundFamiliesInvertRelativeToEachOther() throws {
+        for appearance in try Self.appearances() {
+            // The fill is the *opposite* of the surface it sits on…
+            let fillOnSurface = try Self.contrast(
+                WNNSColor.backgroundPrimary, WNNSColor.fillPrimary, in: appearance)
+            #expect(fillOnSurface >= 4.5, "fillPrimary must stand out on backgroundPrimary")
+
+            // …so content meant for the fill is invisible on the surface, and vice versa.
+            // These are the two mistakes the pairing rule exists to prevent.
+            let fillContentOnSurface = try Self.contrast(
+                WNNSColor.backgroundPrimary, WNNSColor.fillContentPrimary, in: appearance)
+            #expect(
+                fillContentOnSurface < 1.2,
+                """
+                fillContentPrimary is legible on backgroundPrimary in \
+                \(appearance.name.rawValue) (\(fillContentOnSurface)) — the two families no \
+                longer invert, so crossing them would stop being caught
+                """
+            )
+        }
+    }
+
+    // MARK: - Accents
+
+    @Test func accentSetsPairTheirOwnFillAndContent() throws {
+        let accents = Self.allAccents
+        // A zero `accentCount` would make every loop below vacuous, so the suite would report full
+        // coverage of the accents while asserting nothing about any of them.
+        #expect(!accents.isEmpty, "AvatarPalette exposes no accents")
+
+        for appearance in try Self.appearances() {
+            for (name, accent) in accents {
+                let ratio = try Self.contrast(
+                    accent.nsFill, accent.nsContentPrimary, in: appearance)
+                #expect(
+                    ratio >= 4.5,
+                    "accent \(name) contrast \(ratio) in \(appearance.name.rawValue)")
+            }
+        }
+    }
+
+    /// `contentSecondary` is the `500` step, and a mention is drawn in it on top of whichever
+    /// bubble it lands in. The property that makes that possible is that `500` is
+    /// **appearance-invariant** — the same value in Aqua and Dark Aqua — while `fill` and
+    /// `contentPrimary` both cross over between them. A mention therefore needs to know neither
+    /// which bubble it is on nor which appearance is current, which is what let the
+    /// fill-dependent chip go away.
+    ///
+    /// Note what is *not* claimed: that `500` maximizes contrast. It does not. Against the light
+    /// received bubble a bright ramp like lime lands at 1.81, and `lime900` would in fact do
+    /// better there — the other clients draw the `500` step anyway, and this port follows them.
+    /// The floor below is the inherited one, and it is asserted so that reaching for `50` or
+    /// `950` here (which collapses to ~1.05 against one bubble or the other) still fails.
+    @Test func accentContentSecondaryIsAppearanceInvariantAndClearsBothBubbles() throws {
+        let bubbles = [
+            ("sent", WNNSColor.fillPrimary),
+            ("received", WNNSColor.backgroundMessageIncoming),
+        ]
+        let accents = Self.allAccents
+        // A zero `accentCount` would make every loop below vacuous, so the suite would report full
+        // coverage of the accents while asserting nothing about any of them.
+        #expect(!accents.isEmpty, "AvatarPalette exposes no accents")
+
+        for (name, accent) in accents {
+            let resolved = try Self.appearances().map { appearance in
+                try Self.resolvedHex(accent.nsContentSecondary, in: appearance)
+            }
+            #expect(
+                resolved[0] == resolved[1],
+                """
+                accent \(name).contentSecondary differs between appearances \
+                (\(resolved[0]) / \(resolved[1])) — a mention would need to know which \
+                appearance it is drawn in, which is the coupling this token exists to avoid
+                """
+            )
+            // The two steps it must not be replaced with do cross over, which is why they
+            // cannot serve here.
+            let fillHexes = try Self.appearances().map {
+                try Self.resolvedHex(accent.nsFill, in: $0)
+            }
+            #expect(fillHexes[0] != fillHexes[1], "accent \(name).fill should invert")
+        }
+
+        for appearance in try Self.appearances() {
+            for (bubbleName, bubble) in bubbles {
+                for (name, accent) in accents {
+                    let ratio = try Self.contrast(
+                        bubble, accent.nsContentSecondary, in: appearance)
+                    #expect(
+                        ratio >= 1.6,
+                        """
+                        mention accent \(name) on the \(bubbleName) bubble is \(ratio) \
+                        in \(appearance.name.rawValue)
+                        """
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Avatar keying
+
+    /// A mention carries the bech32, not the hex, so its accent is recovered from the first bech32
+    /// data character. It has to agree with what the seed mapping would have said about the decoded
+    /// key — `AvatarPaletteTests` covers that mapping itself; this covers only the bech32 shortcut.
+    @Test func npubAccentAgreesWithTheDecodedHexAccent() throws {
+        // The all-zero key: every data character is `q` (5-bit value 0), and the hex is `0000…`,
+        // so both paths must land on the same accent.
+        let zeroKeyNpub = "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+        #expect(
+            AvatarPalette.accentIndex(forNpub: zeroKeyNpub)
+                == AvatarPalette.accentIndex(for: String(repeating: "0", count: 64)))
+
+        // The derivation is `first 5-bit value >> 1`, so each pair of adjacent bech32 characters
+        // collapses onto one hex digit. `q`/`p` are values 0 and 1 → digit 0; `z`/`r` are 2 and 3 →
+        // digit 1; `l` is the last character in the set, value 31 → digit 15.
+        #expect(AvatarPalette.accentIndex(forNpub: "npub1q") == AvatarPalette.accentIndex(for: "0"))
+        #expect(AvatarPalette.accentIndex(forNpub: "npub1p") == AvatarPalette.accentIndex(for: "0"))
+        #expect(AvatarPalette.accentIndex(forNpub: "npub1z") == AvatarPalette.accentIndex(for: "1"))
+        #expect(AvatarPalette.accentIndex(forNpub: "npub1r") == AvatarPalette.accentIndex(for: "1"))
+        #expect(AvatarPalette.accentIndex(forNpub: "npub1l") == AvatarPalette.accentIndex(for: "f"))
+
+        // Only a bare public key. `nprofile` is TLV-encoded, so its first data character is a record
+        // tag rather than the top of a key, and guessing from it would produce a color that
+        // disagrees with every other client.
+        #expect(AvatarPalette.accentIndex(forNpub: "nprofile1qqqqqq") == nil)
+        #expect(AvatarPalette.accentIndex(forNpub: "note1qqqqqq") == nil)
+        #expect(AvatarPalette.accentIndex(forNpub: "npub1") == nil)
+        #expect(AvatarPalette.accentIndex(forNpub: "") == nil)
+        // `b` is not in the bech32 set (it excludes `1`, `b`, `i`, and `o`).
+        #expect(AvatarPalette.accentIndex(forNpub: "npub1b") == nil)
+
+        // And a mention actually resolves to that accent's `contentSecondary`. `try` rather than
+        // `try?`: with an optional index a missing accent would compare `nil == nil` and pass,
+        // which is the one outcome this assertion exists to catch.
+        let index = try #require(AvatarPalette.accentIndex(forNpub: zeroKeyNpub))
+        #expect(
+            MentionTextPalette.foreground(forNpub: zeroKeyNpub)
+                == AvatarPalette.accent(at: index).contentSecondary)
+    }
+
+    // MARK: - Reactions
+
+    /// The two reaction sets cross over between appearances, because in both the crossed
+    /// cases the chip is sitting on a dark bubble. A set that stopped crossing would read as
+    /// a chip that vanishes into one of the two bubbles.
+    @Test func reactionSetsPairEachStateWithItsContent() throws {
+        let states: [(String, KeyPath<WNReactionColorSet, NSColor>, KeyPath<WNReactionColorSet, NSColor>)] = [
+            ("rest", \.nsFill, \.nsContent),
+            ("hover", \.nsFillHover, \.nsContent),
+            ("selected", \.nsFillSelected, \.nsContentSelected),
+        ]
+
+        for appearance in try Self.appearances() {
+            for isOutgoing in [true, false] {
+                let set = WNReactionColors.set(isOutgoing: isOutgoing)
+                for (stateName, fill, content) in states {
+                    let ratio = try Self.contrast(
+                        set[keyPath: fill], set[keyPath: content], in: appearance)
+                    #expect(
+                        ratio >= 3.0,
+                        """
+                        reaction \(isOutgoing ? "outgoing" : "incoming").\(stateName) contrast \
+                        \(ratio) in \(appearance.name.rawValue)
+                        """
+                    )
+                }
+            }
+        }
+    }
+
+    /// Adding your own reaction has to *read* as a state change, which is the one thing a chip's
+    /// fill is load-bearing for.
+    ///
+    /// Deliberately not asserted against the bubble or the surface behind the chip: the other
+    /// clients let a resting chip's fill match the surface outright — light `incoming` is plain
+    /// white on a white surface — because a resting reaction is meant to read as an emoji rather
+    /// than as a button. The emoji and its count carry it, and `reactionSetsPairEachStateWithItsContent`
+    /// is what guards those.
+    @Test func selectingAReactionChangesItsFillVisibly() throws {
+        for appearance in try Self.appearances() {
+            for isOutgoing in [true, false] {
+                let set = WNReactionColors.set(isOutgoing: isOutgoing)
+                let ratio = try Self.contrast(set.nsFill, set.nsFillSelected, in: appearance)
+                #expect(
+                    ratio >= 4.5,
+                    """
+                    reaction \(isOutgoing ? "outgoing" : "incoming"): selected fill is only \
+                    \(ratio) from the resting fill in \(appearance.name.rawValue)
+                    """
+                )
+            }
+        }
+    }
+
+    // MARK: - Markdown code blocks
+
+    /// A fenced code block (and a math block, which shares the view) has to *name* its foreground
+    /// rather than inherit one, and this is what says so in both appearances.
+    ///
+    /// Two failures hide behind one inheritance. A code block nested in a block quote inherits the
+    /// quote's `backgroundContentSecondary` tint, which is the code block's own fill — so the code
+    /// was drawn in exactly the color behind it and vanished, in both appearances. Everywhere else
+    /// it inherits the app-wide `backgroundContentPrimary`, which clears that mid-gray fill in light
+    /// appearance and only reaches 2.52:1 in dark. The named pair fixes both at once, which is why
+    /// the nested case is covered here rather than by rendering a quote: what went wrong was the
+    /// token, and the token is the same one whatever the block is nested in.
+    @Test func markdownCodeBlockNamesAForegroundThatClearsItsFillInBothAppearances() throws {
+        for appearance in try Self.appearances() {
+            let inherited = try Self.resolvedHex(WNNSColor.backgroundContentSecondary, in: appearance)
+            let named = try Self.resolvedHex(MarkdownCodeBlockPalette.nsContent, in: appearance)
+            #expect(
+                named != inherited,
+                """
+                a code block nested in a block quote would inherit \(inherited) in \
+                \(appearance.name.rawValue), which is its own fill
+                """
+            )
+
+            let ratio = try Self.contrast(
+                MarkdownCodeBlockPalette.nsFill, MarkdownCodeBlockPalette.nsContent, in: appearance)
+            #expect(
+                ratio >= 4.5,
+                "code block contrast \(ratio) in \(appearance.name.rawValue)")
+        }
+    }
+
+    // MARK: - QR codes
+
+    /// The QR pair inverts with the appearance — near-black modules on white in Aqua, white on
+    /// near-black in Dark Aqua — so the question is not contrast but whether a decoder still reads
+    /// the reversed polarity. `CIDetector` is asked directly rather than trusted.
+    @Test func qrCodeDecodesInBothAppearancePolarities() throws {
+        let payload = "marmot:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
+        let context = CIContext()
+        let detector = try #require(
+            CIDetector(
+                ofType: CIDetectorTypeQRCode,
+                context: context,
+                options: [CIDetectorAccuracy: CIDetectorAccuracyHigh]))
+
+        for scheme in [ColorScheme.light, .dark] {
+            let palette = QRCodePalette.resolved(for: scheme)
+            let image = try #require(QRCodeImageView.ciImage(for: payload, palette: palette))
+            let decoded = detector.features(in: image).compactMap {
+                ($0 as? CIQRCodeFeature)?.messageString
+            }
+            #expect(decoded == [payload], "\(scheme) code did not decode: \(decoded)")
+
+            let ratio = try Self.contrast(
+                palette.modules.nsColor, palette.background.nsColor, in: try #require(NSAppearance(named: .aqua)))
+            #expect(ratio >= 4.5, "\(scheme) modules are only \(ratio) from their quiet zone")
+        }
+
+        // And the two polarities really are different — a palette that resolved the same both ways
+        // would pass every assertion above while defeating the point of the pair.
+        #expect(QRCodePalette.resolved(for: .light) != QRCodePalette.resolved(for: .dark))
+    }
+
+    // MARK: - Helpers
+
+    /// Every accent, read through `AvatarPalette`'s list so these tests cover the same twelve sets
+    /// the app actually assigns rather than a second copy that could drift from it.
+    private static var allAccents: [(String, WNAccentColorSet)] {
+        (0..<AvatarPalette.accentCount).map { ("accent \($0)", AvatarPalette.accent(at: $0)) }
+    }
+
+    private static func appearances() throws -> [NSAppearance] {
+        try [NSAppearance.Name.aqua, .darkAqua].map { try #require(NSAppearance(named: $0)) }
+    }
+
+    /// WCAG 2.x contrast ratio, resolved in `appearance` so a dynamic token reports the value
+    /// it will actually draw with.
+    private static func contrast(
+        _ first: NSColor,
+        _ second: NSColor,
+        in appearance: NSAppearance
+    ) throws -> Double {
+        var resolved: (NSColor, NSColor)?
+        appearance.performAsCurrentDrawingAppearance {
+            guard
+                let a = first.usingColorSpace(.sRGB),
+                let b = second.usingColorSpace(.sRGB)
+            else { return }
+            resolved = (a, b)
+        }
+        let (a, b) = try #require(resolved)
+        let first = relativeLuminance(of: a)
+        let second = relativeLuminance(of: b)
+        return (max(first, second) + 0.05) / (min(first, second) + 0.05)
+    }
+
+    /// The sRGB hex a token resolves to under `appearance`, for asserting that a token does —
+    /// or deliberately does not — change between them.
+    private static func resolvedHex(_ color: NSColor, in appearance: NSAppearance) throws -> String {
+        var resolved: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.sRGB)
+        }
+        return hexString(of: try #require(resolved))
+    }
+
+    private static func relativeLuminance(of color: NSColor) -> Double {
+        func linear(_ channel: CGFloat) -> Double {
+            let value = Double(channel)
+            return value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear(color.redComponent)
+            + 0.7152 * linear(color.greenComponent)
+            + 0.0722 * linear(color.blueComponent)
+    }
+
+    private static func hexString(of color: NSColor) -> String {
+        let channels = [color.redComponent, color.greenComponent, color.blueComponent]
+        return channels.map { String(format: "%02X", Int(($0 * 255).rounded())) }.joined()
+    }
+}

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5743,10 +5743,11 @@ struct whitenoise_macTests {
         #expect(!structured.supportsInlineMetadata)
     }
 
-    /// A mention chip has to contrast with the bubble fill behind it, and the row's attributed
-    /// string is built once here — off-main, never rewritten during a body pass — so the fill is
-    /// chosen at mapping time from the direction the row already knows.
-    @Test func mentionChipFollowsTheBubbleDirectionOfTheMessage() {
+    /// A mention is colored by *who it mentions*, not by which bubble it lands in — that is the
+    /// property that let the fill-dependent chip go away. The row's attributed string is built once
+    /// here, off-main and never rewritten during a body pass, so this also pins that a sent and a
+    /// received copy of the same mention come out identical.
+    @Test func mentionTakesTheMentionedAccentRegardlessOfBubbleDirection() {
         let npub = "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
         let tokens = MarkdownDocumentFfi(
             blocks: [
@@ -5756,7 +5757,7 @@ struct whitenoise_macTests {
             ],
             truncated: false
         )
-        func chip(isOutgoing: Bool) -> Color? {
+        func mentionRun(isOutgoing: Bool) -> AttributedString.Runs.Element? {
             MessageItem(
                 id: "mention-\(isOutgoing)",
                 senderName: "Alice",
@@ -5766,13 +5767,19 @@ struct whitenoise_macTests {
                 sentAt: Date(timeIntervalSince1970: 1_700_000_000),
                 isOutgoing: isOutgoing
             )
-            .contentMarkdown?.inlineParagraph?.runs.first?.backgroundColor
+            .contentMarkdown?.inlineParagraph?.runs.first
         }
 
-        // Asserted against the palette constants rather than just "these two differ", so a
-        // reversed mapping fails here instead of passing with the chips swapped.
-        #expect(chip(isOutgoing: true) == MentionChipPalette.onSentBubble)
-        #expect(chip(isOutgoing: false) == MentionChipPalette.onNeutralFill)
+        let accent = MentionTextPalette.foreground(forNpub: npub)
+        #expect(accent != nil)
+        for isOutgoing in [true, false] {
+            let run = mentionRun(isOutgoing: isOutgoing)
+            #expect(run?.foregroundColor == accent)
+            #expect(run?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
+            // No background chip in either direction; the chip is what used to have to know the
+            // fill, and reintroducing one is the regression this guards.
+            #expect(run?.backgroundColor == nil)
+        }
     }
 
     /// The audio player, the download/failed status rows, and the document row draw white content


### PR DESCRIPTION
Now the colors are in the black and white color palette that old flutter app did. It looks like this now. Still needs lots of improvements, but I feel it closer to the White Noise brand now and less generic. 

|dark mode| light mode|
|----|----|
|<img width="1512" height="954" alt="Screenshot 2026-08-07 at 12 51 48 PM" src="https://github.com/user-attachments/assets/ff918e40-5abe-4e56-9154-96a7a0e2f2a4" />|<img width="1508" height="945" alt="Screenshot 2026-08-07 at 12 51 30 PM" src="https://github.com/user-attachments/assets/30137876-0ef7-4e05-b30d-42f9f8ad13c5" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a consistent light and dark appearance color palette across messaging, settings, search, composer, groups, media, and emoji picker screens.
  * Added appearance-aware accent colors, reaction states, semantic status colors, and QR code styling.
  * Updated message mentions to appear bold with optional accent-colored text instead of background chips.
* **Visual Improvements**
  * Refined message bubbles, reactions, attachments, controls, badges, and backgrounds for clearer contrast and consistency.
* **Bug Fixes**
  * Improved mention styling persistence while composing and editing messages.
* **Tests**
  * Added coverage for palette contrast, appearance variants, reactions, accents, and mention rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->