### PR TITLE
Clear input after sending message

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -978,11 +978,12 @@ extension WorkspaceState {
         let text = canonicalizeMentions(in: draftText, selections: composerMentionSelections)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let mediaAttachments = pendingMediaAttachments
-        // `!isSending` is the reentrancy guard: `isSending` flips synchronously here,
-        // but the model only suspends (and `draftText` is only cleared) at the `await`
-        // below. Without this guard a second invocation delivered before SwiftUI
-        // re-renders the disabled send button (Return auto-repeat, double events)
-        // would still observe the old `draftText` and re-send the same message.
+        // `!isSending` is the reentrancy guard: `isSending` flips synchronously here, but an
+        // edit only restores its preserved draft at the `await` below. Without this guard a
+        // second invocation delivered before SwiftUI re-renders the disabled send button
+        // (Return auto-repeat, double events) would still observe the old `draftText` and
+        // re-send the same message. A new draft empties its composer synchronously
+        // (`sendNewDraftIfPossible`), so there the guard is the second line of defence.
         guard let client,
             let activeAccount,
             let selectedChat,
@@ -1035,30 +1036,48 @@ extension WorkspaceState {
         isSending = true
         defer { isSending = false }
 
+        if !mediaAttachments.isEmpty {
+            // Hand the send off and return. Staging started every upload the moment the file
+            // was attached, so most of the time the blobs are already on Blossom — but when
+            // they are not, the wait belongs to the message's bubble, not to the Send button
+            // (#710 blocked the button; this is the hybrid that does not).
+            handOffMediaSend(
+                mediaAttachments,
+                caption: text,
+                draftKey: draftKey,
+                account: activeAccount,
+                client: client
+            )
+            await deletePersistedComposerDraft(
+                for: draftKey,
+                accountRef: activeAccount.accountRef,
+                client: client
+            )
+            return
+        }
+
+        // Text empties the composer on hand-off too, before the publish rather than after it.
+        // Clearing only once `sendText`/`replyToMessage` returned meant the draft sat in the
+        // input for the whole relay round-trip — and since the message's own bubble appears
+        // from the local projection as soon as it is stored, the user saw the same text twice.
+        let restorePoint = ComposerSendSnapshot(
+            text: draftTextByConversation[draftKey] ?? "",
+            mentionSelections: composerMentionSelectionsByConversation[draftKey] ?? [],
+            replyContext: replyDraftContextByConversation[draftKey]
+        )
+        clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
+        await deletePersistedComposerDraft(
+            for: draftKey,
+            accountRef: activeAccount.accountRef,
+            client: client
+        )
+
         do {
-            if !mediaAttachments.isEmpty {
-                // Hand the send off and return. Staging started every upload the moment the file
-                // was attached, so most of the time the blobs are already on Blossom — but when
-                // they are not, the wait belongs to the message's bubble, not to the Send button
-                // (#710 blocked the button; this is the hybrid that does not).
-                handOffMediaSend(
-                    mediaAttachments,
-                    caption: text,
-                    draftKey: draftKey,
-                    account: activeAccount,
-                    client: client
-                )
-                await deletePersistedComposerDraft(
-                    for: draftKey,
-                    accountRef: activeAccount.accountRef,
-                    client: client
-                )
-                return
-            } else if let replyDraftContext {
+            if let replyContext = restorePoint.replyContext {
                 _ = try await client.replyToMessage(
                     accountRef: activeAccount.accountRef,
                     groupIdHex: selectedChat.id,
-                    targetMessageId: replyDraftContext.targetMessageId,
+                    targetMessageId: replyContext.targetMessageId,
                     text: text
                 )
             } else {
@@ -1068,21 +1087,48 @@ extension WorkspaceState {
                     text: text
                 )
             }
-            clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
-            await deletePersistedComposerDraft(
-                for: draftKey,
-                accountRef: activeAccount.accountRef,
-                client: client
-            )
-            // One authoritative re-window so the user sees their just-sent message
-            // immediately, even if the live projection for it is momentarily in flight.
-            // The follow-on delivery-state transitions then arrive as projection deltas
-            // and are applied incrementally by `applyTimelineProjection` — no longer a
-            // full re-map per delivery.
-            await refreshSelectedTimelineAfterSend(groupIdHex: selectedChat.id, account: activeAccount, client: client)
         } catch {
+            restoreComposerAfterFailedSend(restorePoint, for: draftKey)
             lastError = error.localizedDescription
+            return
         }
+        // One authoritative re-window so the user sees their just-sent message
+        // immediately, even if the live projection for it is momentarily in flight.
+        // The follow-on delivery-state transitions then arrive as projection deltas
+        // and are applied incrementally by `applyTimelineProjection` — no longer a
+        // full re-map per delivery.
+        await refreshSelectedTimelineAfterSend(groupIdHex: selectedChat.id, account: activeAccount, client: client)
+    }
+
+    /// What a text send took out of the composer, kept only long enough to put it back if the
+    /// publish fails. Media sends have no equivalent: their attachments move into a pending
+    /// bubble that owns its own retry.
+    private struct ComposerSendSnapshot {
+        let text: String
+        let mentionSelections: [ComposerMentionSelection]
+        let replyContext: MessageReplyContext?
+    }
+
+    /// Returns a failed text send's draft to the composer it was sent from, so the relay being
+    /// unreachable costs a retry rather than the message.
+    ///
+    /// Skipped when that composer is no longer empty: the user started their next message during
+    /// the round-trip, and overwriting live typing is worse than losing the failed draft, which
+    /// `lastError` reports either way. Keyed by the captured `draftKey` for the same reason
+    /// `clearComposerAfterSend` is — the selection may have moved on.
+    private func restoreComposerAfterFailedSend(
+        _ snapshot: ComposerSendSnapshot,
+        for draftKey: ComposerDraftKey
+    ) {
+        guard (draftTextByConversation[draftKey] ?? "").isEmpty,
+            (pendingMediaAttachmentsByConversation[draftKey] ?? []).isEmpty
+        else { return }
+        draftTextByConversation[draftKey] = snapshot.text.isEmpty ? nil : snapshot.text
+        composerMentionSelectionsByConversation[draftKey] =
+            snapshot.mentionSelections.isEmpty ? nil : snapshot.mentionSelections
+        replyDraftContextByConversation[draftKey] = snapshot.replyContext
+        // Re-persist: the send already deleted the stored draft on the way out.
+        composerDraftDidChange(for: draftKey)
     }
 
     /// Moves a media draft out of the composer and into a pending outgoing message, then returns.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -15883,6 +15883,140 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func textComposerEmptiesBeforeThePublishReturns() async throws {
+        // A plain text send must empty the composer on hand-off, exactly like the media path.
+        // Holding the text for the length of the relay round-trip left it sitting in the input
+        // beside the bubble it had already become — the same content visible twice.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.draftText = "Project notes"
+        runtime.messageActionGateEnabled = true
+        async let send: Void = state.sendDraft()
+        while !(state.isSending && runtime.didReachMessageActionGate) {
+            await Task.yield()
+        }
+
+        // The publish is still gated, but the input is already empty.
+        #expect(state.draftText.isEmpty)
+
+        runtime.releaseMessageActionGate()
+        await send
+
+        #expect(runtime.sentText == SentText(groupIdHex: "group", text: "Project notes"))
+        #expect(state.draftText.isEmpty)
+    }
+
+    @MainActor
+    @Test func replyComposerEmptiesBeforeThePublishReturns() async throws {
+        // Same hand-off for the reply path: the quoted-reply bar goes with the text.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.replyDraftContext = MessageReplyContext(
+            targetMessageId: "parent",
+            senderName: "Alice",
+            body: "The launch plan is ready."
+        )
+        state.draftText = "Looks good to me."
+        runtime.messageActionGateEnabled = true
+        async let send: Void = state.sendDraft()
+        while !(state.isSending && runtime.didReachMessageActionGate) {
+            await Task.yield()
+        }
+
+        #expect(state.draftText.isEmpty)
+        #expect(state.replyDraftContext == nil)
+
+        runtime.releaseMessageActionGate()
+        await send
+
+        #expect(
+            runtime.repliedMessage
+                == SentReply(groupIdHex: "group", targetMessageId: "parent", text: "Looks good to me.")
+        )
+        #expect(state.draftText.isEmpty)
+    }
+
+    @MainActor
+    @Test func failedTextSendPutsTheDraftBackInTheComposer() async throws {
+        // Emptying on hand-off must not cost the user their text when the publish fails: the
+        // draft, its mention markers and its reply context all come back for a retry.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        let mentionSelections = [
+            ComposerMentionSelection(
+                range: NSRange(location: 0, length: 6),
+                displayText: "@Alice",
+                npub: "npub1alice"
+            )
+        ]
+        state.replyDraftContext = MessageReplyContext(
+            targetMessageId: "parent",
+            senderName: "Alice",
+            body: "The launch plan is ready."
+        )
+        state.draftText = "@Alice ping"
+        state.composerMentionSelections = mentionSelections
+        runtime.replyToMessageError = NSError(
+            domain: "test.reply",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "relay unreachable"]
+        )
+        await state.sendDraft()
+
+        #expect(state.draftText == "@Alice ping")
+        #expect(state.composerMentionSelections == mentionSelections)
+        #expect(state.replyDraftContext?.targetMessageId == "parent")
+        #expect(state.lastError == "relay unreachable")
+        // The restored draft is dirty again, so it will be persisted rather than left only in memory.
+        #expect(state.dirtyComposerDraftKeys.contains(draftKey))
+        #expect(state.canSend)
+    }
+
+    @MainActor
+    @Test func failedTextSendKeepsWhatTheUserTypedWhileItWasInFlight() async throws {
+        // The restore is a courtesy, not an overwrite. If the emptied composer already holds new
+        // text by the time the failure lands, that text wins — `lastError` reports the loss.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        state.draftText = "first message"
+        runtime.sendTextError = NSError(
+            domain: "test.send",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "relay unreachable"]
+        )
+        runtime.messageActionGateEnabled = true
+        async let send: Void = state.sendDraft()
+        while !(state.isSending && runtime.didReachMessageActionGate) {
+            await Task.yield()
+        }
+
+        // The user starts the next message while the first one is still in flight.
+        state.draftText = "second message"
+        runtime.releaseMessageActionGate()
+        await send
+
+        #expect(state.draftText == "second message")
+        #expect(state.lastError == "relay unreachable")
+    }
+
+    @MainActor
     @Test func sendIsAvailableAgainImmediatelyWhileTheAttachmentIsStillUploading() async throws {
         // The point of the hybrid: staging starts the upload, but a Send pressed before it lands
         // still goes through — the composer empties, the wait moves to a loading bubble, and the
@@ -16473,11 +16607,11 @@ struct whitenoise_macTests {
     @MainActor
     @Test func sendDraftDropsOverlappingDuplicateInvocation() async throws {
         // Issue #78: sendDraft() must guard against reentrancy. `isSending` flips synchronously,
-        // but the model only suspends (and draftText is only cleared) at the `await sendText(...)`.
-        // A second invocation delivered before SwiftUI re-renders the disabled send button
-        // (Return auto-repeat, double events) would otherwise observe the still-unchanged
-        // draftText and re-send the same message. Repro: hold the first send in-flight at the
-        // FFI gate, fire an overlapping second send, then release. Only one text must be sent.
+        // and the composer is emptied synchronously with it, so a second invocation delivered
+        // before SwiftUI re-renders the disabled send button (Return auto-repeat, double events)
+        // is dropped twice over — by `!isSending` and by the now-empty draft. Repro: hold the
+        // first send in-flight at the FFI gate, fire an overlapping second send, then release.
+        // Only one text must be sent.
         let account = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -29305,9 +29439,11 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     // Issue #78 reentrancy-test support: count message-action FFI calls so a test can prove
     // an overlapping duplicate was dropped by the WorkspaceState guard before reaching the runtime.
     private(set) var sendTextCallCount = 0
+    var sendTextError: Error?
     private(set) var retryGroupConvergenceCallCount = 0
     var retryGroupConvergenceError: Error?
     private(set) var replyToMessageCallCount = 0
+    var replyToMessageError: Error?
     private(set) var reactToMessageCallCount = 0
     private(set) var deleteMessageCallCount = 0
     private(set) var editMessageCallCount = 0
@@ -31060,6 +31196,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         sendTextCallCount += 1
         sentText = SentText(groupIdHex: groupIdHex, text: text)
         await messageActionGate.passIfArmed()
+        if let sendTextError {
+            throw sendTextError
+        }
         return SendSummaryFfi(published: 1, messageIds: ["text"])
     }
 
@@ -31079,6 +31218,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         replyToMessageCallCount += 1
         repliedMessage = SentReply(groupIdHex: groupIdHex, targetMessageId: targetMessageId, text: text)
         await messageActionGate.passIfArmed()
+        if let replyToMessageError {
+            throw replyToMessageError
+        }
         return SendSummaryFfi(published: 1, messageIds: ["reply"])
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Text and reply messages now clear from the composer immediately when sent, preventing duplicate submissions.
  - Failed sends can restore the original draft, including mentions and reply context.
  - Any replacement text entered while a send is in progress is preserved.
  - Improved handling of send errors and composer state during rapid or repeated send attempts.
- **Improvements**
  - Successful messages continue to refresh the timeline automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->