### PR TITLE
Clear active account unread badge once chats are read

### DIFF
--- a/whitenoise-mac/Core/AccountUnreadSignal.swift
+++ b/whitenoise-mac/Core/AccountUnreadSignal.swift
@@ -1,0 +1,24 @@
+//
+//  AccountUnreadSignal.swift
+//  whitenoise-mac
+//
+//  Row-derived unread state for the active account, used to decide when the per-account
+//  unread summary behind the switcher avatar badges has gone stale.
+//
+
+import Foundation
+
+/// A comparable snapshot of what the active account's loaded chat rows say about unread state.
+///
+/// The switcher avatar badge shows the backend's per-account summary, which is refreshed far less
+/// often than the rows are. Comparing two of these values answers the only question that matters
+/// for keeping the badge honest: did the rows change unread since the summary was last taken?
+struct AccountUnreadSignal: Equatable, Sendable {
+    /// The account the counts belong to. A switch alone makes the recorded summary stale, even
+    /// when both accounts happen to hold the same totals.
+    let accountId: String
+    /// Unread messages across the account's chats, archived ones included.
+    let totalUnreadCount: Int
+    /// Chats flagged unread, which includes chats marked unread by hand and so carrying no count.
+    let unreadChatCount: Int
+}

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -521,6 +521,12 @@ extension WorkspaceState {
         timelinePagingByChat.removeAll()
         clearConversationMetadata()
         accountUnreadByIdHex.removeAll()
+        // The recorded signal describes counts that no longer exist; keeping it could suppress
+        // the refresh that repopulates the badges after the next account takes over. Bumping the
+        // generation also drops any answer still in flight, which would otherwise repopulate the
+        // badges the teardown just cleared.
+        lastSummarizedAccountUnread = nil
+        accountUnreadSummaryGeneration &+= 1
         // Read markers are keyed by groupIdHex; leaving them behind both retains a
         // record of which messages the signed-out identity read and lets a recurring
         // group id suppress the first legitimate read-mark advance after re-login. The
@@ -657,16 +663,77 @@ extension WorkspaceState {
 
     /// Refresh per-account unread totals without loading each account's full session.
     func refreshAccountUnreadSummary() async {
+        await refreshAccountUnreadSummary(reflecting: currentAccountUnreadSignal())
+    }
+
+    /// Re-run the summary only when the active account's own chat rows have moved its unread total.
+    ///
+    /// The avatar badge reads `accountUnreadByIdHex`, which comes from a different backend query
+    /// than the chat-list subscription feeding the rows. Reading a chat updates the rows live but
+    /// left the summary at its pre-read value, so the active account's avatar kept a badge for
+    /// messages it had already read until the next full reload or account switch (the only two
+    /// callers of the summary). Gating on the row-derived signal keeps the badge honest without
+    /// putting an FFI query on every read-marker advance.
+    func refreshAccountUnreadSummaryIfChatRowsMovedIt() async {
+        let signal = currentAccountUnreadSignal()
+        guard signal != lastSummarizedAccountUnread else { return }
+        await refreshAccountUnreadSummary(reflecting: signal)
+    }
+
+    private func refreshAccountUnreadSummary(reflecting signal: AccountUnreadSignal?) async {
         guard let client else { return }
+        // Two refreshes can be in flight at once (a read-marker advance and a chat-list reload
+        // race routinely), and the FFI answers in whatever order it finishes. Only the newest
+        // request for the still-active account may commit: a late answer landing last would
+        // restore a pre-read total and — because committing also records its signal — leave the
+        // gate suppressing the very refresh that would correct it.
+        accountUnreadSummaryGeneration &+= 1
+        let generation = accountUnreadSummaryGeneration
+        let requestedAccountId = activeAccountId
         do {
             let rows = try await runOffMain { try client.accountUnreadSummary() }
+            guard accountUnreadSummaryGeneration == generation, activeAccountId == requestedAccountId else {
+                return
+            }
             accountUnreadByIdHex = Dictionary(
                 rows.map { ($0.accountIdHex, Int(clamping: $0.unreadCount)) },
                 uniquingKeysWith: { lhs, _ in lhs }
             )
+            // Record the signal captured before the query, not the current one: rows that changed
+            // while it was in flight are not reflected in these totals and must still trigger a
+            // follow-up refresh.
+            lastSummarizedAccountUnread = signal
         } catch {
-            // Unread badges are best-effort; leave the prior values on failure.
+            // Unread badges are best-effort; leave the prior values — and the prior signal, so the
+            // next row change retries — on failure.
         }
+    }
+
+    /// The active account's aggregate unread state as its own loaded chat rows report it.
+    ///
+    /// This is never what the badge displays (that stays the backend summary, which is the only
+    /// value comparable across accounts); it is the cheap local signal for noticing that the
+    /// displayed summary went stale.
+    func currentAccountUnreadSignal() -> AccountUnreadSignal? {
+        guard let activeAccountId else { return nil }
+        // Archived chats carry unread counts too, and the chat-list subscription loads them in the
+        // same snapshot, so a signal built from the active list alone would miss their changes.
+        let chats = (chatsByAccount[activeAccountId] ?? []) + (archivedChatsByAccount[activeAccountId] ?? [])
+        var totalUnreadCount = 0
+        var unreadChatCount = 0
+        for chat in chats {
+            // A change signal, not a displayed count: wrapping addition keeps a pathological
+            // row total (rows clamp to `Int.max`) from trapping here.
+            totalUnreadCount &+= chat.unreadCount
+            if chat.hasUnread {
+                unreadChatCount += 1
+            }
+        }
+        return AccountUnreadSignal(
+            accountId: activeAccountId,
+            totalUnreadCount: totalUnreadCount,
+            unreadChatCount: unreadChatCount
+        )
     }
 
     /// Aggregate unread count for an account's avatar badge in the switcher.
@@ -870,6 +937,8 @@ extension WorkspaceState {
         clearConversationMetadata()
         clearSharedMedia()
         accountUnreadByIdHex.removeAll()
+        lastSummarizedAccountUnread = nil
+        accountUnreadSummaryGeneration &+= 1
         // "Delete All Local Data" must also evict decoded peer/group avatars held in the
         // process-lifetime decoded-image cache; those images derive from attacker-controlled
         // peer `picture` URLs and would otherwise survive the wipe in memory. See #177.

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -152,11 +152,13 @@ extension WorkspaceState {
             // runs on the main actor, leaving non-selected direct chats on their raw fallback.
             startChatListListener(account: activeAccount, subscription: subscription)
             guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
-            await applyChatRows(rows, account: activeAccount)
+            await applyChatRows(rows, account: activeAccount, refreshingAccountUnreadSummary: false)
 
             guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
             await selectInitialChatIfNeeded()
             guard canContinueChatListReload(generation: generation, accountId: accountId) else { return }
+            // Unconditional, unlike the row-gated refreshes: a reload is the one point that also
+            // re-reads the *other* accounts' totals, which no row delta of ours can move.
             await refreshAccountUnreadSummary()
         } catch is CancellationError {
             return
@@ -265,7 +267,14 @@ extension WorkspaceState {
         }
     }
 
-    func applyChatRows(_ rows: [ChatListRowFfi], account: AccountItem) async {
+    /// - Parameter refreshingAccountUnreadSummary: whether this pass owns the unread-summary
+    ///   refresh. A full reload runs its own unconditional refresh right after (the one moment
+    ///   background accounts' totals are re-read), so it opts out rather than query twice.
+    func applyChatRows(
+        _ rows: [ChatListRowFfi],
+        account: AccountItem,
+        refreshingAccountUnreadSummary: Bool = true
+    ) async {
         guard activeAccountId == account.id else { return }
 
         let activeRows = rows.filter { !$0.archived }
@@ -312,6 +321,9 @@ extension WorkspaceState {
         cancelVoiceRecordingIfSelectedMembershipEnded()
         ensureSelectedMessageTimelineStore()
         startChatListEnrichment(rows: rows, account: account)
+        if refreshingAccountUnreadSummary {
+            await refreshAccountUnreadSummaryIfChatRowsMovedIt()
+        }
     }
 
     /// A membership flip to left/removed swaps the selected chat's composer (its recording
@@ -339,6 +351,9 @@ extension WorkspaceState {
         case .removeRow(trigger: _, let groupIdHex):
             removeChat(groupIdHex: groupIdHex, account: account)
             removeArchivedChatFromList(chatId: groupIdHex, forAccountId: account.id)
+            // A removed chat takes its unread messages with it, so the avatar badge has to drop
+            // them too — `removeChat` is synchronous and has no other summary hook.
+            await refreshAccountUnreadSummaryIfChatRowsMovedIt()
         case .snapshot(let trigger, let rows):
             for row in rows {
                 invalidateGroupMemberDetailsCacheIfNeeded(trigger: trigger, groupIdHex: row.groupIdHex)
@@ -376,6 +391,7 @@ extension WorkspaceState {
             if shouldEnrich {
                 startChatListEnrichment(rows: [row], account: account, replacingCurrent: false)
             }
+            await refreshAccountUnreadSummaryIfChatRowsMovedIt()
             return
         }
 
@@ -411,6 +427,10 @@ extension WorkspaceState {
             readStateMetadataEnrichmentAttempts.insert(row.groupIdHex)
             await enrichChatRows([row], account: account)
         }
+        // The read-state fast path lands here: a marker advance clears the row's unread count, and
+        // the avatar badge above the chat list has to follow it down rather than wait for the next
+        // reload or account switch.
+        await refreshAccountUnreadSummaryIfChatRowsMovedIt()
     }
 
     func moveChatToArchived(row: ChatListRowFfi, account: AccountItem) {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1312,6 +1312,11 @@ final class WorkspaceState {
     }
     /// Per-account unread totals keyed by `accountIdHex`, for switcher avatar badges.
     var accountUnreadByIdHex: [String: Int] = [:]
+    /// The active account's row-derived unread signal at the time `accountUnreadByIdHex` was
+    /// last refreshed, so the summary is only re-queried once the rows actually move it.
+    @ObservationIgnored var lastSummarizedAccountUnread: AccountUnreadSignal?
+    /// Bumped per summary request so only the newest one may commit its answer.
+    @ObservationIgnored var accountUnreadSummaryGeneration: UInt64 = 0
     var isSavingRelays = false
     var isPublishingKeyPackage = false
     var isRepublishingKeyPackage = false

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2289,6 +2289,199 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func readingTheActiveAccountsChatsClearsItsAvatarUnreadBadge() async throws {
+        // The rail avatar badge reads the per-account summary, which used to be re-queried only on
+        // sign-in/out and full chat-list reloads. Reading a chat reaches the app as a live row
+        // delta, so the active account's avatar kept a badge for messages it had already read
+        // until the next account switch.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        runtime.accountUnreadSummaryRows = [
+            AccountUnreadFfi(
+                accountIdHex: account.accountIdHex,
+                unreadCount: 5,
+                unreadConversations: 1,
+                hasUnread: true
+            )
+        ]
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        await state.chatListEnrichmentTask?.value
+        let activeAccount = try #require(state.activeAccount)
+        let chat = try #require(state.activeChats.first)
+
+        await state.applyChatListSubscriptionUpdate(
+            .row(
+                trigger: .unreadChanged,
+                row: chatListRow(
+                    groupIdHex: chat.id,
+                    title: "Test Group",
+                    preview: "Unread message",
+                    sender: account.accountIdHex,
+                    timelineAt: 1_700_000_100,
+                    unreadCount: 5,
+                    hasUnread: true
+                )
+            ),
+            account: activeAccount
+        )
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 5)
+
+        // The user opens the chat: the read marker commits and the backend stops reporting unread.
+        runtime.accountUnreadSummaryRows = [
+            AccountUnreadFfi(
+                accountIdHex: account.accountIdHex,
+                unreadCount: 0,
+                unreadConversations: 0,
+                hasUnread: false
+            )
+        ]
+        await state.applyChatListSubscriptionUpdate(
+            .row(
+                trigger: .unreadChanged,
+                row: chatListRow(
+                    groupIdHex: chat.id,
+                    title: "Test Group",
+                    preview: "Unread message",
+                    sender: account.accountIdHex,
+                    timelineAt: 1_700_000_100
+                )
+            ),
+            account: activeAccount
+        )
+
+        #expect(state.activeChats.first?.unreadCount == 0)
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+    }
+
+    @MainActor
+    @Test func chatRowDeltasThatLeaveUnreadAloneDoNotRequeryTheAccountUnreadSummary() async throws {
+        // The badge follows the rows, but a summary query per row delta would put an FFI call on
+        // every read-marker advance and every incoming preview. Only a moved unread total re-queries.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 3)
+        ]
+        let (state, account) = unreadBadgeFixture(runtime: runtime, seededUnreadCount: 3)
+
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 3)
+        let queriesSoFar = runtime.accountUnreadSummaryCallCount
+
+        // A newer message on a row that stays just as unread.
+        await state.applyChatRow(
+            unreadBadgeFixtureRow(timelineAt: 1_700_000_100, unreadCount: 3),
+            account: account,
+            shouldEnrich: false
+        )
+        #expect(state.activeChats.first?.updatedAt == Date(timeIntervalSince1970: 1_700_000_100))
+        #expect(runtime.accountUnreadSummaryCallCount == queriesSoFar)
+
+        // The same row, now read: the badge has to follow it down, so this one does query.
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0)
+        ]
+        await state.applyChatRow(
+            unreadBadgeFixtureRow(timelineAt: 1_700_000_200, unreadCount: 0),
+            account: account,
+            shouldEnrich: false
+        )
+        #expect(runtime.accountUnreadSummaryCallCount == queriesSoFar + 1)
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+    }
+
+    @MainActor
+    @Test func aLateAccountUnreadSummaryAnswerDoesNotRestoreTheClearedBadge() async throws {
+        // A read-marker advance and a chat-list reload race routinely, so two summary queries can
+        // be in flight and answer out of order. A late pre-read answer landing last must not put
+        // the badge back — nor record its signal, which would leave the row gate suppressing the
+        // refresh that would correct it.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 5)
+        ]
+        let (state, account) = unreadBadgeFixture(runtime: runtime, seededUnreadCount: 5)
+
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 5)
+
+        // Park the older query inside the FFI, still holding the pre-read total of 5.
+        runtime.accountUnreadSummaryGateEnabled = true
+        let staleRefresh = Task { await state.refreshAccountUnreadSummary() }
+        #expect(await waitFor { runtime.didReachAccountUnreadSummaryGate })
+
+        // The chat is read: the row delta gates a newer query, which answers first with nothing
+        // unread while the older one is still parked.
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0)
+        ]
+        await state.applyChatRow(
+            unreadBadgeFixtureRow(timelineAt: 1_700_000_100, unreadCount: 0),
+            account: account,
+            shouldEnrich: false
+        )
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+
+        runtime.releaseAccountUnreadSummaryGate()
+        await staleRefresh.value
+
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+        #expect(state.lastSummarizedAccountUnread?.totalUnreadCount == 0)
+    }
+
+    @MainActor
+    @Test func anAccountUnreadSummaryAnswerForASupersededAccountIsDiscarded() async throws {
+        // The totals are keyed by account, but the recorded signal is not: committing an answer
+        // requested by a since-replaced active account would file its counts under the new
+        // account's signal and suppress that account's next refresh.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 5)
+        ]
+        let (state, account) = unreadBadgeFixture(runtime: runtime, seededUnreadCount: 5)
+
+        runtime.accountUnreadSummaryGateEnabled = true
+        let supersededRefresh = Task { await state.refreshAccountUnreadSummary() }
+        #expect(await waitFor { runtime.didReachAccountUnreadSummaryGate })
+
+        // The user switches accounts while the query is still off-main.
+        state.activeAccountId = "some-other-account"
+        runtime.releaseAccountUnreadSummaryGate()
+        await supersededRefresh.value
+
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+        #expect(state.lastSummarizedAccountUnread == nil)
+    }
+
+    @MainActor
+    @Test func aChatListReloadIssuesASingleAccountUnreadSummaryQuery() async throws {
+        // The reload owns one unconditional refresh — the only pass that also re-reads background
+        // accounts' totals — so the snapshot it applies must not gate a second query of its own.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.installGroup(messageGroup())
+        // The selected chat's read-state row is the one other caller that would apply a chat row
+        // during the reload, and it answers off-main; withholding it keeps the queries counted here
+        // attributable to the reload alone.
+        runtime.initializeChatReadStateReturnsRow = false
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0)
+        ]
+        // Seeded unread with a recorded signal to match, so the reload's all-read snapshot moves
+        // the signal and would gate a refresh of its own on top of the reload's own query.
+        let (state, account) = unreadBadgeFixture(runtime: runtime, seededUnreadCount: 5)
+        state.lastSummarizedAccountUnread = state.currentAccountUnreadSignal()
+        state.reloadChatsGeneration = 41
+        let queriesSoFar = runtime.accountUnreadSummaryCallCount
+
+        await state.performChatListReload(accountId: account.id, generation: 41)
+
+        #expect(state.activeChats.first?.unreadCount == 0)
+        #expect(runtime.accountUnreadSummaryCallCount == queriesSoFar + 1)
+    }
+
+    @MainActor
     @Test func resetActiveAccountUIStateClearsReadMarkersAndDeliveredNotificationKeys() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",
