### PR TITLE
Improve chatlist invites UI

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -84,7 +84,9 @@ extension ChatItem {
             title: title,
             publishedTitle: publishedTitle,
             subtitle: subtitle,
-            preview: preview?.text.isEmpty == false ? preview!.text : L10n.string("No messages yet"),
+            // Empty means "no last message"; `ChatItem.previewPlaceholder(locale:)` decides what
+            // the row says instead, since that answer is localized and invite-dependent.
+            preview: preview?.text ?? "",
             previewAttachmentKind: preview?.attachmentKind,
             updatedAt: updatedAt,
             avatarSeed: directPeer?.accountIdHex ?? row.groupIdHex,

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -338,7 +338,7 @@ extension WorkspaceState {
             id: groupIdHex,
             title: title,
             subtitle: isDirect ? L10n.string("Direct message") : L10n.string("Group chat"),
-            preview: L10n.string("No messages yet"),
+            preview: "",
             updatedAt: nil,
             avatarSeed: avatarSeed,
             pictureURL: pictureURL,

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -21245,65 +21245,6 @@
         }
       }
     },
-    "Group invite pending": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gruppeneinladung ausstehend"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invitación al grupo pendiente"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invitation au groupe en attente"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Invito al gruppo in attesa"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Convite do grupo pendente"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Приглашение в группу ожидает"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Grup daveti beklemede"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "群组邀请待处理"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "群組邀請待處理"
-          }
-        }
-      }
-    },
     "Group membership updated": {
       "extractionState": "manual",
       "localizations": {
@@ -21890,6 +21831,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "共同群組"
+          }
+        }
+      }
+    },
+    "Has invited you to a secure chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hat dich zu einem sicheren Chat eingeladen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Te ha invitado a un chat seguro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous a invité à une discussion sécurisée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ti ha invitato a una chat sicura"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convidou você para uma conversa segura"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приглашает вас в защищённый чат"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sizi güvenli bir sohbete davet etti"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "邀请你加入安全聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "邀請你加入安全聊天"
           }
         }
       }
@@ -23544,6 +23544,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "邀請套件"
+          }
+        }
+      }
+    },
+    "Invite pending": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einladung ausstehend"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invitación pendiente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invitation en attente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invito in attesa"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convite pendente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приглашение ожидает"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Davet beklemede"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "邀请待处理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "邀請待處理"
           }
         }
       }
@@ -53584,6 +53643,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "一次最多可傳送 %lld 個附件"
+          }
+        }
+      }
+    },
+    "You have been invited to a secure chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du wurdest zu einem sicheren Chat eingeladen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Has sido invitado a un chat seguro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous avez été invité à une discussion sécurisée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei stato invitato a una chat sicura"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você foi convidado para uma conversa segura"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вас пригласили в защищённый чат"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güvenli bir sohbete davet edildiniz"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已受邀加入安全聊天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已受邀加入安全聊天"
           }
         }
       }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -110,6 +110,11 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     var title: String
     var publishedTitle: String?
     let subtitle: String
+    /// The chat's last message as the row draws it, or empty when the chat has none.
+    ///
+    /// Deliberately *not* pre-filled with a "No messages yet" placeholder: what an empty chat
+    /// says depends on why it is empty — an unanswered invite explains itself here — and the
+    /// answer is localized, so it is resolved at render time by `previewPlaceholder(locale:)`.
     let preview: String
     /// Set when the last message carries attachments, so the row can mark the preview with a
     /// media glyph. Travels with `preview` — anything that carries one forward carries both.
