### PR TITLE
Add outline secondary button

### DIFF
--- a/whitenoise-mac/Views/ComposeFlowViews.swift
+++ b/whitenoise-mac/Views/ComposeFlowViews.swift
@@ -557,7 +557,7 @@ private struct ComposePaneHeader: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            GlassCircleCloseButton(symbol: "chevron.backward", help: "Back", action: onBack)
+            GlassCircleCloseButton(symbol: "chevron.backward", help: "Back", appearance: .outline, action: onBack)
             Spacer()
         }
         .overlay {

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -1506,7 +1506,10 @@ struct PendingGroupInviteComposerNotice: View {
                 .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
                 .help(L10n.string("Accept invite"))
 
-                Button(role: .destructive) {
+                // No destructive `role`: `chat_invite_screen.dart` builds Decline as `outline`,
+                // and the group-details Decline already dropped it. Marking it destructive while
+                // rendering it secondary is a trap — see `WNSecondaryButtonStyle`.
+                Button {
                     Task { await workspace.declineGroupInvite(for: chat) }
                 } label: {
                     HStack(spacing: 8) {
@@ -1521,7 +1524,7 @@ struct PendingGroupInviteComposerNotice: View {
                     .frame(maxWidth: .infinity, minHeight: 40)
                 }
                 .controlSize(.large)
-                .nativeGlassButtonStyle()
+                .buttonStyle(.wnSecondary)
                 .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
                 .help(L10n.string("Decline invite"))
             }

--- a/whitenoise-mac/Views/GroupAddMembersSheet.swift
+++ b/whitenoise-mac/Views/GroupAddMembersSheet.swift
@@ -46,7 +46,7 @@ struct GroupAddMembersSheet: View {
                 .wnFont(.semiBold14)
             Spacer()
             Button(L10n.string("Cancel")) { dismiss() }
-                .buttonStyle(.plain)
+                .buttonStyle(.wnSecondary)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -141,7 +141,7 @@ struct GroupDetailsSheet: View {
                 // Leading, like the compose pane and the settings header: this pane slides
                 // in over the transcript, so the chevron is a back control and reads as one
                 // only on the side you came from.
-                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back to chat") {
+                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back to chat", appearance: .outline) {
                     workspace.closeGroupDetails()
                 }
 
@@ -215,7 +215,7 @@ struct GroupDetailsSheet: View {
                                     .nativeGlassProminentButtonStyle()
                                     .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
 
-                                    Button(role: .destructive) {
+                                    Button {
                                         Task { await workspace.declineSelectedGroupInvite() }
                                     } label: {
                                         Label(
@@ -224,6 +224,7 @@ struct GroupDetailsSheet: View {
                                             systemImage: "xmark.circle"
                                         )
                                     }
+                                    .buttonStyle(.wnSecondary)
                                     .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
 
                                     Spacer()
@@ -285,6 +286,7 @@ struct GroupDetailsSheet: View {
                                 } label: {
                                     Label(L10n.string("Search Web Image"), systemImage: "photo.badge.plus")
                                 }
+                                .buttonStyle(.wnSecondary)
                                 .disabled(workspace.hasInFlightGroupCommit)
                             }
 
@@ -435,6 +437,7 @@ struct GroupDetailsSheet: View {
                             } label: {
                                 Label(L10n.string("Delete expired now"), systemImage: "trash")
                             }
+                            .buttonStyle(.wnSecondary)
                             .disabled(workspace.isSecureDeletingExpired)
                             .help(L10n.string("Securely prune already-expired messages on this device"))
                         }
@@ -442,7 +445,11 @@ struct GroupDetailsSheet: View {
 
                     Section(L10n.string("Group Actions")) {
                         HStack(spacing: 10) {
-                            Button(role: snapshot.archived ? nil : .destructive) {
+                            // Archiving is reversible and the other clients draw it as `outline`
+                            // rather than `destructive` (`group_info_screen.dart`), so it takes the
+                            // secondary style in both directions instead of turning red to archive
+                            // and plain to unarchive.
+                            Button {
                                 showArchiveConfirmation = true
                             } label: {
                                 Label(
@@ -450,14 +457,20 @@ struct GroupDetailsSheet: View {
                                     systemImage: snapshot.archived ? "tray.and.arrow.up" : "archivebox"
                                 )
                             }
+                            .buttonStyle(.wnSecondary)
                             .disabled(workspace.isArchivingGroup)
 
                             if snapshot.isSelfAdmin {
-                                Button(role: .destructive) {
+                                // `group_member_screen.dart` builds "remove admin role" as
+                                // `outline`, keeping `destructive` for removing someone from the
+                                // group. Giving up your own admin rights is reversible by another
+                                // admin, so it follows that split rather than reading as a deletion.
+                                Button {
                                     showSelfDemoteConfirmation = true
                                 } label: {
                                     Label(L10n.string("Step Down as Admin"), systemImage: "star.slash")
                                 }
+                                .buttonStyle(.wnSecondary)
                                 .disabled(workspace.hasInFlightGroupCommit || snapshot.isLastAdmin)
                             }
 
@@ -706,7 +719,7 @@ struct GroupDiagnosticsValueRow: View {
                     Image(systemName: "doc.on.doc")
                         .frame(width: 24, height: 24)
                 }
-                .nativeGlassButtonStyle()
+                .buttonStyle(.wnSecondary)
                 .help(String(format: L10n.string("Copy %@"), title))
             }
         }
@@ -846,7 +859,7 @@ struct ContactDetailsView: View {
             HStack(spacing: 12) {
                 // Leading back control, matching GroupDetailsSheet: both panes slide in
                 // over the transcript and return to it.
-                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back") {
+                GlassCircleCloseButton(symbol: "chevron.backward", help: "Back", appearance: .outline) {
                     workspace.closeContactDetails()
                 }
 
@@ -911,6 +924,7 @@ struct ContactDetailsView: View {
                     } label: {
                         Label(L10n.string("Copy Public Key"), systemImage: "doc.on.doc")
                     }
+                    .buttonStyle(.wnSecondary)
 
                     SettingsErrorView(error: workspace.lastError)
                 }
@@ -1049,6 +1063,7 @@ private struct ContactFollowControl: View {
                         .frame(maxWidth: .infinity)
                     }
                 }
+                .buttonStyle(.wnSecondary)
                 .disabled(workspace.isTogglingFollow)
                 .accessibilityLabel(isFollowing ? L10n.string("Unfollow") : L10n.string("Follow"))
                 .accessibilityIdentifier("contact.details.follow")
@@ -1060,6 +1075,7 @@ private struct ContactFollowControl: View {
                     Label(L10n.string("Retry"), systemImage: "arrow.clockwise")
                         .frame(maxWidth: .infinity)
                 }
+                .buttonStyle(.wnSecondary)
                 .help(L10n.string("Couldn't check whether you follow this person."))
                 .accessibilityIdentifier("contact.details.follow.retry")
             }

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -786,29 +786,69 @@ extension View {
     }
 }
 
-/// Shared 28×28 circular glass dismiss/back control for sheet and column chrome.
+/// Shared 28×28 circular dismiss/back control for sheet and column chrome.
+///
+/// Two appearances, because the two jobs are not the same weight. A **close** ✕ is the only
+/// control in its corner and takes the glass disc. A **back** ‹ is navigation sitting beside a
+/// title, and glass gives it the emphasis of a filled control — so it takes `outline` instead:
+/// `MessagesCircleControlBackground`, the `WnIconButton.outline` disc this app already draws for
+/// the composer and account-rail controls. That puts every back affordance on the secondary tier,
+/// matching the settings header's chevron and `WNSecondaryButtonStyle`.
+///
+/// Note that circle control still strokes `borderTertiary`, which is the same value as its own
+/// `fillSecondary` in Dark Aqua — so its ring is invisible there, exactly the defect
+/// `WNSecondaryButtonStyle` moved to `borderSecondary` to fix. The demotion from glass holds
+/// either way; raising that ring is a separate change because it also restyles the composer.
 struct GlassCircleCloseButton: View {
+    enum Appearance {
+        /// The glass disc. For a ✕ that dismisses.
+        case glass
+        /// The palette's outline circle. For a ‹ that navigates back.
+        case outline
+    }
+
     let symbol: String
     let helpText: String
+    let appearance: Appearance
     let action: () -> Void
 
     init(
         symbol: String = "xmark",
         help: String = "Close",
+        appearance: Appearance = .glass,
         action: @escaping () -> Void
     ) {
         self.symbol = symbol
         self.helpText = help
+        self.appearance = appearance
         self.action = action
     }
 
     var body: some View {
-        Button(action: action) {
-            Image(systemName: symbol)
-                .wnFont(.semiBold12)
-                .frame(width: 28, height: 28)
+        switch appearance {
+        case .glass:
+            Button(action: action) {
+                Image(systemName: symbol)
+                    .wnFont(.semiBold12)
+                    .frame(width: 28, height: 28)
+            }
+            .nativeGlassCircleButtonStyle()
+            .help(L10n.string(helpText))
+
+        case .outline:
+            Button(action: action) {
+                Image(systemName: symbol)
+                    .wnFont(.semiBold12)
+                    // Named rather than inherited: the glyph sits on `fillSecondary`, so it is
+                    // the `fill` family's content token that pairs with it. The app-wide default
+                    // is `backgroundContentPrimary`, which currently resolves to the same value —
+                    // true by coincidence, not by construction. See the pairing rule in `WNNSColor`.
+                    .foregroundStyle(WNColor.fillContentSecondary)
+                    .frame(width: 28, height: 28)
+                    .background { MessagesCircleControlBackground() }
+            }
+            .buttonStyle(.plain)
+            .help(L10n.string(helpText))
         }
-        .nativeGlassCircleButtonStyle()
-        .help(L10n.string(helpText))
     }
 }

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -163,6 +163,7 @@ private struct WelcomeAuthView: View {
                         Button(L10n.string("Cancel")) {
                             workspace.cancelLogin()
                         }
+                        .buttonStyle(.wnSecondary)
                         .disabled(workspace.isAuthenticating)
 
                         Button(
@@ -297,7 +298,7 @@ private struct SignedOutAccountsView: View {
             Button(L10n.string("Use another account")) {
                 workspace.showAccountOnboarding()
             }
-            .nativeGlassButtonStyle()
+            .buttonStyle(.wnSecondary)
             .disabled(workspace.isSigningOutAccount)
 
             if let lastError = workspace.lastError {

--- a/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
@@ -75,7 +75,7 @@ struct SettingsAccountSwitcherCard: View {
                 .wnFont(.semiBold12)
                 .frame(maxWidth: .infinity)
             }
-            .nativeGlassButtonStyle()
+            .buttonStyle(.wnSecondary)
             .help(L10n.string("Switch Account", locale: locale))
             .popover(isPresented: $isSwitcherPresented, arrowEdge: .bottom) {
                 AccountSwitcherPopover(
@@ -417,7 +417,7 @@ struct AddAccountSheet: View {
                         systemImage: "plus.circle"
                     )
                 }
-                .nativeGlassButtonStyle()
+                .buttonStyle(.wnSecondary)
                 .disabled(isAuthenticationBlocked)
 
                 Spacer()
@@ -425,6 +425,7 @@ struct AddAccountSheet: View {
                 Button(L10n.string("Cancel", locale: locale)) {
                     cancel()
                 }
+                .buttonStyle(.wnSecondary)
                 .disabled(workspace.isAuthenticating)
             }
 

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -142,6 +142,7 @@ struct GeneralSettingsView: View {
                 Button(L10n.string("Open Login Items Settings")) {
                     launchAtLogin.openSystemSettings()
                 }
+                .buttonStyle(.wnSecondary)
             }
         case .notFound:
             Label(
@@ -170,7 +171,7 @@ struct SettingsHeader: View {
                             .wnFont(.semiBold14)
                             .frame(width: 28, height: 28)
                     }
-                    .nativeGlassButtonStyle()
+                    .buttonStyle(.wnSecondary)
                     .help(L10n.string("Back to settings"))
                 }
 
@@ -395,7 +396,7 @@ struct PublicIdentityQRCodeSheet: View {
                         systemImage: isConfirming ? "checkmark" : "doc.on.doc"
                     )
                 }
-                .nativeGlassButtonStyle()
+                .buttonStyle(.wnSecondary)
 
                 Spacer()
 
@@ -705,6 +706,7 @@ struct ProfileImagePickerSheet: View {
                     } label: {
                         Label(L10n.string("Choose from Mac"), systemImage: "photo.badge.plus")
                     }
+                    .buttonStyle(.wnSecondary)
                     .disabled(workspace.isUploadingProfileImage)
 
                     Spacer()
@@ -873,6 +875,7 @@ struct IdentityKeysSettingsView: View {
                     } label: {
                         Label(L10n.string("Back Up Private Key…"), systemImage: "key")
                     }
+                    .buttonStyle(.wnSecondary)
                     .disabled(!account.localSigning)
                     .help(
                         account.localSigning
@@ -889,13 +892,17 @@ struct IdentityKeysSettingsView: View {
                     .foregroundStyle(WNColor.backgroundContentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                    Button(role: .destructive) {
+                    Button {
                         showRemoveAccountConfirmation = true
                     } label: {
                         Label(
                             workspace.isRemovingAccount ? L10n.string("Removing...") : L10n.string("Remove Account"),
                             systemImage: "person.crop.circle.badge.minus")
                     }
+                    // Outline rather than red by explicit request, and with no destructive
+                    // `role` to contradict that. The confirmation dialog this opens is
+                    // system-rendered, so the irreversible step is still the one drawn in red.
+                    .buttonStyle(.wnSecondary)
                     .disabled(workspace.isAccountMutationInProgress)
                 }
             } else {
@@ -1202,6 +1209,7 @@ struct AppearanceSettingsView: View {
                 Button(L10n.string("Restore defaults")) {
                     workspace.restoreDefaultQuickReactions()
                 }
+                .buttonStyle(.wnSecondary)
                 .disabled(workspace.quickReactions == ChatReactionDefaults.quick)
             }
         }
@@ -1325,6 +1333,7 @@ struct PrivacySecuritySettingsView: View {
                     } label: {
                         Label(L10n.string("Refresh"), systemImage: "arrow.clockwise")
                     }
+                    .buttonStyle(.wnSecondary)
                     .disabled(workspace.isLoadingAuditLogFiles)
                 }
 
@@ -1514,12 +1523,14 @@ struct NotificationsSettingsView: View {
                     } label: {
                         Label(L10n.string("Allow Notifications"), systemImage: "checkmark.circle")
                     }
+                    .buttonStyle(.wnSecondary)
                 } else if workspace.notificationAuthorizationStatus == .denied {
                     Button {
                         workspace.openSystemNotificationSettings()
                     } label: {
                         Label(L10n.string("Open System Settings"), systemImage: "gear")
                     }
+                    .buttonStyle(.wnSecondary)
                 }
             }
 
@@ -1582,7 +1593,7 @@ struct StorageSettingsView: View {
                 .foregroundStyle(WNColor.backgroundContentSecondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-                Button(role: .destructive) {
+                Button {
                     showClearConfirmation = true
                 } label: {
                     HStack(spacing: 8) {
@@ -1596,6 +1607,10 @@ struct StorageSettingsView: View {
                         )
                     }
                 }
+                // Outline rather than red by explicit request, and with no destructive `role`
+                // to contradict that. The confirmation dialog it opens is system-rendered, so the
+                // irreversible step is still the one drawn in red.
+                .buttonStyle(.wnSecondary)
                 .disabled(
                     workspace.isClearingMediaCache
                         || workspace.isLoadingMediaCacheFootprint
@@ -1679,6 +1694,7 @@ struct DeveloperModeSettingsView: View {
                 } label: {
                     Label(L10n.string("Open Storage Folder"), systemImage: "folder")
                 }
+                .buttonStyle(.wnSecondary)
             }
 
             Section(L10n.string("Diagnostics")) {
@@ -1751,6 +1767,7 @@ struct RelaySettingsView: View {
                     } label: {
                         Label(L10n.string("Add"), systemImage: "plus")
                     }
+                    .buttonStyle(.wnSecondary)
                     .help(L10n.string("Add relay"))
                 }
             }
@@ -1772,6 +1789,7 @@ struct RelaySettingsView: View {
                     } label: {
                         Label(L10n.string("Restore defaults"), systemImage: "arrow.counterclockwise")
                     }
+                    .buttonStyle(.wnSecondary)
                     .disabled(workspace.isSavingRelays)
 
                     if workspace.isLoadingSettings {
@@ -1891,6 +1909,7 @@ struct KeyPackageSettingsView: View {
                                 ? L10n.string("Republishing...") : L10n.string("Republish latest"),
                             systemImage: "arrow.triangle.2.circlepath")
                     }
+                    .buttonStyle(.wnSecondary)
                     .disabled(workspace.isRepublishingKeyPackage || workspace.activeAccount == nil)
 
                     if workspace.isLoadingSettings {

--- a/whitenoise-mac/Views/WNSecondaryButtonStyle.swift
+++ b/whitenoise-mac/Views/WNSecondaryButtonStyle.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// The app's secondary push button: the other clients' `WnButton` in its `outline` form.
+///
+/// `WnButton` (`lib/widgets/wn_button.dart`) has five types, and `outline` is the one the other
+/// clients reach for whenever an action sits *beside* or *under* the primary one — 43 call sites
+/// against 6 destructive ones, which makes it the default for everything that is not the main
+/// action on a screen. This is that type, token for token:
+///
+/// | | Flutter `_buildOutlineButton` | here |
+/// | --- | --- | --- |
+/// | fill | `fillSecondary` | `WNColor.fillSecondary` |
+/// | pointed at | `fillSecondaryHover` | `WNColor.fillSecondaryHover` |
+/// | pressed | — (Material overlay) | `WNColor.fillSecondaryActive` |
+/// | content | `fillContentSecondary` | `WNColor.fillContentSecondary` |
+/// | border | `borderTertiary`, hairline | `WNColor.borderSecondary`, 1pt — see below |
+/// | disabled | fill and content at `0.25` | fill, content **and border** at `0.25` |
+///
+/// Three things worth knowing before touching this:
+///
+/// 1. **The border is the one place this deliberately does not copy Flutter, because copying it
+///    produced no border at all.** `_buildOutlineButton` strokes `borderTertiary`, and in Dark Aqua
+///    that token and `fillSecondary` are *the same value* — both `neutral800`, `#262626`. Stroking
+///    a shape in its own fill color draws nothing, so the dark outline button had no edge
+///    whatsoever, and the Aqua pair (`neutral200` on `neutral100`) is only one ramp step apart and
+///    nearly as faint. `borderSecondary` is the palette's own answer to this: `WNNSColor` documents
+///    it as "a hovered outline, and the resting outline of an editable field", and the other clients
+///    stroke their *visibly* outlined controls with it — `wn_filter_chip`, `wn_dropdown_selector`,
+///    and `wn_input` once it is pointed at. It is also near-appearance-invariant (`neutral500` /
+///    `neutral400`), so it clears both fills by a similar margin.
+///
+///    This is why the border now fades to a quarter alpha when disabled, where an earlier version of
+///    this style held it solid: at `borderTertiary` strength a full-opacity ring was still quieter
+///    than the ghosted content it surrounded, but at `borderSecondary` strength a solid ring around
+///    ghosted content reads as an enabled button. All three parts fade together.
+/// 2. **Padding is keyed to `controlSize`, not to Flutter's `WnButtonSize`.** The Flutter sizes are
+///    phone metrics (`large` is 18pt of vertical padding, a thumb-sized full-width CTA). A mac push
+///    button that tall next to a `.glassProminent` sibling would tower over it. These values are
+///    matched to AppKit's bordered-button heights instead, so a secondary button and a primary one
+///    on the same row line up. The *visual language* is what carries over — the 8pt continuous
+///    radius, the hairline ring, the `fillSecondary` ground — not the phone's spacing.
+/// 3. **`isHovering` lives on a nested `View`, not on the style.** `makeBody` is not a `View`, so
+///    `@State` declared on the `ButtonStyle` itself has no identity to attach to and will not
+///    reliably track. The body is a real view struct for that reason.
+///
+/// The circular icon controls are the *other* half of this port and already exist: see
+/// `MessagesCircleControlBackground`, which is `WnIconButton.outline` drawn on the same four tokens.
+struct WNSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        WNSecondaryButtonBody(configuration: configuration)
+    }
+}
+
+/// The rendered body of `WNSecondaryButtonStyle`.
+///
+/// Separate from the style so it can own `@State` for the pointer and read `\.isEnabled` — a
+/// `ButtonStyle` sees neither. `configuration.isPressed` is the only state the style itself carries.
+///
+/// **This style is deliberately blind to `configuration.role`.** Colouring a `.destructive` button
+/// with `backgroundContentDestructive` here would look like an obvious improvement and is not one:
+/// every secondary button that carried the role did so while being deliberately *not* red — Remove
+/// Account and Clear Cache by explicit request, Decline because the other clients build it as
+/// `outline` rather than `destructive`. Reading the role would have silently turned all three red.
+/// Those call sites have since dropped the role so the two cannot drift apart again. A genuinely
+/// destructive action wants `WnButton.destructive` — a `fillDestructive` ground — not an outline
+/// button with red text, so if that is ever needed, add it as its own style.
+private struct WNSecondaryButtonBody: View {
+    let configuration: ButtonStyle.Configuration
+
+    @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.controlSize) private var controlSize
+    @State private var isHovering = false
+
+    var body: some View {
+        configuration.label
+            .foregroundStyle(content)
+            .padding(.vertical, verticalPadding)
+            .padding(.horizontal, horizontalPadding)
+            .background {
+                RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                    .fill(fill)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                            .stroke(border, lineWidth: 1)
+                    }
+            }
+            .contentShape(.rect(cornerRadius: Self.cornerRadius, style: .continuous))
+            .onHover { isHovering = $0 }
+            .animation(.easeOut(duration: 0.12), value: isHovering)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+
+    /// `outline`'s ground, stepping one neutral rung per state. The disabled quarter-alpha is
+    /// Flutter's `fillSecondary.withValues(alpha: 0.25)`.
+    private var fill: Color {
+        guard isEnabled else { return WNColor.fillSecondary.opacity(Self.disabledOpacity) }
+        if configuration.isPressed { return WNColor.fillSecondaryActive }
+        return isHovering ? WNColor.fillSecondaryHover : WNColor.fillSecondary
+    }
+
+    /// The ring. Held constant across resting, hover and press — what a pointer changes is the
+    /// ground, not the edge — and faded with everything else when disabled.
+    private var border: Color {
+        isEnabled ? WNColor.borderSecondary : WNColor.borderSecondary.opacity(Self.disabledOpacity)
+    }
+
+    /// Paired with `fill` above — both are the `Secondary` half of the palette, so this must never
+    /// be swapped for a `backgroundContent*` token or a literal. See the pairing rule in `WNNSColor`.
+    private var content: Color {
+        isEnabled
+            ? WNColor.fillContentSecondary
+            : WNColor.fillContentSecondary.opacity(Self.disabledOpacity)
+    }
+
+    private var verticalPadding: CGFloat {
+        switch controlSize {
+        case .large: 8
+        case .small: 3
+        case .mini: 2
+        default: 5
+        }
+    }
+
+    private var horizontalPadding: CGFloat {
+        switch controlSize {
+        case .large: 16
+        case .small: 10
+        case .mini: 8
+        default: 12
+        }
+    }
+
+    /// `WnButton`'s radius at every size but `xsmall`.
+    private static let cornerRadius: CGFloat = 8
+    private static let disabledOpacity: Double = 0.25
+}
+
+extension ButtonStyle where Self == WNSecondaryButtonStyle {
+    /// The secondary push button — `WnButton.outline` on the other clients.
+    ///
+    /// Reach for this for any action that is not the primary one on its screen: the alternative in
+    /// a pair (`Decline` beside `Accept`), a sheet's `Cancel`, or a standalone lesser action. The
+    /// primary action keeps `nativeGlassProminentButtonStyle()`.
+    static var wnSecondary: WNSecondaryButtonStyle { WNSecondaryButtonStyle() }
+}


### PR DESCRIPTION
I missed the outline styled buttons like in flutter app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Introduced a consistent secondary button appearance with clear enabled, hovered, pressed, and disabled states.
  * Updated buttons across invites, member management, diagnostics, login, account switching, and settings to use the new styling.
  * Preserved existing disabled-state behavior for account creation and cancellation actions.
  * Added outlined appearances for circular close and back controls.
  * Improved consistency by removing destructive emphasis from non-confirmation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->