### PR TITLE
Let the last admin hand admin over, then leave

### DIFF
--- a/whitenoise-mac/Core/ChatDestructiveActions.swift
+++ b/whitenoise-mac/Core/ChatDestructiveActions.swift
@@ -74,6 +74,22 @@ extension GroupDetailsSnapshot {
     var leaveBlocker: ChatDestructiveActions.LeaveBlocker? {
         ChatDestructiveActions.leaveBlocker(membership: selfMembership, eligibility: leaveEligibility)
     }
+
+    /// The members this account may hand the admin role to on its way out.
+    var adminHandoffCandidates: [GroupMemberItem] {
+        ChatDestructiveActions.adminHandoffCandidates(from: members)
+    }
+
+    /// What the inspector says beneath the leave button. Prefers the handoff hint over the raw
+    /// `.lastAdmin` blocker, so a sole admin with someone to promote is told leaving *will* work
+    /// rather than that it won't.
+    var leaveGuidance: ChatDestructiveActions.LeaveGuidance? {
+        ChatDestructiveActions.leaveGuidance(
+            membership: selfMembership,
+            eligibility: leaveEligibility,
+            hasAdminHandoffCandidate: !adminHandoffCandidates.isEmpty
+        )
+    }
 }
 
 /// Chat awaiting a leave confirmation. `requiresSelfDemote` is captured at preparation time so the
@@ -83,6 +99,22 @@ nonisolated struct ChatLeaveTarget: Equatable, Identifiable {
     let groupIdHex: String
     let title: String
     let requiresSelfDemote: Bool
+
+    var id: String { groupIdHex }
+}
+
+/// Chat awaiting the user's choice of a successor admin, because the account leaving it is the
+/// group's only admin.
+///
+/// The candidate roster is resolved once, when the picker opens, and carried here rather than
+/// re-derived by the sheet: the sheet is presented from `ContentView` and may outlive the selection
+/// of the chat it belongs to, so it cannot read `groupDetailsSnapshot`.
+struct ChatAdminHandoffTarget: Equatable, Identifiable {
+    let groupIdHex: String
+    let title: String
+    /// Never empty — a target with no candidate is the genuine dead end, reported as the
+    /// `.lastAdmin` blocker instead of opening a picker with nothing in it.
+    let candidates: [GroupMemberItem]
 
     var id: String { groupIdHex }
 }
@@ -116,12 +148,24 @@ nonisolated struct ChatActionAlert: Equatable, Identifiable {
         )
     }
 
+    /// The admin handoff a leave depends on failed, so the leave was never attempted. Reported
+    /// separately from `leaveFailed()` because the two leave the group in different states: this one
+    /// left the account exactly where it was, still the sole admin.
+    static func adminHandoffFailed() -> ChatActionAlert {
+        ChatActionAlert(
+            title: L10n.string("Couldn't hand over admin"),
+            message: L10n.string("Try again.")
+        )
+    }
+
     /// Reports why a leave is unavailable, and nothing more.
     ///
     /// Deliberately offers no local-delete alternative: dropping the local copy while still a
     /// member would leave the rest of the group sending messages to someone who can never read
-    /// them, with nothing on the wire to say so. The remedy the message names — promote another
-    /// member to admin, then leave — keeps the group informed.
+    /// them, with nothing on the wire to say so.
+    ///
+    /// Only reached for blockers the app cannot resolve on the user's behalf. A sole admin with a
+    /// promotable member never lands here — that case opens the successor picker instead.
     static func leaveBlocked(_ blocker: ChatDestructiveActions.LeaveBlocker) -> ChatActionAlert {
         ChatActionAlert(
             title: L10n.string("Couldn't leave chat"),
@@ -186,8 +230,13 @@ nonisolated enum ChatDestructiveActions {
         /// `MarmotKitError.LeaveAlreadyRequested`.
         case pending
         /// The account is the group's only admin. MIP-03 §149/§150 forbids an admin self-removal
-        /// that would deplete the admin set, so no sequence of actions lets this account leave —
-        /// another member must be promoted to admin first.
+        /// that would deplete the admin set, so leaving requires promoting another member first.
+        ///
+        /// As a *blocker* this is the dead end only: the app resolves the ordinary case itself by
+        /// offering the successor picker (`LeaveGuidance.adminHandoffRequired`), so this reaches the
+        /// user only when there is nobody to promote — an admin alone in the group, or one whose
+        /// only companions the core refuses to let it promote. Hence the wording, which asks for a
+        /// member rather than for a promotion.
         case lastAdmin
         /// Ordinary group actions are disabled (the group is disbanding, or its lifecycle is
         /// terminal). Reachable from remote admin action even though this app never initiates a
@@ -201,12 +250,35 @@ nonisolated enum ChatDestructiveActions {
                     "Your leave request is pending. This conversation will update when the group commits it."
                 )
             case .lastAdmin:
-                return L10n.string("You're the only admin. Make another member an admin before you leave.")
+                return L10n.string(
+                    "You're the only admin, and there's no one here who can take over. Invite someone before you leave."
+                )
             case .unavailable:
                 return L10n.string("Leaving isn't available for this chat right now.")
             }
         }
 
+    }
+
+    /// What a surface says about leaving beyond offering the button — the inspector's footer today.
+    ///
+    /// Distinguishing the two `.lastAdmin` outcomes is the whole point: a sole admin with a
+    /// promotable member is not blocked, they are one extra step away, and telling them "you can't
+    /// leave" would be wrong.
+    enum LeaveGuidance: Equatable {
+        /// Leaving cannot proceed, for a reason no action in this app resolves.
+        case blocked(LeaveBlocker)
+        /// Leaving works, but routes through the successor picker first.
+        case adminHandoffRequired
+
+        var message: String {
+            switch self {
+            case .blocked(let blocker):
+                return blocker.message
+            case .adminHandoffRequired:
+                return L10n.string("You're the only admin. You'll pick who takes over before you leave.")
+            }
+        }
     }
 
     /// Which destructive action a surface may offer, from membership alone.
