### PR TITLE
Show failed message content

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -174,7 +174,6 @@ extension ChatItem {
             plaintext: preview.plaintext,
             tags: [],
             deleted: preview.deleted,
-            invalidationStatus: nil,
             hasMediaAttachments: false
         )
         let sourceTextIsEmpty = preview.plaintext.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -394,7 +393,6 @@ nonisolated extension MessageItem {
                 plaintext: plaintext,
                 tags: record.tags,
                 deleted: record.deleted,
-                invalidationStatus: record.invalidationStatus,
                 hasMediaAttachments: !mediaAttachments.isEmpty
             )
 
@@ -425,7 +423,6 @@ nonisolated extension MessageItem {
                     document: record.contentTokens,
                     displayedBody: body,
                     deleted: record.deleted,
-                    invalidationStatus: record.invalidationStatus,
                     presentation: presentation
                 ),
             mentionNames: mentionNames,
@@ -911,14 +908,16 @@ nonisolated extension MessageItem {
     /// The Markdown document to render in a chat bubble, or `nil` when the bubble
     /// should fall back to plain text — system rows, deleted messages, or content
     /// the core parsed into no blocks (e.g. media-only / empty plaintext).
+    ///
+    /// An invalidated row is *not* excluded: it still shows its own content, so it renders with
+    /// the same formatting it would have had on delivery.
     fileprivate static func renderableMarkdown(
         document: MarkdownDocumentFfi,
         displayedBody: String,
         deleted: Bool,
-        invalidationStatus: String?,
         presentation: MessagePresentation
     ) -> MarkdownDocumentFfi? {
-        guard presentation.isChatBubble, !deleted, invalidationStatus == nil, !document.blocks.isEmpty else {
+        guard presentation.isChatBubble, !deleted, !document.blocks.isEmpty else {
             return nil
         }
         // Fast path: an unstyled single-paragraph message renders identically to the plain
@@ -955,18 +954,18 @@ nonisolated extension MessageItem {
         return parsedText == displayedBody
     }
 
+    /// Invalidation deliberately has no say here. A message that lost convergence keeps its own
+    /// text — replacing it with a tombstone threw away the one thing the reader wants, which was
+    /// *what* failed to send. The failure is carried by the bubble's delivery footer instead
+    /// (`deliveryIndicator(at:)` → `.failed`), matching the iOS client. Deletion still tombstones:
+    /// there the content is genuinely retracted rather than merely undelivered.
     static func displayText(
         presentation: MessagePresentation,
         plaintext: String,
         tags: [MessageTagFfi],
         deleted: Bool,
-        invalidationStatus: String? = nil,
         hasMediaAttachments: Bool = false
     ) -> String {
-        if invalidationStatus != nil {
-            return L10n.string("Message did not reach the group")
-        }
-
         if deleted {
             return L10n.string("Message deleted")
         }

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -28990,65 +28990,6 @@
         }
       }
     },
-    "Message did not reach the group": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Nachricht hat die Gruppe nicht erreicht"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El mensaje no llegó al grupo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le message n’a pas atteint le groupe"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il messaggio non ha raggiunto il gruppo"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A mensagem não chegou ao grupo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сообщение не доставлено в группу"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mesaj gruba ulaşmadı"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "消息未送达群组"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "訊息未送達群組"
-          }
-        }
-      }
-    },
     "Message preview": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2320,7 +2320,6 @@ nonisolated struct MessageItem: Identifiable, Hashable {
             plaintext: editedPlaintext,
             tags: [],
             deleted: isDeleted,
-            invalidationStatus: invalidationStatus,
             hasMediaAttachments: !mediaAttachments.isEmpty
         )
         let body = MentionDisplayResolver.resolve(in: wireBody, mentionNames: mentionNames)

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -542,6 +542,15 @@ struct MessageBubble: View {
         message.deliveryIndicator(at: deliveryClock)
     }
 
+    /// Hover text for the failure glyph. The bubble keeps the message's own text now, so this
+    /// glyph is the only visible thing saying the send failed — the tooltip carries the reason
+    /// ("Did not reach group" vs. "Not delivered") that the old tombstone body spelled out.
+    /// Empty in every other state, which shows no tooltip.
+    private var deliveryFailureHelp: String {
+        guard deliveryIndicator == .failed else { return "" }
+        return message.statusLabel(for: .failed) ?? ""
+    }
+
     /// The timestamp/delivery footer. One token in both directions, as on the other clients:
     /// `backgroundContentTertiary` is the neutral `400`/`500` step, which is the only rung that
     /// clears the sent bubble and the received bubble in both appearances.
