### PR TITLE
Change mentions color

### DIFF
--- a/whitenoise-mac/Models/MarkdownDisplayModel.swift
+++ b/whitenoise-mac/Models/MarkdownDisplayModel.swift
@@ -536,18 +536,13 @@ nonisolated enum MarkdownDisplayInlineBuilder {
                 MarkdownDisplayLink(url: $0, presentation: presentation)
             }
         )
-        // A mention is set off by weight plus the mentioned person's own accent — the same
-        // treatment the other clients give it, and the reason it needs no knowledge of the fill
-        // it lands on. See `MentionTextPalette`.
-        //
-        // The accent is only applied when it can be derived honestly; where it cannot, the
-        // mention stays bold and inherits the bubble's foreground, which also keeps a linked
-        // `nprofile` reference visible on both sent and received.
+        // A mention is set off by weight plus the app's one blue — the same signal the unread
+        // badge and the pending-invite `+` carry, and the reason it needs no knowledge of the
+        // fill it lands on. It applies to every mention, an `nprofile` included: the color marks
+        // a tag rather than identifying which person is tagged. See `MentionTextPalette`.
         if presentation == .mention {
             attributed.inlinePresentationIntent = intent.union(.stronglyEmphasized)
-            if let accent = MentionTextPalette.foreground(forNpub: entity.bech32) {
-                attributed.foregroundColor = accent
-            }
+            attributed.foregroundColor = MentionTextPalette.foreground
         }
         return attributed
     }

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -523,14 +523,12 @@ enum ComposerMentionMarkerStore {
         guard isExact(selection, in: textView.string), let storage = textView.textStorage else { return }
         storage.addAttribute(.composerMentionNpub, value: selection.npub, range: selection.range)
         storage.addAttribute(.composerMentionDisplayText, value: selection.displayText, range: selection.range)
-        // The same treatment a rendered mention gets — bold, in the mentioned person's accent — so
-        // a token looks the same while you are typing it as it will once it is sent. See
-        // `MentionTextPalette`; where the accent cannot be derived the token stays bold on the
-        // field's own content color.
+        // The same treatment a rendered mention gets — bold, in the app's one blue — so a token
+        // looks the same while you are typing it as it will once it is sent. See
+        // `MentionTextPalette`.
         storage.addAttribute(
             .foregroundColor,
-            value: MentionTextPalette.nsForeground(forNpub: selection.npub)
-                ?? MentionTextPalette.composerFallbackForeground,
+            value: MentionTextPalette.nsForeground,
             range: selection.range
         )
         storage.addAttribute(

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -166,8 +166,9 @@ nonisolated enum AvatarPalette {
         return AvatarColorSet(accents[index])
     }
 
-    /// The whole accent set at `index`, for the callers that need a token the three avatar ones do
-    /// not carry. A mention takes `contentSecondary`; see `MentionTextPalette`.
+    /// The whole accent set at `index`, for the callers that need a rung the three avatar ones do
+    /// not carry, and the only way to enumerate the ramps from outside — which is what the palette
+    /// tests walk to hold every accent to the same contrast floor.
     static func accent(at index: Int) -> WNAccentColorSet {
         accents[index]
     }
@@ -184,37 +185,10 @@ nonisolated enum AvatarPalette {
         guard let first = seed.first, first.isASCII, let nibble = first.hexDigitValue else { return nil }
         return nibble % accents.count
     }
-
-    /// The same mapping for an `npub1…`, without decoding it.
-    ///
-    /// Message bodies carry mentions as bech32, and the accent has to be chosen while the body's
-    /// attributed string is built — off the main actor, with no `Marmot` client in reach, so
-    /// `hexPubkeyFromNpub` (which the other clients call here) is not available.
-    ///
-    /// It is not needed. `accentIndex(for:)` reads exactly one hex digit, and that digit is
-    /// recoverable from the bech32 directly: a bech32 payload is the byte string regrouped into
-    /// 5-bit characters, most significant bits first, so the first data character holds the top
-    /// *five* bits of byte 0 while the first hex digit is its top *four*. Dropping the low bit
-    /// converts between them.
-    ///
-    /// Returns `nil` for anything that is not a plain `npub1…`. `nprofile` in particular is
-    /// TLV-encoded rather than a bare key, so its first data character is a record tag and means
-    /// nothing here — the other clients also restrict the per-user color to `npub` for this reason.
-    static func accentIndex(forNpub npub: String) -> Int? {
-        let prefix = "npub1"
-        guard npub.hasPrefix(prefix),
-            let firstDataCharacter = npub.dropFirst(prefix.count).first,
-            let fiveBitValue = bech32Alphabet.firstIndex(of: firstDataCharacter)
-        else { return nil }
-        return (fiveBitValue >> 1) % accents.count
-    }
-
-    /// The BIP-173 bech32 character set, where a character's index *is* its 5-bit value.
-    private static let bech32Alphabet = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
 }
 
 /// The three tokens an avatar needs from its accent ramp. Mirrors the other clients'
-/// `AvatarColorSet` minus `contentSecondary`, which feeds mentions rather than avatars — reach for
+/// `AvatarColorSet` minus `contentSecondary`, the `500` step no avatar draws — reach for
 /// `WNAccentColors` directly if you need that one.
 nonisolated struct AvatarColorSet {
     let fill: Color
@@ -314,44 +288,40 @@ nonisolated enum AttachmentRowPalette {
     static let detailContent = WNColor.backgroundContentTertiary
 }
 
-/// How an `@mention` is set off from the text around it: **bold, in the mentioned person's own
-/// accent**, with no background chip and no decoration — the same treatment the other clients give
-/// it.
+/// How an `@mention` is set off from the text around it: **bold, in the app's one blue**, with no
+/// background chip and no decoration.
 ///
-/// The color is `accent.contentSecondary`, the `500` step of that person's accent ramp, and the
-/// choice of step is the whole trick. `500` is the one rung of each ramp that is neither the light
-/// surface (`50`) nor the dark one (`950`), so a single value stays legible on every fill a mention
-/// can land on — the sent bubble, the received bubble, an agent row, the composer — in both
-/// appearances, without the mention having to know which of them it is on. That is why this replaced
-/// a background chip: a chip has to be picked per fill, and there is no fill-independent chip.
+/// The color is `intentionInfoContent`, which resolves to the same `blue600`/`blue500` pair the
+/// unread count badge and the pending-invite `+` are drawn in, so every tag in the app carries the
+/// same signal. It replaced the mentioned person's own accent — the `500` step of their avatar ramp
+/// — which drew a tag in amber or orange often enough to read as a warning rather than as a name.
 ///
-/// A mention whose accent cannot be determined (an `nprofile`, which is TLV-encoded rather than a
-/// bare key) stays bold and keeps the surrounding foreground, so it is still marked as a mention but
-/// does not claim to identify a specific person with a color that would be wrong.
+/// One color for every mention also settles the case a per-person accent could not: an `nprofile`
+/// is TLV-encoded rather than a bare key, so no accent could be derived from it and such a mention
+/// used to stay uncolored. Blue identifies a tag, not a person, so it applies to those too.
+///
+/// The token is dynamic rather than one pinned step because both bubble fills cross over with the
+/// appearance, and the pair happens to fall on the right side of each: in Aqua, `blue600` clears
+/// both the near-black sent bubble (3.83) and the light received one (4.74); in Dark Aqua,
+/// `blue500` clears the white sent bubble (3.68) and the dark received one (4.11). A single pinned
+/// step cannot beat that floor — `blue500` everywhere drops to 3.37 on the light received bubble,
+/// `blue600` everywhere to 2.93 on the dark one.
+///
+/// A deliberate divergence from the other clients, which still draw a mention in the mentioned
+/// person's `contentSecondary`; it follows the same divergence `fillInfo` already carries, so the
+/// unread badge and the tag stay one signal on this platform.
 ///
 /// `nonisolated` because a message's attributed string is built off-main while mapping a timeline
 /// window (whitenoise-mac#285), so this must be reachable from outside the main actor.
 nonisolated enum MentionTextPalette {
-    /// The accent color for a mention written as `npub1…`, or `nil` when the reference is not a
-    /// bare public key and no person-specific color can honestly be applied.
-    static func foreground(forNpub npub: String) -> Color? {
-        AvatarPalette.accentIndex(forNpub: npub).map { AvatarPalette.accent(at: $0).contentSecondary }
-    }
+    /// The color of a rendered mention, whatever it references and whichever bubble it lands in.
+    static let foreground = WNColor.intentionInfoContent
 
-    /// AppKit twin, for the composer's `NSTextView` draft tokens. Reads the accent's own
-    /// dynamic `NSColor` rather than converting the SwiftUI one back: `NSColor(someColor)` can
-    /// bake in whichever appearance was current when it ran, which would freeze a draft token's
-    /// color at the appearance the composer first drew under.
-    static func nsForeground(forNpub npub: String) -> NSColor? {
-        AvatarPalette.accentIndex(forNpub: npub).map {
-            AvatarPalette.accent(at: $0).nsContentSecondary
-        }
-    }
-
-    /// The composer draft's fallback for a token whose accent is unknown. The draft sits on
-    /// `backgroundPrimary`, so it takes that surface's primary content color; a rendered message
-    /// body instead inherits whatever its bubble already set.
-    static let composerFallbackForeground = WNNSColor.backgroundContentPrimary
+    /// AppKit twin, for the composer's `NSTextView` draft tokens. Reads the dynamic `NSColor`
+    /// rather than converting the SwiftUI one back: `NSColor(someColor)` can bake in whichever
+    /// appearance was current when it ran, which would freeze a draft token's color at the
+    /// appearance the composer first drew under.
+    static let nsForeground = WNNSColor.intentionInfoContent
 }
 
 enum MessagesLayout {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -3004,24 +3004,23 @@ struct PureValueTests {
         #expect(links(in: mention).map(\.absoluteString) == ["nostr:\(npub)"])
         #expect(underlineStyles(in: mention) == [nil])
 
-        // A mention is bold, in the mentioned person's accent, and carries no background chip.
-        // Asserted against `MentionTextPalette` rather than "it differs from the body" so a
-        // mention that quietly stopped identifying anyone fails here.
+        // A mention is bold, in `MentionTextPalette.foreground`, and carries no background chip.
+        // Asserted against the palette rather than "it differs from the body" so a mention that
+        // quietly stopped being marked at all fails here.
         #expect(mention.runs.allSatisfy { $0.backgroundColor == nil })
         #expect(
             mention.runs.first?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
-        #expect(mention.runs.first?.foregroundColor == MentionTextPalette.foreground(forNpub: npub))
+        #expect(mention.runs.first?.foregroundColor == MentionTextPalette.foreground)
 
-        // An `nprofile` is TLV-encoded rather than a bare key, so no accent can be derived from
-        // it. It stays bold but inherits the surrounding foreground instead of claiming to
-        // identify someone with a color that would be wrong.
+        // An `nprofile` is TLV-encoded rather than a bare key, so it identifies no one this side
+        // of a lookup — which no longer matters, because the color marks a tag rather than the
+        // person tagged. It takes the same blue as any other mention.
         let nprofile = "nprofile1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
         let nprofileMention = MarkdownDisplayInlineBuilder.attributedString(
             from: [.nostrMention(entity: MarkdownNostrEntityFfi(hrp: .nprofile, bech32: nprofile))],
             remainingDepth: 32
         )
-        #expect(MentionTextPalette.foreground(forNpub: nprofile) == nil)
-        #expect(nprofileMention.runs.first?.foregroundColor == nil)
+        #expect(nprofileMention.runs.first?.foregroundColor == MentionTextPalette.foreground)
         #expect(
             nprofileMention.runs.first?.inlinePresentationIntent?.contains(.stronglyEmphasized)
                 == true)

--- a/whitenoise-macTests/SemanticPaletteTests.swift
+++ b/whitenoise-macTests/SemanticPaletteTests.swift
@@ -223,104 +223,44 @@ struct SemanticPaletteTests {
         }
     }
 
-    /// `contentSecondary` is the `500` step, and a mention is drawn in it on top of whichever
-    /// bubble it lands in. The property that makes that possible is that `500` is
-    /// **appearance-invariant** — the same value in Aqua and Dark Aqua — while `fill` and
-    /// `contentPrimary` both cross over between them. A mention therefore needs to know neither
-    /// which bubble it is on nor which appearance is current, which is what let the
-    /// fill-dependent chip go away.
+    /// A mention is one color for everybody — the blue the unread badge and the pending-invite `+`
+    /// already carry — so the first half of this pins the two together. They are separate tokens
+    /// (`intentionInfoContent` and `fillInfo`) that happen to resolve alike, and a tag that
+    /// quietly stopped matching the badge is the regression worth catching.
     ///
-    /// Note what is *not* claimed: that `500` maximizes contrast. It does not. Against the light
-    /// received bubble a bright ramp like lime lands at 1.81, and `lime900` would in fact do
-    /// better there — the other clients draw the `500` step anyway, and this port follows them.
-    /// The floor below is the inherited one, and it is asserted so that reaching for `50` or
-    /// `950` here (which collapses to ~1.05 against one bubble or the other) still fails.
-    @Test func accentContentSecondaryIsAppearanceInvariantAndClearsBothBubbles() throws {
-        let bubbles = [
-            ("sent", WNNSColor.fillPrimary),
-            ("received", WNNSColor.backgroundMessageIncoming),
+    /// The second half is what a per-person accent used to buy: a mention lands on the sent
+    /// bubble, the received bubble and the composer without knowing which, and both bubble fills
+    /// cross over between the appearances. This token crosses over too, and the right way round —
+    /// the darker `600` step falls in Aqua, where the sent bubble is near-black, and the brighter
+    /// `500` in Dark Aqua, where it is white. The floor is 3:1, the WCAG threshold for the bold
+    /// weight a mention is always drawn at; pinning the token to a single step fails it (`blue600`
+    /// everywhere lands at 2.93 on the dark received bubble).
+    @Test func mentionColorIsTheUnreadBlueAndClearsEverySurfaceItLandsOn() throws {
+        let surfaces = [
+            ("sent bubble", WNNSColor.fillPrimary),
+            ("received bubble", WNNSColor.backgroundMessageIncoming),
+            ("composer", WNNSColor.backgroundPrimary),
         ]
-        let accents = Self.allAccents
-        // A zero `accentCount` would make every loop below vacuous, so the suite would report full
-        // coverage of the accents while asserting nothing about any of them.
-        #expect(!accents.isEmpty, "AvatarPalette exposes no accents")
-
-        for (name, accent) in accents {
-            let resolved = try Self.appearances().map { appearance in
-                try Self.resolvedHex(accent.nsContentSecondary, in: appearance)
-            }
-            #expect(
-                resolved[0] == resolved[1],
-                """
-                accent \(name).contentSecondary differs between appearances \
-                (\(resolved[0]) / \(resolved[1])) — a mention would need to know which \
-                appearance it is drawn in, which is the coupling this token exists to avoid
-                """
-            )
-            // The two steps it must not be replaced with do cross over, which is why they
-            // cannot serve here.
-            let fillHexes = try Self.appearances().map {
-                try Self.resolvedHex(accent.nsFill, in: $0)
-            }
-            #expect(fillHexes[0] != fillHexes[1], "accent \(name).fill should invert")
-        }
 
         for appearance in try Self.appearances() {
-            for (bubbleName, bubble) in bubbles {
-                for (name, accent) in accents {
-                    let ratio = try Self.contrast(
-                        bubble, accent.nsContentSecondary, in: appearance)
-                    #expect(
-                        ratio >= 1.6,
-                        """
-                        mention accent \(name) on the \(bubbleName) bubble is \(ratio) \
-                        in \(appearance.name.rawValue)
-                        """
-                    )
-                }
+            let mention = try Self.resolvedHex(MentionTextPalette.nsForeground, in: appearance)
+            let badge = try Self.resolvedHex(WNNSColor.fillInfo, in: appearance)
+            #expect(
+                mention == badge,
+                """
+                the mention color (\(mention)) and the unread badge (\(badge)) have drifted \
+                apart in \(appearance.name.rawValue)
+                """
+            )
+
+            for (surfaceName, surface) in surfaces {
+                let ratio = try Self.contrast(surface, MentionTextPalette.nsForeground, in: appearance)
+                #expect(
+                    ratio >= 3,
+                    "mention on the \(surfaceName) is \(ratio) in \(appearance.name.rawValue)"
+                )
             }
         }
-    }
-
-    // MARK: - Avatar keying
-
-    /// A mention carries the bech32, not the hex, so its accent is recovered from the first bech32
-    /// data character. It has to agree with what the seed mapping would have said about the decoded
-    /// key — `AvatarPaletteTests` covers that mapping itself; this covers only the bech32 shortcut.
-    @Test func npubAccentAgreesWithTheDecodedHexAccent() throws {
-        // The all-zero key: every data character is `q` (5-bit value 0), and the hex is `0000…`,
-        // so both paths must land on the same accent.
-        let zeroKeyNpub = "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
-        #expect(
-            AvatarPalette.accentIndex(forNpub: zeroKeyNpub)
-                == AvatarPalette.accentIndex(for: String(repeating: "0", count: 64)))
-
-        // The derivation is `first 5-bit value >> 1`, so each pair of adjacent bech32 characters
-        // collapses onto one hex digit. `q`/`p` are values 0 and 1 → digit 0; `z`/`r` are 2 and 3 →
-        // digit 1; `l` is the last character in the set, value 31 → digit 15.
-        #expect(AvatarPalette.accentIndex(forNpub: "npub1q") == AvatarPalette.accentIndex(for: "0"))
-        #expect(AvatarPalette.accentIndex(forNpub: "npub1p") == AvatarPalette.accentIndex(for: "0"))
-        #expect(AvatarPalette.accentIndex(forNpub: "npub1z") == AvatarPalette.accentIndex(for: "1"))
-        #expect(AvatarPalette.accentIndex(forNpub: "npub1r") == AvatarPalette.accentIndex(for: "1"))
-        #expect(AvatarPalette.accentIndex(forNpub: "npub1l") == AvatarPalette.accentIndex(for: "f"))
-
-        // Only a bare public key. `nprofile` is TLV-encoded, so its first data character is a record
-        // tag rather than the top of a key, and guessing from it would produce a color that
-        // disagrees with every other client.
-        #expect(AvatarPalette.accentIndex(forNpub: "nprofile1qqqqqq") == nil)
-        #expect(AvatarPalette.accentIndex(forNpub: "note1qqqqqq") == nil)
-        #expect(AvatarPalette.accentIndex(forNpub: "npub1") == nil)
-        #expect(AvatarPalette.accentIndex(forNpub: "") == nil)
-        // `b` is not in the bech32 set (it excludes `1`, `b`, `i`, and `o`).
-        #expect(AvatarPalette.accentIndex(forNpub: "npub1b") == nil)
-
-        // And a mention actually resolves to that accent's `contentSecondary`. `try` rather than
-        // `try?`: with an optional index a missing accent would compare `nil == nil` and pass,
-        // which is the one outcome this assertion exists to catch.
-        let index = try #require(AvatarPalette.accentIndex(forNpub: zeroKeyNpub))
-        #expect(
-            MentionTextPalette.foreground(forNpub: zeroKeyNpub)
-                == AvatarPalette.accent(at: index).contentSecondary)
     }
 
     // MARK: - Reactions

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -5847,11 +5847,11 @@ struct whitenoise_macTests {
         #expect(!structured.supportsInlineMetadata)
     }
 
