### PR TITLE
Update mentions when nickname changes

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
@@ -145,7 +145,7 @@ extension WorkspaceState {
         relabelTimelineSenders(accountIdHex: contact, nickname: nickname)
         relabelComposeContacts(accountIdHex: contact, nickname: nickname)
         relabelContactDetailsTarget(accountIdHex: contact, nickname: nickname)
-        replayTimelineForMentionsOf(contactAccountIdHex: contact)
+        relabelTimelineMentions(ofContactAccountIdHex: contact)
 
         if nickname == nil {
             // Clearing a nickname hands the label back to whatever the peer published, so this
@@ -234,27 +234,44 @@ extension WorkspaceState {
     }
 
     /// A mention token is baked into the bubble's rendered Markdown when the window is projected,
-    /// so — unlike a sender label — it cannot be patched into rows already on screen: the source
-    /// AST the attributed string came from is not retained. Replay the open window instead, the
-    /// same in-memory snapshot replay a late-arriving profile uses.
+    /// so a rename has to reach rows already on screen. It is rewritten in place, exactly as a
+    /// sender label is: each mention run carries the `nostr:` link the projection gave it, so the
+    /// person a run names is recoverable from the rendered string without the source AST.
     ///
-    /// Gated on the contact being in this conversation's roster, so renaming someone the open
-    /// chat could not possibly mention costs one roster scan rather than a transcript re-map.
-    /// Other conversations need nothing here: their `mentionNamesCache` entry is stamped with the
-    /// nickname set, so whenever one is next projected it resolves against the new label. The
-    /// same is true of chat-list previews, which re-resolve on their next row update.
-    private func replayTimelineForMentionsOf(contactAccountIdHex contact: String) {
-        guard let client, let account = activeAccount,
-            let groupIdHex = activeTimelineGroupId,
-            selectedChat?.id == groupIdHex,
-            let members = groupMemberDetailsCache[groupIdHex],
-            members.contains(where: { ContactNicknames.normalizedHex($0.memberIdHex) == contact })
-        else { return }
-
-        // Not cancelling any in-flight replay: a second rename's replay reads the same post-write
-        // state, so the two can only agree, and cancelling one mid-snapshot would drop a repaint.
-        contactNicknameMentionReplayTask = Task { [weak self] in
-            await self?.replaySelectedTimelineWindow(account: account, client: client)
+    /// This deliberately does *not* replay the window. A replay depends on a live timeline
+    /// subscription that can hand back a snapshot — state that is routinely absent while the
+    /// transcript is still on screen (between a listener teardown and its next subscribe, during
+    /// a reconnect, or whenever the runtime has no materialized window to snapshot) — and in every
+    /// such case the rename silently did nothing until the conversation was re-selected. Rewriting
+    /// the runs depends on nothing but the rows themselves, is synchronous with the gesture, and
+    /// costs less than the re-map a replay performed: no snapshot, no FFI, no re-parse, and no
+    /// work at all for bubbles that never mention the renamed person.
+    ///
+    /// Every materialized window is relabeled, not just the selected chat's, for the reason
+    /// `relabelTimelineSenders` does the same: a background window would otherwise keep the stale
+    /// label until it is next projected. Chat-list previews re-resolve on their next row update,
+    /// and every other group's `mentionNamesCache` entry is stamped with the nickname set, so it
+    /// rebuilds against the new label whenever it is next read.
+    private func relabelTimelineMentions(ofContactAccountIdHex contact: String) {
+        var didChangeSelectedChat = false
+        for (groupIdHex, store) in messageTimelineStores {
+            // The label is resolved through the same projection this window was built from, over
+            // the same roster entry, so an in-place relabel and the next re-projection cannot
+            // disagree. Without a roster there is no npub to relabel by and no published name to
+            // fall back to, which is also the state in which the mention is already rendering as
+            // truncated bech32 — nothing to do until enrichment warms the roster again.
+            guard let members = groupMemberDetailsCache[groupIdHex],
+                let member = members.first(where: { ContactNicknames.normalizedHex($0.memberIdHex) == contact }),
+                !member.npub.isEmpty
+            else { continue }
+            let label = Self.mentionNames(from: [member], nicknames: activeContactNicknames)[member.npub]
+            guard store.relabelMention(bech32: member.npub, name: label) else { continue }
+            if case .chat(let selectedGroupIdHex) = selection, selectedGroupIdHex == groupIdHex {
+                didChangeSelectedChat = true
+            }
+        }
+        if didChangeSelectedChat {
+            selectedChatRevision &+= 1
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -538,6 +538,42 @@ final class MessageTimelineStore {
         return true
     }
 
+    /// Rewrites every mention of one person in this materialized window, the counterpart of
+    /// `relabelSender` for the labels baked into a bubble's body. Rows that do not mention them
+    /// are skipped without allocating, so the cost is proportional to the mentions actually on
+    /// screen rather than to the window size.
+    ///
+    /// Both the rendered rows and the pre-edit bases are relabeled: an edited row renders from its
+    /// base, and a base left with the stale label would resurface it on the next recompute.
+    ///
+    /// An edited row cannot be relabeled directly — it carries no Markdown (`applyingEdit` drops
+    /// it) and resolves its mentions into plain text from the base's `mentionNames` — so the rows
+    /// whose base changed are re-rendered through the ordinary edit-overlay path afterwards.
+    /// Without that, an edited bubble kept the old label until the next full recomputation.
+    @discardableResult
+    func relabelMention(bech32: String, name: String?) -> Bool {
+        var didChange = false
+        for index in messages.indices {
+            guard let relabeled = messages[index].applyingMentionLabel(bech32: bech32, name: name) else { continue }
+            messages[index] = relabeled
+            lookup[relabeled.id] = relabeled
+            didChange = true
+        }
+        var relabeledBaseIds: Set<String> = []
+        for (id, base) in baseMessagesById {
+            guard let relabeled = base.applyingMentionLabel(bech32: bech32, name: name) else { continue }
+            baseMessagesById[id] = relabeled
+            relabeledBaseIds.insert(id)
+            didChange = true
+        }
+        if recomputeRenderedMessages(withIds: relabeledBaseIds) {
+            didChange = true
+        }
+        guard didChange else { return false }
+        rebuildDisplayItems()
+        return true
+    }
+
     private func relabelReplyQuotes(ofSender accountIdHex: String) -> Bool {
         var didChange = false
         for index in messages.indices {
@@ -624,6 +660,27 @@ final class MessageTimelineStore {
             didChange = true
         }
         lastRenderEditCandidateVisitCount = candidateVisitCount
+        return didChange
+    }
+
+    /// Re-renders only the rows whose base was just mutated, through the same edit-overlay path
+    /// `recomputeAllRenderedMessages` uses, so a targeted base mutation can never leave a rendered
+    /// row derived from the old base. Visiting only the changed ids keeps the cost proportional to
+    /// the mutation instead of to the window, and rows that render identically are left untouched.
+    ///
+    /// `lastRenderEditCandidateVisitCount` is deliberately not written here: it reports the most
+    /// recent *full* render pass, and a partial count would misreport it.
+    private func recomputeRenderedMessages(withIds ids: Set<String>) -> Bool {
+        guard !ids.isEmpty else { return false }
+        var didChange = false
+        for id in ids {
+            guard let index = indexById[id], let base = baseMessagesById[id] else { continue }
+            let rendered = renderedMessage(from: base).message
+            guard messages[index] != rendered else { continue }
+            messages[index] = rendered
+            lookup[id] = rendered
+            didChange = true
+        }
         return didChange
     }
 
@@ -1007,10 +1064,6 @@ final class WorkspaceState {
     var contactNicknamesByOwner: [String: [String: String]] = [:]
     @ObservationIgnored var contactNicknameRevision: UInt64 = 0
     @ObservationIgnored var cachedContactNicknames: NicknameStamped<ContactNicknames>?
-    /// Replays the open transcript after a nickname write so mention tokens already baked into
-    /// rendered bubbles pick up the new label. Held only so tests can await it — a replay that
-    /// outlives its conversation re-checks the account and subscription before applying anything.
-    @ObservationIgnored var contactNicknameMentionReplayTask: Task<Void, Never>?
     @ObservationIgnored let chatRestorationStore: any ChatRestorationStoring
     /// Set only for the duration of an automatic selection made past a preserved memory. See
     /// `withRememberedChatPreserved(_:_:)`.

--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -42,6 +42,15 @@ nonisolated struct MarkdownDisplayDocument {
     /// children in one bubble.
     static let maxDisplayNodes = 256
 
+    /// Direct construction from an already-rendered block tree. Used only by the in-place mention
+    /// relabel (`MarkdownMentionRelabeling`), which rewrites runs of an existing document rather
+    /// than re-deriving one from the AST — there is no budget or depth to re-apply, both having
+    /// been enforced when this document was first built.
+    init(blocks: [MarkdownDisplayBlockNode], truncated: Bool) {
+        self.blocks = blocks
+        self.truncated = truncated
+    }
+
     init(
         document: MarkdownDocumentFfi,
         mentionNames: MarkdownMentionNames = [:]
@@ -503,18 +512,15 @@ nonisolated enum MarkdownDisplayInlineBuilder {
         intent: InlinePresentationIntent,
         mentionNames: MarkdownMentionNames
     ) -> AttributedString {
-        let shortReference = shortBech32(entity.bech32)
+        let shortReference = MarkdownMentionText.shortBech32(entity.bech32)
         let displayText: String
         let presentation: MarkdownDisplayLink.Presentation
         switch entity.hrp {
         case .npub, .nprofile:
             // A known group member renders as "@Display Name"; otherwise the truncated bech32
-            // keeps the reference legible and tappable.
-            if let name = PeerDisplayText.sanitize(mentionNames[entity.bech32]) {
-                displayText = "@\(name)"
-            } else {
-                displayText = "@\(shortReference)"
-            }
+            // keeps the reference legible and tappable. One shared rule with the in-place
+            // relabel, so a rename lands on exactly the text a re-projection would have produced.
+            displayText = MarkdownMentionText.label(forBech32: entity.bech32, name: mentionNames[entity.bech32])
             presentation = .mention
         case .note, .nevent, .naddr, .nrelay:
             displayText = shortReference
@@ -544,10 +550,5 @@ nonisolated enum MarkdownDisplayInlineBuilder {
             }
         }
         return attributed
-    }
-
-    private static func shortBech32(_ bech32: String) -> String {
-        guard bech32.count > 16 else { return bech32 }
-        return "\(bech32.prefix(10))...\(bech32.suffix(4))"
     }
 }

--- a/whitenoise-mac/Models/MarkdownMentionRelabeling.swift
+++ b/whitenoise-mac/Models/MarkdownMentionRelabeling.swift
@@ -1,0 +1,181 @@
+//
+//  MarkdownMentionRelabeling.swift
+//  whitenoise-mac
+//
+//  Rewrites the mention tokens inside an already-rendered Markdown display model when the label
+//  a mention resolves to changes — the viewer setting or clearing a private nickname.
+//
+//  A mention is baked into the bubble's attributed string once, off-main, when the window is
+//  projected (see `MarkdownDisplayModel`), and the source AST it came from is deliberately not
+//  retained. Relabelling in place is what lets a rename land on rows already on screen without
+//  re-materializing the window: no snapshot of the timeline subscription, no FFI, no re-parse,
+//  and no work at all for rows that do not mention the renamed person.
+//
+//  Every mention run carries the `nostr:<bech32>` link the projection gave it, so the person a
+//  run refers to is recoverable from the rendered string itself. The accent a mention is drawn
+//  in is derived from that same bech32 rather than from the label, so it survives a rename
+//  untouched — as does emphasis, and the link itself.
+//
+
+import Foundation
+
+/// The text a mention renders as. Shared by the projection (`MarkdownDisplayInlineBuilder`) and
+/// by the in-place relabel below, so a renamed mention can never drift from what the next
+/// re-projection of the same window would produce.
+nonisolated enum MarkdownMentionText {
+    /// `@Label` when a label is known, else the truncated bech32 that keeps an unresolvable
+    /// reference legible and tappable.
+    static func label(forBech32 bech32: String, name: String?) -> String {
+        guard let name = PeerDisplayText.sanitize(name) else { return "@\(shortBech32(bech32))" }
+        return "@\(PeerDisplayText.strippingBidiControls(name))"
+    }
+
+    static func shortBech32(_ bech32: String) -> String {
+        guard bech32.count > 16 else { return bech32 }
+        return "\(bech32.prefix(10))...\(bech32.suffix(4))"
+    }
+}
+
+// `nonisolated` for the same reason the display model itself is: these are pure value
+// transformations, reachable from `MessageItem`'s nonisolated mapping, and must not inherit the
+// module's default main-actor isolation (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`).
+nonisolated extension MarkdownDisplayDocument {
+    /// A copy of this document with every mention of `bech32` reading as `name`'s label, or nil
+    /// when the document mentions nobody by that reference. Nil rather than an equal copy on
+    /// purpose: the caller uses it to leave untouched rows — the overwhelming majority on any
+    /// rename — completely alone instead of churning identical values through the timeline store.
+    func relabelingMention(bech32: String, name: String?) -> MarkdownDisplayDocument? {
+        guard let link = MarkdownLinkPolicy.nostrURL(for: bech32) else { return nil }
+        let label = MarkdownMentionText.label(forBech32: bech32, name: name)
+        var didChange = false
+        var relabeled: [MarkdownDisplayBlockNode] = []
+        relabeled.reserveCapacity(blocks.count)
+        for node in blocks {
+            relabeled.append(
+                MarkdownDisplayBlockNode(
+                    id: node.id,
+                    block: node.block.relabelingMention(link: link, label: label, didChange: &didChange)
+                )
+            )
+        }
+        guard didChange else { return nil }
+        return MarkdownDisplayDocument(blocks: relabeled, truncated: truncated)
+    }
+}
+
+nonisolated extension MarkdownDisplayBlock {
+    /// Recurses over the block tree the same way the builder does. Blocks that cannot contain an
+    /// inline run — rules, code, math — are returned as they are, so nesting costs nothing.
+    fileprivate func relabelingMention(
+        link: URL,
+        label: String,
+        didChange: inout Bool
+    ) -> MarkdownDisplayBlock {
+        switch self {
+        case .paragraph(let text):
+            return .paragraph(Self.relabeling(text, link: link, label: label, didChange: &didChange))
+
+        case .heading(let level, let text):
+            return .heading(
+                level: level,
+                text: Self.relabeling(text, link: link, label: label, didChange: &didChange)
+            )
+
+        case .blockQuote(let nodes):
+            return .blockQuote(Self.relabeling(nodes, link: link, label: label, didChange: &didChange))
+
+        case .list(let items):
+            var relabeled: [MarkdownDisplayListItem] = []
+            relabeled.reserveCapacity(items.count)
+            for item in items {
+                relabeled.append(
+                    MarkdownDisplayListItem(
+                        id: item.id,
+                        marker: item.marker,
+                        blocks: Self.relabeling(item.blocks, link: link, label: label, didChange: &didChange)
+                    )
+                )
+            }
+            return .list(items: relabeled)
+
+        case .table(let header, let rows):
+            var relabeledHeader: [MarkdownDisplayTableCell] = []
+            relabeledHeader.reserveCapacity(header.count)
+            for cell in header {
+                relabeledHeader.append(
+                    MarkdownDisplayTableCell(
+                        id: cell.id,
+                        text: Self.relabeling(cell.text, link: link, label: label, didChange: &didChange)
+                    )
+                )
+            }
+            var relabeledRows: [MarkdownDisplayTableRow] = []
+            relabeledRows.reserveCapacity(rows.count)
+            for row in rows {
+                var cells: [MarkdownDisplayTableCell] = []
+                cells.reserveCapacity(row.cells.count)
+                for cell in row.cells {
+                    cells.append(
+                        MarkdownDisplayTableCell(
+                            id: cell.id,
+                            text: Self.relabeling(cell.text, link: link, label: label, didChange: &didChange)
+                        )
+                    )
+                }
+                relabeledRows.append(MarkdownDisplayTableRow(id: row.id, cells: cells))
+            }
+            return .table(header: relabeledHeader, rows: relabeledRows)
+
+        case .thematicBreak, .codeBlock, .mathBlock:
+            return self
+        }
+    }
+
+    private static func relabeling(
+        _ nodes: [MarkdownDisplayBlockNode],
+        link: URL,
+        label: String,
+        didChange: inout Bool
+    ) -> [MarkdownDisplayBlockNode] {
+        var relabeled: [MarkdownDisplayBlockNode] = []
+        relabeled.reserveCapacity(nodes.count)
+        for node in nodes {
+            relabeled.append(
+                MarkdownDisplayBlockNode(
+                    id: node.id,
+                    block: node.block.relabelingMention(link: link, label: label, didChange: &didChange)
+                )
+            )
+        }
+        return relabeled
+    }
+
+    /// Rebuilds the string only when it actually carries a run for this person, and copies each
+    /// run's attributes onto the replacement so the mention keeps its accent, weight, and link.
+    private static func relabeling(
+        _ text: AttributedString,
+        link: URL,
+        label: String,
+        didChange: inout Bool
+    ) -> AttributedString {
+        guard
+            text.runs.contains(where: { run in
+                run.link == link && String(text[run.range].characters) != label
+            })
+        else { return text }
+
+        var result = AttributedString()
+        for run in text.runs {
+            let slice = text[run.range]
+            guard run.link == link, String(slice.characters) != label else {
+                result.append(AttributedString(slice))
+                continue
+            }
+            var replacement = AttributedString(label)
+            replacement.setAttributes(run.attributes)
+            result.append(replacement)
+            didChange = true
+        }
+        return result
+    }
+}

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2001,8 +2001,12 @@ nonisolated struct MessageItem: Identifiable, Hashable {
     /// Pre-rendered Markdown display model for the message body. The Marmot core supplies
     /// parsed tokens; `MessageItem` converts them once so SwiftUI body/layout passes do not
     /// rebuild attributed strings or enumerated block arrays while scrolling.
-    let contentMarkdown: MarkdownDisplayDocument?
-    let mentionNames: MarkdownMentionNames
+    /// `var` for the same reason `senderName` is: the label a mention resolves to can change under
+    /// a materialized row (the viewer sets or clears a private nickname), and rewriting the runs
+    /// that name that person is far cheaper than re-projecting the window — see
+    /// `applyingMentionLabel(bech32:name:)`.
+    var contentMarkdown: MarkdownDisplayDocument?
+    var mentionNames: MarkdownMentionNames
     let trimmedBody: String
     let sentAt: Date
     let timelineAt: UInt64
@@ -2035,6 +2039,23 @@ nonisolated struct MessageItem: Identifiable, Hashable {
             copy.publishedSenderName = nil
         }
         return copy == self ? nil : copy
+    }
+
+    /// Relabels this row's mentions of one person — `bech32` is the npub the mention travels as,
+    /// `name` the label it should now read as (nil restores the truncated-bech32 fallback).
+    ///
+    /// Returns nil when this row does not mention them, so a rename touches only the bubbles that
+    /// actually name the renamed person instead of re-rendering the window. The rewrite works off
+    /// the `nostr:` link the projection put on every mention run, so it also upgrades a mention
+    /// that was rendered before the roster was known and is still showing truncated bech32.
+    nonisolated func applyingMentionLabel(bech32: String, name: String?) -> MessageItem? {
+        guard let relabeled = contentMarkdown?.relabelingMention(bech32: bech32, name: name) else { return nil }
+        var copy = self
+        copy.contentMarkdown = relabeled
+        // Kept in step with the rendered runs: `mentionNames` is what equality compares, and it is
+        // what the next projection of this window will be built from.
+        copy.mentionNames[bech32] = name
+        return copy
     }
 
     /// Relabels the sender of the message this row quotes. A quote stores a resolved name rather

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1399,6 +1399,65 @@ struct PureValueTests {
             ]))
     }
 
+    /// An edited row carries no Markdown — `applyingEdit` drops it and resolves the mention into
+    /// plain text from the base's `mentionNames` — so relabeling only the base would leave the
+    /// bubble on the old label until the next full recomputation.
+    @MainActor
+    @Test func relabelingAMentionRerendersEditedRowsFromTheirBase() async throws {
+        let npub = "npub1alyce"
+        let store = MessageTimelineStore.loaded(with: [
+            MessageItem(
+                id: "target",
+                senderAccountIdHex: "alice",
+                senderName: "alice",
+                body: "ping @\(npub)",
+                contentMarkdown: MarkdownDocumentFfi(
+                    blocks: [
+                        .paragraph(inlines: [
+                            .text(content: "ping "),
+                            .nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: npub)),
+                        ])
+                    ],
+                    truncated: false
+                ),
+                mentionNames: [npub: "Alice"],
+                sentAt: Date(timeIntervalSince1970: 1_800_000_000),
+                timelineAt: 1_800_000_000,
+                isOutgoing: false
+            )
+        ])
+        // The edit republishes the same mention token, so the label the row shows comes purely
+        // from the map the base carries.
+        let applied = store.applyProjection(
+            upserts: [],
+            removals: [],
+            editMutations: [
+                editUpsert(
+                    makeEditOverlay(editId: "edit-1", plaintext: "ping @\(npub) again", timelineAt: 1_800_000_060)
+                )
+            ],
+            anchoredToNewest: true,
+            windowLimit: 10
+        )
+        #expect(applied.didChange)
+        #expect(store.lookup["target"]?.body == "ping @Alice again")
+        #expect(store.lookup["target"]?.isEdited == true)
+
+        #expect(store.relabelMention(bech32: npub, name: "Mum"))
+        #expect(store.lookup["target"]?.body == "ping @Mum again")
+        #expect(store.displayItems.first?.message.body == "ping @Mum again")
+        // Still an edit, still rendered from the same base.
+        #expect(store.lookup["target"]?.isEdited == true)
+
+        // Clearing drops the entry, so the edited row's plain text falls back to the raw token —
+        // exactly what `applyingEdit` produces from an empty map, which is the parity that matters.
+        #expect(store.relabelMention(bech32: npub, name: nil))
+        #expect(store.lookup["target"]?.body == "ping @\(npub) again")
+
+        // And re-applying the same label is reported as no change rather than churning the row.
+        #expect(!store.relabelMention(bech32: npub, name: nil))
+    }
+
     @MainActor
     @Test func messageTimelineStoreAppliesEditOverlaysToTargets() async throws {
         // Regression for whitenoise-mac#419: standalone edit overlays patch materialized targets,
@@ -3143,6 +3202,60 @@ struct PureValueTests {
         #expect(items.last?.blocks.isEmpty == false)
     }
 
+    /// The in-place mention relabel has to reach every inline run in the tree, not just the
+    /// top-level paragraph a one-line message renders as — a mention inside a quote, a list item,
+    /// or a table cell is the same person under the same label.
+    @Test func mentionRelabelRewritesEveryNestedRunAndLeavesOtherReferencesAlone() async throws {
+        let alice = "npub1alyce"
+        let note = "note1someeventreference0000"
+        let mention: MarkdownInlineFfi = .nostrMention(
+            entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: alice)
+        )
+        let paragraph: MarkdownBlockFfi = .paragraph(inlines: [.text(content: "hi "), mention])
+        let document = MarkdownDisplayDocument(
+            document: MarkdownDocumentFfi(
+                blocks: [
+                    paragraph,
+                    .heading(level: 2, inlines: [mention]),
+                    .blockQuote(blocks: [paragraph], blankLinesBefore: Data([0])),
+                    .listBlock(
+                        kind: .bullet(marker: "-"),
+                        tight: true,
+                        items: [MarkdownListItemFfi(blocks: [paragraph], checked: nil)]
+                    ),
+                    .table(
+                        alignments: [.left],
+                        header: [MarkdownTableCellFfi(inlines: [mention])],
+                        rows: [[MarkdownTableCellFfi(inlines: [mention])]]
+                    ),
+                    .paragraph(inlines: [
+                        .nostrMention(entity: MarkdownNostrEntityFfi(hrp: .note, bech32: note))
+                    ]),
+                ],
+                truncated: false
+            ),
+            mentionNames: [alice: "Alice"]
+        )
+        #expect(markdownDisplayText(document).contains("@Alice"))
+
+        let relabeled = try #require(document.relabelingMention(bech32: alice, name: "Mum"))
+        let text = markdownDisplayText(relabeled)
+        #expect(!text.contains("@Alice"))
+        // One run each in the paragraph, heading, quote, list item, table header, and table body.
+        #expect(text.components(separatedBy: "@Mum").count - 1 == 6)
+        // An unrelated reference keeps its own rendering, and the document's own flags survive.
+        #expect(text.contains(MarkdownMentionText.shortBech32(note)))
+        #expect(relabeled.truncated == document.truncated)
+        #expect(relabeled.blocks.map(\.id) == document.blocks.map(\.id))
+
+        // Clearing the label falls back to the truncated reference, and a document that never
+        // mentions this person is reported as unchanged rather than copied.
+        let cleared = try #require(relabeled.relabelingMention(bech32: alice, name: nil))
+        #expect(markdownDisplayText(cleared).contains("@\(MarkdownMentionText.shortBech32(alice))"))
+        #expect(cleared.relabelingMention(bech32: "npub1nobody", name: "Nobody") == nil)
+        #expect(relabeled.relabelingMention(bech32: alice, name: "Mum") == nil)
+    }
+
     @Test func normalMarkdownTableIsNotTruncatedByDisplayBudget() async throws {
         let document = wideMarkdownTable(columns: 4, rows: 3)
         let display = MarkdownDisplayDocument(document: document)
@@ -4482,6 +4595,37 @@ private func longMarkdownList(itemCount: Int) -> MarkdownDocumentFfi {
         ],
         truncated: false
     )
+}
+
+/// Every inline run in a rendered document, flattened, so a relabel can be asserted across nested
+/// block kinds without reaching into each case at the call site.
+private func markdownDisplayText(_ document: MarkdownDisplayDocument) -> String {
+    func text(of blocks: [MarkdownDisplayBlockNode]) -> String {
+        blocks.map { text(of: $0.block) }.joined(separator: "\n")
+    }
+
+    func text(of block: MarkdownDisplayBlock) -> String {
+        switch block {
+        case .paragraph(let value):
+            return String(value.characters)
+        case .heading(_, let value):
+            return String(value.characters)
+        case .blockQuote(let inner):
+            return text(of: inner)
+        case .list(let items):
+            return items.map { text(of: $0.blocks) }.joined(separator: "\n")
+        case .table(let header, let rows):
+            let headerText = header.map { String($0.text.characters) }
+            let rowText = rows.flatMap { $0.cells.map { String($0.text.characters) } }
+            return (headerText + rowText).joined(separator: "\n")
+        case .codeBlock(let value), .mathBlock(let value):
+            return value
+        case .thematicBreak:
+            return ""
+        }
+    }
+
+    return text(of: document.blocks)
 }
 
 private func markdownDisplayNodeCount(_ document: MarkdownDisplayDocument) -> Int {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -14190,10 +14190,9 @@ struct whitenoise_macTests {
     }
 
     /// A mention is baked into the bubble's attributed string when the window is projected, so
-    /// nicknaming someone the open conversation mentions cannot be patched in the way a sender
-    /// label can — it needs the window replayed. Every earlier message has to change, including
-    /// ones no live delta would ever revisit, and clearing the nickname has to give the published
-    /// name back.
+    /// nicknaming someone the open conversation mentions has to reach rows already on screen.
+    /// Every earlier message has to change, including ones no live delta would ever revisit, and
+    /// clearing the nickname has to give the published name back.
     @MainActor
     @Test func nicknamingAMentionedMemberRepaintsTheOpenTranscript() async throws {
         let account = AccountSummaryFfi(
@@ -14245,7 +14244,9 @@ struct whitenoise_macTests {
             },
             groupIdHex: "direct-group"
         )
-        let state = WorkspaceState(clientFactory: { runtime })
+        let nicknames = isolatedContactNicknameStore()
+        defer { try? FileManager.default.removeItem(at: nicknames.directoryURL) }
+        let state = WorkspaceState(contactNicknameStore: nicknames.store, clientFactory: { runtime })
 
         await state.bootstrap()
         await state.loadMessages(groupIdHex: "direct-group")
@@ -14260,16 +14261,178 @@ struct whitenoise_macTests {
         let projectedIds = (state.messagesByChat["direct-group"] ?? []).map(\.id)
 
         state.setContactNickname("Mum", forContactAccountIdHex: aliceId)
-        await state.contactNicknameMentionReplayTask?.value
 
         #expect(renderedMentions() == Array(repeating: "ping @Mum", count: 3))
-        // Replayed, not reloaded: the same rows in the same order.
+        // Relabeled, not reloaded: the same rows in the same order.
         #expect((state.messagesByChat["direct-group"] ?? []).map(\.id) == projectedIds)
 
         state.setContactNickname(nil, forContactAccountIdHex: aliceId)
-        await state.contactNicknameMentionReplayTask?.value
 
         #expect(renderedMentions() == Array(repeating: "ping @Alice Cooper", count: 3))
+    }
+
+    /// The regression behind "I renamed a member, came back to the chat, and the old mentions still
+    /// showed the old name; it only fixed itself after I navigated away and back".
+    ///
+    /// A rename must reach the mentions in a materialized window with no live timeline
+    /// subscription to snapshot — the state between a listener teardown and its next subscribe,
+    /// during a reconnect, or whenever the runtime has no window to hand back. The transcript is
+    /// still on screen throughout, and re-selecting the conversation (which re-projects from
+    /// scratch) is exactly the workaround this test forbids. It also has to be free of FFI: the
+    /// rows are rewritten in place, not re-fetched.
+    @MainActor
+    @Test func nicknamingAMentionedGroupMemberRelabelsWithoutReplayingTheWindow() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let mentionTokens = MarkdownDocumentFfi(
+            blocks: [
+                .paragraph(inlines: [
+                    .text(content: "ping "),
+                    .nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: "npub1alyce")),
+                ])
+            ],
+            truncated: false
+        )
+        let baseTime: UInt64 = 1_700_000_000
+        runtime.installMessages(
+            (0..<3).map { index in
+                appMessage(
+                    id: "message-\(index)",
+                    groupIdHex: "group",
+                    sender: bobId,
+                    plaintext: "ping @npub1alyce",
+                    contentTokens: mentionTokens,
+                    kind: 9,
+                    recordedAt: baseTime + UInt64(index)
+                )
+            },
+            groupIdHex: "group"
+        )
+        let nicknames = isolatedContactNicknameStore()
+        defer { try? FileManager.default.removeItem(at: nicknames.directoryURL) }
+        let state = WorkspaceState(contactNicknameStore: nicknames.store, clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "group")
+
+        func renderedMentions() -> [String] {
+            (state.messagesByChat["group"] ?? []).map { message in
+                message.contentMarkdown?.inlineParagraph.map { String($0.characters) } ?? ""
+            }
+        }
+
+        #expect(renderedMentions() == Array(repeating: "ping @Alice", count: 3))
+        let projectedIds = (state.messagesByChat["group"] ?? []).map(\.id)
+
+        // The transcript stays on screen, but there is no subscription left to snapshot.
+        state.stopTimelineListener()
+        #expect(state.activeTimelineSubscription == nil)
+        runtime.clearSyncCallThreadRecords()
+        runtime.clearTimelineMessageQueries()
+        let buildsBefore = state.messageTimelineStores["group"]?.displayItemsBuildCount ?? 0
+
+        state.setContactNickname("Mum", forContactAccountIdHex: aliceId)
+
+        // Landed on the gesture, with no window fetched and no re-anchoring of the window.
+        #expect(renderedMentions() == Array(repeating: "ping @Mum", count: 3))
+        #expect((state.messagesByChat["group"] ?? []).map(\.id) == projectedIds)
+        #expect(runtime.syncCallThreadRecord("timelineMessagesSubscription.snapshot").isEmpty)
+        #expect(runtime.timelineMessageQueries.isEmpty)
+        #expect(state.messageTimelineStores["group"]?.displayItemsBuildCount == buildsBefore + 1)
+
+        // The mention keeps everything the projection gave it besides the label: it is still a
+        // tappable `nostr:` reference to the same person, still emphasized, still accented.
+        let relabeled = try #require((state.messagesByChat["group"] ?? []).first?.contentMarkdown?.inlineParagraph)
+        let mentionRun = relabeled.runs.first { $0.link != nil }
+        #expect(mentionRun?.link == MarkdownLinkPolicy.nostrURL(for: "npub1alyce"))
+        #expect(mentionRun?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
+        #expect(mentionRun?.foregroundColor == MentionTextPalette.foreground(forNpub: "npub1alyce"))
+
+        // Renaming somebody this conversation neither mentions nor lists must not touch a row.
+        let buildsAfterRename = state.messageTimelineStores["group"]?.displayItemsBuildCount ?? 0
+        state.setContactNickname("Carol", forContactAccountIdHex: String(repeating: "c0", count: 32))
+        #expect(state.messageTimelineStores["group"]?.displayItemsBuildCount == buildsAfterRename)
+
+        // Renaming the *sender* relabels their name above the bubble (`relabelTimelineSenders`)
+        // and must leave the mention inside it alone.
+        state.setContactNickname("Bobby", forContactAccountIdHex: bobId)
+        #expect(renderedMentions() == Array(repeating: "ping @Mum", count: 3))
+        #expect((state.messagesByChat["group"] ?? []).allSatisfy { $0.senderName == "Bobby" })
+
+        // Clearing hands the label back to the name the member published.
+        state.setContactNickname(nil, forContactAccountIdHex: aliceId)
+        #expect(renderedMentions() == Array(repeating: "ping @Alice", count: 3))
+    }
+
+    /// The in-place relabel has to agree with what a full re-projection of the same window would
+    /// produce, or the label would flip back on the next delta. Renaming with no subscription and
+    /// then re-projecting the window must land on the same text.
+    @MainActor
+    @Test func mentionRelabelMatchesTheNextReprojectionOfTheWindow() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let bobId = "bob1234567890bob1234567890bob1234567890bob1234567890bob1"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let mentionTokens = MarkdownDocumentFfi(
+            blocks: [
+                .paragraph(inlines: [
+                    .text(content: "ping "),
+                    .nostrMention(entity: MarkdownNostrEntityFfi(hrp: .npub, bech32: "npub1alyce")),
+                ])
+            ],
+            truncated: false
+        )
+        runtime.installMessages(
+            [
+                appMessage(
+                    id: "message-0",
+                    groupIdHex: "group",
+                    sender: bobId,
+                    plaintext: "ping @npub1alyce",
+                    contentTokens: mentionTokens,
+                    kind: 9,
+                    recordedAt: 1_700_000_000
+                )
+            ],
+            groupIdHex: "group"
+        )
+        let nicknames = isolatedContactNicknameStore()
+        defer { try? FileManager.default.removeItem(at: nicknames.directoryURL) }
+        let state = WorkspaceState(contactNicknameStore: nicknames.store, clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.loadMessages(groupIdHex: "group")
+
+        func renderedMention() -> String? {
+            (state.messagesByChat["group"] ?? []).first?.contentMarkdown?.inlineParagraph
+                .map { String($0.characters) }
+        }
+
+        state.stopTimelineListener()
+        state.setContactNickname("Mum", forContactAccountIdHex: aliceId)
+        let afterRelabel = renderedMention()
+        #expect(afterRelabel == "ping @Mum")
+
+        await state.loadMessages(groupIdHex: "group")
+        #expect(renderedMention() == afterRelabel)
     }
 
     @MainActor
@@ -33277,6 +33440,22 @@ private func firstParagraph(in blocks: [MarkdownDisplayBlockNode]) -> Attributed
         }
     }
     return nil