@@ -154,6 +159,30 @@ nonisolated struct ChatItem: Identifiable, Hashable {
 
     /// True when the local account can use the outbound composer for this chat.
     var canUseComposer: Bool { !pendingConfirmation && !isNoLongerMember }
+
+    /// What the row draws where the last message would go, for a chat that has no last message.
+    /// `nil` means `preview` carries a real message and should be drawn as-is.
+    ///
+    /// An unanswered invite spends this line saying so, the way the other clients do, rather than
+    /// wearing a capsule beside its title: the line is the one part of the row that is otherwise
+    /// empty for exactly the chats an invite arrives in, and it has the width to say who invited
+    /// you. The `+` badge in the unread slot is the other half of that reading.
+    ///
+    /// Resolved here rather than baked into `preview` at mapping time because it is localized:
+    /// the chat list is not rebuilt on a language switch, so a stored translation would keep the
+    /// previous language until some unrelated update happened to rebuild the row.
+    func previewPlaceholder(locale: Locale = AppLanguage.currentLocale) -> String? {
+        guard preview.isEmpty else { return nil }
+        guard ChatRowStatus.status(for: self) == .pendingInvite else {
+            return L10n.string("No messages yet", locale: locale)
+        }
+        // A direct invite's row title is the person who sent it, so this line continues from it.
+        // A group invite's title is the group, and the chat-list row carries no welcomer, so it
+        // stays subjectless rather than guessing at a name.
+        return isDirect
+            ? L10n.string("Has invited you to a secure chat", locale: locale)
+            : L10n.string("You have been invited to a secure chat", locale: locale)
+    }
 
     /// The other party's account hex, for a direct chat whose peer has actually resolved.
     ///

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -634,6 +634,8 @@ struct ChatRowContent: View {
     var isPinned = false
     var searchResult: GlobalMessageSearchResult?
 
+    private var rowStatus: ChatRowStatus? { ChatRowStatus.status(for: chat) }
+
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
             ProfileImageAvatarView(
@@ -652,14 +654,16 @@ struct ChatRowContent: View {
                         .lineLimit(1)
                     // Precedence lives in `ChatRowStatus` so the badge and the row's
                     // destructive menu item are decided by one rule.
-                    switch ChatRowStatus.status(for: chat) {
+                    switch rowStatus {
                     case .leaving:
                         LeavingGroupBadge()
                     case .membershipEnded(let membership):
                         MembershipEndedBadge(membership: membership)
-                    case .pendingInvite:
-                        PendingInviteBadge()
-                    case nil:
+                    // A pending invite reports itself on the line below instead — the invite text
+                    // where the last message would be, the `+` badge where the unread count would
+                    // be. The two capsules above stay here because they report a settled state
+                    // about the chat rather than something waiting on the reader.
+                    case .pendingInvite, nil:
                         EmptyView()
                     }
                     if isPinned {
@@ -694,10 +698,15 @@ struct ChatRowContent: View {
                     if searchResult == nil {
                         ChatDeliveryStateIcon(state: chat.latestMessageDelivery)
                     }
-                    // The three unread signals share `fillInfo` with `UnreadCountBadge`: a row can
-                    // show the mention pill next to the count, and one of them in the neutral fill
-                    // would read as a different kind of thing than the other.
-                    if chat.hasUnread {
+                    // An unanswered invite takes this slot outright, the way the other clients
+                    // read it: it is the one thing in the chat that is actually waiting on you,
+                    // and a count beside it would offer messages the invite has not let you open.
+                    if rowStatus == .pendingInvite {
+                        PendingInviteBadge()
+                    } else if chat.hasUnread {
+                        // The three unread signals share `fillInfo` with `UnreadCountBadge`: a row
+                        // can show the mention pill next to the count, and one of them in the
+                        // neutral fill would read as a different kind of thing than the other.
                         if chat.hasMention {
                             Image(systemName: "at")
                                 .font(.caption2.weight(.bold))
@@ -730,6 +739,11 @@ struct ChatRowContent: View {
         // A search hit shows the matched message rather than the chat's last one, so the
         // last-message glyph would describe the wrong message.
         guard let searchResult else {
+            // What an empty chat says here depends on why it is empty, and an unanswered invite
+            // says so in words rather than in a badge beside the title.
+            if let placeholder = chat.previewPlaceholder(locale: locale) {
+                return Text(placeholder)
+            }
             guard let kind = chat.previewAttachmentKind else { return Text(chat.preview) }
             // Inline in the same `Text` so the glyph wraps, truncates and picks up the row's
             // preview font and secondary style along with the words.
@@ -789,24 +803,32 @@ private struct ChatTimestampText: View, Equatable {
     }
 }
 
-/// An invitation waiting on an answer. This is the other clients' `ChatStatusType.request`, which
-/// is the one chat-row status they draw in the info intention rather than in neutral gray — it is
-/// the only one that is asking the reader for something. Taking the intention's own background and
-/// content tokens (`intentionInfoBackground` + `intentionInfoContent`) is how the reference styles
-/// every info surface, and it is also why this capsule has no hairline: the intention pair is
-/// self-contained, and a neutral `borderTertiary` ring drawn around a blue wash belongs to neither
-/// family. The neutral capsule stays on `LeavingGroupBadge` and `MembershipEndedBadge`, which
-/// report a state rather than ask for a decision.
+/// An invitation waiting on an answer, drawn in the row's unread slot as a `+` on the same
+/// `fillInfo` disc the unread count and the mention pill use.
+///
+/// This is the other clients' `ChatStatusType.request`, and sharing the unread badge's shape is
+/// the whole point of it: an invite and an unread message are the same kind of claim on the
+/// reader — something in this chat is waiting — so they belong in the same slot, in the same fill,
+/// distinguished only by the glyph. `+` reads as "join", which is the answer the row is asking
+/// for. The neutral title-side capsule stays on `LeavingGroupBadge` and `MembershipEndedBadge`,
+/// which report a settled state rather than ask for a decision.
+///
+/// Icon-only, so it carries both an accessibility label and a hover explanation; the row's
+/// preview line says the same thing in words.
+///
+/// Both read "Invite pending" rather than "Group invite pending" or the bare "Invite":
+/// `ChatRowStatus` never looks at `isDirect`, so this badge sits on direct invites too, and the
+/// "Invite" key belongs to the group sheet's action button — translated as a verb ("Einladen",
+/// "Invitar"), which is not what a status badge is saying.
 struct PendingInviteBadge: View {
     var body: some View {
-        Label(L10n.string("Invite"), systemImage: "envelope.badge")
-            .font(.caption2.weight(.semibold))
-            .labelStyle(.titleAndIcon)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .foregroundStyle(WNColor.intentionInfoContent)
-            .background(WNColor.intentionInfoBackground, in: Capsule())
-            .help(L10n.string("Group invite pending"))
+        Image(systemName: "plus")
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(WNColor.fillContentInfo)
+            .frame(width: 18, height: 18)
+            .background(Circle().fill(WNColor.fillInfo))
+            .accessibilityLabel(L10n.string("Invite pending"))
+            .help(L10n.string("Invite pending"))
     }
 }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -3795,6 +3795,62 @@ struct PureValueTests {
         #expect(ChatDestructiveActions.action(for: leaving) == nil)
     }
 
+    // MARK: - Chat row preview line
+
+    /// An unanswered invite says so where the last message would go, so the row explains itself in
+    /// words instead of in a capsule beside the title. Direct and group invites read differently
+    /// because only the direct row's title names the person who sent it.
+    @Test func pendingInviteWithoutMessagesExplainsItselfInThePreviewLine() {
+        let english = Locale(identifier: "en")
+
+        #expect(
+            invitePreviewChat(isDirect: true, preview: "").previewPlaceholder(locale: english)
+                == "Has invited you to a secure chat"
+        )
+        #expect(
+            invitePreviewChat(isDirect: false, preview: "").previewPlaceholder(locale: english)
+                == "You have been invited to a secure chat"
+        )
+    }
+
+    /// The invite line is a *placeholder*: an invite that already carries history shows that
+    /// history, exactly as an accepted chat would.
+    @Test func pendingInviteCarryingMessagesShowsThemRatherThanTheInviteLine() {
+        #expect(
+            invitePreviewChat(isDirect: true, preview: "Alice: Welcome in")
+                .previewPlaceholder(locale: Locale(identifier: "en")) == nil
+        )
+    }
+
+    /// Only a pending invite gets the invite wording; every other empty chat keeps the neutral
+    /// placeholder, including one whose invite flag survives alongside an ended membership —
+    /// `ChatRowStatus` settles that precedence, and the preview line must not re-decide it.
+    @Test func emptyChatsThatAreNotPendingInvitesKeepTheNeutralPlaceholder() {
+        let english = Locale(identifier: "en")
+
+        #expect(
+            invitePreviewChat(isDirect: true, preview: "", pendingConfirmation: false)
+                .previewPlaceholder(locale: english) == "No messages yet"
+        )
+        #expect(
+            invitePreviewChat(isDirect: false, preview: "", membership: .removed)
+                .previewPlaceholder(locale: english) == "No messages yet"
+        )
+        #expect(
+            invitePreviewChat(isDirect: false, preview: "", leaveRequestPending: true)
+                .previewPlaceholder(locale: english) == "No messages yet"
+        )
+    }
+
+    /// The line is resolved against the caller's locale rather than baked in at mapping time,
+    /// which is what lets a language switch reach a chat list nothing else rebuilt.
+    @Test func invitePreviewLineFollowsTheRequestedLocale() {
+        let chat = invitePreviewChat(isDirect: false, preview: "")
+        let spanish = chat.previewPlaceholder(locale: Locale(identifier: AppLanguage.spanish.rawValue))
+        #expect(spanish == "Has sido invitado a un chat seguro")
+        #expect(spanish != chat.previewPlaceholder(locale: Locale(identifier: "en")))
+    }
+
     // MARK: - PeerProfileRefreshGate
 
     @Test func peerProfileGateDedupesInFlightAttemptsForTheSameAccount() {
@@ -4173,6 +4229,29 @@ private func destructiveActionChat(
         unreadCount: 0,
         isDirect: isDirect,
         leaveRequestPending: leaveRequestPending,
+        selfMembership: membership
+    )
+}
+
+private func invitePreviewChat(
+    isDirect: Bool,
+    preview: String,
+    pendingConfirmation: Bool = true,
+    leaveRequestPending: Bool = false,
+    membership: ChatSelfMembership = .member
+) -> ChatItem {
+    ChatItem(
+        id: "group",
+        title: "Alice",
+        subtitle: "",
+        preview: preview,
+        updatedAt: nil,
+        avatarSeed: "seed",
+        pictureURL: nil,
+        unreadCount: 0,
+        isDirect: isDirect,
+        leaveRequestPending: leaveRequestPending,
+        pendingConfirmation: pendingConfirmation,
         selfMembership: membership
     )
 }

--- a/whitenoise-macTests/SemanticPaletteTests.swift
+++ b/whitenoise-macTests/SemanticPaletteTests.swift
@@ -103,9 +103,9 @@ struct SemanticPaletteTests {
             // into the row, which is the complaint this token was added to fix.
             ("fillInfo", WNNSColor.fillInfo, WNNSColor.fillContentInfo, 3.0),
             ("fillDisabled", WNNSColor.fillDisabled, WNNSColor.fillContentDisabled, 1.4),
-            // The intentions are background/content pairs like any other, and are used as pairs:
-            // the pending-invite badge draws `intentionInfoContent` on `intentionInfoBackground`,
-            // the way the other clients style every info surface. Held to the large-text bar rather
+            // The intentions are background/content pairs like any other, and the app draws them
+            // as pairs — an intention's content on its own wash, the way the other clients style
+            // every info/success/warning/error surface. Held to the large-text bar rather
             // than the body-text one, because that is where the reference palette actually sits —
             // a `600` step on a `50` wash of the same hue measures 3.15 (success, Aqua) to 5.6, and
             // these surfaces carry short bold labels and glyphs, never running text. The bar still

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5443,6 +5443,39 @@ struct whitenoise_macTests {
         #expect(!chat.isNoLongerMember)
     }
 
+    /// A chat with no last message maps to an *empty* preview rather than a baked-in placeholder,
+    /// which is the signal `ChatItem.previewPlaceholder(locale:)` reads to decide whether the row
+    /// says "No messages yet" or explains an unanswered invite.
+    @Test func chatRowWithoutMessagesMapsToAnEmptyPreview() async throws {
+        let row = ChatListRowFfi(
+            groupIdHex: "invited-group",
+            archived: false,
+            pendingConfirmation: true,
+            title: "Planning",
+            groupName: "Planning",
+            avatarUrl: nil,
+            avatar: nil,
+            lastMessage: nil,
+            unreadCount: 0,
+            hasUnread: false,
+            unreadMentionCount: 0,
+            unreadMention: false,
+            firstUnreadMessageIdHex: nil,
+            lastReadMessageIdHex: nil,
+            lastReadTimelineAt: nil,
+            updatedAt: 1_700_000_000,
+            selfMembership: .member
+        )
+
+        let chat = ChatItem(row: row, activeAccountIdHex: "self")
+
+        #expect(chat.preview.isEmpty)
+        #expect(
+            chat.previewPlaceholder(locale: Locale(identifier: "en"))
+                == "You have been invited to a secure chat"
+        )
+    }
+
     @Test func pendingInviteChatCannotUseComposerUntilConfirmed() {
         let activeChat = ChatItem(
             id: "active-group",


### PR DESCRIPTION

Before this PR, invites where shown with an invite badge with text and a "No messages" text if there was no message yet. Now, taking the old flutter app design, we use the badge with a + and an invite text in the place of the last message preview.

<img width="300" height="86" alt="Screenshot 2026-08-07 at 4 17 07 PM" src="https://github.com/user-attachments/assets/ed583027-8d10-4d7c-8754-647aa373dcc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat list previews for empty chats and pending invitations.
  - Preserved existing message previews when invitation status is present.
  - Positioned pending invitations in the unread area with clearer, accessible indicators.

- **Localization**
  - Added context-aware invitation placeholder text in supported languages.

- **Tests**
  - Added coverage for localized placeholders, message history, empty chats, and invitation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->