-    /// A mention is colored by *who it mentions*, not by which bubble it lands in — that is the
-    /// property that let the fill-dependent chip go away. The row's attributed string is built once
-    /// here, off-main and never rewritten during a body pass, so this also pins that a sent and a
+    /// A mention is colored by the palette, not by which bubble it lands in — that is the property
+    /// that let the fill-dependent chip go away. The row's attributed string is built once here,
+    /// off-main and never rewritten during a body pass, so this also pins that a sent and a
     /// received copy of the same mention come out identical.
-    @Test func mentionTakesTheMentionedAccentRegardlessOfBubbleDirection() {
+    @Test func mentionTakesTheMentionColorRegardlessOfBubbleDirection() {
         let npub = "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0l5v8"
         let tokens = MarkdownDocumentFfi(
             blocks: [
@@ -5874,11 +5874,9 @@ struct whitenoise_macTests {
             .contentMarkdown?.inlineParagraph?.runs.first
         }
 
-        let accent = MentionTextPalette.foreground(forNpub: npub)
-        #expect(accent != nil)
         for isOutgoing in [true, false] {
             let run = mentionRun(isOutgoing: isOutgoing)
-            #expect(run?.foregroundColor == accent)
+            #expect(run?.foregroundColor == MentionTextPalette.foreground)
             #expect(run?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
             // No background chip in either direction; the chip is what used to have to know the
             // fill, and reintroducing one is the regression this guards.
@@ -14351,12 +14349,12 @@ struct whitenoise_macTests {
         #expect(state.messageTimelineStores["group"]?.displayItemsBuildCount == buildsBefore + 1)
 
         // The mention keeps everything the projection gave it besides the label: it is still a
-        // tappable `nostr:` reference to the same person, still emphasized, still accented.
+        // tappable `nostr:` reference to the same person, still emphasized, still colored.
         let relabeled = try #require((state.messagesByChat["group"] ?? []).first?.contentMarkdown?.inlineParagraph)
         let mentionRun = relabeled.runs.first { $0.link != nil }
         #expect(mentionRun?.link == MarkdownLinkPolicy.nostrURL(for: "npub1alyce"))
         #expect(mentionRun?.inlinePresentationIntent?.contains(.stronglyEmphasized) == true)
-        #expect(mentionRun?.foregroundColor == MentionTextPalette.foreground(forNpub: "npub1alyce"))
+        #expect(mentionRun?.foregroundColor == MentionTextPalette.foreground)
 
         // Renaming somebody this conversation neither mentions nor lists must not touch a row.
         let buildsAfterRename = state.messageTimelineStores["group"]?.displayItemsBuildCount ?? 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized mention text colors across messages, composer views, and platforms.
  * Mentions now use a consistent blue palette designed to remain readable in light and dark appearances.
  * Removed varying per-person mention colors for a more uniform visual experience.

* **Tests**
  * Updated color and contrast checks to reflect the standardized mention styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->