+}
+
+/// A nickname store rooted in a directory of this test's own.
+///
+/// `bootstrap()` creates a real `ContactNicknameFileStore` under the Marmot storage root when none
+/// is injected, and the fake runtime's root is a fixed path shared by every test — so a test that
+/// writes a nickname and does not inject a store persists it for whatever runs next, which then
+/// reads it back through `loadContactNicknames()`. That is invisible until the suite happens to
+/// order a nickname-writing test ahead of one asserting a published name (it broke
+/// `steadyStatePeerProfileRefreshMakesNoRequestsAcrossWindowsAndDeltas`, which expected
+/// "Alice Cooper" and got "Mum"). Injecting a per-test directory makes the test hermetic in both
+/// directions rather than relying on it to clear up after itself.
+private func isolatedContactNicknameStore() -> (store: ContactNicknameFileStore, directoryURL: URL) {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("whitenoise-nicknames-\(UUID().uuidString)", isDirectory: true)
+    return (ContactNicknameFileStore(directoryURL: directory), directory)
 }
 
 private func restoreDefault(_ value: Any?, forKey key: String) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contact nickname changes now update existing message mentions immediately across materialized timeline content.
  * Mention labels remain consistent in nested formatting, including lists, quotes, headings, and tables.
  * Clearing a nickname restores the contact’s published name.

* **Bug Fixes**
  * Prevented unnecessary message-window reloads when contact nicknames change.
  * Preserved message identity, links, metadata, and formatting while updating mentions.
  * Improved consistency after timeline refreshes and when no active timeline is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->