### PR TITLE
Show nicknames in mentions

### DIFF
--- a/whitenoise-mac/Core/ComposerMentionSupport.swift
+++ b/whitenoise-mac/Core/ComposerMentionSupport.swift
@@ -15,22 +15,33 @@ nonisolated struct ComposerMentionCandidate: Identifiable, Equatable, Sendable {
     let memberIdHex: String
     /// Avatar/profile seed — the member's account id (falls back to the member id).
     let accountIdHex: String
+    /// What the picker inserts and the row shows: the viewer's private nickname when one is set,
+    /// else the published name, else a shortened reference.
     let displayName: String
+    /// The published name `displayName` hides; nil when no nickname applies.
+    let publishedDisplayName: String?
     let npub: String
+    /// Every name this member answers to — the label above, plus the published name a nickname
+    /// hides. Both the picker filter and send-time canonicalization walk this, so a draft that
+    /// spells out the peer's real name still leaves the composer as an npub.
+    let searchableNames: [String]
 
     // Lowercased match fields, precomputed once — `filter` runs on every keystroke.
-    let displayNameLowercased: String
+    let searchableNamesLowercased: [String]
     let npubLowercased: String
     let memberIdHexLowercased: String
 
-    init(details: GroupMemberDetailsFfi) {
+    init(details: GroupMemberDetailsFfi, nickname: String? = nil) {
         memberIdHex = details.memberIdHex
         accountIdHex = details.account ?? details.memberIdHex
         npub = details.npub
         let reference = details.npub.isEmpty ? memberIdHex : details.npub
-        displayName = PeerDisplayText.sanitize(details.displayName) ?? DisplayText.short(reference, head: 10, tail: 6)
+        let published = PeerDisplayText.sanitize(details.displayName)
+        displayName = nickname ?? published ?? DisplayText.short(reference, head: 10, tail: 6)
+        publishedDisplayName = WorkspaceState.publishedContactName(published, overriddenBy: nickname)
+        searchableNames = [displayName, publishedDisplayName].compactMap { $0 }
         id = memberIdHex
-        displayNameLowercased = displayName.lowercased()
+        searchableNamesLowercased = searchableNames.map { $0.lowercased() }
         npubLowercased = npub.lowercased()
         memberIdHexLowercased = memberIdHex.lowercased()
     }
@@ -103,7 +114,7 @@ nonisolated enum ComposerMentionQuery {
         } else {
             let needle = trimmed.lowercased()
             filtered = candidates.filter { candidate in
-                candidate.displayNameLowercased.contains(needle)
+                candidate.searchableNamesLowercased.contains { $0.contains(needle) }
                     || candidate.npubLowercased.contains(needle)
                     || candidate.memberIdHexLowercased.contains(needle)
             }
@@ -122,8 +133,15 @@ nonisolated enum ComposerMentionCanonicalizer {
     private static let underscoreScalar = UnicodeScalar("_")
     private static let slashScalar = UnicodeScalar("/")
 
-    /// Rewrite every "@DisplayName" in `text` that matches a candidate to "@npub…", so the wire
-    /// format carries stable public keys rather than display names.
+    /// A written name that identifies exactly one member, and the npub it must become.
+    private struct MentionAlias {
+        let name: String
+        let npub: String
+    }
+
+    /// Rewrite every "@Name" in `text` that matches a candidate to "@npub…", so the wire format
+    /// carries stable public keys rather than display names. A member is matchable under any of
+    /// their `searchableNames`, which is what lets a private nickname be typed and still send.
     static func canonicalize(
         _ text: String,
         selections: [ComposerMentionSelection] = [],
@@ -131,25 +149,7 @@ nonisolated enum ComposerMentionCanonicalizer {
     ) -> String {
         guard text.contains("@") else { return text }
         let canonical = canonicalizeSelections(in: text, selections: selections)
-        let replacements =
-            Dictionary(grouping: candidates, by: \.displayName)
-            .values
-            // A typed name is safe to infer only when every matching roster entry identifies the
-            // same npub. Picker selections above remain unambiguous even for duplicate names.
-            .compactMap { matches -> ComposerMentionCandidate? in
-                let npubs = Set(matches.map(\.npub).filter { !$0.isEmpty })
-                guard npubs.count == 1, let onlyNpub = npubs.first else { return nil }
-                return matches.first { $0.npub == onlyNpub }
-            }
-            .filter { candidate in
-                !candidate.npub.isEmpty
-                    && !candidate.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    // A peer-controlled name that is itself a profile reference must never
-                    // retarget the literal reference the sender typed. Picker selections were
-                    // already canonicalized by their exact range above and remain supported.
-                    && !MarkdownLinkPolicy.isResolvableProfileReference(candidate.displayName)
-            }
-            .sorted { $0.displayName.count > $1.displayName.count }
+        let replacements = unambiguousAliases(in: candidates)
         guard !replacements.isEmpty else { return canonical }
 
         var inferred = ""
@@ -157,9 +157,9 @@ nonisolated enum ComposerMentionCanonicalizer {
         while index < canonical.endIndex {
             if canonical[index] == "@",
                 leftBoundaryAllowsMention(at: index, in: canonical),
-                let match = matchCandidate(in: canonical, at: index, candidates: replacements)
+                let match = matchAlias(in: canonical, at: index, aliases: replacements)
             {
-                inferred += "@\(match.candidate.npub)"
+                inferred += "@\(match.alias.npub)"
                 index = match.endIndex
                 continue
             }
@@ -167,6 +167,31 @@ nonisolated enum ComposerMentionCanonicalizer {
             index = canonical.index(after: index)
         }
         return inferred
+    }
+
+    /// Every roster name that resolves to one npub, longest first so a short name that prefixes a
+    /// longer one cannot consume it.
+    private static func unambiguousAliases(in candidates: [ComposerMentionCandidate]) -> [MentionAlias] {
+        let written = candidates.flatMap { candidate in
+            candidate.searchableNames.map { (name: $0, npub: candidate.npub) }
+        }
+        return Dictionary(grouping: written, by: \.name)
+            // A typed name is safe to infer only when every roster entry carrying it identifies
+            // the same npub — including across the two names one member may answer to. Picker
+            // selections above remain unambiguous even for duplicate names.
+            .compactMap { name, matches -> MentionAlias? in
+                let npubs = Set(matches.map(\.npub).filter { !$0.isEmpty })
+                guard npubs.count == 1, let onlyNpub = npubs.first else { return nil }
+                return MentionAlias(name: name, npub: onlyNpub)
+            }
+            .filter { alias in
+                !alias.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    // A peer-controlled name that is itself a profile reference must never
+                    // retarget the literal reference the sender typed. Picker selections were
+                    // already canonicalized by their exact range above and remain supported.
+                    && !MarkdownLinkPolicy.isResolvableProfileReference(alias.name)
+            }
+            .sorted { $0.name.count > $1.name.count }
     }
 
     private static func canonicalizeSelections(
@@ -208,17 +233,17 @@ nonisolated enum ComposerMentionCanonicalizer {
         return true
     }
 
-    private static func matchCandidate(
+    private static func matchAlias(
         in text: String,
         at atIndex: String.Index,
-        candidates: [ComposerMentionCandidate]
-    ) -> (candidate: ComposerMentionCandidate, endIndex: String.Index)? {
+        aliases: [MentionAlias]
+    ) -> (alias: MentionAlias, endIndex: String.Index)? {
         let nameStart = text.index(after: atIndex)
-        for candidate in candidates {
-            guard text[nameStart...].hasPrefix(candidate.displayName) else { continue }
-            let nameEnd = text.index(nameStart, offsetBy: candidate.displayName.count)
+        for alias in aliases {
+            guard text[nameStart...].hasPrefix(alias.name) else { continue }
+            let nameEnd = text.index(nameStart, offsetBy: alias.name.count)
             guard rightBoundaryAllowsMention(at: nameEnd, in: text) else { continue }
-            return (candidate, nameEnd)
+            return (alias, nameEnd)
         }
         return nil
     }

--- a/whitenoise-mac/Core/ContactNicknames.swift
+++ b/whitenoise-mac/Core/ContactNicknames.swift
@@ -20,8 +20,12 @@ nonisolated struct ContactNicknames: Equatable, Sendable {
 
     var isEmpty: Bool { byContactIdHex.isEmpty }
 
+    /// The `isEmpty` check comes first so the overwhelmingly common "this account has nicknamed
+    /// nobody" case costs one flag read. Projections that fold nicknames in walk a whole roster
+    /// per rebuild, and normalizing each member's hex allocates.
     func nickname(forContactAccountIdHex hex: String) -> String? {
-        guard !ownerAccountIdHex.isEmpty, let contact = Self.normalizedHex(hex) else { return nil }
+        guard !byContactIdHex.isEmpty, !ownerAccountIdHex.isEmpty, let contact = Self.normalizedHex(hex)
+        else { return nil }
         return byContactIdHex[contact]
     }
 
@@ -48,5 +52,26 @@ nonisolated struct ContactNicknames: Equatable, Sendable {
     static func sanitized(_ raw: String?) -> String? {
         guard let sanitized = PeerDisplayText.sanitize(raw) else { return nil }
         return sanitized.count <= maxLength ? sanitized : String(sanitized.prefix(maxLength))
+    }
+}
+
+/// Identifies the nickname set a projection was built from: whose private labels, and which
+/// revision of them. Comparing one is a string and an integer, so a memoized projection can
+/// prove it is still current on a hot path without rebuilding or hashing the map itself.
+nonisolated struct ContactNicknameStamp: Equatable, Sendable {
+    let ownerAccountIdHex: String
+    let revision: UInt64
+}
+
+/// A projection memoized against the nickname set that produced it. Nicknames are folded into
+/// projections rather than resolved at render time, so every such memo has to be able to say
+/// which labels it was baked with — see `WorkspaceState.contactNicknameStamp`.
+nonisolated struct NicknameStamped<Value: Sendable>: Sendable {
+    let stamp: ContactNicknameStamp
+    let value: Value
+
+    /// The memoized value, or nil once the nickname set has moved on since it was built.
+    func value(at stamp: ContactNicknameStamp) -> Value? {
+        self.stamp == stamp ? value : nil
     }
 }

--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -19,6 +19,21 @@ extension AccountItem {
     }
 }
 
+extension GroupMemberDetailsFfi {
+    /// The viewer's private nickname for this member, or nil where none applies.
+    ///
+    /// Keyed on `memberIdHex` — the member's pubkey — because that is what a nickname is stored
+    /// against everywhere else (`groupDetailsSnapshot`, `requestPeerProfileRefresh`). `account`
+    /// is the local account *label*, not an id, so it must never be used here.
+    ///
+    /// Self rows never take one: `ContactNicknames.owner` refuses to write a nickname for one of
+    /// this device's accounts, but an account added *after* someone nicknamed it still has the
+    /// old entry on file, and it must not surface as your own name.
+    nonisolated func nickname(from nicknames: ContactNicknames) -> String? {
+        isSelf ? nil : nicknames.nickname(forContactAccountIdHex: memberIdHex)
+    }
+}
+
 extension ChatSelfMembership {
     nonisolated init(_ membership: SelfMembershipFfi) {
         switch membership {

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -681,8 +681,13 @@ extension WorkspaceState {
                 return ChatItem(row: row, activeAccountIdHex: account.accountIdHex)
             }
             // The roster is already in hand here, so resolving the preview's "@npub…" mentions to
-            // names costs only a dictionary build — no extra FFI on the chat-list path.
-            mentionNames = Self.mentionNames(from: members)
+            // names costs only a dictionary build — no extra FFI on the chat-list path. Resolved
+            // against the enriching account's own nicknames, not the active one's: enrichment can
+            // still be in flight across a switch, and private labels are per-account.
+            mentionNames = Self.mentionNames(
+                from: members,
+                nicknames: contactNicknames(forOwnerAccountIdHex: account.accountIdHex)
+            )
             directPeer = await directPeerProfile(
                 from: members,
                 groupIdHex: row.groupIdHex,

--- a/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import MarmotKit
 import OSLog
 
 private let contactNicknameLogger = Logger(subsystem: "com.whitenoise.storage", category: "ContactNicknames")
@@ -44,22 +45,28 @@ extension WorkspaceState {
     /// private label on another account's banner.
     func contactNicknames(forOwnerAccountIdHex ownerAccountIdHex: String) -> ContactNicknames {
         guard let owner = ContactNicknames.normalizedHex(ownerAccountIdHex) else { return .none }
-        if let cached = cachedContactNicknames,
-            cached.ownerAccountIdHex == owner,
-            cached.revision == contactNicknameRevision
-        {
-            return cached.value
-        }
+        let stamp = ContactNicknameStamp(ownerAccountIdHex: owner, revision: contactNicknameRevision)
+        if let cached = cachedContactNicknames?.value(at: stamp) { return cached }
         let value = ContactNicknames(
             ownerAccountIdHex: owner,
             byContactIdHex: contactNicknamesByOwner[owner] ?? [:]
         )
-        cachedContactNicknames = CachedContactNicknames(
-            ownerAccountIdHex: owner,
-            revision: contactNicknameRevision,
-            value: value
-        )
+        cachedContactNicknames = NicknameStamped(stamp: stamp, value: value)
         return value
+    }
+
+    /// Which nickname set the active account resolves against right now. Projections that fold
+    /// nicknames in stamp themselves with this and re-check it instead of rebuilding: the map
+    /// itself is never compared, only an account id and a counter.
+    ///
+    /// Reads the observed map for the same reason `activeContactNicknames` does — a SwiftUI body
+    /// that gets a memoized projection back must still be subscribed to the next nickname write.
+    var contactNicknameStamp: ContactNicknameStamp {
+        _ = contactNicknamesByOwner
+        return ContactNicknameStamp(
+            ownerAccountIdHex: ContactNicknames.normalizedHex(activeAccount?.accountIdHex ?? "") ?? "",
+            revision: contactNicknameRevision
+        )
     }
 
     func contactNickname(forContactAccountIdHex contactAccountIdHex: String) -> String? {
@@ -138,6 +145,7 @@ extension WorkspaceState {
         relabelTimelineSenders(accountIdHex: contact, nickname: nickname)
         relabelComposeContacts(accountIdHex: contact, nickname: nickname)
         relabelContactDetailsTarget(accountIdHex: contact, nickname: nickname)
+        replayTimelineForMentionsOf(contactAccountIdHex: contact)
 
         if nickname == nil {
             // Clearing a nickname hands the label back to whatever the peer published, so this
@@ -222,6 +230,31 @@ extension WorkspaceState {
         }
         if didChangeSelectedChat {
             selectedChatRevision &+= 1
+        }
+    }
+
+    /// A mention token is baked into the bubble's rendered Markdown when the window is projected,
+    /// so — unlike a sender label — it cannot be patched into rows already on screen: the source
+    /// AST the attributed string came from is not retained. Replay the open window instead, the
+    /// same in-memory snapshot replay a late-arriving profile uses.
+    ///
+    /// Gated on the contact being in this conversation's roster, so renaming someone the open
+    /// chat could not possibly mention costs one roster scan rather than a transcript re-map.
+    /// Other conversations need nothing here: their `mentionNamesCache` entry is stamped with the
+    /// nickname set, so whenever one is next projected it resolves against the new label. The
+    /// same is true of chat-list previews, which re-resolve on their next row update.
+    private func replayTimelineForMentionsOf(contactAccountIdHex contact: String) {
+        guard let client, let account = activeAccount,
+            let groupIdHex = activeTimelineGroupId,
+            selectedChat?.id == groupIdHex,
+            let members = groupMemberDetailsCache[groupIdHex],
+            members.contains(where: { ContactNicknames.normalizedHex($0.memberIdHex) == contact })
+        else { return }
+
+        // Not cancelling any in-flight replay: a second rename's replay reads the same post-write
+        // state, so the two can only agree, and cancelling one mid-snapshot would drop a repaint.
+        contactNicknameMentionReplayTask = Task { [weak self] in
+            await self?.replaySelectedTimelineWindow(account: account, client: client)
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+Drafts.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Drafts.swift
@@ -124,7 +124,10 @@ extension WorkspaceState {
                     client: client
                 )
             {
-                mentionNames = Self.mentionNames(from: members)
+                mentionNames = Self.mentionNames(
+                    from: members,
+                    nicknames: contactNicknames(forOwnerAccountIdHex: account.accountIdHex)
+                )
             } else {
                 mentionNames = [:]
             }

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -205,7 +205,9 @@ extension WorkspaceState {
         }
     }
 
-    static func publishedContactName(_ published: String?, overriddenBy nickname: String?) -> String? {
+    /// `nonisolated` so the pure value types that carry a nickname-first label — the mention
+    /// candidate among them — can record the overridden name the same way this actor does.
+    nonisolated static func publishedContactName(_ published: String?, overriddenBy nickname: String?) -> String? {
         guard let nickname, let published = published?.nilIfBlank, published != nickname else { return nil }
         return published
     }

--- a/whitenoise-mac/Core/WorkspaceState+Mentions.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Mentions.swift
@@ -6,6 +6,11 @@
 //  candidate list for an active query, and the send-time rewrite of "@DisplayName" to the
 //  member's stable "@npub…" so mentions travel as public keys, not display names.
 //
+//  Both projections here fold in the viewer's private nicknames, so a mention reads as the name
+//  the viewer gave the person wherever it renders. The nickname never leaves the device: it is
+//  applied on the way *out* of the wire format (npub → label) and stripped on the way back in
+//  (label → npub), so the message a peer receives is byte-identical either way.
+//
 
 import Foundation
 import MarmotKit
@@ -16,10 +21,14 @@ extension WorkspaceState {
         guard let selectedChat,
             let members = groupMemberDetailsCache[selectedChat.id]
         else { return [] }
-        if let cached = mentionRosterCache[selectedChat.id] { return cached }
+        let stamp = contactNicknameStamp
+        if let cached = mentionRosterCache[selectedChat.id]?.value(at: stamp) { return cached }
 
-        let roster = members.filter { !$0.isSelf }.map(ComposerMentionCandidate.init(details:))
-        mentionRosterCache[selectedChat.id] = roster
+        let nicknames = activeContactNicknames
+        let roster = members.filter { !$0.isSelf }.map { member in
+            ComposerMentionCandidate(details: member, nickname: member.nickname(from: nicknames))
+        }
+        mentionRosterCache[selectedChat.id] = NicknameStamped(stamp: stamp, value: roster)
         #if DEBUG
             mentionRosterBuildCount += 1
         #endif
@@ -46,26 +55,41 @@ extension WorkspaceState {
         return ComposerMentionCanonicalizer.canonicalize(text, selections: selections, candidates: roster)
     }
 
-    /// npub → sanitized display name from the roster already in cache (no FFI), used by the
-    /// transcript and chat-list previews to render "@npub…" mention tokens back as
-    /// "@Display Name". Reads only the cache — never triggers a `groupDetails` lookup — so it is
-    /// safe on the timeline hot path and cannot re-drive a failed/uncached group's lookup (#40).
-    /// Empty until some other path (chat-list enrichment, the mention picker, sender-name
-    /// fallback) has warmed the roster, in which case mentions keep the truncated-bech32 form.
+    /// npub → display name from the roster already in cache (no FFI), used by the transcript and
+    /// chat-list previews to render "@npub…" mention tokens back as "@Display Name". Reads only
+    /// the cache — never triggers a `groupDetails` lookup — so it is safe on the timeline hot path
+    /// and cannot re-drive a failed/uncached group's lookup (#40). Empty until some other path
+    /// (chat-list enrichment, the mention picker, sender-name fallback) has warmed the roster, in
+    /// which case mentions keep the truncated-bech32 form.
+    ///
+    /// The memo is stamped with the nickname set it was built from, so a nickname write costs one
+    /// stamp comparison here rather than an eager sweep over every group's projection.
     func cachedMentionNames(groupIdHex: String) -> MarkdownMentionNames {
-        if let cached = mentionNamesCache[groupIdHex] { return cached }
+        let stamp = contactNicknameStamp
+        if let cached = mentionNamesCache[groupIdHex]?.value(at: stamp) { return cached }
 
-        let names = Self.mentionNames(from: groupMemberDetailsCache[groupIdHex] ?? [])
-        mentionNamesCache[groupIdHex] = names
+        let names = Self.mentionNames(
+            from: groupMemberDetailsCache[groupIdHex] ?? [],
+            nicknames: activeContactNicknames
+        )
+        mentionNamesCache[groupIdHex] = NicknameStamped(stamp: stamp, value: names)
         #if DEBUG
             mentionNamesBuildCount += 1
         #endif
         return names
     }
 
-    static func mentionNames(from members: [GroupMemberDetailsFfi]) -> MarkdownMentionNames {
+    /// A private nickname outranks the published name here exactly as it does on a chat row or a
+    /// sender label — a mention is the same person under the same label. It also *is* a name for
+    /// a member who published none, who would otherwise render as truncated bech32.
+    nonisolated static func mentionNames(
+        from members: [GroupMemberDetailsFfi],
+        nicknames: ContactNicknames
+    ) -> MarkdownMentionNames {
         members.reduce(into: MarkdownMentionNames()) { map, member in
-            guard !member.npub.isEmpty, let name = PeerDisplayText.sanitize(member.displayName) else { return }
+            guard !member.npub.isEmpty,
+                let name = member.nickname(from: nicknames) ?? PeerDisplayText.sanitize(member.displayName)
+            else { return }
             map[member.npub] = name
         }
     }

--- a/whitenoise-mac/Core/WorkspaceState+PeerProfiles.swift
+++ b/whitenoise-mac/Core/WorkspaceState+PeerProfiles.swift
@@ -332,35 +332,22 @@ extension WorkspaceState {
         }
     }
 
-    /// Replays the open conversation's authoritative window so every row re-resolves its
-    /// sender name — including rows the live delta path would never revisit.
+    /// Replays the open conversation's authoritative window so every row re-resolves whatever the
+    /// projection bakes into it — sender names, and the mention tokens rendered into each bubble
+    /// — including rows the live delta path would never revisit.
     ///
     /// `snapshot()` is a pure in-memory clone of the window the runtime already holds: no
     /// store read, no relay traffic, and identical bounds, so a scrolled-back reader keeps
     /// their position and pagination state. `loadMessages` would instead re-run the
     /// initial-load path and re-anchor the window to the head.
-    private func reprojectSelectedTimelineForPeerProfiles(
-        ids: Set<String>,
-        account: AccountItem,
-        client: any MarmotRuntime
-    ) async {
+    ///
+    /// Callers decide whether a replay is worth it; this only re-checks that the window it is
+    /// about to replace is still the one on screen, which is also what makes it safe for a
+    /// caller whose conversation or account moved on while it was suspended.
+    func replaySelectedTimelineWindow(account: AccountItem, client: any MarmotRuntime) async {
         guard let subscription = activeTimelineSubscription,
             let groupIdHex = activeTimelineGroupId,
             selectedChat?.id == groupIdHex
-        else { return }
-
-        // Replay only when a resolved id is one the open window's rows actually name. Most
-        // requests come from rosters and reaction lists — a 40-member group whose members
-        // have never posted, or reactors whose rows read `peerProfileFFICache` directly and
-        // repaint on their own. Replaying for those re-maps and re-diffs the whole transcript
-        // to produce byte-identical rows, once per debounce window for the length of a drain.
-        //
-        // `timelineProjectedSenderIds` is the exact `senderIds` set the last projection of
-        // this window resolved, so it covers reply-quote authors and group-system actors too
-        // — identities the materialized `MessageItem`s do not carry and a scan of the store
-        // would miss.
-        guard let projectedSenderIds = timelineProjectedSenderIds[groupIdHex],
-            !projectedSenderIds.isDisjoint(with: ids)
         else { return }
 
         guard let page = try? await runOffMain({ subscription.snapshot() }) else { return }
@@ -376,6 +363,31 @@ extension WorkspaceState {
             client: client,
             owner: .subscription(subscription)
         )
+    }
+
+    /// Replays the open window for peers that just became nameable.
+    private func reprojectSelectedTimelineForPeerProfiles(
+        ids: Set<String>,
+        account: AccountItem,
+        client: any MarmotRuntime
+    ) async {
+        guard let groupIdHex = activeTimelineGroupId, selectedChat?.id == groupIdHex else { return }
+
+        // Replay only when a resolved id is one the open window's rows actually name. Most
+        // requests come from rosters and reaction lists — a 40-member group whose members
+        // have never posted, or reactors whose rows read `peerProfileFFICache` directly and
+        // repaint on their own. Replaying for those re-maps and re-diffs the whole transcript
+        // to produce byte-identical rows, once per debounce window for the length of a drain.
+        //
+        // `timelineProjectedSenderIds` is the exact `senderIds` set the last projection of
+        // this window resolved, so it covers reply-quote authors and group-system actors too
+        // — identities the materialized `MessageItem`s do not carry and a scan of the store
+        // would miss.
+        guard let projectedSenderIds = timelineProjectedSenderIds[groupIdHex],
+            !projectedSenderIds.isDisjoint(with: ids)
+        else { return }
+
+        await replaySelectedTimelineWindow(account: account, client: client)
     }
 
     /// Re-titles direct-chat rows whose peer just became nameable.

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -998,7 +998,11 @@ final class WorkspaceState {
     @ObservationIgnored var directPeerMemoryStore: (any DirectPeerMemoryStoring)?
     var contactNicknamesByOwner: [String: [String: String]] = [:]
     @ObservationIgnored var contactNicknameRevision: UInt64 = 0
-    @ObservationIgnored var cachedContactNicknames: CachedContactNicknames?
+    @ObservationIgnored var cachedContactNicknames: NicknameStamped<ContactNicknames>?
+    /// Replays the open transcript after a nickname write so mention tokens already baked into
+    /// rendered bubbles pick up the new label. Held only so tests can await it — a replay that
+    /// outlives its conversation re-checks the account and subscription before applying anything.
+    @ObservationIgnored var contactNicknameMentionReplayTask: Task<Void, Never>?
     @ObservationIgnored let chatRestorationStore: any ChatRestorationStoring
     /// Set only for the duration of an automatic selection made past a preserved memory. See
     /// `withRememberedChatPreserved(_:_:)`.
@@ -1632,10 +1636,13 @@ final class WorkspaceState {
     var groupMemberDetailsCache: [String: [GroupMemberDetailsFfi]] = [:]
     /// Mention-picker projections derived from `groupMemberDetailsCache`. Kept outside Observation
     /// so reading or populating the cache from a view body does not schedule another render.
-    @ObservationIgnored var mentionRosterCache: [String: [ComposerMentionCandidate]] = [:]
+    /// Both mention caches fold in the viewer's private nicknames, so both are stamped with the
+    /// nickname set they were built from: a nickname write invalidates them for the cost of a
+    /// comparison on the read path, without touching any group whose projection is never read again.
+    @ObservationIgnored var mentionRosterCache: [String: NicknameStamped<[ComposerMentionCandidate]>] = [:]
     /// Timeline Markdown mention projections share the same roster lifetime as the picker cache.
     /// Keeping this separate avoids rebuilding and sanitizing every member on each projection delta.
-    @ObservationIgnored var mentionNamesCache: [String: MarkdownMentionNames] = [:]
+    @ObservationIgnored var mentionNamesCache: [String: NicknameStamped<MarkdownMentionNames>] = [:]
     var groupMemberDetailsLookups: [String: GroupMemberDetailsLookup] = [:]
     var readStateMetadataEnrichmentAttempts = Set<String>()
     var nextGroupMemberDetailsLookupToken: UInt64 = 0
@@ -1783,12 +1790,6 @@ final class WorkspaceState {
                 )
             }
         }
-    }
-
-    struct CachedContactNicknames {
-        let ownerAccountIdHex: String
-        let revision: UInt64
-        let value: ContactNicknames
     }
 
     /// Cached raw output of the per-sender profile FFI lookups.
@@ -2582,10 +2583,7 @@ final class WorkspaceState {
                         PeerDisplayText.sanitize(member.displayName),
                         PeerDisplayText.sanitize(member.account),
                     ]) ?? DisplayText.short(member.npub, head: 12, tail: 8)
-                // You cannot nickname yourself, so `isSelf` rows always read the published name.
-                let nickname =
-                    member.isSelf
-                    ? nil : nicknames.nickname(forContactAccountIdHex: member.memberIdHex)
+                let nickname = member.nickname(from: nicknames)
                 let displayName = nickname ?? published
                 return GroupMemberItem(
                     id: member.memberIdHex,

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -134,6 +134,10 @@ private struct ComposerMentionRow: View {
 
     @State private var isHovered = false
 
+    private var shortNpub: String? {
+        candidate.npub.isEmpty ? nil : DisplayText.short(candidate.npub)
+    }
+
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 8) {
@@ -149,8 +153,10 @@ private struct ComposerMentionRow: View {
                         .font(.callout.weight(.medium))
                         .foregroundStyle(WNColor.backgroundContentPrimary)
                         .lineLimit(1)
-                    if !candidate.npub.isEmpty {
-                        Text(DisplayText.short(candidate.npub))
+                    // Under a private nickname, who the person actually publishes as says more
+                    // about which of two similarly-nicknamed contacts this is than their npub.
+                    if let subtitle = candidate.publishedDisplayName ?? shortNpub {
+                        Text(subtitle)
                             .font(.caption)
                             .foregroundStyle(WNColor.backgroundContentSecondary)
                             .lineLimit(1)

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -78,6 +78,73 @@ struct PureValueTests {
         )
     }
 
+    /// A nickname is what the picker inserts, so it has to canonicalize — but the published name
+    /// stays live too: a draft written before the nickname existed, or one where the sender typed
+    /// the name they see elsewhere, must still leave as an npub rather than as literal text.
+    @Test func nicknamedMemberCanonicalizesUnderEitherName() {
+        let candidates = [mentionCandidate(id: "alice", displayName: "Alice", npub: "npub1alice", nickname: "Mum")]
+
+        #expect(ComposerMentionCanonicalizer.canonicalize("Hi @Mum", candidates: candidates) == "Hi @npub1alice")
+        #expect(ComposerMentionCanonicalizer.canonicalize("Hi @Alice", candidates: candidates) == "Hi @npub1alice")
+    }
+
+    /// Nicknames are chosen by the viewer, so nothing stops one from colliding with another
+    /// member's published name. That is the same ambiguity two identical display names create,
+    /// and it has to be resolved the same way: refuse to guess, and let the picker disambiguate.
+    @Test func aNicknameCollidingWithAnotherMembersRealNameIsNotGuessed() {
+        let candidates = [
+            mentionCandidate(id: "alice", displayName: "Alice", npub: "npub1alice", nickname: "Bob"),
+            mentionCandidate(id: "bob", displayName: "Bob", npub: "npub1bob"),
+        ]
+
+        #expect(ComposerMentionCanonicalizer.canonicalize("Hi @Bob", candidates: candidates) == "Hi @Bob")
+        // The names that stayed unique still resolve.
+        #expect(ComposerMentionCanonicalizer.canonicalize("Hi @Alice", candidates: candidates) == "Hi @npub1alice")
+    }
+
+    @Test func nicknamedMentionCandidateIsFoundByEitherNameAndKeepsThePublishedOne() {
+        let nicknamed = mentionCandidate(id: "alice", displayName: "Alice", npub: "npub1alice", nickname: "Mum")
+
+        #expect(nicknamed.displayName == "Mum")
+        #expect(nicknamed.publishedDisplayName == "Alice")
+        #expect(nicknamed.searchableNames == ["Mum", "Alice"])
+        #expect(ComposerMentionQuery.filter([nicknamed], matching: "mum").map(\.id) == ["alice"])
+        #expect(ComposerMentionQuery.filter([nicknamed], matching: "alic").map(\.id) == ["alice"])
+        #expect(ComposerMentionQuery.filter([nicknamed], matching: "bob").isEmpty)
+
+        // No nickname means nothing is being overridden, so there is no second name to record.
+        let plain = mentionCandidate(id: "bob", displayName: "Bob", npub: "npub1bob")
+        #expect(plain.publishedDisplayName == nil)
+        #expect(plain.searchableNames == ["Bob"])
+    }
+
+    /// A nickname is the only name a member who published none has, so it must reach the mention
+    /// map — that member renders as truncated bech32 without it.
+    @Test func mentionNamesPreferNicknamesAndNameAnUnpublishedMember() {
+        let members = [
+            mentionMember(id: "self", displayName: "Local", npub: "npub1self", isSelf: true),
+            mentionMember(id: "alice", displayName: "Alice", npub: "npub1alice"),
+            mentionMember(id: "bob", displayName: "", npub: "npub1bob"),
+            mentionMember(id: "carol", displayName: "Carol", npub: "npub1carol"),
+        ]
+        let nicknames = ContactNicknames(
+            ownerAccountIdHex: "owner",
+            byContactIdHex: ["alice": "Mum", "bob": "Plumber", "self": "Not Me"]
+        )
+
+        let names = WorkspaceState.mentionNames(from: members, nicknames: nicknames)
+
+        #expect(names["npub1alice"] == "Mum")
+        #expect(names["npub1bob"] == "Plumber")
+        #expect(names["npub1carol"] == "Carol")
+        // A nickname on file for one of this device's own accounts is never your own label.
+        #expect(names["npub1self"] == "Local")
+        // Nothing published and nothing private stays unnamed, so the bech32 fallback survives.
+        #expect(
+            WorkspaceState.mentionNames(from: members, nicknames: .none)["npub1bob"] == nil
+        )
+    }
+
     @Test func ambiguousTypedMentionIsNotGuessedWithoutPickerSelection() {
         let candidates = [
             mentionCandidate(id: "first", displayName: "Alex", npub: "npub1qqqq"),
@@ -484,6 +551,92 @@ struct PureValueTests {
         #expect(state.mentionRosterBuildCount == 2)
         #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1bob"] == "Bob")
         #expect(state.mentionNamesBuildCount == 2)
+    }
+
+    /// Mention projections fold nicknames in, so they must notice a nickname write — but noticing
+    /// it may not cost anything on the read path, which the timeline hits on every window and
+    /// every keystroke. Exactly one rebuild per write, and none at all for a write that changed
+    /// nothing.
+    @MainActor
+    @Test func mentionProjectionsRebuildOncePerNicknameWrite() {
+        let account = AccountItem.samples[0]
+        let group = ChatItem.samples[0]
+        let state = WorkspaceState(
+            accounts: [account],
+            chatsByAccount: [account.id: [group]],
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+        state.activeAccountId = account.id
+        state.selection = .chat(group.id)
+        state.storeGroupMembers(
+            [
+                mentionMember(id: "self", displayName: "Local", npub: "npub1self", isSelf: true),
+                mentionMember(id: "alice", displayName: "Alice", npub: "npub1alice"),
+            ],
+            for: group.id
+        )
+
+        #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1alice"] == "Alice")
+        #expect(state.mentionRoster().map(\.displayName) == ["Alice"])
+        #expect(state.mentionNamesBuildCount == 1)
+        #expect(state.mentionRosterBuildCount == 1)
+
+        state.setContactNickname("Mum", forContactAccountIdHex: "alice")
+
+        #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1alice"] == "Mum")
+        #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1alice"] == "Mum")
+        #expect(state.mentionNamesBuildCount == 2)
+        #expect(state.mentionRoster().map(\.displayName) == ["Mum"])
+        #expect(state.mentionRoster().map(\.publishedDisplayName) == ["Alice"])
+        #expect(state.mentionRosterBuildCount == 2)
+
+        // Re-saving the same nickname is not a change, so nothing is invalidated.
+        state.setContactNickname("Mum", forContactAccountIdHex: "alice")
+        #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1alice"] == "Mum")
+        _ = state.mentionRoster()
+        #expect(state.mentionNamesBuildCount == 2)
+        #expect(state.mentionRosterBuildCount == 2)
+
+        // Clearing hands the label back to the published name, through the same one rebuild.
+        state.setContactNickname(nil, forContactAccountIdHex: "alice")
+        #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1alice"] == "Alice")
+        #expect(state.mentionRoster().map(\.displayName) == ["Alice"])
+        #expect(state.mentionNamesBuildCount == 3)
+        #expect(state.mentionRosterBuildCount == 3)
+    }
+
+    /// A nickname belongs to the account that set it. Two accounts sharing a conversation must
+    /// never read each other's private labels out of a projection cached under one group id.
+    @MainActor
+    @Test func mentionNamesAreScopedToTheAccountThatNicknamedTheContact() {
+        let owner = AccountItem.samples[0]
+        let other = AccountItem.samples[1]
+        let group = ChatItem.samples[0]
+        let state = WorkspaceState(
+            accounts: [owner, other],
+            chatsByAccount: [owner.id: [group], other.id: [group]],
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+        state.activeAccountId = owner.id
+        state.selection = .chat(group.id)
+        state.storeGroupMembers(
+            [mentionMember(id: "alice", displayName: "Alice", npub: "npub1alice")],
+            for: group.id
+        )
+
+        state.setContactNickname("Mum", forContactAccountIdHex: "alice")
+        #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1alice"] == "Mum")
+
+        state.activeAccountId = other.id
+        #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1alice"] == "Alice")
+        #expect(state.mentionRoster().map(\.displayName) == ["Alice"])
+
+        state.activeAccountId = owner.id
+        #expect(state.cachedMentionNames(groupIdHex: group.id)["npub1alice"] == "Mum")
     }
 
     @MainActor
@@ -4256,8 +4409,16 @@ private func invitePreviewChat(
     )
 }
 
-private func mentionCandidate(id: String, displayName: String, npub: String) -> ComposerMentionCandidate {
-    ComposerMentionCandidate(details: mentionMember(id: id, displayName: displayName, npub: npub))
+private func mentionCandidate(
+    id: String,
+    displayName: String,
+    npub: String,
+    nickname: String? = nil
+) -> ComposerMentionCandidate {
+    ComposerMentionCandidate(
+        details: mentionMember(id: id, displayName: displayName, npub: npub),
+        nickname: nickname
+    )
 }
 
 private func mentionMember(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -14118,6 +14118,89 @@ struct whitenoise_macTests {
         #expect(state.activeChats.first?.pictureURL == "https://example.com/alice.png")
     }
 
+    /// A mention is baked into the bubble's attributed string when the window is projected, so
+    /// nicknaming someone the open conversation mentions cannot be patched in the way a sender
+    /// label can — it needs the window replayed. Every earlier message has to change, including
+    /// ones no live delta would ever revisit, and clearing the nickname has to give the published
+    /// name back.
+    @MainActor
+    @Test func nicknamingAMentionedMemberRepaintsTheOpenTranscript() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let aliceNpub = "npub1alyce"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cooper",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Cooper",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let mentionTokens = MarkdownDocumentFfi(
+            blocks: [
+                .paragraph(inlines: [
+                    .text(content: "ping "),
+                    .nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: aliceNpub)),
+                ])
+            ],
+            truncated: false
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<3).map { index in
+                appMessage(
+                    id: "message-\(index)",
+                    groupIdHex: "direct-group",
+                    sender: aliceId,
+                    plaintext: "ping @\(aliceNpub)",
+                    contentTokens: mentionTokens,
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "direct-group"
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "direct-group")
+
+        func renderedMentions() -> [String] {
+            (state.messagesByChat["direct-group"] ?? []).map { message in
+                message.contentMarkdown?.inlineParagraph.map { String($0.characters) } ?? ""
+            }
+        }
+
+        #expect(renderedMentions() == Array(repeating: "ping @Alice Cooper", count: 3))
+        let projectedIds = (state.messagesByChat["direct-group"] ?? []).map(\.id)
+
+        state.setContactNickname("Mum", forContactAccountIdHex: aliceId)
+        await state.contactNicknameMentionReplayTask?.value
+
+        #expect(renderedMentions() == Array(repeating: "ping @Mum", count: 3))
+        // Replayed, not reloaded: the same rows in the same order.
+        #expect((state.messagesByChat["direct-group"] ?? []).map(\.id) == projectedIds)
+
+        state.setContactNickname(nil, forContactAccountIdHex: aliceId)
+        await state.contactNicknameMentionReplayTask?.value
+
+        #expect(renderedMentions() == Array(repeating: "ping @Alice Cooper", count: 3))
+    }
+
     @MainActor
     @Test func steadyStatePeerProfileRefreshMakesNoRequestsAcrossWindowsAndDeltas() async throws {
         // The render/projection paths call `requestPeerProfileRefresh` unconditionally, so the
@@ -31833,6 +31916,7 @@ private func appMessage(
     groupIdHex: String,
     sender: String,
     plaintext: String,
+    contentTokens: MarkdownDocumentFfi = emptyMarkdownDocument(),
     kind: UInt64,
     tags: [MessageTagFfi] = [],
     recordedAt: UInt64
@@ -31843,7 +31927,7 @@ private func appMessage(
         groupIdHex: groupIdHex,
         sender: sender,
         plaintext: plaintext,
-        contentTokens: emptyMarkdownDocument(),
+        contentTokens: contentTokens,
         kind: kind,
         tags: tags,
         sourceEpoch: nil,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added private nickname support for mention search, display, and canonicalization.
  * Mentions now recognize nicknames, published names, npubs, and member IDs.
  * Nickname changes automatically refresh mentions in drafts, chat lists, and open conversations.
  * Mention suggestions show published names or shortened npubs when available.

* **Bug Fixes**
  * Improved account-specific nickname handling and prevented ambiguous aliases from resolving incorrectly.
  * Clearing a nickname now restores the published display name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->