### PR TITLE
Show loading only in auth action that is running

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -314,8 +314,8 @@ extension WorkspaceState {
     func signUp() async {
         guard !isAuthenticating else { return }
         lastError = nil
-        isAuthenticating = true
-        defer { isAuthenticating = false }
+        authenticationActivity = .signUp
+        defer { authenticationActivity = nil }
 
         guard let client = await clientForAuthentication() else { return }
 
@@ -342,11 +342,11 @@ extension WorkspaceState {
         guard !identity.isEmpty else { return }
 
         lastError = nil
-        isAuthenticating = true
+        authenticationActivity = .login
         // Scrub the entered nsec (private key) on every exit path so it never
         // outlives the login call, including failures. See issue #32.
         defer {
-            isAuthenticating = false
+            authenticationActivity = nil
             clearEnteredLoginIdentity()
         }
 
@@ -899,7 +899,7 @@ extension WorkspaceState {
         isSending = false
         authenticationMode = .landing
         loginIdentity = ""
-        isAuthenticating = false
+        authenticationActivity = nil
         profileDraft = ProfileDraft()
         relaySettings = .defaults
         selectedRelaySection = .nip65

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -921,6 +921,14 @@ final class WorkspaceState {
         case login
     }
 
+    /// Which authentication path is in flight, so only that path's button shows progress
+    /// while the others merely disable. A single `isAuthenticating` bool made "Log in" and
+    /// "Create identity" both read as loading whenever either one ran.
+    enum AuthenticationActivity: Equatable {
+        case login
+        case signUp
+    }
+
     struct ComposerDraftKey: Hashable {
         let accountId: String
         let chatId: String
@@ -1163,7 +1171,11 @@ final class WorkspaceState {
     var inFlightDeleteMessageIds = Set<String>()
     var authenticationMode: AuthenticationMode = .landing
     var loginIdentity = ""
-    var isAuthenticating = false
+    var authenticationActivity: AuthenticationActivity?
+    /// Any authentication in flight, whichever path it is. Controls used by *both* paths
+    /// (the nsec field, Cancel, the account switcher) disable on this; a button that owns
+    /// one path shows its progress label from `authenticationActivity` instead.
+    var isAuthenticating: Bool { authenticationActivity != nil }
     var profileDraft = ProfileDraft()
     var relaySettings = RelaySettingsSnapshot.defaults
     var selectedRelaySection: RelaySettingsSection = .nip65

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -115,7 +115,7 @@ private struct WelcomeAuthView: View {
                     Task { await workspace.signUp() }
                 } label: {
                     Text(
-                        workspace.isAuthenticating && workspace.authenticationMode == .landing
+                        workspace.authenticationActivity == .signUp
                             ? L10n.string("Creating...")
                             : L10n.string("Create New Identity")
                     )
@@ -154,7 +154,11 @@ private struct WelcomeAuthView: View {
                         }
                         .disabled(workspace.isAuthenticating)
 
-                        Button(workspace.isAuthenticating ? L10n.string("Logging in...") : L10n.string("Log in")) {
+                        Button(
+                            workspace.authenticationActivity == .login
+                                ? L10n.string("Logging in...")
+                                : L10n.string("Log in")
+                        ) {
                             Task { await workspace.login() }
                         }
                         .nativeGlassProminentButtonStyle()

--- a/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
@@ -397,7 +397,7 @@ struct AddAccountSheet: View {
                     Task { await addAccount { await workspace.login() } }
                 } label: {
                     Label(
-                        workspace.isAuthenticating
+                        workspace.authenticationActivity == .login
                             ? L10n.string("Logging in...", locale: locale)
                             : L10n.string("Log in with key", locale: locale),
                         systemImage: "key"
@@ -411,7 +411,7 @@ struct AddAccountSheet: View {
                     Task { await addAccount { await workspace.signUp() } }
                 } label: {
                     Label(
-                        workspace.isAuthenticating
+                        workspace.authenticationActivity == .signUp
                             ? L10n.string("Creating...", locale: locale)
                             : L10n.string("Create identity", locale: locale),
                         systemImage: "plus.circle"

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -585,6 +585,77 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func signUpMarksOnlyTheSignUpPathAsAuthenticating() async throws {
+        // Both authentication buttons used to read a single `isAuthenticating` bool, so creating
+        // an identity also put the "Log in" button into its "Logging in..." loading label. Only
+        // the running path reports progress; the other is disabled via `isAuthenticating`.
+        let created = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [], createdAccount: created)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.authenticationActivity == nil)
+        #expect(!state.isAuthenticating)
+
+        runtime.createIdentityGateEnabled = true
+        async let pendingSignUp: Void = state.signUp()
+        while !runtime.didReachCreateIdentityGate {
+            await Task.yield()
+        }
+
+        #expect(state.authenticationActivity == .signUp)
+        #expect(state.authenticationActivity != .login)
+        #expect(state.isAuthenticating)
+
+        runtime.releaseCreateIdentityGate()
+        await pendingSignUp
+
+        #expect(state.authenticationActivity == nil)
+        #expect(!state.isAuthenticating)
+    }
+
+    @MainActor
+    @Test func loginMarksOnlyTheLoginPathAsAuthenticating() async throws {
+        let loggedIn = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [], createdAccount: loggedIn)
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showLogin()
+        state.loginIdentity = "nsec1desktop"
+
+        runtime.loginGateEnabled = true
+        async let pendingLogin: Void = state.login()
+        while !runtime.didReachLoginGate {
+            await Task.yield()
+        }
+
+        #expect(state.authenticationActivity == .login)
+        #expect(state.authenticationActivity != .signUp)
+        #expect(state.isAuthenticating)
+
+        runtime.releaseLoginGate()
+        await pendingLogin
+
+        #expect(state.authenticationActivity == nil)
+        #expect(!state.isAuthenticating)
+    }
+
+    @MainActor
     @Test func bootstrapRunsSynchronousRuntimeReadsOffMainThread() async throws {
         // Regression for #17: WorkspaceState is @MainActor, but blocking sync FFI reads
         // (account listing/profile/name/npub plus settings probes) must not execute on
@@ -29706,6 +29777,24 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var didReachCreateGroupGate: Bool {
         createGroupGate.didReach
     }
+    /// Hold `createIdentity` / `login` in flight so a test can observe which authentication
+    /// path is running while it runs — the state a progress label reads.
+    private let createIdentityGate = AsyncFfiGate()
+    var createIdentityGateEnabled: Bool {
+        get { createIdentityGate.isEnabled }
+        set { createIdentityGate.isEnabled = newValue }
+    }
+    var didReachCreateIdentityGate: Bool {
+        createIdentityGate.didReach
+    }
+    private let loginGate = AsyncFfiGate()
+    var loginGateEnabled: Bool {
+        get { loginGate.isEnabled }
+        set { loginGate.isEnabled = newValue }
+    }
+    var didReachLoginGate: Bool {
+        loginGate.didReach
+    }
     /// Issue #228 last-request-wins support for synchronous notification FFI reads: when armed,
     /// the first `notificationSettings` call blocks on the FFI queue until released, holding an
     /// older account's result while the test switches accounts and loads the newer snapshot.
@@ -30135,14 +30224,24 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func createIdentity(defaultRelays: [String], bootstrapRelays: [String]) async throws -> AccountSummaryFfi {
         guard let createdAccount else { throw FakeMarmotRuntimeError.missingCreatedAccount }
+        await createIdentityGate.passIfArmed()
         addOrReplaceAccount(createdAccount)
         return createdAccount
     }
 
+    func releaseCreateIdentityGate() {
+        createIdentityGate.release()
+    }
+
     func login(identity: String, defaultRelays: [String], bootstrapRelays: [String]) async throws -> AccountSummaryFfi {
         guard let createdAccount else { throw FakeMarmotRuntimeError.missingCreatedAccount }
+        await loginGate.passIfArmed()
         addOrReplaceAccount(createdAccount)
         return createdAccount
+    }
+
+    func releaseLoginGate() {
+        loginGate.release()
     }
 
     /// Mirrors the real runtime: `login` / `createIdentity` add the account to


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sign-up and login now display distinct progress messages, such as “Creating…” and “Logging in…”.
  * Authentication progress is cleared correctly after each operation completes or is canceled.
  * Account switching and new-install flows now maintain accurate authentication state.

* **Tests**
  * Added coverage confirming separate sign-up and login activity states and proper cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->