### PR TITLE
Fix last chat navigation for multiple accounts

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -55,7 +55,6 @@ extension WorkspaceState {
             restoreOrSelectFirstAccount()
             await configureObservabilityRuntimeBestEffort()
             if accounts.isEmpty {
-                discardStartupChatRestoration()
                 phase = .onboarding
                 runtime.recordHostPerformance(
                     operation: .splashReady,
@@ -92,10 +91,22 @@ extension WorkspaceState {
             reselectActiveAccount()
             return
         }
-        switchActiveAccount(
-            account,
-            finalSelection: chatsByAccount[account.id]?.first.map { WorkspaceSelection.chat($0.id) }
-        )
+        switchActiveAccount(account, finalSelection: chatSelection(forSwitchTo: account))
+    }
+
+    /// Where the rail lands when the identity changes. The remembered conversation is looked up for
+    /// the account being switched *to*, so each identity returns to its own last chat instead of
+    /// inheriting whatever the outgoing account happened to have open.
+    ///
+    /// An account that remembers a conversation its cached rows cannot resolve yet lands on nothing:
+    /// selecting a substitute would immediately overwrite the memory through `selection`'s `didSet`,
+    /// so the decision is deferred to `selectInitialChatIfNeeded()` once the fresh snapshot arrives.
+    private func chatSelection(forSwitchTo account: AccountItem) -> WorkspaceSelection? {
+        if let remembered = rememberedChat(forAccount: account) {
+            return .chat(remembered.id)
+        }
+        guard !hasRememberedChat(forAccount: account) else { return nil }
+        return chatsByAccount[account.id]?.first.map { WorkspaceSelection.chat($0.id) }
     }
 
     /// Handles a rail tap on the avatar that is *already* active. Running the real switch here
@@ -114,13 +125,19 @@ extension WorkspaceState {
         }
         // Already looking at a conversation: leave every cache, listener, and selection alone.
         guard isShowingSettings || selection == nil else { return }
-        guard let chat = mostRecentChat(in: activeChats) else {
+        // The avatar is also the way back from Settings, which is where a settings-anchored account
+        // switch leaves the user — so this is the moment that switch's chat decision finally gets
+        // made, and it has to honor the same per-account memory the rail does. It asks without
+        // forgetting: a tap can land while the account's rows are still the stale cache, which is no
+        // basis for deciding a memory is dead.
+        let outcome = rememberedChatOutcomeForActiveAccount()
+        guard let chat = outcome.chat ?? mostRecentChat(in: activeChats) else {
             if isShowingSettings {
                 selection = nil
             }
             return
         }
-        selectChat(chat)
+        withRememberedChatPreserved(outcome.preservesMemory) { selectChat(chat) }
     }
 
     func selectAccountFromSettings(_ account: AccountItem) {
@@ -166,7 +183,6 @@ extension WorkspaceState {
         to account: AccountItem,
         preservingMessageCacheFor groupIdHex: String?
     ) {
-        discardStartupChatRestoration()
         dismissGlobalMessageSearch()
         invalidateSidebarMessageSearch(clearQuery: true)
         leaveActiveConversation()

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -88,7 +88,6 @@ extension WorkspaceState {
 
     func reloadChats(forceFreshSnapshot: Bool = false) async {
         guard client != nil, let activeAccount else {
-            discardStartupChatRestoration()
             cancelChatListReload()
             stopChatListListener()
             return
@@ -765,14 +764,16 @@ extension WorkspaceState {
         return payload
     }
 
+    /// Picks the conversation for an account that has none selected — at launch, and again once a
+    /// switch's fresh snapshot lands. The active account's remembered chat outranks its most recent
+    /// one, which is what makes the memory account-scoped in effect and not just in storage.
     func selectInitialChatIfNeeded() async {
-        let restoredChat = consumeStartupRestoredChat()
-        guard selection == nil,
-            !isShowingSettings,
-            let chat = restoredChat ?? mostRecentChat(in: activeChats)
-        else { return }
+        guard selection == nil, !isShowingSettings else { return }
 
-        selection = .chat(chat.id)
+        let outcome = resolveRememberedChatForActiveAccount()
+        guard let chat = outcome.chat ?? mostRecentChat(in: activeChats) else { return }
+
+        withRememberedChatPreserved(outcome.preservesMemory) { selection = .chat(chat.id) }
         closeNewChatComposer()
         pruneMessageCache(keeping: chat.id)
         beginTimelineInitialLoadIfNeeded(groupIdHex: chat.id)

--- a/whitenoise-mac/Core/WorkspaceState+ChatRestoration.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatRestoration.swift
@@ -2,10 +2,35 @@
 //  WorkspaceState+ChatRestoration.swift
 //  whitenoise-mac
 //
-//  Optional, account-scoped restoration of the chat selected at app termination.
+//  Optional restoration of the conversation each account last had selected. The memory is per
+//  account, and so is every read of it: launching, switching identities on the rail, and coming
+//  back to the chats from Settings all reopen the conversation belonging to the account that is
+//  active at that moment, never one carried over from another identity.
 //
 
 import Foundation
+
+/// What an account's memory says to do when the app — not the user — has to pick a conversation.
+nonisolated enum RememberedChatOutcome {
+    /// Reopen this remembered conversation.
+    case reopen(ChatItem)
+    /// Nothing to reopen, but the account still remembers a conversation that is only temporarily
+    /// unrestorable (archived). The stand-in the caller falls back to must not be persisted over it.
+    case fallBackPreservingMemory
+    /// Nothing to reopen and nothing to protect: whatever the caller falls back to becomes the
+    /// account's new memory, exactly as a user-made selection would.
+    case fallBack
+
+    var chat: ChatItem? {
+        guard case .reopen(let chat) = self else { return nil }
+        return chat
+    }
+
+    var preservesMemory: Bool {
+        if case .fallBackPreservingMemory = self { return true }
+        return false
+    }
+}
 
 @MainActor
 extension WorkspaceState {
@@ -23,6 +48,7 @@ extension WorkspaceState {
 
     func persistSelectedChatForRestorationIfEnabled() {
         guard restoreLastSelectedChat,
+            !isPreservingRememberedChat,
             let activeAccount,
             case .chat(let groupIdHex) = selection
         else { return }
@@ -33,35 +59,84 @@ extension WorkspaceState {
         )
     }
 
-    /// Resolves the saved chat exactly once, after the launch account's first chat snapshot is
-    /// available. A later sign-in or manual account switch in the same process is not a launch
-    /// restoration and must retain the ordinary most-recent-chat behavior.
-    func consumeStartupRestoredChat() -> ChatItem? {
-        guard shouldResolveStartupChatSelection else { return nil }
-        shouldResolveStartupChatSelection = false
+    /// Whether `account` remembers a conversation at all — answerable before its chat list has been
+    /// loaded, which is what lets an account switch decline to select some substitute row. Selecting
+    /// one would write straight back through `selection`'s `didSet` and destroy the memory before it
+    /// could ever be honored.
+    func hasRememberedChat(forAccount account: AccountItem) -> Bool {
+        rememberedChatId(forAccount: account) != nil
+    }
 
-        guard restoreLastSelectedChat,
-            let activeAccount,
-            !activeAccount.signedOut,
-            let groupIdHex = chatRestorationStore.targetGroupId(
-                forOwnerAccountIdHex: activeAccount.accountIdHex
-            )
+    /// The conversation to reopen for `account`, or `nil` when the setting is off, the account
+    /// remembers nothing, or its currently loaded chat list cannot resolve the memory. Works for a
+    /// background account as well as the active one, so a switch can land on the right conversation
+    /// immediately when that account's rows are already cached.
+    func rememberedChat(forAccount account: AccountItem) -> ChatItem? {
+        guard let groupIdHex = rememberedChatId(forAccount: account),
+            let chat = chatItem(accountId: account.id, chatId: groupIdHex),
+            !chat.isNoLongerMember,
+            // Archiving hides the row, and every switch resets the sidebar to the active filter, so
+            // reopening an archived conversation would show a transcript with no row beside it. The
+            // memory survives archiving; it just stops being restored while the chat is filed away.
+            archivedChatItem(accountId: account.id, chatId: groupIdHex) == nil
         else { return nil }
-
-        guard let chat = activeChats.first(where: { $0.id == groupIdHex }),
-            !chat.isNoLongerMember
-        else {
-            chatRestorationStore.removeTarget(
-                forOwnerAccountIdHex: activeAccount.accountIdHex
-            )
-            return nil
-        }
 
         return chat
     }
 
-    func discardStartupChatRestoration() {
-        shouldResolveStartupChatSelection = false
+    /// What the active account's memory says to do, without touching that memory. Safe to ask
+    /// against a chat list that may still be a stale cache — a rail tap taken before the account's
+    /// fresh snapshot has landed.
+    func rememberedChatOutcomeForActiveAccount() -> RememberedChatOutcome {
+        guard let activeAccount,
+            let groupIdHex = rememberedChatId(forAccount: activeAccount)
+        else { return .fallBack }
+
+        if let chat = rememberedChat(forAccount: activeAccount) {
+            return .reopen(chat)
+        }
+        // Filed away rather than gone, so the memory keeps pointing at it and unarchiving returns
+        // the user to it.
+        if archivedChatItem(accountId: activeAccount.id, chatId: groupIdHex) != nil {
+            return .fallBackPreservingMemory
+        }
+        return .fallBack
+    }
+
+    /// The same answer, plus the cleanup half: a memory the account can never act on again — it left
+    /// the group, or the conversation is gone from its list entirely — is forgotten so the ordinary
+    /// most-recent pick takes over for good.
+    ///
+    /// Only for callers whose `activeChats`/`archivedChats` are a *completed* snapshot, since
+    /// forgetting a conversation the list has merely not loaded yet cannot be undone. That is a
+    /// property of the caller, not of the lists being non-empty: an account whose snapshot really is
+    /// empty must forget a dead memory, and a stale cache with rows in it must not act at all.
+    /// `performChatListReload` applies both lists immediately before the one caller that qualifies.
+    func resolveRememberedChatForActiveAccount() -> RememberedChatOutcome {
+        let outcome = rememberedChatOutcomeForActiveAccount()
+        guard case .fallBack = outcome,
+            let activeAccount,
+            rememberedChatId(forAccount: activeAccount) != nil
+        else { return outcome }
+
+        // A memory that survived neither branch above: the snapshot has no openable conversation
+        // under that id, whether it omits it entirely or carries it with membership ended.
+        chatRestorationStore.removeTarget(forOwnerAccountIdHex: activeAccount.accountIdHex)
+        return outcome
+    }
+
+    /// Runs `body` with the restoration write suspended when `preserved` is set, so a conversation
+    /// the app picked on the user's behalf cannot overwrite a memory that resolution deliberately
+    /// left in place. Without this, falling back past an archived conversation would forget it on the
+    /// very next selection and unarchiving would find nothing to return to.
+    func withRememberedChatPreserved(_ preserved: Bool, _ body: () -> Void) {
+        guard preserved else {
+            body()
+            return
+        }
+        isPreservingRememberedChat = true
+        defer { isPreservingRememberedChat = false }
+        body()
     }
 
     func removeChatRestorationTarget(forOwnerAccountIdHex accountIdHex: String) {
@@ -70,6 +145,10 @@ extension WorkspaceState {
 
     func clearChatRestorationTargets() {
         chatRestorationStore.clearTargets()
-        shouldResolveStartupChatSelection = false
+    }
+
+    private func rememberedChatId(forAccount account: AccountItem) -> String? {
+        guard restoreLastSelectedChat, !account.signedOut else { return nil }
+        return chatRestorationStore.targetGroupId(forOwnerAccountIdHex: account.accountIdHex)
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1000,7 +1000,9 @@ final class WorkspaceState {
     @ObservationIgnored var contactNicknameRevision: UInt64 = 0
     @ObservationIgnored var cachedContactNicknames: CachedContactNicknames?
     @ObservationIgnored let chatRestorationStore: any ChatRestorationStoring
-    @ObservationIgnored var shouldResolveStartupChatSelection = true
+    /// Set only for the duration of an automatic selection made past a preserved memory. See
+    /// `withRememberedChatPreserved(_:_:)`.
+    @ObservationIgnored var isPreservingRememberedChat = false
     @ObservationIgnored let quickReactionStore: any QuickReactionStoring
     @ObservationIgnored var mediaReferenceIndexes: [MediaReferenceCacheKey: MediaReferenceIndex] = [:]
     @ObservationIgnored var mediaReferenceIndexTasks: [MediaReferenceCacheKey: MediaReferenceIndexTask] = [:]

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -41284,61 +41284,61 @@
         }
       }
     },
-    "Restore last selected chat on launch": {
+    "Restore last selected chat": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Beim Start letzten ausgewählten Chat wiederherstellen"
+            "value": "Letzten ausgewählten Chat wiederherstellen"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Restaurar el último chat seleccionado al abrir"
+            "value": "Restaurar el último chat seleccionado"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Restaurer la dernière discussion sélectionnée au lancement"
+            "value": "Restaurer la dernière discussion sélectionnée"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ripristina all’avvio l’ultima chat selezionata"
+            "value": "Ripristina l’ultima chat selezionata"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Restaurar a última conversa selecionada ao abrir"
+            "value": "Restaurar a última conversa selecionada"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Восстанавливать последний выбранный чат при запуске"
+            "value": "Восстанавливать последний выбранный чат"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Başlatıldığında son seçilen sohbeti geri yükle"
+            "value": "Son seçilen sohbeti geri yükle"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "启动时恢复上次选择的聊天"
+            "value": "恢复上次选择的聊天"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "啟動時還原上次選擇的聊天"
+            "value": "還原上次選擇的聊天"
           }
         }
       }
@@ -41638,61 +41638,61 @@
         }
       }
     },
-    "Return to the last conversation selected for this account after White Noise finishes loading.": {
+    "Return to the last conversation selected for this account, both on launch and when you switch accounts.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kehre nach dem Laden von White Noise zur letzten für diesen Account ausgewählten Unterhaltung zurück."
+            "value": "Kehre beim Start und beim Wechsel des Accounts zur letzten für diesen Account ausgewählten Unterhaltung zurück."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vuelve a la última conversación seleccionada para esta cuenta cuando White Noise termine de cargar."
+            "value": "Vuelve a la última conversación seleccionada para esta cuenta, tanto al abrir la app como al cambiar de cuenta."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Revenez à la dernière conversation sélectionnée pour ce compte une fois White Noise chargé."
+            "value": "Revenez à la dernière conversation sélectionnée pour ce compte, au lancement comme lors d’un changement de compte."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Torna all’ultima conversazione selezionata per questo account al termine del caricamento di White Noise."
+            "value": "Torna all’ultima conversazione selezionata per questo account, sia all’avvio sia quando cambi account."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Volte à última conversa selecionada para esta conta depois que o White Noise terminar de carregar."
+            "value": "Volte à última conversa selecionada para esta conta, tanto ao abrir o app como ao trocar de conta."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Возвращаться к последнему выбранному для этого аккаунта разговору после загрузки White Noise."
+            "value": "Возвращаться к последнему выбранному для этого аккаунта разговору при запуске и при переключении аккаунтов."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "White Noise yüklenmeyi bitirdikten sonra bu hesap için son seçilen sohbete dön."
+            "value": "Hem uygulama açıldığında hem de hesap değiştirdiğinizde bu hesap için son seçilen sohbete dön."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "White Noise 加载完成后，返回此账户上次选择的会话。"
+            "value": "启动时以及切换账户时，都返回此账户上次选择的会话。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "White Noise 載入完成後，返回此帳號上次選擇的對話。"
+            "value": "啟動時以及切換帳號時，都回到此帳號上次選擇的對話。"
           }
         }
       }

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -93,7 +93,7 @@ struct GeneralSettingsView: View {
                 Divider()
 
                 Toggle(
-                    L10n.string("Restore last selected chat on launch"),
+                    L10n.string("Restore last selected chat"),
                     isOn: Binding(
                         get: { workspace.restoreLastSelectedChat },
                         set: { workspace.setRestoreLastSelectedChat($0) }
@@ -102,7 +102,8 @@ struct GeneralSettingsView: View {
 
                 Text(
                     L10n.string(
-                        "Return to the last conversation selected for this account after White Noise finishes loading.")
+                        "Return to the last conversation selected for this account, both on launch and when you switch accounts."
+                    )
                 )
                 .font(.caption)
                 .foregroundStyle(WNColor.backgroundContentSecondary)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -11965,6 +11965,268 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func accountSwitchOpensTheChatRememberedForTheAccountBeingSwitchedTo() async throws {
+        // The memory was per account in storage but only ever read at launch, so a switch fell back
+        // to the new account's newest row — and then persisted *that* as the account's last chat,
+        // erasing the real one. One hop was enough to make the whole setting look account-blind.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+
+        let first = AccountItem(
+            id: "First Account",
+            accountRef: "First Account",
+            displayName: "First Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111"
+        )
+        let second = AccountItem(
+            id: "Second Account",
+            accountRef: "Second Account",
+            displayName: "Second Account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222"
+        )
+        let firstRemembered = chatListOrderingTestItem(id: "first-older", title: "First Older", updatedAt: 100)
+        let firstNewest = chatListOrderingTestItem(id: "first-newer", title: "First Newer", updatedAt: 300)
+        let secondRemembered = chatListOrderingTestItem(id: "second-older", title: "Second Older", updatedAt: 150)
+        let secondNewest = chatListOrderingTestItem(id: "second-newer", title: "Second Newer", updatedAt: 350)
+        let store = InMemoryChatRestorationStore(
+            isEnabled: true,
+            targetsByAccount: [
+                first.accountIdHex: firstRemembered.id,
+                second.accountIdHex: secondRemembered.id,
+            ]
+        )
+        let state = WorkspaceState(accounts: [first, second], chatRestorationStore: store)
+        // Loaded after init: a fixture whose rows are already cached lets the initializer select one,
+        // which would persist it and overwrite the very memory under test.
+        state.setChats([firstNewest, firstRemembered], forAccountId: first.id)
+        state.setChats([secondNewest, secondRemembered], forAccountId: second.id)
+        state.activeAccountId = first.id
+        state.selection = .chat(firstRemembered.id)
+
+        state.selectAccount(second)
+
+        #expect(state.activeAccountId == second.id)
+        #expect(state.selection == .chat(secondRemembered.id))
+        #expect(store.targetsByAccount[first.accountIdHex] == firstRemembered.id)
+
+        state.selectAccount(first)
+
+        #expect(state.selection == .chat(firstRemembered.id))
+        #expect(store.targetsByAccount[second.accountIdHex] == secondRemembered.id)
+    }
+
+    @MainActor
+    @Test func accountSwitchWithoutCachedRowsDefersRestorationToTheFreshSnapshot() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+
+        let first = AccountItem(
+            id: "First Account",
+            accountRef: "First Account",
+            displayName: "First Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111"
+        )
+        let second = AccountItem(
+            id: "Second Account",
+            accountRef: "Second Account",
+            displayName: "Second Account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222"
+        )
+        let firstChat = chatListOrderingTestItem(id: "first-chat", title: "First Chat", updatedAt: 100)
+        let secondRemembered = chatListOrderingTestItem(id: "second-older", title: "Second Older", updatedAt: 150)
+        let secondNewest = chatListOrderingTestItem(id: "second-newer", title: "Second Newer", updatedAt: 350)
+        let store = InMemoryChatRestorationStore(
+            isEnabled: true,
+            targetsByAccount: [second.accountIdHex: secondRemembered.id]
+        )
+        let state = WorkspaceState(accounts: [first, second], chatRestorationStore: store)
+        state.setChats([firstChat], forAccountId: first.id)
+        state.activeAccountId = first.id
+        state.selection = .chat(firstChat.id)
+
+        state.selectAccount(second)
+
+        // The second account's rows have never been loaded in this process, so the switch lands on
+        // nothing rather than on a stand-in row: selecting one would persist through `selection` and
+        // destroy the memory before the snapshot could honor it.
+        #expect(state.selection == nil)
+        #expect(store.targetsByAccount[second.accountIdHex] == secondRemembered.id)
+
+        state.setChats([secondNewest, secondRemembered], forAccountId: second.id)
+        await state.selectInitialChatIfNeeded()
+
+        #expect(state.selection == .chat(secondRemembered.id))
+    }
+
+    @MainActor
+    @Test func accountSwitchNeverAdoptsAnotherAccountsRememberedChat() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+
+        let first = AccountItem(
+            id: "First Account",
+            accountRef: "First Account",
+            displayName: "First Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111"
+        )
+        let second = AccountItem(
+            id: "Second Account",
+            accountRef: "Second Account",
+            displayName: "Second Account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222"
+        )
+        // Both accounts are members of the same group, which is the only way a global last-chat
+        // memory could ever resolve for the wrong identity.
+        let shared = chatListOrderingTestItem(id: "shared-group", title: "Shared", updatedAt: 100)
+        let secondOwn = chatListOrderingTestItem(id: "second-own", title: "Second Own", updatedAt: 350)
+        let store = InMemoryChatRestorationStore(
+            isEnabled: true,
+            targetsByAccount: [first.accountIdHex: shared.id]
+        )
+        let state = WorkspaceState(accounts: [first, second], chatRestorationStore: store)
+        state.setChats([shared], forAccountId: first.id)
+        state.setChats([secondOwn, shared], forAccountId: second.id)
+        state.activeAccountId = first.id
+        state.selection = .chat(shared.id)
+
+        state.selectAccount(second)
+
+        #expect(state.selection == .chat(secondOwn.id))
+        #expect(store.targetsByAccount[first.accountIdHex] == shared.id)
+        #expect(store.targetsByAccount[second.accountIdHex] == secondOwn.id)
+    }
+
+    @MainActor
+    @Test func archivingTheRememberedChatStopsRestoringItWithoutForgettingIt() async throws {
+        let account = AccountItem(
+            id: "Desktop Account",
+            accountRef: "Desktop Account",
+            displayName: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        )
+        let remembered = chatListOrderingTestItem(id: "archived-group", title: "Archived", updatedAt: 100)
+        let newest = chatListOrderingTestItem(id: "active-group", title: "Active", updatedAt: 300)
+        let store = InMemoryChatRestorationStore(
+            isEnabled: true,
+            targetsByAccount: [account.accountIdHex: remembered.id]
+        )
+        let state = WorkspaceState(accounts: [account], chatRestorationStore: store)
+        state.activeAccountId = account.id
+        state.setChats([newest], forAccountId: account.id)
+        state.setArchivedChats([remembered], forAccountId: account.id)
+        state.selection = nil
+
+        // Every switch resets the sidebar to the active filter, so reopening an archived
+        // conversation would show a transcript with no row beside it.
+        #expect(state.rememberedChat(forAccount: account) == nil)
+
+        await state.selectInitialChatIfNeeded()
+
+        // The stand-in gets selected, but must not be written over the memory: unarchiving has to
+        // bring the conversation back, unlike one that has genuinely left the account's list.
+        #expect(state.selection == .chat(newest.id))
+        #expect(store.targetsByAccount[account.accountIdHex] == remembered.id)
+        // The suspension lasts exactly as long as that one automatic selection.
+        #expect(!state.isPreservingRememberedChat)
+        state.selectChat(newest)
+        #expect(store.targetsByAccount[account.accountIdHex] == newest.id)
+    }
+
+    @MainActor
+    @Test func returningToTheChatsFromSettingsKeepsAnArchivedRememberedChat() async throws {
+        // The rail avatar is the way back from Settings, and it picks a conversation for the user —
+        // so it needs the same protection as the post-snapshot pass, or a settings-anchored account
+        // switch would quietly forget an archived memory on the way out.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+
+        let account = AccountItem(
+            id: "Desktop Account",
+            accountRef: "Desktop Account",
+            displayName: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        )
+        let remembered = chatListOrderingTestItem(id: "archived-group", title: "Archived", updatedAt: 100)
+        let newest = chatListOrderingTestItem(id: "active-group", title: "Active", updatedAt: 300)
+        let store = InMemoryChatRestorationStore(
+            isEnabled: true,
+            targetsByAccount: [account.accountIdHex: remembered.id]
+        )
+        let state = WorkspaceState(accounts: [account], chatRestorationStore: store)
+        state.activeAccountId = account.id
+        state.setChats([newest], forAccountId: account.id)
+        state.setArchivedChats([remembered], forAccountId: account.id)
+        state.showSettings(.overview)
+
+        state.selectAccount(account)
+
+        #expect(state.selection == .chat(newest.id))
+        #expect(store.targetsByAccount[account.accountIdHex] == remembered.id)
+    }
+
+    @MainActor
+    @Test func completedSnapshotWithNoChatsForgetsTheRememberedChat() async throws {
+        // Emptiness used to stand in for "the list has not loaded", which let a dead memory outlive
+        // the snapshot that disproved it. What makes a list authoritative is the caller — this one
+        // runs directly after `applyChatRows` — not whether it happens to have rows.
+        let account = AccountItem(
+            id: "Desktop Account",
+            accountRef: "Desktop Account",
+            displayName: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        )
+        let store = InMemoryChatRestorationStore(
+            isEnabled: true,
+            targetsByAccount: [account.accountIdHex: "deleted-group"]
+        )
+        let state = WorkspaceState(accounts: [account], chatRestorationStore: store)
+        state.activeAccountId = account.id
+        state.setChats([], forAccountId: account.id)
+        state.selection = nil
+
+        await state.selectInitialChatIfNeeded()
+
+        #expect(state.selection == nil)
+        #expect(store.targetsByAccount[account.accountIdHex] == nil)
+    }
+
+    @MainActor
+    @Test func railTapBeforeTheSnapshotLandsNeverForgetsTheRememberedChat() async throws {
+        // The rail can be tapped while the account's rows are still whatever was cached earlier in
+        // the process. Deciding a memory is dead from that list would destroy it just before the
+        // fresh snapshot arrives to honor it.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+
+        let account = AccountItem(
+            id: "Desktop Account",
+            accountRef: "Desktop Account",
+            displayName: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        )
+        let store = InMemoryChatRestorationStore(
+            isEnabled: true,
+            targetsByAccount: [account.accountIdHex: "not-loaded-yet"]
+        )
+        let state = WorkspaceState(accounts: [account], chatRestorationStore: store)
+        state.activeAccountId = account.id
+        state.showSettings(.overview)
+
+        state.selectAccount(account)
+
+        // Nothing to land on yet, so the tap leaves Settings without a conversation — and, crucially,
+        // with the memory intact for `selectInitialChatIfNeeded()` to honor.
+        #expect(state.selection == nil)
+        #expect(store.targetsByAccount[account.accountIdHex] == "not-loaded-yet")
+
+        state.setChats(
+            [chatListOrderingTestItem(id: "not-loaded-yet", title: "Late", updatedAt: 100)], forAccountId: account.id)
+        await state.selectInitialChatIfNeeded()
+
+        #expect(state.selection == .chat("not-loaded-yet"))
+    }
+
+    @MainActor
     @Test func bootstrapSelectsMostRecentChatAndLoadsTimeline() async throws {
         let account = AccountSummaryFfi(
             label: "Desktop Account",


### PR DESCRIPTION
If I had accounts A and B logged in same device. If A was in a DM with C, then switched to B, sent a message to A and then switched to A, instead of keeping the chat with C, it showed the chat with B.  This PR fixes this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restores each account’s last selected conversation when launching or switching accounts.
  * Defers restoration until conversation data is available, with sensible fallback selection.
  * Preserves valid archived conversation selections.

* **Bug Fixes**
  * Prevents conversations from being incorrectly restored across accounts.
  * Clears stale selections when account data confirms they are unavailable.

* **Settings & Localization**
  * Updated restoration settings text and translations to reflect launch and account-switch behavior.

* **Tests**
  * Added coverage for account-specific restoration and loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->