@@ -564,7 +573,9 @@ struct MessageBubble: View {
                     // metadata's own tint next to the timestamp.
                     .foregroundStyle(
                         deliveryIndicator == .failed
-                            ? WNColor.backgroundContentDestructiveSecondary : metadataColor)
+                            ? WNColor.backgroundContentDestructiveSecondary : metadataColor
+                    )
+                    .help(deliveryFailureHelp)
             }
         }
         .wnFont(.medium10)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6462,8 +6462,52 @@ struct whitenoise_macTests {
         #expect(messages[0].contentMarkdown == nil)
         #expect(messages[1].body == "\\*")
         #expect(messages[1].contentMarkdown != nil)
-        #expect(messages[2].body == "Message did not reach the group")
-        #expect(messages[2].contentMarkdown == nil)
+        // An invalidated row keeps its own text and its own formatting — the failure is carried
+        // by the delivery footer, not by replacing the body.
+        #expect(messages[2].body == "**Failed**")
+        #expect(messages[2].contentMarkdown != nil)
+    }
+
+    /// whitenoise-mac: a message that lost convergence used to be replaced by a
+    /// "Message did not reach the group" tombstone, throwing away the one thing the reader
+    /// needs — what it was that failed to send. It now renders like the iOS client: the real
+    /// content, marked failed by the footer's error glyph.
+    @MainActor
+    @Test func invalidatedMessagesKeepTheirContentAndFailInTheFooter() async throws {
+        let page = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "outgoing-invalidated",
+                    groupIdHex: "group",
+                    sender: "self",
+                    plaintext: "Meet at seven",
+                    recordedAt: 1_800_000_000,
+                    invalidationStatus: "LosingBranch"
+                ),
+                timelineMessage(
+                    id: "incoming-invalidated",
+                    groupIdHex: "group",
+                    sender: "alice",
+                    plaintext: "Bring the keys",
+                    recordedAt: 1_800_000_001,
+                    invalidationStatus: "LosingBranch"
+                ),
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+
+        let messages = MessageItem.timeline(from: page, activeAccountIdHex: "self")
+        let sentAt = Date(timeIntervalSince1970: 1_800_000_000)
+
+        #expect(messages.map(\.body) == ["Meet at seven", "Bring the keys"])
+        // Both directions fail on sight: convergence has already decided, so neither waits out
+        // the pending-delivery grace window.
+        #expect(messages.allSatisfy { $0.deliveryIndicator(at: sentAt) == .failed })
+        #expect(messages.allSatisfy { $0.statusLabel(for: .failed) == "Did not reach group" })
+        // Convergence-lost content stays read-only — reacting to or replying to a message the
+        // group never accepted would address a branch that no longer exists.
+        #expect(messages.allSatisfy { !$0.supportsChatActions })
     }
 
     @MainActor
@@ -7038,7 +7082,7 @@ struct whitenoise_macTests {
         let failed = MessageItem(
             id: "failed",
             senderName: "Jeff",
-            body: "Message did not reach the group",
+            body: "Lost the branch",
             sentAt: sentAt,
             invalidationStatus: "signature-check-failed",
             isOutgoing: true
@@ -18062,7 +18106,7 @@ struct whitenoise_macTests {
             of: MessageItem(
                 id: "failed",
                 senderName: "Alice",
-                body: "Message did not reach the group",
+                body: "Lost the branch",
                 sentAt: sentAt,
                 invalidationStatus: "signature-check-failed",
                 isOutgoing: true


### PR DESCRIPTION
|Before| After|
|----|----|
|<img width="387" height="70" alt="Screenshot 2026-08-13 at 11 19 51 AM" src="https://github.com/user-attachments/assets/38dab6d2-8e16-4f48-bd79-a63689cd3b73" />|<img width="183" height="67" alt="Screenshot 2026-08-13 at 11 17 43 AM" src="https://github.com/user-attachments/assets/0fca4958-b759-49c5-96d0-e87e6841f9d9" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalidated messages now retain their original text and Markdown formatting.
  * Deleted messages continue to display tombstones as expected.
  * Delivery failures are clearly indicated with status labels and helpful tooltips.
  * Chat actions are disabled appropriately for failed messages.
  * Non-chat and system message behavior remains unchanged.
  * Removed an outdated delivery-failure message from localized content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->