### PR TITLE
Add missing translations in switch account flow

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -6041,7 +6041,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "账号"
+            "value": "账户"
           }
         },
         "zh-Hant": {
@@ -6129,25 +6129,25 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Actifs"
+            "value": "Actif"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Attive"
+            "value": "Attivo"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativos"
+            "value": "Ativa"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Активные"
+            "value": "Активный"
           }
         },
         "tr": {
@@ -6300,7 +6300,7 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Agregar cuenta"
+            "value": "Añadir cuenta"
           }
         },
         "fr": {
@@ -14071,7 +14071,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Создать новый идентификатор"
+            "value": "Создать новую личность"
           }
         },
         "tr": {
@@ -26556,13 +26556,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "本地签约"
+            "value": "本地签名"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "本地簽約"
+            "value": "本地簽署"
           }
         }
       }

--- a/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
@@ -100,12 +100,25 @@ struct SettingsAccountSwitcherCard: View {
                         accountPendingRemoval = account
                     }
                 )
+                // A popover is hosted in its own window, so SwiftUI re-derives the
+                // system-backed environment values — `\.locale` among them — instead of
+                // inheriting the one ContentView injects. `AccountSwitcherPopover` is a
+                // separate `View` that reads `@Environment(\.locale)` for itself, so
+                // without this it resolves every label against the *system* language and
+                // renders English while the rest of the app follows the preference. The
+                // confirmation dialogs below don't need it: their closures capture this
+                // view's own `locale`. Same re-injection as the global search sheet in
+                // `ContentView`.
+                .environment(workspace)
+                .environment(\.locale, workspace.preferredLocale)
             }
         }
         .padding(10)
         .glassCard()
         .sheet(isPresented: $isAddAccountPresented) {
             AddAccountSheet()
+                .environment(workspace)
+                .environment(\.locale, workspace.preferredLocale)
         }
         .removeAccountConfirmation(
             account: accountPendingRemoval,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization for account management, active status, identity creation, and local signing terminology across multiple languages.
  * Account switching and account creation views now consistently use the app’s configured language and workspace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->