@@ -270,5 +342,46 @@ nonisolated enum ChatDestructiveActions {
         if eligibility.leaveRequestPending { return .pending }
         if canLeave(eligibility) { return nil }
         return eligibility.isLastAdmin ? .lastAdmin : .unavailable
+    }
+
+    /// Whether the `.lastAdmin` block is the resolvable kind — the one the successor picker exists
+    /// for. `false` for every other blocker, including a `.lastAdmin` with nobody to promote.
+    static func offersAdminHandoff(
+        _ blocker: LeaveBlocker?,
+        hasAdminHandoffCandidate: Bool
+    ) -> Bool {
+        blocker == .lastAdmin && hasAdminHandoffCandidate
+    }
+
+    /// The blocker a surface should explain, refined by whether the app can resolve it in-flow.
+    /// `nil` when leaving is plain and needs no explanation.
+    static func leaveGuidance(
+        membership: ChatSelfMembership,
+        eligibility: ChatLeaveEligibility,
+        hasAdminHandoffCandidate: Bool
+    ) -> LeaveGuidance? {
+        guard let blocker = leaveBlocker(membership: membership, eligibility: eligibility) else {
+            return nil
+        }
+        if offersAdminHandoff(blocker, hasAdminHandoffCandidate: hasAdminHandoffCandidate) {
+            return .adminHandoffRequired
+        }
+        return .blocked(blocker)
+    }
+}
+
+extension ChatDestructiveActions {
+    /// The members a departing last admin may hand the admin role to.
+    ///
+    /// `canPromote` is the core's own verdict on whether the promotion would commit, so it — not the
+    /// app's reading of the roster — decides who is offered. A member who is already an admin is
+    /// excluded because promoting them changes nothing, and self for the obvious reason. An empty
+    /// result means the `.lastAdmin` block is a genuine dead end.
+    ///
+    /// `@MainActor` rather than `nonisolated` like the rest of this policy: the target builds with
+    /// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, which isolates `GroupMemberItem`'s members.
+    @MainActor
+    static func adminHandoffCandidates(from members: [GroupMemberItem]) -> [GroupMemberItem] {
+        members.filter { !$0.isSelf && !$0.isAdmin && $0.canPromote }
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -715,7 +715,14 @@ extension WorkspaceState {
             let activeAccount,
             leavingChatId == nil,
             preparingChatLeaveId == nil,
-            chatPendingLeave == nil
+            chatPendingLeave == nil,
+            chatPendingAdminHandoff == nil,
+            // A handoff already running *is* a leave in progress, but it does not claim
+            // `leavingChatId` until its promotion commits. Without this, a second tap in that window
+            // resolves eligibility, still finds the sole-admin block, and — because the re-entrancy
+            // guard correctly declines to reopen the picker — reports a blocker for a leave that is
+            // in fact about to succeed.
+            handingOffAdminChatId == nil
         else { return }
 
         preparingChatLeaveId = groupIdHex
@@ -735,7 +742,7 @@ extension WorkspaceState {
             await presentChatLeaveDecision(
                 groupIdHex: groupIdHex,
                 title: title,
-                eligibility: ChatLeaveEligibility(state)
+                state: state
             )
         } catch {
             guard activeAccountId == accountId else { return }
@@ -745,16 +752,20 @@ extension WorkspaceState {
 
     /// Turn resolved eligibility into either a confirmation dialog or a blocker report. Shared by
     /// both phases so the confirm path re-applies exactly the checks the prepare path applied.
+    ///
+    /// Takes the whole `GroupManagementStateFfi` rather than the projected `ChatLeaveEligibility`
+    /// because the sole-admin branch needs its `memberActions` to know who may be promoted.
     private func presentChatLeaveDecision(
         groupIdHex: String,
         title: String,
-        eligibility: ChatLeaveEligibility
+        state: GroupManagementStateFfi
     ) async {
         // Both callers only reach here after their surface decided the action was `.leave`, which
         // already implies an active membership — so `.member` is the right assumption rather than a
         // re-lookup. If the account was in fact removed in the meantime, the core reports
         // `canLeave: false` with `isLastAdmin: false`, which lands on `.unavailable`; the next chat
         // -list reload then flips the row to `.deleteLocally` on its own.
+        let eligibility = ChatLeaveEligibility(state)
         guard
             let blocker = ChatDestructiveActions.leaveBlocker(
                 membership: .member,
@@ -769,19 +780,125 @@ extension WorkspaceState {
             return
         }
 
-        await reportLeaveBlocker(blocker)
+        await reportLeaveBlocker(blocker, groupIdHex: groupIdHex, title: title, state: state)
     }
 
     /// Both phases resolve the same blocker and must react to it identically, so they share this.
-    private func reportLeaveBlocker(_ blocker: ChatDestructiveActions.LeaveBlocker) async {
+    private func reportLeaveBlocker(
+        _ blocker: ChatDestructiveActions.LeaveBlocker,
+        groupIdHex: String,
+        title: String,
+        state: GroupManagementStateFfi
+    ) async {
         switch blocker {
         case .pending:
             // Already leaving: no dialog and no error — refresh so the row shows its
             // `LeavingGroupBadge` instead.
             await reloadChats(forceFreshSnapshot: true)
-        case .lastAdmin, .unavailable:
+        case .lastAdmin:
+            // The one blocker the app can clear on the user's behalf: offer the successor picker,
+            // and only report the dead end when there is nobody to hand admin to.
+            //
+            // `handingOffAdminChatId` is the re-entrancy guard. `confirmChatAdminHandoff` runs the
+            // leave through `confirmChatLeave`, which re-reads eligibility; if the promotion
+            // committed but the core still reports this account as the last admin, reopening the
+            // picker the user just used would loop. Report the blocker instead.
+            if handingOffAdminChatId != groupIdHex,
+                await presentChatAdminHandoff(groupIdHex: groupIdHex, title: title, state: state)
+            {
+                return
+            }
+            chatActionAlert = .leaveBlocked(blocker)
+        case .unavailable:
             chatActionAlert = .leaveBlocked(blocker)
         }
+    }
+
+    /// Open the successor picker for a sole admin who wants to leave. Returns false when the roster
+    /// is unreadable or holds nobody this account may promote, leaving the caller to report the
+    /// blocker.
+    ///
+    /// The roster comes from a fresh `groupDetails` read rather than from `groupDetailsSnapshot`: the
+    /// leave can be started from a sidebar row while an entirely different chat is open, and the
+    /// promotion has to name a member of *this* group.
+    private func presentChatAdminHandoff(
+        groupIdHex: String,
+        title: String,
+        state: GroupManagementStateFfi
+    ) async -> Bool {
+        guard let client, let activeAccount else { return false }
+        let accountId = activeAccount.id
+        guard
+            let details = try? await client.groupDetails(
+                accountRef: activeAccount.accountRef,
+                groupIdHex: groupIdHex
+            ),
+            activeAccountId == accountId
+        else { return false }
+
+        // Reuses the one roster projection the inspector uses, so the picker shows the same
+        // nicknames, avatars and admin badges as the member list — and reads `canPromote` from the
+        // same `memberActions` the core just returned.
+        let members = groupDetailsSnapshot(from: details, managementState: state).members
+        let candidates = ChatDestructiveActions.adminHandoffCandidates(from: members)
+        guard !candidates.isEmpty else { return false }
+
+        chatPendingAdminHandoff = ChatAdminHandoffTarget(
+            groupIdHex: groupIdHex,
+            title: title,
+            candidates: candidates
+        )
+        return true
+    }
+
+    /// Promote `successor`, then run the leave the promotion unblocked.
+    ///
+    /// The two halves are deliberately sequential and not merged into one core call: the promotion
+    /// is its own group commit, and if it fails the account must be left exactly where it was —
+    /// still admin, still a member — rather than half-way out. The leave itself goes through
+    /// `confirmChatLeave`, which re-reads eligibility and owns the self-demote-then-remove sequence,
+    /// so this method adds no second copy of that logic.
+    func confirmChatAdminHandoff(_ target: ChatAdminHandoffTarget, successor: GroupMemberItem) async {
+        guard let client,
+            let activeAccount,
+            leavingChatId == nil,
+            handingOffAdminChatId == nil
+        else { return }
+
+        chatPendingAdminHandoff = nil
+        let accountId = activeAccount.id
+        let groupIdHex = target.groupIdHex
+        handingOffAdminChatId = groupIdHex
+        defer {
+            if handingOffAdminChatId == groupIdHex {
+                handingOffAdminChatId = nil
+            }
+        }
+
+        do {
+            let result = try await client.promoteAdminDetailed(
+                accountRef: activeAccount.accountRef,
+                groupIdHex: groupIdHex,
+                memberRef: successor.npub
+            )
+            guard activeAccountId == accountId else { return }
+            // The returned details describe `groupIdHex`, which is not necessarily the chat on
+            // screen — so they may only be applied when it is. Otherwise just drop the stale roster
+            // so the next reader refetches.
+            if selectedChat?.id == groupIdHex {
+                applyGroupMutationResult(result)
+            } else {
+                invalidateGroupMembers(for: groupIdHex)
+            }
+        } catch {
+            guard activeAccountId == accountId else { return }
+            chatActionAlert = .adminHandoffFailed()
+            return
+        }
+
+        await confirmChatLeave(
+            ChatLeaveTarget(groupIdHex: groupIdHex, title: target.title, requiresSelfDemote: true)
+        )
     }
 
     func confirmChatLeave(_ target: ChatLeaveTarget) async {
@@ -819,7 +936,12 @@ extension WorkspaceState {
                 membership: .member,
                 eligibility: eligibility
             ) {
-                await reportLeaveBlocker(blocker)
+                await reportLeaveBlocker(
+                    blocker,
+                    groupIdHex: groupIdHex,
+                    title: target.title,
+                    state: state
+                )
                 return
             }
 
@@ -895,6 +1017,7 @@ extension WorkspaceState {
 
     func clearPendingChatDestructiveActions() {
         chatPendingLeave = nil
+        chatPendingAdminHandoff = nil
         chatPendingLocalDelete = nil
         chatActionAlert = nil
         preparingChatLeaveId = nil
@@ -1303,6 +1426,10 @@ extension WorkspaceState {
             || isUpdatingDisappearingMessages
             || isLeavingGroup
             || isSavingGroupImage
+            // A successor promotion is a group commit like any other. Included even though the
+            // handoff may target a chat other than the one on screen, matching `isLeavingGroup`,
+            // which is likewise cross-chat: the inspector's exclusion is intentionally coarse.
+            || handingOffAdminChatId != nil
     }
 
     func mutateGroupMember(_ member: GroupMemberItem, action: GroupMemberMutationAction) async {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1095,6 +1095,14 @@ final class WorkspaceState {
     /// a view because a SwiftUI `contextMenu` closure is torn down on selection and so cannot host
     /// the dialog itself — the same reason `messagePendingDeletion` lives here.
     var chatPendingLeave: ChatLeaveTarget?
+    /// Chat awaiting the user's choice of a successor admin before its leave can run, or `nil`.
+    /// Lives here for the same reason `chatPendingLeave` does — the sidebar row menu that starts the
+    /// leave cannot host the picker.
+    var chatPendingAdminHandoff: ChatAdminHandoffTarget?
+    /// Group currently promoting a successor admin on the way out, or `nil`. Per-chat like
+    /// `leavingChatId`, and doubles as the re-entrancy guard that keeps a handoff whose leave still
+    /// reports `.lastAdmin` from re-opening the picker it came from.
+    var handingOffAdminChatId: String?
     /// Chat awaiting the user's local-delete confirmation, or `nil`.
     var chatPendingLocalDelete: ChatLocalDeleteTarget?
     /// Outcome of a chat-list-initiated destructive action that needs reporting, or `nil`.

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -10778,6 +10778,65 @@
         }
       }
     },
+    "Choose a new admin": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neuen Admin auswählen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un nuevo administrador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisir un nouvel administrateur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli un nuovo amministratore"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha um novo administrador"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите нового администратора"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni bir yönetici seç"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择新管理员"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇新管理員"
+          }
+        }
+      }
+    },
     "Choose an account": {
       "comment": "A heading for the user to choose an account.",
       "extractionState": "manual",
@@ -13028,6 +13087,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "無法下載此影片。"
+          }
+        }
+      }
+    },
+    "Couldn't hand over admin": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Admin-Rolle konnte nicht übergeben werden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo transferir la administración"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de transférer le rôle d’administrateur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non è stato possibile trasferire il ruolo di amministratore"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível transferir a administração"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось передать права администратора"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yöneticilik devredilemedi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法移交管理员"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法移交管理員"
           }
         }
       }
