### PR TITLE
Remove full data mode from logs settings

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -703,7 +703,6 @@ extension WorkspaceState {
                 relayTelemetryEnabled: telemetry.exportEnabled,
                 relayTelemetryIntervalSeconds: telemetry.exportIntervalSeconds,
                 auditLoggingEnabled: auditLog.enabled,
-                auditFullDataLogging: auditLog.dataMode == .fullData,
                 telemetryCredentialsAvailable: config.telemetryCredentialsAvailable,
                 auditLogCredentialsAvailable: config.auditLogCredentialsAvailable
             )
@@ -767,39 +766,15 @@ extension WorkspaceState {
 
         do {
             try await configureObservabilityRuntime()
-            // Preserve the current data-mode posture when flipping the enabled flag.
-            let dataMode: AuditDataModeFfi =
-                privacySecuritySettings.auditFullDataLogging ? .fullData : .obfuscatedSensitiveData
+            // Audit logging is a single on/off choice here. Every write pins the data mode to
+            // the minimum privacy-safe record set, which also downgrades a `.fullData` posture
+            // left behind by another client or an older build.
             let stored = try await client.setAuditLogSettings(
-                settings: AuditLogSettingsFfi(enabled: enabled, dataMode: dataMode)
+                settings: AuditLogSettingsFfi(enabled: enabled, dataMode: .obfuscatedSensitiveData)
             )
             privacySecuritySettings.auditLoggingEnabled = stored.enabled
-            privacySecuritySettings.auditFullDataLogging = stored.dataMode == .fullData
             privacySecuritySettings.auditLogCredentialsAvailable = telemetryBuildConfig.auditLogCredentialsAvailable
             await loadAuditLogFiles()
-        } catch {
-            lastError = error.localizedDescription
-        }
-    }
-
-    func setAuditFullDataLogging(_ enabled: Bool) async {
-        guard let client, !isSavingPrivacySecurity else { return }
-
-        lastError = nil
-        isSavingPrivacySecurity = true
-        privacySecuritySettingsGeneration &+= 1
-        defer { isSavingPrivacySecurity = false }
-
-        do {
-            try await configureObservabilityRuntime()
-            let stored = try await client.setAuditLogSettings(
-                settings: AuditLogSettingsFfi(
-                    enabled: privacySecuritySettings.auditLoggingEnabled,
-                    dataMode: enabled ? .fullData : .obfuscatedSensitiveData
-                )
-            )
-            privacySecuritySettings.auditLoggingEnabled = stored.enabled
-            privacySecuritySettings.auditFullDataLogging = stored.dataMode == .fullData
         } catch {
             lastError = error.localizedDescription
         }

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -20594,65 +20594,6 @@
         }
       }
     },
-    "Full Data Logging": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vollständige Datenprotokollierung"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registro completo de datos"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Journalisation complète des données"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registrazione completa dei dati"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registro completo de dados"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Полное журналирование данных"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tam veri kaydı"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整数据日志"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整資料日誌"
-          }
-        }
-      }
-    },
     "General": {
       "extractionState": "manual",
       "localizations": {
@@ -24785,65 +24726,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "離開群組"
-          }
-        }
-      }
-    },
-    "Leave off to keep sensitive data obfuscated.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lass die Option aus, damit sensible Daten verschleiert bleiben."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Déjalo desactivado para mantener ofuscados los datos sensibles."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laissez cette option désactivée pour que les données sensibles restent masquées."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lascia l’opzione disattivata per mantenere offuscati i dati sensibili."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deixe desativado para manter os dados sensíveis ofuscados."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Оставьте выключенным, чтобы конфиденциальные данные оставались скрытыми."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hassas verilerin gizli kalması için kapalı bırakın."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保持关闭可使敏感数据保持模糊处理。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保持關閉可使敏感資料保持模糊處理。"
           }
         }
       }
