### PR TITLE
Change unread badge color

### DIFF
--- a/whitenoise-mac/Views/Palette/WNColor.swift
+++ b/whitenoise-mac/Views/Palette/WNColor.swift
@@ -56,6 +56,8 @@ nonisolated enum WNColor {
     static let fillDestructiveHover = Color(nsColor: WNNSColor.fillDestructiveHover)
     static let fillDestructiveActive = Color(nsColor: WNNSColor.fillDestructiveActive)
 
+    static let fillInfo = Color(nsColor: WNNSColor.fillInfo)
+
     static let fillDisabled = Color(nsColor: WNNSColor.fillDisabled)
     static let fillContentDisabled = Color(nsColor: WNNSColor.fillContentDisabled)
 
@@ -65,6 +67,7 @@ nonisolated enum WNColor {
     static let fillContentSecondary = Color(nsColor: WNNSColor.fillContentSecondary)
     static let fillContentTertiary = Color(nsColor: WNNSColor.fillContentTertiary)
     static let fillContentQuaternary = Color(nsColor: WNNSColor.fillContentQuaternary)
+    static let fillContentInfo = Color(nsColor: WNNSColor.fillContentInfo)
 
     // MARK: - Borders
 

--- a/whitenoise-mac/Views/Palette/WNNSColor.swift
+++ b/whitenoise-mac/Views/Palette/WNNSColor.swift
@@ -115,6 +115,19 @@ nonisolated enum WNNSColor {
     static let fillDestructiveActive = NSColor.wnDynamic(
         "wn.fillDestructiveActive", light: WNColorRamp.red500, dark: WNColorRamp.red500)
 
+    /// The unread signal: the count badge, the mention pill, the manual-unread dot. The one
+    /// fill in the palette that carries a hue rather than inverting with the surface, because
+    /// an unread count has to be told apart from the chrome around it — `fillPrimary` is
+    /// already the sent bubble, the send button and the selected row, so a badge drawn in it
+    /// reads as more of the same rather than as something waiting for you. Follows the blue's
+    /// own convention of a `600` step in light and a brighter `500` in dark, which is what
+    /// keeps the pill separated from the near-black row behind it.
+    ///
+    /// Not part of `semantic_colors.dart` — the Flutter client draws this badge in
+    /// `fillPrimary`. The divergence is deliberate; see `fillContentInfo` for the pairing.
+    static let fillInfo = NSColor.wnDynamic(
+        "wn.fillInfo", light: WNColorRamp.blue600, dark: WNColorRamp.blue500)
+
     static let fillDisabled = NSColor.wnDynamic(
         "wn.fillDisabled", light: WNColorRamp.neutral300, dark: WNColorRamp.neutral650)
     static let fillContentDisabled = NSColor.wnDynamic(
@@ -135,6 +148,11 @@ nonisolated enum WNNSColor {
     /// both appearances, because both of those fills are dark in both.
     static let fillContentQuaternary = NSColor.wnDynamic(
         "wn.fillContentQuaternary", light: WNColorRamp.white, dark: WNColorRamp.white)
+    /// Content on `fillInfo` — the unread count itself. White in both appearances for the
+    /// same reason `fillContentQuaternary` is: the fill it sits on is a saturated blue in
+    /// both, so this pair does not cross over the way `fillPrimary`'s does.
+    static let fillContentInfo = NSColor.wnDynamic(
+        "wn.fillContentInfo", light: WNColorRamp.white, dark: WNColorRamp.white)
 
     // MARK: - Borders
 

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -18,13 +18,14 @@ struct UnreadCountBadge: View {
     var body: some View {
         Text(verbatim: count > 99 ? "99+" : "\(count)")
             .font(font)
-            // `fillPrimary` + `fillContentPrimary`, the pair the other clients give the unread
-            // count. Both invert between appearances, so the count is white on a near-black pill in
-            // light and near-black on a white pill in dark.
-            .foregroundStyle(WNColor.fillContentPrimary)
+            // `fillInfo` + `fillContentInfo`: a white count on a blue pill in both appearances.
+            // Deliberately *not* `fillPrimary`, which this used to take — that token is already the
+            // sent bubble, the send button and the selected row, so an unread count drawn in it read
+            // as chrome instead of as something waiting for you.
+            .foregroundStyle(WNColor.fillContentInfo)
             .padding(.horizontal, 5)
             .frame(minWidth: 18, minHeight: 18)
-            .background(Capsule().fill(WNColor.fillPrimary))
+            .background(Capsule().fill(WNColor.fillInfo))
     }
 }
 
@@ -693,20 +694,23 @@ struct ChatRowContent: View {
                     if searchResult == nil {
                         ChatDeliveryStateIcon(state: chat.latestMessageDelivery)
                     }
+                    // The three unread signals share `fillInfo` with `UnreadCountBadge`: a row can
+                    // show the mention pill next to the count, and one of them in the neutral fill
+                    // would read as a different kind of thing than the other.
                     if chat.hasUnread {
                         if chat.hasMention {
                             Image(systemName: "at")
                                 .font(.caption2.weight(.bold))
-                                .foregroundStyle(WNColor.fillContentPrimary)
+                                .foregroundStyle(WNColor.fillContentInfo)
                                 .frame(width: 18, height: 18)
-                                .background(Circle().fill(WNColor.fillPrimary))
+                                .background(Circle().fill(WNColor.fillInfo))
                                 .help(L10n.string("You were mentioned"))
                         }
                         if chat.unreadCount > 0 {
                             UnreadCountBadge(count: chat.unreadCount, font: MessagesType.badge)
                         } else {
                             Circle()
-                                .fill(WNColor.fillPrimary)
+                                .fill(WNColor.fillInfo)
                                 .frame(width: 9, height: 9)
                                 .accessibilityLabel(L10n.string("Marked unread"))
                         }

--- a/whitenoise-macTests/SemanticPaletteTests.swift
+++ b/whitenoise-macTests/SemanticPaletteTests.swift
@@ -93,6 +93,15 @@ struct SemanticPaletteTests {
             ("fillSecondaryHover", WNNSColor.fillSecondaryHover, WNNSColor.fillContentSecondary, 4.5),
             ("fillSecondary/tertiary", WNNSColor.fillSecondary, WNNSColor.fillContentTertiary, 2.0),
             ("fillDestructive", WNNSColor.fillDestructive, WNNSColor.fillContentQuaternary, 4.5),
+            // The unread badge. Held to the large-text bar rather than the body-text one, and this
+            // is the one place in the table where that is a real concession: white on `blue600`
+            // measures 5.17 in Aqua, but white on the brighter `blue500` measures 3.68 in Dark
+            // Aqua. The dark step is the brighter one on purpose — it is what separates the pill
+            // from the near-black row, which `fillInfo/onSecondary` below asserts — and the content
+            // it carries is a bold two-glyph numeral in a capsule, never running text. Going the
+            // other way (`blue600` in dark) would buy 4.5 here and spend it on a pill that recedes
+            // into the row, which is the complaint this token was added to fix.
+            ("fillInfo", WNNSColor.fillInfo, WNNSColor.fillContentInfo, 3.0),
             ("fillDisabled", WNNSColor.fillDisabled, WNNSColor.fillContentDisabled, 1.4),
             // The intentions are background/content pairs like any other, and are used as pairs:
             // the pending-invite badge draws `intentionInfoContent` on `intentionInfoBackground`,
@@ -109,6 +118,12 @@ struct SemanticPaletteTests {
             // An intention wash is laid over the app's own surfaces, so it has to be told apart
             // from them too — a badge whose capsule matches the row behind it is not a badge.
             ("intentionInfo/onPrimary", WNNSColor.backgroundPrimary, WNNSColor.intentionInfoContent, 4.5),
+            // The unread pill against the surfaces it is actually drawn on: the chat-list row
+            // (`backgroundSecondary`) and the account rail (`backgroundTertiary`). A badge whose
+            // capsule matches the row behind it is not a badge — this is the half of the pair that
+            // `fillInfo`'s lowered text bar is buying.
+            ("fillInfo/onSecondary", WNNSColor.backgroundSecondary, WNNSColor.fillInfo, 4.5),
+            ("fillInfo/onTertiary", WNNSColor.backgroundTertiary, WNNSColor.fillInfo, 4.5),
             // The scrim over media, and the chrome drawn on it.
             ("overlayTertiary", WNNSColor.overlayTertiary, WNNSColor.fillContentQuaternary, 4.5),
         ]
@@ -150,6 +165,43 @@ struct SemanticPaletteTests {
                 """
             )
         }
+    }
+
+    /// The unread badge's whole job is to not look like the rest of the chrome, so the property
+    /// worth asserting is not its contrast but that it is a *hue* — `fillPrimary`, the token it
+    /// used to take, is a neutral that inverts with the surface, which is why a badge drawn in it
+    /// read as another piece of chrome rather than as an unread count.
+    @Test func theUnreadFillIsAHueRatherThanTheNeutralPrimaryFill() throws {
+        for appearance in try Self.appearances() {
+            let info = try #require(
+                Self.resolvedComponents(WNNSColor.fillInfo, in: appearance))
+            let primary = try Self.resolvedHex(WNNSColor.fillPrimary, in: appearance)
+            let unread = try Self.resolvedHex(WNNSColor.fillInfo, in: appearance)
+
+            #expect(
+                info.blue > info.red && info.blue > info.green,
+                """
+                fillInfo resolves to \(unread) in \(appearance.name.rawValue), which is not a \
+                blue — a neutral here is the regression this token exists to prevent
+                """
+            )
+            #expect(
+                unread != primary,
+                "fillInfo collapsed onto fillPrimary (\(primary)) in \(appearance.name.rawValue)")
+        }
+
+        // Brighter in dark than in light, the way the palette's other blues run. Flattening the two
+        // steps to one value would still pass every assertion above while giving up the separation
+        // from the near-black row that the dark step is chosen for.
+        let steps = try Self.appearances().map { try Self.resolvedHex(WNNSColor.fillInfo, in: $0) }
+        #expect(steps == ["2563EB", "3B82F6"], "fillInfo should be blue600 in Aqua, blue500 in Dark Aqua")
+
+        // The content on it does *not* cross over — unlike `fillContentPrimary`, which is the
+        // reason that pair cannot be reused here.
+        let content = try Self.appearances().map {
+            try Self.resolvedHex(WNNSColor.fillContentInfo, in: $0)
+        }
+        #expect(content == ["FFFFFF", "FFFFFF"])
     }
 
     // MARK: - Accents
@@ -430,6 +482,20 @@ struct SemanticPaletteTests {
             resolved = color.usingColorSpace(.sRGB)
         }
         return hexString(of: try #require(resolved))
+    }
+
+    /// The sRGB channels a token resolves to under `appearance`, for asserting on a token's hue
+    /// rather than on its contrast against something else.
+    private static func resolvedComponents(
+        _ color: NSColor,
+        in appearance: NSAppearance
+    ) -> (red: CGFloat, green: CGFloat, blue: CGFloat)? {
+        var resolved: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.sRGB)
+        }
+        guard let resolved else { return nil }
+        return (resolved.redComponent, resolved.greenComponent, resolved.blueComponent)
     }
 
     private static func relativeLuminance(of color: NSColor) -> Double {


### PR DESCRIPTION
In flutter app the unread badge was blue and in color palette changes it ended up primary (black in light, white in dark mode). This PR changes it to fill info (the blue color)

Now it looks like this
<img width="300" alt="badges" src="https://github.com/user-attachments/assets/b61530be-808e-4ab4-be86-2eedb2d21c4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated unread badges, mention icons, and indicators to use a distinct informational blue color scheme.
  * Improved readability with white content text across light and dark appearances.

* **Tests**
  * Added coverage validating color contrast, hue, appearance variants, and content color for unread indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->