@@ -27212,6 +27330,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "設為管理員"
+          }
+        }
+      }
+    },
+    "Make Admin & Leave": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zum Admin machen und verlassen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombrar administrador y salir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nommer administrateur et quitter"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nomina amministratore ed esci"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tornar administrador e sair"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назначить и выйти"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yönetici yap ve çık"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设为管理员并退出"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設為管理員並退出"
           }
         }
       }
@@ -54473,61 +54650,179 @@
         }
       }
     },
-    "You're the only admin. Make another member an admin before you leave.": {
+    "You're the only admin of “%@”. Pick who takes over, and you'll leave once they're admin.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Du bist der einzige Admin. Mache ein anderes Mitglied zum Admin, bevor du die Gruppe verlässt."
+            "value": "Du bist der einzige Admin von „%@“. Wähle aus, wer übernimmt – du verlässt den Chat, sobald diese Person Admin ist."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eres el único administrador. Nombra administrador a otro miembro antes de salir."
+            "value": "Eres el único administrador de «%@». Elige quién toma el relevo y saldrás en cuanto esa persona sea administradora."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vous êtes le seul administrateur. Faites d’un autre membre un administrateur avant de partir."
+            "value": "Vous êtes le seul administrateur de « %@ ». Choisissez qui prend le relais : vous quitterez la discussion dès que cette personne sera administratrice."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sei l'unico amministratore. Rendi un altro membro un amministratore prima di andartene."
+            "value": "Sei l'unico amministratore di «%@». Scegli chi prende il tuo posto: uscirai appena sarà amministratore."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Você é o único administrador. Torne outro membro um administrador antes de sair."
+            "value": "Você é o único administrador de “%@”. Escolha quem vai assumir e você sairá assim que essa pessoa for administradora."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ты единственный администратор. Прежде чем уйти, сделайте другого участника администратором."
+            "value": "Вы единственный администратор «%@». Выберите, кто примет эту роль, — вы выйдете, как только он станет администратором."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tek yönetici sensin. Ayrılmadan önce başka bir üyeyi yönetici yapın."
+            "value": "“%@” sohbetinin tek yöneticisisin. Devralacak kişiyi seç; o yönetici olur olmaz sohbetten çıkacaksın."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "您是唯一的管理员。在您离开之前让另一位成员成为管理员。"
+            "value": "你是“%@”的唯一管理员。选择接手的人，对方成为管理员后你就会退出。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "您是唯一的管理員。在您離開之前讓另一位成員成為管理員。"
+            "value": "你是「%@」的唯一管理員。選擇接手的人，對方成為管理員後你就會退出。"
+          }
+        }
+      }
+    },
+    "You're the only admin, and there's no one here who can take over. Invite someone before you leave.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du bist der einzige Admin, und hier ist niemand, der übernehmen kann. Lade jemanden ein, bevor du gehst."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eres el único administrador y no hay nadie que pueda tomar el relevo. Invita a alguien antes de salir."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous êtes le seul administrateur et personne ici ne peut prendre le relais. Invitez quelqu’un avant de partir."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei l'unico amministratore e qui non c'è nessuno che possa prendere il tuo posto. Invita qualcuno prima di uscire."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você é o único administrador e não há ninguém aqui que possa assumir. Convide alguém antes de sair."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы единственный администратор, и передать эту роль здесь некому. Пригласите кого-нибудь, прежде чем выйти."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tek yöneticisin ve burada devralabilecek kimse yok. Çıkmadan önce birini davet et."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你是唯一的管理员，这里没有人可以接手。退出前请先邀请他人。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你是唯一的管理員，這裡沒有人可以接手。退出前請先邀請他人。"
+          }
+        }
+      }
+    },
+    "You're the only admin. You'll pick who takes over before you leave.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du bist der einzige Admin. Vor dem Verlassen wählst du aus, wer übernimmt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eres el único administrador. Antes de salir, elegirás quién toma el relevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous êtes le seul administrateur. Avant de quitter, vous choisirez qui prend le relais."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei l'unico amministratore. Prima di uscire scegli chi prende il tuo posto."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você é o único administrador. Antes de sair, você escolherá quem vai assumir."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы единственный администратор. Перед выходом вы выберете, кто примет эту роль."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tek yöneticisin. Çıkmadan önce devralacak kişiyi seçeceksin."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你是唯一的管理员。退出前你需要选择接手的人。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你是唯一的管理員。退出前你需要選擇接手的人。"
           }
         }
       }