@@ -38798,65 +38680,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "收件者"
-          }
-        }
-      }
-    },
-    "Record decrypted message content and full identifiers. ": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entschlüsselten Nachrichteninhalt und vollständige Kennungen aufzeichnen. "
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registrar el contenido descifrado de los mensajes y los identificadores completos. "
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enregistrer le contenu déchiffré des messages et les identifiants complets. "
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registra il contenuto decrittografato dei messaggi e gli identificatori completi. "
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Registrar o conteúdo descriptografado das mensagens e os identificadores completos. "
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Записывать расшифрованное содержимое сообщений и полные идентификаторы. "
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Şifresi çözülmüş mesaj içeriğini ve tam tanımlayıcıları kaydet. "
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "记录已解密的消息内容和完整标识符。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "記錄已解密的訊息內容和完整識別碼。"
           }
         }
       }

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2764,10 +2764,10 @@ enum NotificationPreviewMode: String, CaseIterable, Identifiable {
 struct PrivacySecuritySettingsSnapshot: Equatable {
     var relayTelemetryEnabled: Bool
     var relayTelemetryIntervalSeconds: UInt64
+    /// Audit logging is a single on/off choice on macOS. Records are always written
+    /// with `AuditDataModeFfi.obfuscatedSensitiveData`; this client never asks the
+    /// core for the full-data posture.
     var auditLoggingEnabled: Bool
-    /// When true the audit log records decrypted content and full identifiers
-    /// (`AuditDataModeFfi.fullData`); otherwise identifiers are obfuscated/hashed.
-    var auditFullDataLogging: Bool
     var telemetryCredentialsAvailable: Bool
     var auditLogCredentialsAvailable: Bool
 
@@ -2775,7 +2775,6 @@ struct PrivacySecuritySettingsSnapshot: Equatable {
         relayTelemetryEnabled: false,
         relayTelemetryIntervalSeconds: 60,
         auditLoggingEnabled: false,
-        auditFullDataLogging: false,
         telemetryCredentialsAvailable: false,
         auditLogCredentialsAvailable: false
     )

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -1283,26 +1283,6 @@ struct PrivacySecuritySettingsView: View {
                 }
                 .disabled(workspace.isSavingPrivacySecurity)
 
-                Toggle(
-                    isOn: Binding(
-                        get: { workspace.privacySecuritySettings.auditFullDataLogging },
-                        set: { enabled in
-                            Task { await workspace.setAuditFullDataLogging(enabled) }
-                        }
-                    )
-                ) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Label(L10n.string("Full Data Logging"), systemImage: "eye.trianglebadge.exclamationmark")
-                        Text(
-                            L10n.string("Record decrypted message content and full identifiers. ")
-                                + L10n.string("Leave off to keep sensitive data obfuscated.")
-                        )
-                        .wnFont(.medium10)
-                        .foregroundStyle(WNColor.backgroundContentSecondary)
-                    }
-                }
-                .disabled(workspace.isSavingPrivacySecurity || !workspace.privacySecuritySettings.auditLoggingEnabled)
-
                 if workspace.isSavingPrivacySecurity {
                     HStack(spacing: 10) {
                         ProgressView()

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -26871,6 +26871,36 @@ struct whitenoise_macTests {
         #expect(runtime.storedAuditLogSettings.enabled)
         #expect(!state.privacySecuritySettings.relayTelemetryEnabled)
         #expect(state.privacySecuritySettings.auditLoggingEnabled)
+        // macOS never requests sensitive capture: the persisted posture stays obfuscated.
+        #expect(runtime.storedAuditLogSettings.dataMode == .obfuscatedSensitiveData)
+    }
+
+    @MainActor
+    @Test func enablingAuditLoggingDowngradesAFullDataPostureToObfuscated() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        // A core that already carries the sensitive posture -- set by another client,
+        // or left behind by an older build of this app.
+        runtime.storedAuditLogSettings = AuditLogSettingsFfi(enabled: false, dataMode: .fullData)
+        let state = WorkspaceState(
+            telemetryBuildConfigProvider: {
+                telemetryBuildConfig(telemetryToken: "otlp-token", auditToken: "audit-token")
+            },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        await state.setAuditLoggingEnabled(true)
+
+        #expect(runtime.storedAuditLogSettings.enabled)
+        #expect(runtime.storedAuditLogSettings.dataMode == .obfuscatedSensitiveData)
+        #expect(state.privacySecuritySettings.auditLoggingEnabled)
+
+        await state.setAuditLoggingEnabled(false)
+
+        #expect(!runtime.storedAuditLogSettings.enabled)
+        #expect(runtime.storedAuditLogSettings.dataMode == .obfuscatedSensitiveData)
+        #expect(!state.privacySecuritySettings.auditLoggingEnabled)
     }
 
     @MainActor
@@ -26910,7 +26940,6 @@ struct whitenoise_macTests {
         #expect(state.privacySecuritySettings.relayTelemetryEnabled)
         #expect(state.privacySecuritySettings.relayTelemetryIntervalSeconds == 120)
         #expect(state.privacySecuritySettings.auditLoggingEnabled)
-        #expect(state.privacySecuritySettings.auditFullDataLogging)
         #expect(state.auditLogFiles.map(\.path) == ["/tmp/audit-1.jsonl"])
         #expect(state.lastError == "Observability configuration failed.")
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy & Security**
  * Removed the option to record full audit data.
  * Audit logging now consistently stores sensitive information in obfuscated form.
  * Existing full-data logging settings are automatically downgraded when audit logging is changed.
* **Bug Fixes**
  * Updated privacy settings behavior to prevent sensitive content and full identifiers from being recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->