### PR TITLE
Make chatlist sidebar width adjustable

### DIFF
--- a/whitenoise-mac/Core/ChatListWidthPolicy.swift
+++ b/whitenoise-mac/Core/ChatListWidthPolicy.swift
@@ -1,0 +1,94 @@
+//
+//  ChatListWidthPolicy.swift
+//  whitenoise-mac
+//
+//  The one rule for how wide the chat-list drawer may be, so the resize handle,
+//  the restored preference and the collapsed-row rendering can never disagree
+//  about what "collapsed" means.
+//
+
+import CoreGraphics
+import Foundation
+
+/// Widths the chat-list drawer is allowed to take, and the snap that turns a drag
+/// into one of them.
+///
+/// There are deliberately only two regimes, not one continuous range: a *full* row
+/// (avatar, title, timestamp, preview) between `minimumExpandedWidth` and
+/// `maximumWidth`, and an *avatar-only* rail at `collapsedWidth`. Nothing renders in
+/// between, because the widths in between are exactly the ones where a group name
+/// truncates mid-word — the drawer would technically still fit the title column and
+/// would spend it on three clipped characters. Dragging past `collapseThreshold`
+/// therefore snaps: the row changes kind rather than shrinking further.
+nonisolated enum ChatListWidthPolicy {
+    /// Avatar-only rail: the 46pt row avatar plus the list's own horizontal padding
+    /// (8 on the `LazyVStack`, 6 on the collapsed row) on both sides.
+    static let collapsedWidth: CGFloat = 84
+    /// Narrowest full row: measured as the width at which the title column still holds a
+    /// short group name whole next to its timestamp. Below it names like "Search Load 4"
+    /// start ellipsizing, which is the thing the rail exists to avoid. Manrope is wider-set
+    /// than the system face this drawer used to be typeset in, so this is 30pt further out
+    /// than the same measurement gave before the type ramp landed — re-measure it here
+    /// (`ImageRenderer` over `ChatRowContent`) if the ramp moves again.
+    static let minimumExpandedWidth: CGFloat = 250
+    /// The width the drawer shipped at, kept as the widest allowed so the detail
+    /// pane never loses room it had before the drawer became resizable.
+    static let maximumWidth: CGFloat = 300
+    static let defaultWidth: CGFloat = maximumWidth
+
+    /// Midpoint between the two regimes: a drag crossing it collapses, and a drag
+    /// back across it restores the narrowest full row. One threshold in both
+    /// directions (rather than separate collapse/expand thresholds) keeps the
+    /// handle's position predictable — where you let go is where it snapped.
+    static let collapseThreshold: CGFloat = (collapsedWidth + minimumExpandedWidth) / 2
+
+    /// Resolves a dragged width to an allowed one.
+    ///
+    /// `allowsCollapse` is false while the drawer is showing something other than the
+    /// chat list (settings, the compose flow): those panes have no avatar-only form, so
+    /// a drag there bottoms out at `minimumExpandedWidth` instead of snapping shut.
+    static func resolve(proposedWidth: CGFloat, allowsCollapse: Bool = true) -> CGFloat {
+        guard proposedWidth.isFinite else { return defaultWidth }
+        if allowsCollapse, proposedWidth < collapseThreshold { return collapsedWidth }
+        return min(max(proposedWidth, minimumExpandedWidth), maximumWidth)
+    }
+
+    static func isCollapsed(width: CGFloat) -> Bool {
+        width < minimumExpandedWidth
+    }
+
+    /// One keyboard/VoiceOver step of the handle.
+    static let stepIncrement: CGFloat = 20
+
+    enum Step {
+        case narrower
+        case wider
+    }
+
+    /// Steps between allowed widths for an accessibility adjustment. This cannot go through
+    /// `resolve` alone: from `minimumExpandedWidth`, `resolve(220 - 20)` clamps straight back
+    /// to 220, so the collapsed rail would be unreachable without a pointer. The narrowest
+    /// full width therefore steps *to* the rail, and the rail steps back to it.
+    static func stepped(from width: CGFloat, toward step: Step, allowsCollapse: Bool = true) -> CGFloat {
+        guard width.isFinite else { return defaultWidth }
+        switch step {
+        case .narrower:
+            if isCollapsed(width: width) { return collapsedWidth }
+            if width <= minimumExpandedWidth {
+                return allowsCollapse ? collapsedWidth : minimumExpandedWidth
+            }
+            return max(minimumExpandedWidth, width - stepIncrement)
+        case .wider:
+            if isCollapsed(width: width) { return minimumExpandedWidth }
+            return min(maximumWidth, width + stepIncrement)
+        }
+    }
+
+    /// Restores a persisted width. A missing key means "never resized", which is the
+    /// default width — *not* `resolve(0)`, which would read an absent preference as a
+    /// collapsed drawer.
+    static func restored(storedWidth: Double?) -> CGFloat {
+        guard let storedWidth else { return defaultWidth }
+        return resolve(proposedWidth: CGFloat(storedWidth))
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Navigation.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Navigation.swift
@@ -114,4 +114,57 @@ extension WorkspaceState {
     func toggleChatList() {
         isChatListVisible.toggle()
     }
+
+    /// Whether the drawer is currently the chat list rather than the settings list or the
+    /// compose flow. Only the chat list has an avatar-only form, so this gates collapsing.
+    var isChatListDrawerShowingChats: Bool {
+        if case .settings = selection { return false }
+        return !isNewChatComposerVisible
+    }
+
+    /// The width the drawer should render at. Equals `chatListWidth` while the chat list is
+    /// showing; a settings or compose pane is floored to the narrowest full width, since
+    /// neither has anything to show inside an avatar-only rail. Visiting one of those panes
+    /// deliberately does *not* rewrite `chatListWidth`, so a collapsed chat list is still
+    /// collapsed when the user comes back to it.
+    var chatListDrawerWidth: CGFloat {
+        isChatListDrawerShowingChats
+            ? chatListWidth
+            : max(chatListWidth, ChatListWidthPolicy.minimumExpandedWidth)
+    }
+
+    /// True when the drawer is rendering as an avatar-only rail.
+    var isChatListCollapsed: Bool {
+        ChatListWidthPolicy.isCollapsed(width: chatListDrawerWidth)
+    }
+
+    /// Commits a drag on the drawer's resize handle. `proposedWidth` is the raw dragged
+    /// width; `ChatListWidthPolicy` decides which allowed width that lands on.
+    func resizeChatListDrawer(toProposedWidth proposedWidth: CGFloat) {
+        let resolved = ChatListWidthPolicy.resolve(
+            proposedWidth: proposedWidth,
+            allowsCollapse: isChatListDrawerShowingChats
+        )
+        guard resolved != chatListWidth else { return }
+        let wasCollapsed = isChatListCollapsed
+        chatListWidth = resolved
+        // A row-filtering query the user can no longer see or clear is worse than no
+        // query: the collapsed rail shows a silently short list with no search field to
+        // explain it. Collapsing therefore releases the sidebar search.
+        if !wasCollapsed, isChatListCollapsed, !searchText.isEmpty {
+            invalidateSidebarMessageSearch(clearQuery: true)
+        }
+    }
+
+    /// Keyboard/VoiceOver equivalent of dragging the handle, so the drawer width is not
+    /// reachable by pointer alone.
+    func stepChatListDrawerWidth(_ step: ChatListWidthPolicy.Step) {
+        resizeChatListDrawer(
+            toProposedWidth: ChatListWidthPolicy.stepped(
+                from: chatListDrawerWidth,
+                toward: step,
+                allowsCollapse: isChatListDrawerShowingChats
+            )
+        )
+    }
 }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1103,6 +1103,15 @@ final class WorkspaceState {
     var chatActionAlert: ChatActionAlert?
     var mutatingChatPreferenceIds: Set<String> = []
     var isChatListVisible = true
+    /// The user's chosen drawer width, always one of the widths `ChatListWidthPolicy`
+    /// allows. Read `chatListDrawerWidth` for what to actually render — a pane with no
+    /// avatar-only form is floored to the narrowest full width without overwriting the
+    /// preference stored here.
+    var chatListWidth: CGFloat {
+        didSet {
+            UserDefaults.standard.set(Double(chatListWidth), forKey: Self.chatListWidthKey)
+        }
+    }
     var draftText: String {
         get {
             guard let selectedComposerDraftKey else { return "" }
@@ -1747,6 +1756,7 @@ final class WorkspaceState {
     static let appearancePreferenceKey = "whitenoise.mac.appearancePreference"
     static let notificationPreviewModeKey = "whitenoise.mac.notificationPreviewMode"
     static let loadRemoteImagesKey = "whitenoise.mac.loadRemoteImages"
+    static let chatListWidthKey = "whitenoise.mac.chatListWidth"
     static let deliveredNotificationKeyLimit = 256
     static let timelinePageLimit: UInt32 = 100
     /// Upper bound on the materialized live window, matching the runtime's
@@ -2051,6 +2061,9 @@ final class WorkspaceState {
         // Defaults to false: bool(forKey:) returns false when the key is absent, which is the
         // privacy-preserving default (remote peer images are not fetched until the user opts in).
         self.loadRemoteImages = UserDefaults.standard.bool(forKey: Self.loadRemoteImagesKey)
+        self.chatListWidth = ChatListWidthPolicy.restored(
+            storedWidth: UserDefaults.standard.object(forKey: Self.chatListWidthKey) as? Double
+        )
         let storedAppearance = UserDefaults.standard.string(forKey: Self.appearancePreferenceKey)
         self.appearancePreference = storedAppearance.flatMap(AppearancePreference.init(rawValue:)) ?? .system
         let storedPreviewMode = UserDefaults.standard.string(forKey: Self.notificationPreviewModeKey)

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -41225,6 +41225,66 @@
         }
       }
     },
+    "Resize chat list": {
+      "comment": "Accessibility label for the draggable divider that sets the chat list's width.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Breite der Chatliste ändern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redimensionar la lista de chats"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redimensionner la liste des discussions"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ridimensiona l'elenco chat"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redimensionar a lista de bate-papos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить ширину списка чатов"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sohbet listesini yeniden boyutlandır"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "调整聊天列表宽度"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "調整聊天列表寬度"
+          }
+        }
+      }
+    },
     "Resolving...": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Views/ChatListResizeHandle.swift
+++ b/whitenoise-mac/Views/ChatListResizeHandle.swift
@@ -1,0 +1,135 @@
+//
+//  ChatListResizeHandle.swift
+//  whitenoise-mac
+//
+//  The divider between the chat-list drawer and the detail pane, made draggable.
+//
+
+import AppKit
+import SwiftUI
+
+/// `GlassSeparator` plus a grab area: hovering it shows a resize cursor and a grabber at the
+/// pointer, and pressing and dragging resizes the drawer through `ChatListWidthPolicy`.
+///
+/// The separator keeps its 1pt width in layout; everything interactive is an *overlay*, which
+/// is not clipped to the parent's bounds. Widening the strip therefore reaches a few points
+/// into the drawer and the detail pane — into the chat rows' outer padding, never their
+/// content — instead of opening a gutter between the two panes that would show the window
+/// background through the seam.
+struct ChatListResizeHandle: View {
+    @Environment(WorkspaceState.self) private var workspace
+    @State private var isPointerInside = false
+    /// Vertical position of the grabber within the strip, quantized to 4pt so sweeping the
+    /// pointer along a tall divider writes state a handful of times instead of once per pixel.
+    /// Kept through a drag that leaves the strip, so the grabber does not blink out mid-resize.
+    @State private var grabberY: CGFloat?
+    /// Drawer width when the current press began. Every frame of the drag is measured against
+    /// this rather than against the live width, so the resolved snap cannot feed back into the
+    /// next frame's translation.
+    @State private var widthAtPressStart: CGFloat?
+    /// Mirrors whether this view currently owns a pushed `NSCursor`, so the push/pop pairing
+    /// survives the pointer leaving the strip mid-drag (when the cursor must stay) and the
+    /// drawer being hidden while hovered (when it must not leak).
+    @State private var hasPushedCursor = false
+
+    private var isEngaged: Bool { isPointerInside || widthAtPressStart != nil }
+
+    var body: some View {
+        GlassSeparator()
+            .overlay {
+                if isEngaged {
+                    Rectangle()
+                        .fill(WNColor.borderPrimary)
+                }
+            }
+            .overlay {
+                Color.clear
+                    .frame(width: MessagesLayout.chatListResizeGrabWidth)
+                    .contentShape(.rect)
+                    .overlay(alignment: .top) {
+                        if isEngaged, let grabberY {
+                            ChatListResizeGrabber()
+                                .offset(y: grabberY - MessagesLayout.chatListResizeGrabberHeight / 2)
+                        }
+                    }
+                    .onContinuousHover(coordinateSpace: .local) { phase in
+                        switch phase {
+                        case .active(let location):
+                            isPointerInside = true
+                            let quantized = (location.y / 4).rounded() * 4
+                            if grabberY != quantized { grabberY = quantized }
+                        case .ended:
+                            isPointerInside = false
+                            if widthAtPressStart == nil { grabberY = nil }
+                        }
+                        syncCursor()
+                    }
+                    // `.global`: the handle moves as the drawer resizes, so a local
+                    // translation would be measured against a start point that has itself
+                    // slid out from under the pointer.
+                    .gesture(
+                        DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                            .onChanged { value in
+                                let start = widthAtPressStart ?? workspace.chatListDrawerWidth
+                                if widthAtPressStart == nil {
+                                    widthAtPressStart = start
+                                    syncCursor()
+                                }
+                                workspace.resizeChatListDrawer(
+                                    toProposedWidth: start + value.translation.width
+                                )
+                            }
+                            .onEnded { _ in
+                                widthAtPressStart = nil
+                                if !isPointerInside { grabberY = nil }
+                                syncCursor()
+                            }
+                    )
+                    .accessibilityElement()
+                    .accessibilityIdentifier("chat.list.resize.handle")
+                    .accessibilityLabel(L10n.string("Resize chat list"))
+                    .accessibilityAdjustableAction { direction in
+                        switch direction {
+                        case .increment:
+                            workspace.stepChatListDrawerWidth(.wider)
+                        case .decrement:
+                            workspace.stepChatListDrawerWidth(.narrower)
+                        @unknown default:
+                            break
+                        }
+                    }
+                    .onDisappear {
+                        isPointerInside = false
+                        widthAtPressStart = nil
+                        grabberY = nil
+                        syncCursor()
+                    }
+            }
+    }
+
+    private func syncCursor() {
+        let shouldShowResizeCursor = isEngaged
+        if shouldShowResizeCursor, !hasPushedCursor {
+            NSCursor.resizeLeftRight.push()
+            hasPushedCursor = true
+        } else if !shouldShowResizeCursor, hasPushedCursor {
+            NSCursor.pop()
+            hasPushedCursor = false
+        }
+    }
+}
+
+/// The pill that appears under the pointer on the divider — the visible answer to "is this
+/// draggable?", since a 1pt hairline gives no other affordance.
+private struct ChatListResizeGrabber: View {
+    var body: some View {
+        Capsule(style: .continuous)
+            .fill(WNColor.fillSecondary)
+            .overlay {
+                Capsule(style: .continuous)
+                    .strokeBorder(WNColor.borderPrimary, lineWidth: 1)
+            }
+            .frame(width: 5, height: MessagesLayout.chatListResizeGrabberHeight)
+            .allowsHitTesting(false)
+    }
+}

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -360,6 +360,12 @@ enum MessagesLayout {
     static let accountRailAvatarSize: CGFloat = 46
     static let accountRailAvatarFrameSize: CGFloat = 58
     static let sidebarTitlebarTopPadding: CGFloat = 42
+    static let chatRowAvatarSize: CGFloat = 46
+    /// Grab width of the drawer's resize handle. The divider itself stays 1pt in layout —
+    /// the grab area is an overlay, so widening it never opens a gutter between the drawer
+    /// and the detail pane; it only reaches a few points into each.
+    static let chatListResizeGrabWidth: CGFloat = 11
+    static let chatListResizeGrabberHeight: CGFloat = 34
 }
 
 /// Semantic type ramp for the messenger chrome, naming the roles the shell uses so a view

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -23,11 +23,22 @@ struct MessengerShellView: View {
                     Group {
                         if workspace.isChatListVisible {
                             ChatListDrawerView()
-                                .frame(width: 300, alignment: .leading)
+                                // Deliberately un-animated: the width is dragged, so animating
+                                // it would re-wrap the non-lazy transcript on every frame of the
+                                // drag *and* again through the collapse snap — the same layout
+                                // storm the `isChatListVisible` transition below is scoped away
+                                // from. The snap is a single jump instead.
+                                .frame(width: workspace.chatListDrawerWidth, alignment: .leading)
                                 .transition(.move(edge: .leading).combined(with: .opacity))
 
-                            GlassSeparator()
+                            ChatListResizeHandle()
                                 .transition(.opacity)
+                                // The handle's grab area is an overlay reaching a few points
+                                // into both neighbours, and later siblings in an `HStack` are
+                                // hit-tested first — without this the detail pane would swallow
+                                // the right half of the strip and the divider would only be
+                                // grabbable from the drawer side.
+                                .zIndex(1)
                         }
                     }
                     // Scope the sidebar transition to the drawer. The detail pane

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -188,63 +188,13 @@ struct ChatListDrawerView: View {
                 let filter = workspace.chatListFilter
                 let isShowingArchived = filter == .archived
                 let visibleChats = visibleChats(for: filter)
+                let isCollapsed = workspace.isChatListCollapsed
 
-                VStack(spacing: 10) {
-                    HStack(spacing: 8) {
-                        Text(filter.title)
-                            .wnFont(MessagesType.paneTitle)
-                        Spacer()
-                        Button {
-                            workspace.presentGlobalMessageSearch()
-                        } label: {
-                            Image(systemName: "text.magnifyingglass")
-                                .wnFont(.semiBold14)
-                                .frame(width: 34, height: 34)
-                                .background {
-                                    MessagesCircleControlBackground()
-                                }
-                        }
-                        .buttonStyle(.plain)
-                        .help(L10n.string("Search all messages"))
-                        if !isShowingArchived {
-                            Button {
-                                workspace.showNewChat()
-                            } label: {
-                                Image(systemName: "square.and.pencil")
-                                    .wnFont(.semiBold14)
-                                    .frame(width: 34, height: 34)
-                                    .background {
-                                        MessagesCircleControlBackground()
-                                    }
-                            }
-                            .buttonStyle(.plain)
-                            .keyboardShortcut("n", modifiers: .command)
-                            .help(L10n.string("New chat"))
-                        }
-                    }
-
-                    HStack(spacing: 8) {
-                        MessagesSearchField(
-                            text: $workspace.searchText,
-                            accessibilityIdentifier: "chat.search",
-                            placeholder: L10n.string("Search all messages")
-                        )
-                        .frame(maxWidth: .infinity)
-                        .onChange(of: workspace.searchText) { _, _ in
-                            workspace.scheduleSidebarMessageSearch()
-                        }
-
-                        if workspace.isSearchingSidebarMessages {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
-
-                        ChatListFilterMenu()
-                    }
+                if isCollapsed {
+                    CollapsedChatListHeader(isShowingArchived: isShowingArchived)
+                } else {
+                    ChatListHeader(filter: filter, isShowingArchived: isShowingArchived)
                 }
-                .padding(.horizontal, 12)
-                .padding(.top, MessagesLayout.sidebarTitlebarTopPadding)
-                .padding(.bottom, 12)
 
                 GlassSeparator(axis: .horizontal)
 
@@ -254,6 +204,7 @@ struct ChatListDrawerView: View {
                             ChatSidebarRow(
                                 chat: chat,
                                 isArchived: isShowingArchived,
+                                isCollapsed: isCollapsed,
                                 searchResult: workspace.sidebarMessageSearchResult(for: chat)
                             )
                         }
@@ -263,7 +214,10 @@ struct ChatListDrawerView: View {
                 }
                 .accessibilityIdentifier(isShowingArchived ? "chat.archived.list" : "chat.list")
                 .overlay {
-                    if visibleChats.isEmpty {
+                    // `ContentUnavailableView` needs room for an icon over two lines of prose;
+                    // in the collapsed rail it would render as a column of hyphenated fragments.
+                    // An empty rail is legible on its own, and widening it brings the wording back.
+                    if visibleChats.isEmpty, !isCollapsed {
                         if workspace.isSearchingSidebarMessages {
                             ProgressView()
                                 .controlSize(.small)
@@ -305,6 +259,121 @@ extension ChatListDrawerView {
             chats = workspace.archivedChats
         }
         return workspace.sidebarSearchFilteredChats(chats)
+    }
+}
+
+private struct ChatListHeader: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let filter: ChatListFilter
+    let isShowingArchived: Bool
+
+    var body: some View {
+        @Bindable var workspace = workspace
+
+        VStack(spacing: 10) {
+            HStack(spacing: 8) {
+                Text(filter.title)
+                    .wnFont(MessagesType.paneTitle)
+                Spacer()
+                Button {
+                    workspace.presentGlobalMessageSearch()
+                } label: {
+                    Image(systemName: "text.magnifyingglass")
+                        .wnFont(.semiBold14)
+                        .frame(width: 34, height: 34)
+                        .background {
+                            MessagesCircleControlBackground()
+                        }
+                }
+                .buttonStyle(.plain)
+                .help(L10n.string("Search all messages"))
+                if !isShowingArchived {
+                    Button {
+                        workspace.showNewChat()
+                    } label: {
+                        Image(systemName: "square.and.pencil")
+                            .wnFont(.semiBold14)
+                            .frame(width: 34, height: 34)
+                            .background {
+                                MessagesCircleControlBackground()
+                            }
+                    }
+                    .buttonStyle(.plain)
+                    .keyboardShortcut("n", modifiers: .command)
+                    .help(L10n.string("New chat"))
+                }
+            }
+
+            HStack(spacing: 8) {
+                MessagesSearchField(
+                    text: $workspace.searchText,
+                    accessibilityIdentifier: "chat.search",
+                    placeholder: L10n.string("Search all messages")
+                )
+                .frame(maxWidth: .infinity)
+                .onChange(of: workspace.searchText) { _, _ in
+                    workspace.scheduleSidebarMessageSearch()
+                }
+
+                if workspace.isSearchingSidebarMessages {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                ChatListFilterMenu()
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, MessagesLayout.sidebarTitlebarTopPadding)
+        .padding(.bottom, 12)
+    }
+}
+
+/// Header for the avatar-only rail: the pane title and the row-filtering search field have no
+/// room, so what is left is the three controls that still make sense at 84pt, stacked. Global
+/// search stays reachable (it opens its own sheet), which is why dropping the inline field is
+/// survivable — and `resizeChatListDrawer` clears any query on the way in, so the rail can
+/// never show a silently filtered list.
+private struct CollapsedChatListHeader: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let isShowingArchived: Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Button {
+                workspace.presentGlobalMessageSearch()
+            } label: {
+                Image(systemName: "text.magnifyingglass")
+                    .wnFont(.semiBold14)
+                    .frame(width: 34, height: 34)
+                    .background {
+                        MessagesCircleControlBackground()
+                    }
+            }
+            .buttonStyle(.plain)
+            .help(L10n.string("Search all messages"))
+
+            if !isShowingArchived {
+                Button {
+                    workspace.showNewChat()
+                } label: {
+                    Image(systemName: "square.and.pencil")
+                        .wnFont(.semiBold14)
+                        .frame(width: 34, height: 34)
+                        .background {
+                            MessagesCircleControlBackground()
+                        }
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut("n", modifiers: .command)
+                .help(L10n.string("New chat"))
+            }
+
+            ChatListFilterMenu()
+        }
+        .padding(.horizontal, 8)
+        .padding(.top, MessagesLayout.sidebarTitlebarTopPadding)
+        .padding(.bottom, 12)
     }
 }
 
@@ -391,18 +460,26 @@ private struct ChatSidebarRow: View {
     @Environment(WorkspaceState.self) private var workspace
     let chat: ChatItem
     let isArchived: Bool
+    let isCollapsed: Bool
     let searchResult: GlobalMessageSearchResult?
 
     var body: some View {
         Button {
             workspace.selectChat(chat)
         } label: {
-            ChatRowContent(
-                chat: chat,
-                isSelected: workspace.selection == .chat(chat.id),
-                isPinned: !isArchived && workspace.isChatPinned(chat),
-                searchResult: searchResult
-            )
+            if isCollapsed {
+                CollapsedChatRowContent(
+                    chat: chat,
+                    isSelected: workspace.selection == .chat(chat.id)
+                )
+            } else {
+                ChatRowContent(
+                    chat: chat,
+                    isSelected: workspace.selection == .chat(chat.id),
+                    isPinned: !isArchived && workspace.isChatPinned(chat),
+                    searchResult: searchResult
+                )
+            }
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(isArchived ? "chat.archived.row.\(chat.id)" : "chat.row.\(chat.id)")
@@ -643,7 +720,7 @@ struct ChatRowContent: View {
                 initials: chat.title,
                 sanitizedPictureURL: chat.sanitizedPictureURL,
                 localImagePayload: chat.groupImagePayload,
-                size: 46,
+                size: MessagesLayout.chatRowAvatarSize,
                 isSelected: false
             )
 
@@ -757,6 +834,82 @@ struct ChatRowContent: View {
             + Text(searchResult.snippet.match).wnFont(.bold12)
             .foregroundColor(WNColor.intentionInfoContent)
             + Text(searchResult.snippet.trailing)
+    }
+}
+
+/// The chat row at the drawer's narrowest width: the avatar, and the one badge that says
+/// something is waiting on the reader.
+///
+/// This exists so the drawer never has to render a *truncated* row. Title, timestamp and
+/// preview are dropped wholesale rather than clipped — a group name cut mid-word tells the
+/// reader less than the avatar already does, and `ChatListWidthPolicy` snaps past the widths
+/// where that would be the only option.
+///
+/// Everything the row stops showing in words it still says on hover: the title, and "Muted"
+/// when the chat is, in the same `title — state` form the account rail uses.
+struct CollapsedChatRowContent: View {
+    let chat: ChatItem
+    let isSelected: Bool
+
+    private var rowStatus: ChatRowStatus? { ChatRowStatus.status(for: chat) }
+
+    private var hoverDescription: String {
+        chat.muted ? "\(chat.title) — \(L10n.string("Muted"))" : chat.title
+    }
+
+    var body: some View {
+        ProfileImageAvatarView(
+            seed: chat.avatarSeed,
+            initials: chat.title,
+            sanitizedPictureURL: chat.sanitizedPictureURL,
+            localImagePayload: chat.groupImagePayload,
+            size: MessagesLayout.chatRowAvatarSize,
+            isSelected: false
+        )
+        .overlay(alignment: .topTrailing) {
+            // Nudged onto the avatar's corner rather than centred over its face, the way the
+            // account rail places its own badge. The row's padding leaves room for it, so
+            // nothing is clipped.
+            badge
+                .offset(x: 3, y: -3)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity)
+        .background {
+            MessagesSidebarRowBackground(isSelected: isSelected)
+        }
+        .contentShape(.rect)
+        .help(hoverDescription)
+        .accessibilityLabel(hoverDescription)
+    }
+
+    /// One badge, in the rail's single badge slot, so it has to be the most urgent claim on the
+    /// reader rather than all of them: an unanswered invite, then a mention (which the bare count
+    /// beside it would not distinguish from ordinary traffic), then the count, then the
+    /// manually-marked-unread dot. The expanded row, which has the width for it, still shows the
+    /// mention pill and the count together.
+    @ViewBuilder
+    private var badge: some View {
+        if rowStatus == .pendingInvite {
+            PendingInviteBadge()
+        } else if chat.hasUnread {
+            if chat.hasMention {
+                Image(systemName: "at")
+                    .wnFont(.bold10)
+                    .foregroundStyle(WNColor.fillContentInfo)
+                    .frame(width: 18, height: 18)
+                    .background(Circle().fill(WNColor.fillInfo))
+                    .accessibilityLabel(L10n.string("You were mentioned"))
+            } else if chat.unreadCount > 0 {
+                UnreadCountBadge(count: chat.unreadCount, textStyle: MessagesType.badge)
+            } else {
+                Circle()
+                    .fill(WNColor.fillInfo)
+                    .frame(width: 9, height: 9)
+                    .accessibilityLabel(L10n.string("Marked unread"))
+            }
+        }
     }
 }
 

--- a/whitenoise-macTests/ChatListWidthTests.swift
+++ b/whitenoise-macTests/ChatListWidthTests.swift
@@ -1,0 +1,235 @@
+//
+//  ChatListWidthTests.swift
+//  whitenoise-macTests
+//
+//  Guards on the resizable chat-list drawer.
+//
+//  The mistake these exist to catch is the drawer coming to rest at a width nothing
+//  renders correctly at: wide enough for the title column but too narrow for a name,
+//  or "collapsed" because an absent preference read as zero.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import whitenoise_mac
+
+@Suite(.serialized)
+struct ChatListWidthTests {
+    @Test func resolveClampsToTheAllowedFullRange() {
+        #expect(ChatListWidthPolicy.resolve(proposedWidth: 1_000) == ChatListWidthPolicy.maximumWidth)
+        #expect(ChatListWidthPolicy.resolve(proposedWidth: 260) == 260)
+        #expect(
+            ChatListWidthPolicy.resolve(proposedWidth: ChatListWidthPolicy.minimumExpandedWidth - 1)
+                == ChatListWidthPolicy.minimumExpandedWidth
+        )
+    }
+
+    @Test func resolveSnapsPastTheThresholdInsteadOfNarrowingFurther() {
+        #expect(
+            ChatListWidthPolicy.resolve(proposedWidth: ChatListWidthPolicy.collapseThreshold - 1)
+                == ChatListWidthPolicy.collapsedWidth
+        )
+        #expect(ChatListWidthPolicy.resolve(proposedWidth: 0) == ChatListWidthPolicy.collapsedWidth)
+        #expect(ChatListWidthPolicy.resolve(proposedWidth: -400) == ChatListWidthPolicy.collapsedWidth)
+        // At and above the threshold the drawer stays a full row, at its narrowest.
+        #expect(
+            ChatListWidthPolicy.resolve(proposedWidth: ChatListWidthPolicy.collapseThreshold)
+                == ChatListWidthPolicy.minimumExpandedWidth
+        )
+    }
+
+    /// The whole point of the snap: there is no resting width between the avatar rail and the
+    /// narrowest full row, because those are exactly the widths that truncate a group name.
+    @Test func noProposedWidthResolvesBetweenTheTwoRegimes() {
+        for proposed in stride(from: CGFloat(-200), through: 600, by: 1) {
+            let resolved = ChatListWidthPolicy.resolve(proposedWidth: proposed)
+            #expect(
+                resolved == ChatListWidthPolicy.collapsedWidth
+                    || (resolved >= ChatListWidthPolicy.minimumExpandedWidth
+                        && resolved <= ChatListWidthPolicy.maximumWidth),
+                "\(proposed) resolved to an unrenderable \(resolved)"
+            )
+        }
+    }
+
+    @Test func resolveRefusesToCollapseAPaneWithNoRailForm() {
+        #expect(
+            ChatListWidthPolicy.resolve(proposedWidth: 40, allowsCollapse: false)
+                == ChatListWidthPolicy.minimumExpandedWidth
+        )
+        #expect(
+            ChatListWidthPolicy.resolve(proposedWidth: 280, allowsCollapse: false) == 280
+        )
+    }
+
+    @Test func resolveFallsBackToTheDefaultForANonFiniteWidth() {
+        #expect(ChatListWidthPolicy.resolve(proposedWidth: .nan) == ChatListWidthPolicy.defaultWidth)
+        #expect(ChatListWidthPolicy.resolve(proposedWidth: .infinity) == ChatListWidthPolicy.defaultWidth)
+    }
+
+    /// An absent preference means "never resized", not zero. Routing the missing key through
+    /// `resolve` would read a first launch as a collapsed drawer.
+    @Test func restoringAnAbsentPreferenceGivesTheDefaultWidthNotACollapsedDrawer() {
+        #expect(ChatListWidthPolicy.restored(storedWidth: nil) == ChatListWidthPolicy.defaultWidth)
+        #expect(ChatListWidthPolicy.defaultWidth == ChatListWidthPolicy.maximumWidth)
+        #expect(!ChatListWidthPolicy.isCollapsed(width: ChatListWidthPolicy.restored(storedWidth: nil)))
+        let insideRange = ChatListWidthPolicy.minimumExpandedWidth + 20
+        #expect(ChatListWidthPolicy.restored(storedWidth: Double(insideRange)) == insideRange)
+        // A width persisted by an older/newer build outside the range is pulled back in.
+        #expect(ChatListWidthPolicy.restored(storedWidth: 900) == ChatListWidthPolicy.maximumWidth)
+        #expect(ChatListWidthPolicy.restored(storedWidth: 12) == ChatListWidthPolicy.collapsedWidth)
+    }
+
+    @Test func isCollapsedSplitsExactlyAtTheNarrowestFullRow() {
+        #expect(ChatListWidthPolicy.isCollapsed(width: ChatListWidthPolicy.collapsedWidth))
+        #expect(ChatListWidthPolicy.isCollapsed(width: ChatListWidthPolicy.minimumExpandedWidth - 0.5))
+        #expect(!ChatListWidthPolicy.isCollapsed(width: ChatListWidthPolicy.minimumExpandedWidth))
+        #expect(!ChatListWidthPolicy.isCollapsed(width: ChatListWidthPolicy.maximumWidth))
+    }
+
+    /// Without the explicit hop at the boundary, `minimumExpandedWidth - stepIncrement` clamps
+    /// straight back to `minimumExpandedWidth` and the rail is unreachable without a pointer.
+    @Test func steppingReachesBothRegimesFromTheKeyboard() {
+        #expect(
+            ChatListWidthPolicy.stepped(from: ChatListWidthPolicy.minimumExpandedWidth, toward: .narrower)
+                == ChatListWidthPolicy.collapsedWidth
+        )
+        #expect(
+            ChatListWidthPolicy.stepped(from: ChatListWidthPolicy.collapsedWidth, toward: .wider)
+                == ChatListWidthPolicy.minimumExpandedWidth
+        )
+        #expect(
+            ChatListWidthPolicy.stepped(from: ChatListWidthPolicy.collapsedWidth, toward: .narrower)
+                == ChatListWidthPolicy.collapsedWidth
+        )
+        #expect(
+            ChatListWidthPolicy.stepped(from: ChatListWidthPolicy.maximumWidth, toward: .wider)
+                == ChatListWidthPolicy.maximumWidth
+        )
+        // The middle of the full range, so a step in either direction lands mid-range rather
+        // than on a clamp regardless of where the two ends sit.
+        let midRange = (ChatListWidthPolicy.minimumExpandedWidth + ChatListWidthPolicy.maximumWidth) / 2
+        #expect(
+            ChatListWidthPolicy.stepped(from: midRange, toward: .narrower)
+                == midRange - ChatListWidthPolicy.stepIncrement
+        )
+        #expect(
+            ChatListWidthPolicy.stepped(from: midRange, toward: .wider)
+                == midRange + ChatListWidthPolicy.stepIncrement
+        )
+        // A step never lands between the regimes either.
+        #expect(
+            ChatListWidthPolicy.stepped(
+                from: ChatListWidthPolicy.minimumExpandedWidth + 5,
+                toward: .narrower
+            ) == ChatListWidthPolicy.minimumExpandedWidth
+        )
+        #expect(
+            ChatListWidthPolicy.stepped(
+                from: ChatListWidthPolicy.minimumExpandedWidth,
+                toward: .narrower,
+                allowsCollapse: false
+            ) == ChatListWidthPolicy.minimumExpandedWidth
+        )
+    }
+
+    @MainActor
+    @Test func aDragCollapsesTheDrawerAndReleasesTheSidebarSearch() {
+        let restore = ChatListWidthTests.clearStoredWidth()
+        defer { restore() }
+        let state = WorkspaceState()
+
+        #expect(state.chatListDrawerWidth == ChatListWidthPolicy.defaultWidth)
+        #expect(!state.isChatListCollapsed)
+
+        state.searchText = "dinner"
+        state.resizeChatListDrawer(toProposedWidth: 90)
+
+        #expect(state.isChatListCollapsed)
+        #expect(state.chatListDrawerWidth == ChatListWidthPolicy.collapsedWidth)
+        // A query the rail can neither show nor clear would filter the list invisibly.
+        #expect(state.searchText.isEmpty)
+
+        state.searchText = "dinner"
+        state.resizeChatListDrawer(toProposedWidth: 250)
+
+        #expect(!state.isChatListCollapsed)
+        #expect(state.chatListDrawerWidth == 250)
+        // Widening is not a reason to throw the query away.
+        #expect(state.searchText == "dinner")
+    }
+
+    @MainActor
+    @Test func settingsFloorsTheRenderedWidthWithoutForgettingACollapsedChatList() {
+        let restore = ChatListWidthTests.clearStoredWidth()
+        defer { restore() }
+        let state = WorkspaceState()
+        state.resizeChatListDrawer(toProposedWidth: 90)
+        #expect(state.chatListWidth == ChatListWidthPolicy.collapsedWidth)
+
+        state.selection = .settings(.profile)
+
+        #expect(!state.isChatListDrawerShowingChats)
+        #expect(state.chatListDrawerWidth == ChatListWidthPolicy.minimumExpandedWidth)
+        #expect(!state.isChatListCollapsed)
+        // Merely visiting settings must not overwrite the preference.
+        #expect(state.chatListWidth == ChatListWidthPolicy.collapsedWidth)
+
+        state.selection = .chat("group")
+        #expect(state.isChatListCollapsed)
+    }
+
+    @MainActor
+    @Test func aPaneWithNoRailFormCannotBeDraggedShut() {
+        let restore = ChatListWidthTests.clearStoredWidth()
+        defer { restore() }
+        let state = WorkspaceState()
+        state.isNewChatComposerVisible = true
+
+        #expect(!state.isChatListDrawerShowingChats)
+        state.resizeChatListDrawer(toProposedWidth: 20)
+
+        #expect(state.chatListWidth == ChatListWidthPolicy.minimumExpandedWidth)
+        #expect(!state.isChatListCollapsed)
+    }
+
+    @MainActor
+    @Test func steppingTheDrawerPersistsTheResolvedWidth() {
+        let restore = ChatListWidthTests.clearStoredWidth()
+        defer { restore() }
+        let state = WorkspaceState()
+
+        state.stepChatListDrawerWidth(.narrower)
+        #expect(state.chatListWidth == ChatListWidthPolicy.maximumWidth - ChatListWidthPolicy.stepIncrement)
+        #expect(
+            UserDefaults.standard.object(forKey: WorkspaceState.chatListWidthKey) as? Double
+                == Double(state.chatListWidth)
+        )
+
+        while !state.isChatListCollapsed {
+            state.stepChatListDrawerWidth(.narrower)
+        }
+        #expect(state.chatListWidth == ChatListWidthPolicy.collapsedWidth)
+
+        state.stepChatListDrawerWidth(.wider)
+        #expect(state.chatListWidth == ChatListWidthPolicy.minimumExpandedWidth)
+    }
+
+    /// `WorkspaceState` reads and writes `UserDefaults.standard` for this preference, so a test
+    /// that constructs one has to start from a known state and put the user's own width back.
+    @MainActor
+    private static func clearStoredWidth() -> () -> Void {
+        let defaults = UserDefaults.standard
+        let previous = defaults.object(forKey: WorkspaceState.chatListWidthKey) as? Double
+        defaults.removeObject(forKey: WorkspaceState.chatListWidthKey)
+        return {
+            if let previous {
+                defaults.set(previous, forKey: WorkspaceState.chatListWidthKey)
+            } else {
+                defaults.removeObject(forKey: WorkspaceState.chatListWidthKey)
+            }
+        }
+    }
+}


### PR DESCRIPTION
I like signal sidebar feature to adjust the width of the chatlist sidebar. Now it looks like this:

|Collapsed| Smaller but not yet collapsed|
|----|----|
|<img width="188" height="456" alt="Screenshot 2026-08-10 at 2 37 56 PM" src="https://github.com/user-attachments/assets/72d5272a-5a10-4b08-be88-c342b0a05a0c" />|<img width="346" height="526" alt="Screenshot 2026-08-10 at 2 37 47 PM" src="https://github.com/user-attachments/assets/4c1dfb30-b8a7-435a-b13b-c71412b28809" />|



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a resizable chat-list drawer with drag, keyboard, and accessibility controls.
  * Added collapsed mode for a compact chat-list view with avatars and status indicators.
  * Chat-list width preferences are now saved and restored between sessions.
  * Settings and compose views maintain an appropriate minimum width.
  * Added localized accessibility labels for resizing in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->