### PR TITLE
Change wording in removed system messages

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -601,6 +601,9 @@ nonisolated extension MessageItem {
             return String(format: L10n.string("%@ added %@"), actorName, subjectName)
         }
         if let subjectStartName {
+            if event.subjectAccountIdHex == activeAccountIdHex {
+                return L10n.string("You were added")
+            }
             return String(format: L10n.string("%@ was added"), subjectStartName)
         }
         if let actorName {
@@ -643,6 +646,9 @@ nonisolated extension MessageItem {
             return String(format: L10n.string("%@ removed %@"), actorName, subjectName)
         }
         if let subjectStartName {
+            if event.subjectAccountIdHex == activeAccountIdHex {
+                return L10n.string("You were removed")
+            }
             return String(format: L10n.string("%@ was removed"), subjectStartName)
         }
         if let actorName {
@@ -748,6 +754,9 @@ nonisolated extension MessageItem {
             return String(format: L10n.string("%@ removed %@ as admin"), actorName, subjectName)
         }
         if let subjectStartName {
+            if event.subjectAccountIdHex == activeAccountIdHex {
+                return L10n.string("You are no longer an admin")
+            }
             return String(format: L10n.string("%@ is no longer an admin"), subjectStartName)
         }
         if let actorName {

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -53589,6 +53589,65 @@
         }
       }
     },
+    "You are no longer an admin": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du bist nicht mehr Admin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya no eres administrador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous n’êtes plus administrateur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non sei più amministratore"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você não é mais administrador"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы больше не администратор"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Artık yönetici değilsiniz"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你不再是管理员"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你不再是管理員"
+          }
+        }
+      }
+    },
     "You can keep reading the history, but new messages can't be sent.": {
       "extractionState": "manual",
       "localizations": {
@@ -54002,6 +54061,65 @@
         }
       }
     },
+    "You were added": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du wurdest hinzugefügt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Te añadieron"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous avez été ajouté"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei stato aggiunto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você foi adicionado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вас добавили"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eklendiniz"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已被添加"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已被新增"
+          }
+        }
+      }
+    },
     "You were made an admin": {
       "extractionState": "manual",
       "localizations": {
@@ -54116,6 +54234,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "有人提到了你"
+          }
+        }
+      }
+    },
+    "You were removed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du wurdest entfernt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Te eliminaron"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous avez été retiré"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei stato rimosso"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você foi removido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вас удалили"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çıkarıldınız"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已被移除"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你已被移除"
           }
         }
       }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -7340,6 +7340,77 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func timelineMappingKeepsVerbAgreementForActorlessSelfSystemEvents() async throws {
+        let bob = String(repeating: "b", count: 64)
+        let profiles = [bob: ChatPeerProfile(accountIdHex: bob, displayName: "Bob", pictureURL: nil)]
+
+        func selfEvent(_ id: String, systemType: String, text: String, recordedAt: UInt64)
+            -> TimelineMessageRecordFfi
+        {
+            timelineMessage(
+                id: id,
+                groupIdHex: "group",
+                sender: "",
+                plaintext: "",
+                kind: 1210,
+                recordedAt: recordedAt,
+                groupSystem: groupSystemEvent(
+                    systemType: systemType,
+                    text: text,
+                    actorAccountIdHex: nil,
+                    subjectAccountIdHex: bob
+                )
+            )
+        }
+
+        let page = TimelinePageFfi(
+            messages: [
+                selfEvent("added", systemType: "member_added", text: "Member added", recordedAt: 1),
+                selfEvent(
+                    "removed",
+                    systemType: "member_removed",
+                    text: "Member removed",
+                    recordedAt: 2
+                ),
+                selfEvent(
+                    "demoted",
+                    systemType: "admin_removed",
+                    text: "Admin removed",
+                    recordedAt: 3
+                ),
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        // Without an actor the subject is the sentence subject, so "You" must take a
+        // second-person verb: "You was removed" is what these events used to read.
+        let localMessages = MessageItem.timeline(
+            from: page,
+            activeAccountIdHex: bob,
+            senderProfiles: profiles
+        )
+        #expect(
+            localMessages.map(\.body) == [
+                "You were added",
+                "You were removed",
+                "You are no longer an admin",
+            ])
+
+        let remoteMessages = MessageItem.timeline(
+            from: page,
+            activeAccountIdHex: String(repeating: "a", count: 64),
+            senderProfiles: profiles
+        )
+        #expect(
+            remoteMessages.map(\.body) == [
+                "\(isolated("Bob")) was added",
+                "\(isolated("Bob")) was removed",
+                "\(isolated("Bob")) is no longer an admin",
+            ])
+    }
+
+    @MainActor
     @Test func mediaOnlyTimelineMessageMapsAttachmentWithoutUnsupportedText() async throws {
         let reference = mediaAttachmentReference(mediaType: "image/png", fileName: "photo.png")
         let page = TimelinePageFfi(


### PR DESCRIPTION
In the case where I was removed from a group, the wording was weird

|Before| After|
|----|----|
|<img width="300"  alt="after" src="https://github.com/user-attachments/assets/5a96d4a7-ae3f-40df-9ab6-27b5d7a8e603" />|<img width="300"  alt="before" src="https://github.com/user-attachments/assets/279498eb-408f-492b-a9f6-801e10f6301e" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved group activity messages when you are added, removed, or demoted from admin.
  - Messages now address you directly for clearer, more natural wording.
  - Added localized translations for these messages in nine languages.

- **Bug Fixes**
  - Corrected message phrasing for self-authored group system events while preserving named descriptions for other members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->