@@ -31431,6 +31624,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func initializeChatReadState(accountRef: String, groupIdHex: String) throws -> ChatListRowFfi? {
         recordSyncCall("initializeChatReadState")
+        guard initializeChatReadStateReturnsRow else { return nil }
         return groups.first(where: { $0.groupIdHex == groupIdHex }).map(chatListRow(for:))
     }
 
@@ -31721,6 +31915,23 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
         secureDeleteExpiredGate.didReach
     }
     var accountUnreadSummaryRows: [AccountUnreadFfi] = []
+    var accountUnreadSummaryCallCount = 0
+    /// Withholds the selected chat's read-state row, so a test can keep the timeline's off-main
+    /// `applyChatRow` out of a window where it counts chat-list work.
+    var initializeChatReadStateReturnsRow = true
+    private let accountUnreadSummaryGate = BlockingFfiGate()
+    /// Parks the first summary query off-main so a later one can overtake it.
+    var accountUnreadSummaryGateEnabled: Bool {
+        get { accountUnreadSummaryGate.isEnabled }
+        set { accountUnreadSummaryGate.isEnabled = newValue }
+    }
+    var didReachAccountUnreadSummaryGate: Bool {
+        accountUnreadSummaryGate.didReach
+    }
+
+    func releaseAccountUnreadSummaryGate() {
+        accountUnreadSummaryGate.release()
+    }
 
     func parseMarkdown(text: String) -> MarkdownDocumentFfi {
         parseMarkdownCallCount += 1
@@ -31728,7 +31939,12 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func accountUnreadSummary() throws -> [AccountUnreadFfi] {
-        accountUnreadSummaryRows
+        accountUnreadSummaryCallCount += 1
+        // Snapshot before parking, the way the real query answers from the store as it stood when
+        // the call was made: a gated call must come back with stale totals, not fresh ones.
+        let rows = accountUnreadSummaryRows
+        accountUnreadSummaryGate.passIfArmed()
+        return rows
     }
 
     func signOut(accountRef: String, deleteKeyPackages: Bool) async throws -> SignOutOutcomeFfi {
@@ -32743,7 +32959,9 @@ private func chatListRow(
     selfMembership: SelfMembershipFfi = .member,
     attachmentKind: ChatListAttachmentKindFfi? = nil,
     attachmentCount: UInt32 = 0,
-    deleted: Bool = false
+    deleted: Bool = false,
+    unreadCount: UInt64 = 0,
+    hasUnread: Bool = false
 ) -> ChatListRowFfi {
     ChatListRowFfi(
         groupIdHex: groupIdHex,
@@ -32766,8 +32984,8 @@ private func chatListRow(
             attachmentCount: attachmentCount,
             deliveryState: .notApplicable
         ),
-        unreadCount: 0,
-        hasUnread: false,
+        unreadCount: unreadCount,
+        hasUnread: hasUnread,
         unreadMentionCount: 0,
         unreadMention: false,
         firstUnreadMessageIdHex: nil,
@@ -33087,6 +33305,65 @@ private func notificationUpdate(
         reactedToPreview: nil,
         timestampMs: 1_700_000_000_000,
         isFromSelf: isFromSelf
+    )
+}
+
+private let unreadBadgeFixtureAccountIdHex =
+    "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+/// A workspace wired to a runtime and one seeded chat, deliberately **without** `bootstrap()`.
+///
+/// Tests that count summary queries or park one mid-flight cannot bootstrap: it returns while the
+/// chat-list enrichment task it spawned is still running (and, with messages installed, timeline
+/// work too), and that task re-upserts rows from the bootstrap snapshot. Either lands inside the
+/// measurement window on a loaded machine — which is how the count guard here failed in CI while
+/// passing 25 runs in a row locally.
+@MainActor
+private func unreadBadgeFixture(
+    runtime: FakeMarmotRuntime,
+    seededUnreadCount: Int
+) -> (state: WorkspaceState, account: AccountItem) {
+    let account = AccountItem(
+        id: "Desktop Account",
+        accountRef: "Desktop Account",
+        displayName: "Desktop Account",
+        accountIdHex: unreadBadgeFixtureAccountIdHex
+    )
+    let chat = chatListOrderingTestItem(
+        id: "group",
+        title: "Test Group",
+        updatedAt: 1_700_000_000,
+        unreadCount: seededUnreadCount
+    )
+    let state = WorkspaceState(
+        accounts: [account],
+        chatsByAccount: [account.id: [chat]],
+        clientFactory: { runtime }
+    )
+    state.client = runtime
+    state.activeAccountId = account.id
+    return (state, account)
+}
+
+/// A delta for the fixture's seeded chat, carrying only a fresh timestamp and unread count.
+private func unreadBadgeFixtureRow(timelineAt: UInt64, unreadCount: UInt64) -> ChatListRowFfi {
+    chatListRow(
+        groupIdHex: "group",
+        title: "Test Group",
+        preview: "A newer message",
+        sender: unreadBadgeFixtureAccountIdHex,
+        timelineAt: timelineAt,
+        unreadCount: unreadCount,
+        hasUnread: unreadCount > 0
+    )
+}
+
+private func unreadSummaryRow(accountIdHex: String, unreadCount: UInt64) -> AccountUnreadFfi {
+    AccountUnreadFfi(
+        accountIdHex: accountIdHex,
+        unreadCount: unreadCount,
+        unreadConversations: unreadCount > 0 ? 1 : 0,
+        hasUnread: unreadCount > 0
     )
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account unread badges so they clear reliably after reading chats.
  * Reduced unnecessary unread-count refreshes when unrelated chat rows change.
  * Prevented stale responses from overwriting current unread totals.
  * Improved retry behavior when unread-count updates fail.
  * Kept unread counts accurate when chats are archived, removed, reloaded, or marked as read.

* **Tests**
  * Added coverage for badge clearing, refresh efficiency, reload handling, retries, and stale responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->