--- a/whitenoise-mac/Views/ChatAdminHandoffSheet.swift
+++ b/whitenoise-mac/Views/ChatAdminHandoffSheet.swift
@@ -1,0 +1,153 @@
+//
+//  ChatAdminHandoffSheet.swift
+//  whitenoise-mac
+//
+//  The successor picker a sole admin sees instead of a dead end when they leave a group.
+//
+//  MIP-03 forbids an admin self-removal that would empty the admin set, so the last admin of a
+//  group genuinely cannot leave it as-is. The app used to stop there and say so, leaving the user to
+//  work out that the fix was to open the member list, promote somebody, and try again. This sheet is
+//  that fix, made into one step: pick who takes over, and the promotion and the leave run together.
+//
+
+import SwiftUI
+
+struct ChatAdminHandoffSheet: View {
+    @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.dismiss) private var dismiss
+
+    let target: ChatAdminHandoffTarget
+
+    /// Nothing is preselected on purpose: handing someone the admin role is a consequential choice,
+    /// and a default would let a distracted return-press pick for them.
+    @State private var selectedMemberId: String?
+
+    private var selectedMember: GroupMemberItem? {
+        target.candidates.first { $0.id == selectedMemberId }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            explanation
+            Divider()
+            candidateList
+            Divider()
+            footer
+        }
+        .frame(width: 420, height: 460)
+    }
+
+    private var header: some View {
+        HStack {
+            Text(L10n.string("Choose a new admin"))
+                .wnFont(.semiBold14)
+            Spacer()
+            Button(L10n.string("Cancel")) { dismiss() }
+                .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var explanation: some View {
+        Text(
+            String(
+                format: L10n.string(
+                    "You're the only admin of “%@”. Pick who takes over, and you'll leave once they're admin."
+                ),
+                PeerDisplayText.templateFragment(target.title)
+            )
+        )
+        .wnFont(.medium12)
+        .foregroundStyle(WNColor.backgroundContentSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var candidateList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(target.candidates) { candidate in
+                    ChatAdminHandoffCandidateRow(
+                        candidate: candidate,
+                        isSelected: candidate.id == selectedMemberId
+                    ) {
+                        selectedMemberId = candidate.id
+                    }
+
+                    if candidate.id != target.candidates.last?.id {
+                        Divider().padding(.leading, 54)
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button {
+                guard let selectedMember else { return }
+                Task { await workspace.confirmChatAdminHandoff(target, successor: selectedMember) }
+            } label: {
+                Text(L10n.string("Make Admin & Leave")).frame(minWidth: 96)
+            }
+            .keyboardShortcut(.defaultAction)
+            .nativeGlassProminentButtonStyle()
+            // Only the leave half is destructive, and it is the half the confirmation below the
+            // button already describes — so the affordance stays a plain prominent action rather
+            // than shouting at a user whose alternative is being stuck in the group forever.
+            .disabled(selectedMember == nil || workspace.hasInFlightGroupCommit)
+        }
+        .padding(16)
+    }
+}
+
+/// One selectable successor. Mirrors `GroupMemberRow`'s identity presentation — same avatar seed,
+/// same nickname-aware `displayName`, same `detailLabel` — so the person picked here is recognisably
+/// the person seen in the member list.
+private struct ChatAdminHandoffCandidateRow: View {
+    let candidate: GroupMemberItem
+    let isSelected: Bool
+    let select: () -> Void
+
+    var body: some View {
+        Button(action: select) {
+            HStack(spacing: 10) {
+                AvatarView(
+                    seed: candidate.id,
+                    initials: candidate.initials,
+                    size: 32,
+                    isSelected: false
+                )
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(candidate.displayName)
+                        .wnFont(.medium12)
+                        .lineLimit(1)
+                    Text(candidate.detailLabel)
+                        .wnFont(.medium10)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(
+                        isSelected ? WNColor.fillPrimary : WNColor.backgroundContentTertiary
+                    )
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}

--- a/whitenoise-mac/Views/ChatDestructiveActionsConfirmation.swift
+++ b/whitenoise-mac/Views/ChatDestructiveActionsConfirmation.swift
@@ -2,9 +2,10 @@
 //  ChatDestructiveActionsConfirmation.swift
 //  whitenoise-mac
 //
-//  The single confirmation and reporting surface for the two destructive chat actions. Both the
-//  sidebar row context menu and the group-details inspector drive it through workspace state, so
-//  each action has exactly one dialog and one wording in the whole app.
+//  The single confirmation and reporting surface for the two destructive chat actions, plus the
+//  admin handoff a sole admin's leave routes through. Both the sidebar row context menu and the
+//  group-details inspector drive it through workspace state, so each action has exactly one dialog
+//  and one wording in the whole app.
 //
 //  It has to live on state rather than in a view for the same reason `messageDeletionConfirmation`
 //  does: a SwiftUI `contextMenu` closure is torn down when an item is chosen, so a dialog declared
@@ -39,6 +40,12 @@ private struct ChatDestructiveActionsConfirmationModifier: ViewModifier {
                 Button(L10n.string("Cancel"), role: .cancel) {}
             } message: { target in
                 Text(leaveMessage(target))
+            }
+            // A sheet rather than a confirmation dialog because this step asks for a choice from a
+            // roster, not a yes/no. It is attached here for the same reason the dialogs above are:
+            // the leave can start from a sidebar row whose menu is already torn down.
+            .sheet(item: $workspace.chatPendingAdminHandoff) { target in
+                ChatAdminHandoffSheet(target: target)
             }
             .confirmationDialog(
                 localDeleteTitle(workspace.chatPendingLocalDelete),

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -462,10 +462,10 @@ struct GroupDetailsSheet: View {
                             }
 
                             // Leave / Delete come from the same policy the sidebar row menu uses, so
-                            // the two surfaces cannot disagree on which is legal. Unlike a row, the
-                            // inspector holds full eligibility, so it can offer the local delete up
-                            // front when leaving is structurally impossible — the sole admin of a
-                            // chat can never leave it, and would otherwise be offered neither.
+                            // the two surfaces cannot disagree on which is legal. Membership is the
+                            // whole rule: a member is offered the leave even when eligibility will
+                            // block it, and `prepareSelectedChatLeave` either explains the block or —
+                            // for a sole admin — opens the successor picker that resolves it.
                             switch snapshot.destructiveAction {
                             case .leave:
                                 Button(role: .destructive) {
@@ -479,7 +479,8 @@ struct GroupDetailsSheet: View {
                                 }
                                 .disabled(
                                     workspace.leavingChatId != nil
-                                        || workspace.preparingChatLeaveId != nil)
+                                        || workspace.preparingChatLeaveId != nil
+                                        || workspace.handingOffAdminChatId != nil)
 
                             case .deleteLocally:
                                 Button(role: .destructive) {
@@ -505,10 +506,12 @@ struct GroupDetailsSheet: View {
                             Spacer()
                         }
 
-                        // Sourced from the shared blocker so the footer and the row menu's alert
-                        // cannot drift apart.
-                        if let blocker = snapshot.leaveBlocker {
-                            Text(blocker.message)
+                        // Sourced from the shared policy so the footer and the row menu's alert
+                        // cannot drift apart. `leaveGuidance` rather than `leaveBlocker` because the
+                        // sole admin of a group with someone to promote is not blocked — they are one
+                        // extra step from leaving, and the footer says which step.
+                        if let guidance = snapshot.leaveGuidance {
+                            Text(guidance.message)
                                 .wnFont(.medium12)
                                 .foregroundStyle(WNColor.backgroundContentSecondary)
                         }

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -528,7 +528,10 @@ private struct ChatSidebarRowMenuItems: View {
                         systemImage: "rectangle.portrait.and.arrow.right"
                     )
                 }
-                .disabled(workspace.leavingChatId != nil || workspace.preparingChatLeaveId != nil)
+                .disabled(
+                    workspace.leavingChatId != nil
+                        || workspace.preparingChatLeaveId != nil
+                        || workspace.handingOffAdminChatId != nil)
 
             case .deleteLocally:
                 Button(role: .destructive) {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -3860,15 +3860,105 @@ struct PureValueTests {
             ChatDestructiveActions.leaveBlocker(membership: .member, eligibility: lastAdmin)
                 == .lastAdmin
         )
-        // Leaving can never succeed here, and the answer is still Leave — reported as blocked, with
-        // the remedy named. It is deliberately *not* swapped for a local delete: the group has to
-        // learn that this account stopped reading, and only a leave tells them.
+        // The answer is still Leave, and it is deliberately *not* swapped for a local delete: the
+        // group has to learn that this account stopped reading, and only a leave tells them. What
+        // happens next depends on whether anyone can take the admin role over — see
+        // `soleAdminWithASuccessorIsGuidedToTheHandoffRatherThanBlocked`.
         #expect(
             ChatDestructiveActions.action(membership: .member, leaveRequestPending: false) == .leave
         )
         #expect(
             ChatActionAlert.leaveBlocked(.lastAdmin).message
-                == L10n.string("You're the only admin. Make another member an admin before you leave.")
+                == L10n.string(
+                    "You're the only admin, and there's no one here who can take over. Invite someone before you leave."
+                )
+        )
+    }
+
+    /// The reason this flow exists: a sole admin with a member who can take over is not blocked,
+    /// they are one step from leaving. Only the genuine dead end — nobody to promote — may be
+    /// reported as a blocker.
+    @Test func soleAdminWithASuccessorIsGuidedToTheHandoffRatherThanBlocked() {
+        let lastAdmin = leaveEligibility(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: true
+        )
+
+        #expect(
+            ChatDestructiveActions.leaveGuidance(
+                membership: .member,
+                eligibility: lastAdmin,
+                hasAdminHandoffCandidate: true
+            ) == .adminHandoffRequired
+        )
+        #expect(
+            ChatDestructiveActions.leaveGuidance(
+                membership: .member,
+                eligibility: lastAdmin,
+                hasAdminHandoffCandidate: false
+            ) == .blocked(.lastAdmin)
+        )
+        // One promises the leave will happen, the other says it cannot — sharing wording would make
+        // the footer a lie in whichever case it was not written for.
+        #expect(
+            ChatDestructiveActions.LeaveGuidance.adminHandoffRequired.message
+                != ChatDestructiveActions.LeaveBlocker.lastAdmin.message
+        )
+    }
+
+    /// `.lastAdmin` is the only blocker a promotion resolves. A pending leave and a disabled group
+    /// are unaffected by who else could be made admin, and must never open the picker.
+    @Test func onlyTheSoleAdminBlockIsResolvedByHandingAdminOver() {
+        let pending = leaveEligibility(canLeave: false, leaveRequestPending: true, isLastAdmin: true)
+        let unavailable = leaveEligibility(canLeave: false, isLastAdmin: false)
+
+        for eligibility in [pending, unavailable] {
+            let blocker = ChatDestructiveActions.leaveBlocker(
+                membership: .member,
+                eligibility: eligibility
+            )
+            #expect(!ChatDestructiveActions.offersAdminHandoff(blocker, hasAdminHandoffCandidate: true))
+            #expect(
+                ChatDestructiveActions.leaveGuidance(
+                    membership: .member,
+                    eligibility: eligibility,
+                    hasAdminHandoffCandidate: true
+                ) == blocker.map(ChatDestructiveActions.LeaveGuidance.blocked)
+            )
+        }
+
+        // And a leave with nothing wrong with it needs no footer at all, candidates or not.
+        for hasCandidate in [false, true] {
+            #expect(
+                ChatDestructiveActions.leaveGuidance(
+                    membership: .member,
+                    eligibility: leaveEligibility(canLeave: true),
+                    hasAdminHandoffCandidate: hasCandidate
+                ) == nil
+            )
+        }
+    }
+
+    /// `canPromote` is the core's verdict on whether the promotion would commit, so it decides who
+    /// is offered. Self, existing admins, and anyone the core won't let this account promote are all
+    /// useless as successors — offering them would produce a picker whose choice fails.
+    @MainActor
+    @Test func adminHandoffCandidatesAreOnlyMembersThePromotionWouldActuallyWorkFor() {
+        let members = [
+            handoffMember(id: "self", isSelf: true, isAdmin: true, canPromote: true),
+            handoffMember(id: "already-admin", isAdmin: true, canPromote: true),
+            handoffMember(id: "not-promotable", canPromote: false),
+            handoffMember(id: "successor", canPromote: true),
+        ]
+
+        #expect(ChatDestructiveActions.adminHandoffCandidates(from: members).map(\.id) == ["successor"])
+        #expect(ChatDestructiveActions.adminHandoffCandidates(from: []).isEmpty)
+        // An admin alone in the group is the dead end the `.lastAdmin` blocker still reports.
+        #expect(
+            ChatDestructiveActions.adminHandoffCandidates(
+                from: [handoffMember(id: "self", isSelf: true, isAdmin: true, canPromote: true)]
+            ).isEmpty
         )
     }
 
@@ -4369,6 +4459,28 @@ private func leaveEligibility(
         requiresSelfDemoteBeforeLeave: requiresSelfDemoteBeforeLeave,
         leaveRequestPending: leaveRequestPending,
         isLastAdmin: isLastAdmin
+    )
+}
+
+@MainActor
+private func handoffMember(
+    id: String,
+    isSelf: Bool = false,
+    isAdmin: Bool = false,
+    canPromote: Bool = false
+) -> GroupMemberItem {
+    GroupMemberItem(
+        id: id,
+        displayName: id,
+        publishedDisplayName: nil,
+        npub: "npub1\(id)",
+        accountLabel: nil,
+        isLocal: isSelf,
+        isAdmin: isAdmin,
+        isSelf: isSelf,
+        canRemove: false,
+        canPromote: canPromote,
+        canDemote: isAdmin
     )
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -21737,7 +21737,10 @@ struct whitenoise_macTests {
         isLastAdmin: Bool = false,
         leaveRequestPending: Bool = false,
         selfIsAdmin: Bool = false,
-        openingInspector: Bool = false
+        openingInspector: Bool = false,
+        // Empty by default, which is also the "nobody can be promoted" case the sole-admin dead end
+        // needs. Pass actions when the test is about who may take the admin role over.
+        memberActions: [GroupMemberActionStateFfi] = []
     ) async throws -> WorkspaceState {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
@@ -21751,7 +21754,7 @@ struct whitenoise_macTests {
                 canLeave: canLeave,
                 requiresSelfDemoteBeforeLeave: requiresSelfDemoteBeforeLeave,
                 leaveRequestPending: leaveRequestPending,
-                memberActions: []
+                memberActions: memberActions
             )
         )
         if openingInspector {
@@ -22361,14 +22364,170 @@ struct whitenoise_macTests {
 
         #expect(state.chatPendingLeave == nil)
         #expect(state.chatPendingLocalDelete == nil)
+        // No `memberActions`, so the core has named nobody this account may promote: the successor
+        // picker would be an empty list, and the honest answer is the blocker.
+        #expect(state.chatPendingAdminHandoff == nil)
         #expect(runtime.leaveGroupCallCount == 0)
         #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+        #expect(runtime.promoteAdminDetailedCallCount == 0)
         #expect(runtime.locallyDeletedGroupIds.isEmpty)
         let alert = try #require(state.chatActionAlert)
         #expect(alert.message == ChatDestructiveActions.LeaveBlocker.lastAdmin.message)
         // The chat is still listed and still a member's chat — nothing was silently dropped.
         #expect(state.activeChats.contains { $0.id == chat.id })
         #expect(ChatDestructiveActions.action(for: chat) == .leave)
+    }
+
+    /// The sole admin of a group with someone who *can* take over gets the successor picker rather
+    /// than the dead end — and gets it before anything is committed, so cancelling costs nothing.
+    @MainActor
+    @Test func soleAdminLeaveOffersASuccessorPickerRatherThanADeadEnd() async throws {
+        let state = try await soleAdminWithSuccessorState()
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+
+        let handoff = try #require(state.chatPendingAdminHandoff)
+        #expect(handoff.groupIdHex == chat.id)
+        #expect(handoff.title == chat.title)
+        // Alice only: Bob carries no action state, so the core has not said he may be promoted.
+        #expect(handoff.candidates.map(\.npub) == ["npub1alyce"])
+        // A question, not a commit: nothing about the group has changed, and no blocker was reported.
+        #expect(state.chatActionAlert == nil)
+        #expect(state.chatPendingLeave == nil)
+        #expect(runtime.promoteAdminDetailedCallCount == 0)
+        #expect(runtime.leaveGroupCallCount == 0)
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+        #expect(state.activeChats.contains { $0.id == chat.id })
+    }
+
+    /// The point of the whole flow: one confirmation promotes the successor, steps this account down,
+    /// and removes it — in that order, because MIP-03 rejects any other.
+    @MainActor
+    @Test func confirmedHandoffPromotesTheSuccessorThenLeaves() async throws {
+        let state = try await soleAdminWithSuccessorState()
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+        let handoff = try #require(state.chatPendingAdminHandoff)
+        let successor = try #require(handoff.candidates.first)
+
+        await state.confirmChatAdminHandoff(handoff, successor: successor)
+
+        #expect(runtime.promotedAdminRef == "npub1alyce")
+        #expect(runtime.groupMutationOrder == ["promote", "selfDemote", "leave"])
+        #expect(runtime.leftGroupIdHex == chat.id)
+        #expect(state.chatActionAlert == nil)
+        // Every marker released, so neither the picker nor the leave can be re-offered as in flight.
+        #expect(state.chatPendingAdminHandoff == nil)
+        #expect(state.handingOffAdminChatId == nil)
+        #expect(state.leavingChatId == nil)
+        #expect(!state.hasInFlightGroupCommit)
+    }
+
+    /// A promotion that fails must leave the account exactly where it was — still admin, still a
+    /// member — and say so as its own failure. Reporting it as a failed *leave* would be a lie, and
+    /// carrying on to the removal would be the self-removal MIP-03 forbids.
+    @MainActor
+    @Test func failedHandoffNeverAttemptsTheLeaveItWouldHaveUnblocked() async throws {
+        let state = try await soleAdminWithSuccessorState()
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+        runtime.promoteAdminError = FakeMarmotRuntimeError.unused
+
+        await state.prepareChatLeave(for: chat)
+        let handoff = try #require(state.chatPendingAdminHandoff)
+
+        await state.confirmChatAdminHandoff(handoff, successor: try #require(handoff.candidates.first))
+
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+        #expect(runtime.leaveGroupCallCount == 0)
+        #expect(runtime.groupMutationOrder.isEmpty)
+        #expect(state.chatActionAlert == ChatActionAlert.adminHandoffFailed())
+        #expect(state.chatPendingAdminHandoff == nil)
+        #expect(state.handingOffAdminChatId == nil)
+        #expect(state.activeChats.contains { $0.id == chat.id })
+    }
+
+    /// The re-entrancy guard. `confirmChatAdminHandoff` finishes through `confirmChatLeave`, which
+    /// re-reads eligibility; a core that still calls this account the last admin after the promotion
+    /// committed must produce a report, not the picker the user just used — which would reopen
+    /// forever.
+    @MainActor
+    @Test func handoffWhoseLeaveStillReportsSoleAdminDoesNotReopenThePicker() async throws {
+        let state = try await soleAdminWithSuccessorState()
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+        runtime.keepsManagementStateAfterPromote = true
+
+        await state.prepareChatLeave(for: chat)
+        let handoff = try #require(state.chatPendingAdminHandoff)
+
+        await state.confirmChatAdminHandoff(handoff, successor: try #require(handoff.candidates.first))
+
+        #expect(runtime.promoteAdminDetailedCallCount == 1)
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+        #expect(runtime.leaveGroupCallCount == 0)
+        #expect(state.chatPendingAdminHandoff == nil)
+        #expect(state.chatActionAlert?.message == ChatDestructiveActions.LeaveBlocker.lastAdmin.message)
+        #expect(state.handingOffAdminChatId == nil)
+    }
+
+    /// A handoff claims `leavingChatId` only once its promotion commits, so between the confirmation
+    /// and that commit the leave is in progress with none of the usual markers set. A second attempt
+    /// in that window must be ignored: it would otherwise resolve eligibility, still find the
+    /// sole-admin block, and report a blocker for a leave that is about to succeed.
+    @MainActor
+    @Test func leaveIsNotRePreparedWhileTheHandoffPromotionIsStillInFlight() async throws {
+        let state = try await soleAdminWithSuccessorState()
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+        let handoff = try #require(state.chatPendingAdminHandoff)
+        let successor = try #require(handoff.candidates.first)
+
+        runtime.groupMutationGateEnabled = true
+        async let handoffRun: Void = state.confirmChatAdminHandoff(handoff, successor: successor)
+        while !(state.handingOffAdminChatId == chat.id && runtime.didReachGroupMutationGate) {
+            await Task.yield()
+        }
+
+        await state.prepareChatLeave(for: chat)
+        #expect(state.chatActionAlert == nil)
+        #expect(state.chatPendingLeave == nil)
+        #expect(state.chatPendingAdminHandoff == nil)
+
+        runtime.releaseGroupMutationGate()
+        await handoffRun
+
+        // The one handoff still completes, and exactly once.
+        #expect(runtime.promoteAdminDetailedCallCount == 1)
+        #expect(runtime.groupMutationOrder == ["promote", "selfDemote", "leave"])
+        #expect(state.chatActionAlert == nil)
+    }
+
+    /// The sole admin of a fixture group in which Alice — and only Alice — may be promoted.
+    @MainActor
+    private func soleAdminWithSuccessorState() async throws -> WorkspaceState {
+        try await leavableChatState(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: true,
+            selfIsAdmin: true,
+            memberActions: [
+                GroupMemberActionStateFfi(
+                    memberIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+                    isSelf: false,
+                    isAdmin: false,
+                    canRemove: true,
+                    canPromote: true,
+                    canDemote: false
+                )
+            ]
+        )
     }
 
     @MainActor
@@ -29553,6 +29712,11 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     /// Ordered log of the group mutations a leave can issue, so tests can assert that a
     /// self-demote precedes the leave it unblocks rather than merely accompanying it.
     private(set) var groupMutationOrder: [String] = []
+    var promoteAdminError: Error?
+    /// Suppresses the management-state recomputation a promotion normally triggers, so a test can
+    /// pose as a core that still reports this account as the blocked sole admin after the promote
+    /// committed.
+    var keepsManagementStateAfterPromote = false
     private(set) var acceptedInviteGroupIds: [String] = []
     private(set) var acceptGroupInviteCallCount = 0
     private(set) var declinedInviteGroupIds: [String] = []
@@ -30749,9 +30913,19 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     {
         promoteAdminDetailedCallCount += 1
         await groupMutationGate.passIfArmed()
+        if let promoteAdminError { throw promoteAdminError }
+        groupMutationOrder.append("promote")
         promotedAdminRef = memberRef
+        let managementStateBeforePromote = groupManagementStateById[groupIdHex]
         updateMember(groupIdHex: groupIdHex, matching: memberRef) { member in
             member.isAdmin = true
+        }
+        // `updateMember` recomputes the management state from the new admin set, so a second admin
+        // clears both `isLastAdmin` and the leave block — which is exactly what the
+        // hand-admin-over-then-leave flow depends on. This knob poses as a core that reports no
+        // change at all, so the leave that follows still sees the sole-admin block.
+        if keepsManagementStateAfterPromote, let managementStateBeforePromote {
+            groupManagementStateById[groupIdHex] = managementStateBeforePromote
         }
         return try groupMutationResult(groupIdHex: groupIdHex, messageId: "group-promote")
     }


### PR DESCRIPTION
When the last admin wanted to leave, the flow was blocked explaining that it had to assign a new admin before leaving. This PR adds a flow to include a new admin immediately