### PR TITLE
Fix last message author in chatlist to show nicknames

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -54,7 +54,8 @@ extension ChatItem {
         directPeer: ChatPeerProfile? = nil,
         groupAvatarURL: String? = nil,
         groupImagePayload: DownloadedMediaPayload? = nil,
-        mentionNames: MarkdownMentionNames = [:]
+        mentionNames: MarkdownMentionNames = [:],
+        lastSenderNickname: String? = nil
     ) {
         let groupName = PeerDisplayText.sanitize(row.groupName) ?? ""
         let peerName = PeerDisplayText.sanitize(directPeer?.displayName)
@@ -76,7 +77,12 @@ extension ChatItem {
             )
         }
         let preview = row.lastMessage.map {
-            ChatItem.previewProjection(for: $0, activeAccountIdHex: activeAccountIdHex, mentionNames: mentionNames)
+            ChatItem.previewProjection(
+                for: $0,
+                activeAccountIdHex: activeAccountIdHex,
+                mentionNames: mentionNames,
+                senderNickname: lastSenderNickname
+            )
         }
         // MDK owns durable chat ordering. `updatedAt` includes maintenance-only
         // writes and must not make a conversation jump in the sidebar.
@@ -103,6 +109,7 @@ extension ChatItem {
             // the row says instead, since that answer is localized and invite-dependent.
             preview: preview?.text ?? "",
             previewAttachmentKind: preview?.attachmentKind,
+            previewAttribution: preview?.attribution,
             updatedAt: updatedAt,
             avatarSeed: directPeer?.accountIdHex ?? row.groupIdHex,
             pictureURL: directPeer?.pictureURL ?? groupAvatarURL,
@@ -148,12 +155,14 @@ extension ChatItem {
     private struct PreviewProjection {
         let text: String
         var attachmentKind: ChatPreviewAttachmentKind?
+        var attribution: ChatPreviewAttribution?
     }
 
     private static func previewProjection(
         for preview: ChatListMessagePreviewFfi,
         activeAccountIdHex: String?,
-        mentionNames: MarkdownMentionNames = [:]
+        mentionNames: MarkdownMentionNames = [:],
+        senderNickname: String? = nil
     ) -> PreviewProjection {
         if preview.deleted {
             return PreviewProjection(text: L10n.string("Message deleted"))
@@ -192,17 +201,35 @@ extension ChatItem {
                 ? ChatPreviewAttachmentKind(preview.attachmentKind)
                 : nil
         }
-        guard presentation.isChatBubble,
-            preview.sender != activeAccountIdHex,
-            let senderName = PeerDisplayText.sanitize(preview.senderDisplayName),
-            !senderName.isEmpty
-        else {
+        guard presentation.isChatBubble else {
             return PreviewProjection(text: body, attachmentKind: attachmentKind)
         }
 
+        // Your own last word is attributed to you, the way the other clients do it, so a row you
+        // spoke in last does not read as though the peer did. Localized as a whole template
+        // because the separator is not ": " in every language.
+        if let activeAccountIdHex, !activeAccountIdHex.isEmpty, preview.sender == activeAccountIdHex {
+            return PreviewProjection(
+                text: String(format: L10n.string("You: %@"), body),
+                attachmentKind: attachmentKind
+            )
+        }
+
+        // A private nickname outranks the published name here exactly as it does in the row title —
+        // the last sender is the same person under the same label.
+        let publishedSenderName = PeerDisplayText.sanitize(preview.senderDisplayName)
         return PreviewProjection(
-            text: "\(PeerDisplayText.templateFragment(senderName)): \(body)",
-            attachmentKind: attachmentKind
+            text: attributedPreviewText(body: body, senderName: senderNickname ?? publishedSenderName),
+            attachmentKind: attachmentKind,
+            // Only a sender the row can name is relabelable; an unidentified one still gets
+            // whatever name came with the preview, it just cannot be renamed in place.
+            attribution: preview.sender.nilIfBlank.map { sender in
+                ChatPreviewAttribution(
+                    senderAccountIdHex: sender,
+                    publishedSenderName: publishedSenderName,
+                    body: body
+                )
+            }
         )
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -526,8 +526,24 @@ extension WorkspaceState {
             // The no-enrich fast path (e.g. a live `newLastMessage`) can't fetch the roster, but a
             // recently viewed group usually has it cached — resolve preview mentions when so, which
             // covers the just-sent-message case; otherwise the reference keeps its bech32 form.
-            mentionNames: cachedMentionNames(groupIdHex: row.groupIdHex)
+            mentionNames: cachedMentionNames(groupIdHex: row.groupIdHex),
+            lastSenderNickname: lastMessageSenderNickname(in: row, account: account)
         )
+    }
+
+    /// The viewer's private label for whoever sent this row's last message, for the preview's
+    /// attribution prefix.
+    ///
+    /// This runs once per row on every chat-list snapshot and delta, so it stays two reads in the
+    /// common case: `contactNicknames(forOwnerAccountIdHex:)` returns a memo stamped with the
+    /// nickname revision, and `nickname(forContactAccountIdHex:)` short-circuits on an account that
+    /// has nicknamed nobody. No FFI, no roster.
+    func lastMessageSenderNickname(in row: ChatListRowFfi, account: AccountItem) -> String? {
+        guard let sender = row.lastMessage?.sender.nilIfBlank, sender != account.accountIdHex else { return nil }
+        // Scoped to the row's own account, not the active one: a delta can still land for a
+        // background account, and private labels are per-account.
+        return contactNicknames(forOwnerAccountIdHex: account.accountIdHex)
+            .nickname(forContactAccountIdHex: sender)
     }
 
     func startChatListEnrichment(
@@ -636,6 +652,7 @@ extension WorkspaceState {
             subtitle: enrichedItem.subtitle,
             preview: current.preview,
             previewAttachmentKind: current.previewAttachmentKind,
+            previewAttribution: current.previewAttribution,
             updatedAt: current.updatedAt,
             avatarSeed: enrichedItem.avatarSeed,
             pictureURL: enrichedItem.pictureURL ?? current.pictureURL,
@@ -736,7 +753,8 @@ extension WorkspaceState {
             directPeer: directPeer,
             groupAvatarURL: groupAvatarURL,
             groupImagePayload: groupImagePayload,
-            mentionNames: mentionNames
+            mentionNames: mentionNames,
+            lastSenderNickname: lastMessageSenderNickname(in: row, account: account)
         )
     }
 

--- a/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ContactNicknames.swift
@@ -52,6 +52,9 @@ extension WorkspaceState {
             byContactIdHex: contactNicknamesByOwner[owner] ?? [:]
         )
         cachedContactNicknames = NicknameStamped(stamp: stamp, value: value)
+        #if DEBUG
+            contactNicknameSnapshotBuildCount += 1
+        #endif
         return value
     }
 
@@ -141,7 +144,7 @@ extension WorkspaceState {
         else { return }
         let nickname = activeContactNicknames.nickname(forContactAccountIdHex: contact)
 
-        relabelDirectChats(forAccountId: accountId, peerAccountIdHex: contact, nickname: nickname)
+        relabelChatRows(forAccountId: accountId, contactAccountIdHex: contact, nickname: nickname)
         relabelTimelineSenders(accountIdHex: contact, nickname: nickname)
         relabelComposeContacts(accountIdHex: contact, nickname: nickname)
         relabelContactDetailsTarget(accountIdHex: contact, nickname: nickname)
@@ -188,19 +191,31 @@ extension WorkspaceState {
         }
     }
 
-    /// Retitle the direct chats whose peer is this contact. `avatarSeed` is the peer's account
-    /// hex for a direct chat, so this touches exactly those rows and never a group.
-    private func relabelDirectChats(forAccountId accountId: String, peerAccountIdHex: String, nickname: String?) {
+    /// Retitle the direct chats whose peer is this contact, and re-attribute any row whose
+    /// last-message preview names them.
+    ///
+    /// Both in one pass over each list: a rename touches the title of the DM with that person and
+    /// the "Name: message" line of every chat they last spoke in, and splitting them would walk the
+    /// chat list twice and bump its generation twice. The title match is on `avatarSeed`, which
+    /// carries the peer's account hex for a direct chat, so it never catches a group; the preview
+    /// match is on the last sender, which can be any row.
+    private func relabelChatRows(forAccountId accountId: String, contactAccountIdHex: String, nickname: String?) {
         // Returns nil when nothing moved, so an unrelated contact's nickname never churns the
         // chat-list generation (and with it the memoized sidebar filter).
         let relabeled: ([ChatItem]) -> [ChatItem]? = { chats in
             var next = chats
             var didChange = false
             for index in next.indices {
-                guard next[index].isDirect,
-                    ContactNicknames.normalizedHex(next[index].avatarSeed) == peerAccountIdHex
-                else { continue }
-                let candidate = next[index].applyingNickname(nickname)
+                var candidate = next[index]
+                if candidate.isDirect,
+                    ContactNicknames.normalizedHex(candidate.avatarSeed) == contactAccountIdHex
+                {
+                    candidate = candidate.applyingNickname(nickname)
+                }
+                candidate = candidate.relabelingPreviewSender(
+                    accountIdHex: contactAccountIdHex,
+                    nickname: nickname
+                )
                 guard candidate != next[index] else { continue }
                 next[index] = candidate
                 didChange = true
@@ -249,9 +264,11 @@ extension WorkspaceState {
     ///
     /// Every materialized window is relabeled, not just the selected chat's, for the reason
     /// `relabelTimelineSenders` does the same: a background window would otherwise keep the stale
-    /// label until it is next projected. Chat-list previews re-resolve on their next row update,
-    /// and every other group's `mentionNamesCache` entry is stamped with the nickname set, so it
-    /// rebuilds against the new label whenever it is next read.
+    /// label until it is next projected. A chat-list preview's mention tokens are baked the same
+    /// way and re-resolve on the row's next update — its attribution prefix, the part of that line
+    /// a rename is visibly about, is patched immediately by `relabelChatRows` — and every other
+    /// group's `mentionNamesCache` entry is stamped with the nickname set, so it rebuilds against
+    /// the new label whenever it is next read.
     private func relabelTimelineMentions(ofContactAccountIdHex contact: String) {
         var didChangeSelectedChat = false
         for (groupIdHex, store) in messageTimelineStores {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -191,6 +191,7 @@ nonisolated struct ChatListOrdering {
             subtitle: current.subtitle,
             preview: chat.preview,
             previewAttachmentKind: chat.previewAttachmentKind,
+            previewAttribution: chat.previewAttribution,
             updatedAt: chat.updatedAt,
             avatarSeed: current.avatarSeed,
             pictureURL: current.pictureURL,
@@ -1726,6 +1727,10 @@ final class WorkspaceState {
         @ObservationIgnored var mentionRosterBuildCount = 0
         /// Test-only instrumentation for verifying timeline mention-name projections are reused.
         @ObservationIgnored var mentionNamesBuildCount = 0
+        /// Test-only instrumentation for verifying the nickname snapshot is reused across a
+        /// chat-list projection: every row's preview attribution resolves through it, so a
+        /// per-row rebuild would put a map reduction on the chat-list hot path.
+        @ObservationIgnored var contactNicknameSnapshotBuildCount = 0
 
         /// Test-only instrumentation: the number of times `messageSenderProfiles` had to fetch the
         /// group member list to build the sender-name fallback map. In the all-resolved steady

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -115,10 +115,16 @@ nonisolated struct ChatItem: Identifiable, Hashable {
     /// Deliberately *not* pre-filled with a "No messages yet" placeholder: what an empty chat
     /// says depends on why it is empty — an unanswered invite explains itself here — and the
     /// answer is localized, so it is resolved at render time by `previewPlaceholder(locale:)`.
-    let preview: String
+    ///
+    /// `private(set)` so the only in-place writer is `relabelingPreviewSender` below, which
+    /// recomposes the attribution prefix from `previewAttribution`.
+    private(set) var preview: String
     /// Set when the last message carries attachments, so the row can mark the preview with a
     /// media glyph. Travels with `preview` — anything that carries one forward carries both.
     let previewAttachmentKind: ChatPreviewAttachmentKind?
+    /// The parts `preview` was composed from, set only when the line is attributed to another
+    /// account. Travels with `preview` for the same reason `previewAttachmentKind` does.
+    let previewAttribution: ChatPreviewAttribution?
     let updatedAt: Date?
     let avatarSeed: String
     /// `private(set)` so the only in-place writer is `replacingPeerPresentation` below, which
@@ -195,6 +201,38 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         return avatarSeed
     }
 
+    /// A chat row's last-message line with the sender it is attributed to, or the line alone when
+    /// nobody's name precedes it.
+    ///
+    /// The name is bidi-isolated so a peer-controlled display name cannot reorder the message text
+    /// that follows it. An empty name means "unattributed" — a member who published no name and
+    /// carries no nickname has nothing to put here.
+    nonisolated static func attributedPreviewText(body: String, senderName: String?) -> String {
+        guard let senderName, !senderName.isEmpty else { return body }
+        return "\(PeerDisplayText.templateFragment(senderName)): \(body)"
+    }
+
+    /// A copy whose last-message attribution reflects `nickname`, or `self` when this row's
+    /// preview is not attributed to that account.
+    ///
+    /// Recomposing the line beats re-projecting the row: a nickname write must not put chat-list
+    /// enrichment (roster + profile FFI) back on a user gesture. Rows the nickname does not touch
+    /// return unchanged so an unrelated contact's rename never churns the chat-list generation.
+    nonisolated func relabelingPreviewSender(accountIdHex: String, nickname: String?) -> ChatItem {
+        guard let previewAttribution,
+            ContactNicknames.normalizedHex(previewAttribution.senderAccountIdHex) == accountIdHex
+        else { return self }
+
+        let text = Self.attributedPreviewText(
+            body: previewAttribution.body,
+            senderName: nickname ?? previewAttribution.publishedSenderName
+        )
+        guard text != preview else { return self }
+        var copy = self
+        copy.preview = text
+        return copy
+    }
+
     /// A copy whose title reflects `nickname`, leaving every other field identical.
     ///
     /// Applying a private nickname must not re-run chat-list enrichment, so a nickname write
@@ -255,6 +293,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         subtitle: String,
         preview: String,
         previewAttachmentKind: ChatPreviewAttachmentKind? = nil,
+        previewAttribution: ChatPreviewAttribution? = nil,
         updatedAt: Date?,
         avatarSeed: String,
         pictureURL: String?,
@@ -280,6 +319,7 @@ nonisolated struct ChatItem: Identifiable, Hashable {
         self.subtitle = subtitle
         self.preview = preview
         self.previewAttachmentKind = previewAttachmentKind
+        self.previewAttribution = previewAttribution
         self.updatedAt = updatedAt
         self.avatarSeed = avatarSeed
         self.pictureURL = pictureURL
@@ -312,6 +352,21 @@ nonisolated enum ChatMessageDeliveryState: Hashable, Sendable {
     case pending
     case delivered
     case failed
+}
+
+/// Who a chat row's last-message line is attributed to, kept alongside the composed `preview` so
+/// a nickname write can recompose the prefix in place.
+///
+/// Present whenever the last message came from *another* account — including one that published no
+/// name, since nicknaming them is exactly what gives that line a prefix. Your own messages read
+/// "You:" in every language, which no private label can change, so they never carry one.
+nonisolated struct ChatPreviewAttribution: Hashable, Sendable {
+    let senderAccountIdHex: String
+    /// The name that sender publishes — what the prefix falls back to with no nickname on file,
+    /// and what clearing one restores. `nil` for a member who published none.
+    let publishedSenderName: String?
+    /// The last-message line without its attribution prefix.
+    let body: String
 }
 
 /// Which attachment glyph a chat row draws ahead of its last-message preview.

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1062,6 +1062,96 @@ struct PureValueTests {
         )
     }
 
+    /// A row whose last word was yours has to say so, in both a group and a DM — otherwise your
+    /// own message reads as though the other side sent it.
+    @Test func chatRowAttributesYourOwnLastMessageToYou() async throws {
+        let selfIdHex = String(repeating: "5", count: 64)
+        func chat(groupName: String, plaintext: String, sender: String) -> ChatItem {
+            ChatItem(
+                row: chatRow(groupName: groupName, sender: sender, senderDisplayName: "Alice", plaintext: plaintext),
+                activeAccountIdHex: selfIdHex
+            )
+        }
+
+        let ownGroupMessage = chat(groupName: "Planning", plaintext: "On my way", sender: selfIdHex)
+        #expect(ownGroupMessage.preview == String(format: L10n.string("You: %@"), "On my way"))
+        // Nothing to relabel: "You" is not a name a nickname can override.
+        #expect(ownGroupMessage.previewAttribution == nil)
+
+        let ownDirectMessage = ChatItem(
+            row: chatRow(groupName: "", sender: selfIdHex, senderDisplayName: "Alice", plaintext: "On my way"),
+            activeAccountIdHex: selfIdHex,
+            directPeer: ChatPeerProfile(accountIdHex: aliceIdHex, displayName: "Alice", pictureURL: nil)
+        )
+        #expect(ownDirectMessage.isDirect)
+        #expect(ownDirectMessage.preview == String(format: L10n.string("You: %@"), "On my way"))
+
+        // The attribution wraps whatever the line resolved to, media wording included.
+        let ownAttachment = chat(groupName: "Planning", plaintext: "", sender: selfIdHex)
+        #expect(ownAttachment.preview == String(format: L10n.string("You: %@"), L10n.string("Attachment")))
+
+        // Someone else's message keeps its own name, and stays relabelable.
+        let peerMessage = chat(groupName: "Planning", plaintext: "On my way", sender: aliceIdHex)
+        #expect(peerMessage.preview == "\(bidiIsolated("Alice")): On my way")
+        #expect(peerMessage.previewAttribution?.senderAccountIdHex == aliceIdHex)
+        #expect(peerMessage.previewAttribution?.publishedSenderName == "Alice")
+        #expect(peerMessage.previewAttribution?.body == "On my way")
+
+        // With no account resolved yet, no message can be claimed as your own.
+        let unattributed = ChatItem(
+            row: chatRow(groupName: "Planning", sender: selfIdHex, senderDisplayName: "Alice", plaintext: "Hi"),
+            activeAccountIdHex: nil
+        )
+        #expect(unattributed.preview == "\(bidiIsolated("Alice")): Hi")
+    }
+
+    /// The preview's author is the same person as the row title and the sender label, so the
+    /// viewer's private label has to reach it too.
+    @Test func chatRowLastSenderPrefixPrefersTheNickname() async throws {
+        let row = chatRow(groupName: "Planning", sender: aliceIdHex, senderDisplayName: "Alice", plaintext: "Hi")
+
+        let nicknamed = ChatItem(row: row, activeAccountIdHex: "self", lastSenderNickname: "Mum")
+        #expect(nicknamed.preview == "\(bidiIsolated("Mum")): Hi")
+        // The published name is recorded so clearing the nickname restores it.
+        #expect(nicknamed.previewAttribution?.publishedSenderName == "Alice")
+
+        // A member who published no name has nothing to prefix with — until they are nicknamed.
+        let anonymous = chatRow(groupName: "Planning", sender: aliceIdHex, senderDisplayName: nil, plaintext: "Hi")
+        #expect(ChatItem(row: anonymous, activeAccountIdHex: "self").preview == "Hi")
+        #expect(
+            ChatItem(row: anonymous, activeAccountIdHex: "self", lastSenderNickname: "Mum").preview
+                == "\(bidiIsolated("Mum")): Hi"
+        )
+    }
+
+    /// Relabeling recomposes the line from the parts it was built from, so a rename lands without
+    /// re-running chat-list enrichment — and touches nothing else on the row.
+    @Test func chatRowPreviewRelabelsOnlyItsOwnLastSender() async throws {
+        let row = chatRow(groupName: "Planning", sender: aliceIdHex, senderDisplayName: "Alice", plaintext: "Hi")
+        let chat = ChatItem(row: row, activeAccountIdHex: "self")
+
+        let renamed = chat.relabelingPreviewSender(accountIdHex: aliceIdHex, nickname: "Mum")
+        #expect(renamed.preview == "\(bidiIsolated("Mum")): Hi")
+        #expect(renamed.previewAttribution == chat.previewAttribution)
+        #expect(renamed.title == chat.title)
+        #expect(renamed.unreadCount == chat.unreadCount)
+
+        // Clearing hands the line back to the published name, exactly as `applyingNickname` does.
+        #expect(renamed.relabelingPreviewSender(accountIdHex: aliceIdHex, nickname: nil) == chat)
+
+        // Another contact's rename must leave the row untouched, so the chat-list generation and
+        // the memoized sidebar filter never churn for it.
+        #expect(chat.relabelingPreviewSender(accountIdHex: String(repeating: "b", count: 64), nickname: "Dad") == chat)
+        #expect(chat.relabelingPreviewSender(accountIdHex: aliceIdHex, nickname: "Alice") == chat)
+
+        // A row with no attributed sender has nothing to recompose.
+        let own = ChatItem(
+            row: chatRow(groupName: "Planning", sender: "self", senderDisplayName: "You", plaintext: "Hi"),
+            activeAccountIdHex: "self"
+        )
+        #expect(own.relabelingPreviewSender(accountIdHex: "self", nickname: "Me") == own)
+    }
+
     @Test func chatListRowClampsOversizedUnreadCounts() async throws {
         // Regression for whitenoise-mac#242: unread counts cross the FFI boundary as
         // UInt64, and Int(value) traps above Int.max while mapping the chat list.
@@ -4431,6 +4521,51 @@ struct PureValueTests {
 /// 64-char hex built from a short seed, so tests read as `hex("a")` rather than a wall of digits.
 private func hex(_ seed: String) -> String {
     String((seed + String(repeating: "0", count: 64)).prefix(64))
+}
+
+/// The peer whose messages the chat-row preview tests attribute.
+private let aliceIdHex = hex("a11ce")
+
+/// A display name as a template composes it: bidi-isolated so peer-controlled text cannot
+/// reorder what follows it.
+private func bidiIsolated(_ text: String) -> String {
+    "\u{2068}\(text)\u{2069}"
+}
+
+private func chatRow(
+    groupName: String,
+    sender: String,
+    senderDisplayName: String?,
+    plaintext: String
+) -> ChatListRowFfi {
+    ChatListRowFfi(
+        groupIdHex: "group",
+        archived: false,
+        pendingConfirmation: false,
+        title: groupName.isEmpty ? "Alice" : groupName,
+        groupName: groupName,
+        avatarUrl: nil,
+        avatar: nil,
+        lastMessage: ChatListMessagePreviewFfi(
+            messageIdHex: "message-1",
+            sender: sender,
+            senderDisplayName: senderDisplayName,
+            plaintext: plaintext,
+            contentTokens: MarkdownDocumentFfi(blocks: [], truncated: false),
+            kind: 9,
+            timelineAt: 1_700_000_000,
+            deleted: false
+        ),
+        unreadCount: 0,
+        hasUnread: false,
+        unreadMentionCount: 0,
+        unreadMention: false,
+        firstUnreadMessageIdHex: nil,
+        lastReadMessageIdHex: nil,
+        lastReadTimelineAt: nil,
+        updatedAt: 1_700_000_000,
+        selfMembership: .member
+    )
 }
 
 private func discoveryProfile(displayName: String? = nil, picture: String? = nil) -> UserProfileMetadataFfi {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1936,6 +1936,216 @@ struct whitenoise_macTests {
         #expect(state.contactNickname(forContactAccountIdHex: contact) == nil)
     }
 
+    /// A rename has to reach the "Name: message" line of every chat that person last spoke in —
+    /// including groups, which carry no nicknamed title to relabel — and it has to land on the
+    /// gesture rather than waiting for that chat's next message.
+    @MainActor
+    @Test func settingANicknameReattributesChatRowPreviews() async throws {
+        let account = desktopAccount()
+        let contact = String(repeating: "2", count: 64)
+        let other = String(repeating: "3", count: 64)
+        func row(id: String, title: String, sender: String, senderName: String, body: String) -> ChatItem {
+            ChatItem(
+                id: id,
+                title: title,
+                subtitle: "Group message",
+                preview: "\(isolated(senderName)): \(body)",
+                previewAttribution: ChatPreviewAttribution(
+                    senderAccountIdHex: sender,
+                    publishedSenderName: senderName,
+                    body: body
+                ),
+                updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                avatarSeed: id,
+                pictureURL: nil,
+                unreadCount: 0
+            )
+        }
+        let group = row(id: "group", title: "Book club", sender: contact, senderName: "Alice", body: "Hey")
+        let otherGroup = row(id: "other-group", title: "Climbing", sender: other, senderName: "Bob", body: "Yo")
+        let archived = row(id: "archived", title: "Old crew", sender: contact, senderName: "Alice", body: "Bye")
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-nickname-preview-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let state = WorkspaceState(
+            accounts: [AccountItem(summary: account)],
+            chatsByAccount: [account.label: [group, otherGroup]],
+            contactNicknameStore: ContactNicknameFileStore(directoryURL: directory),
+            clientFactory: { FakeMarmotRuntime(accounts: [account]) }
+        )
+        state.activeAccountId = account.label
+        state.setArchivedChats([archived], forAccountId: account.label)
+
+        state.setContactNickname("Mum", forContactAccountIdHex: contact)
+
+        #expect(state.chatItem(accountId: account.label, chatId: "group")?.preview == "\(isolated("Mum")): Hey")
+        let relabeledArchive = state.archivedChatItem(accountId: account.label, chatId: "archived")
+        #expect(relabeledArchive?.preview == "\(isolated("Mum")): Bye")
+        // Another contact's row must not churn — the chat-list generation and the memoized
+        // sidebar filter both key off these values.
+        #expect(state.chatItem(accountId: account.label, chatId: "other-group") == otherGroup)
+
+        state.setContactNickname(nil, forContactAccountIdHex: contact)
+
+        #expect(state.chatItem(accountId: account.label, chatId: "group") == group)
+        #expect(state.archivedChatItem(accountId: account.label, chatId: "archived") == archived)
+    }
+
+    /// The nickname also has to be folded in when the row is *projected*, not just patched onto
+    /// rows already on screen — otherwise the next message in that chat brings the published name
+    /// back.
+    @MainActor
+    @Test func projectedChatRowAttributesItsLastSenderByNickname() async throws {
+        let account = desktopAccount()
+        let contact = String(repeating: "2", count: 64)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-nickname-projection-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = ContactNicknameFileStore(directoryURL: directory)
+        let state = WorkspaceState(
+            accounts: [AccountItem(summary: account)],
+            contactNicknameStore: store,
+            clientFactory: { FakeMarmotRuntime(accounts: [account]) }
+        )
+        state.activeAccountId = account.label
+        let activeAccount = try #require(state.activeAccount)
+
+        let peerRow = ChatListRowFfi(
+            groupIdHex: "group",
+            archived: false,
+            pendingConfirmation: false,
+            title: "Book club",
+            groupName: "Book club",
+            avatarUrl: nil,
+            avatar: nil,
+            lastMessage: ChatListMessagePreviewFfi(
+                messageIdHex: "message-1",
+                sender: contact,
+                senderDisplayName: "Alice",
+                plaintext: "Hey",
+                contentTokens: emptyMarkdownDocument(),
+                kind: 9,
+                timelineAt: 1_700_000_000,
+                deleted: false
+            ),
+            unreadCount: 0,
+            hasUnread: false,
+            unreadMentionCount: 0,
+            unreadMention: false,
+            firstUnreadMessageIdHex: nil,
+            lastReadMessageIdHex: nil,
+            lastReadTimelineAt: nil,
+            updatedAt: 1_700_000_000,
+            selfMembership: .member
+        )
+
+        #expect(state.baseChatItem(from: peerRow, account: activeAccount).preview == "\(isolated("Alice")): Hey")
+
+        state.setContactNickname("Mum", forContactAccountIdHex: contact)
+
+        let projected = state.baseChatItem(from: peerRow, account: activeAccount)
+        #expect(projected.preview == "\(isolated("Mum")): Hey")
+        #expect(projected.previewAttribution?.publishedSenderName == "Alice")
+        // An account added *after* someone nicknamed it still has that entry on file. It must
+        // never surface as your own name: the row still reads "You".
+        try store.write([contact: "Mum", account.accountIdHex: "Me"], forOwnerAccountIdHex: account.accountIdHex)
+        state.loadContactNicknames()
+        let ownRow = ChatListRowFfi(
+            groupIdHex: "group",
+            archived: false,
+            pendingConfirmation: false,
+            title: "Book club",
+            groupName: "Book club",
+            avatarUrl: nil,
+            avatar: nil,
+            lastMessage: ChatListMessagePreviewFfi(
+                messageIdHex: "message-2",
+                sender: account.accountIdHex,
+                senderDisplayName: "Desktop",
+                plaintext: "On my way",
+                contentTokens: emptyMarkdownDocument(),
+                kind: 9,
+                timelineAt: 1_700_000_001,
+                deleted: false
+            ),
+            unreadCount: 0,
+            hasUnread: false,
+            unreadMentionCount: 0,
+            unreadMention: false,
+            firstUnreadMessageIdHex: nil,
+            lastReadMessageIdHex: nil,
+            lastReadTimelineAt: nil,
+            updatedAt: 1_700_000_001,
+            selfMembership: .member
+        )
+
+        #expect(
+            state.baseChatItem(from: ownRow, account: activeAccount).preview
+                == String(format: L10n.string("You: %@"), "On my way")
+        )
+        #expect(state.baseChatItem(from: peerRow, account: activeAccount).preview == "\(isolated("Mum")): Hey")
+    }
+
+    /// Every row's preview attribution resolves against the nickname map, and a chat-list snapshot
+    /// projects hundreds of rows at once. The snapshot behind that lookup must be built once per
+    /// nickname revision, not once per row.
+    @MainActor
+    @Test func projectingManyChatRowsBuildsTheNicknameSnapshotOnce() async throws {
+        let account = desktopAccount()
+        let contact = String(repeating: "2", count: 64)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whitenoise-nickname-cost-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let state = WorkspaceState(
+            accounts: [AccountItem(summary: account)],
+            contactNicknameStore: ContactNicknameFileStore(directoryURL: directory),
+            clientFactory: { FakeMarmotRuntime(accounts: [account]) }
+        )
+        state.activeAccountId = account.label
+        let activeAccount = try #require(state.activeAccount)
+        state.setContactNickname("Mum", forContactAccountIdHex: contact)
+
+        let rows = (0..<200).map { index in
+            ChatListRowFfi(
+                groupIdHex: "group-\(index)",
+                archived: false,
+                pendingConfirmation: false,
+                title: "Book club \(index)",
+                groupName: "Book club \(index)",
+                avatarUrl: nil,
+                avatar: nil,
+                lastMessage: ChatListMessagePreviewFfi(
+                    messageIdHex: "message-\(index)",
+                    sender: contact,
+                    senderDisplayName: "Alice",
+                    plaintext: "Hey",
+                    contentTokens: emptyMarkdownDocument(),
+                    kind: 9,
+                    timelineAt: 1_700_000_000,
+                    deleted: false
+                ),
+                unreadCount: 0,
+                hasUnread: false,
+                unreadMentionCount: 0,
+                unreadMention: false,
+                firstUnreadMessageIdHex: nil,
+                lastReadMessageIdHex: nil,
+                lastReadTimelineAt: nil,
+                updatedAt: 1_700_000_000,
+                selfMembership: .member
+            )
+        }
+
+        let baseline = state.contactNicknameSnapshotBuildCount
+        let projected = rows.map { state.baseChatItem(from: $0, account: activeAccount) }
+
+        #expect(projected.allSatisfy { $0.preview == "\(isolated("Mum")): Hey" })
+        #expect(state.contactNicknameSnapshotBuildCount == baseline)
+    }
+
     @MainActor
     @Test func ownAccountsCannotBeNicknamed() async throws {
         let account = desktopAccount()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat previews identify messages sent by you with “You.”
  * Previews use private contact nicknames when available, with published names as fallback.
  * Sender attribution updates automatically when contact nicknames change.
  * Attribution works consistently for group chats, direct messages, attachments, and archived chats.

* **Tests**
  * Added coverage for attribution, nickname updates, fallback behavior, and large chat lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->