### PR TITLE
Show the inviter name in a pending invite

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -1514,7 +1514,11 @@ extension WorkspaceState {
         _ details: GroupDetailsFfi,
         managementState: GroupManagementStateFfi
     ) {
-        storeGroupMembers(details.members, for: details.group.groupIdHex)
+        storeGroupMembers(
+            details.members,
+            welcomerAccountIdHex: details.group.welcomerAccountIdHex,
+            for: details.group.groupIdHex
+        )
         let snapshot = groupDetailsSnapshot(from: details, managementState: managementState)
         groupDetailsSnapshot = snapshot
         groupProfileDraftName = snapshot.name
@@ -1599,12 +1603,18 @@ extension WorkspaceState {
             && groupImageSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines) == query
     }
 
-    func storeGroupMembers(_ members: [GroupMemberDetailsFfi], for groupIdHex: String) {
+    func storeGroupMembers(
+        _ members: [GroupMemberDetailsFfi],
+        welcomerAccountIdHex: String?,
+        for groupIdHex: String
+    ) {
         groupMemberDetailsLookups[groupIdHex]?.task.cancel()
         groupMemberDetailsLookups[groupIdHex] = nil
         mentionRosterCache[groupIdHex] = nil
         mentionNamesCache[groupIdHex] = nil
         groupMemberDetailsCache[groupIdHex] = members
+        groupWelcomerCache[groupIdHex] =
+            welcomerAccountIdHex?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfBlank
         // Every roster the app learns about flows through here, including the one chat-list
         // enrichment fetches for a freshly received invite. The welcoming account is always
         // a member of the group it invited us to, so this covers the inviter too — the
@@ -1618,6 +1628,7 @@ extension WorkspaceState {
         // peer recovery scan run again for it.
         unrecoverableDirectPeerGroupIds.remove(groupIdHex)
         groupMemberDetailsCache[groupIdHex] = nil
+        groupWelcomerCache[groupIdHex] = nil
         mentionRosterCache[groupIdHex] = nil
         mentionNamesCache[groupIdHex] = nil
         groupMemberDetailsLookups[groupIdHex]?.task.cancel()
@@ -1628,6 +1639,7 @@ extension WorkspaceState {
     func clearGroupMemberCache() {
         unrecoverableDirectPeerGroupIds.removeAll()
         groupMemberDetailsCache.removeAll()
+        groupWelcomerCache.removeAll()
         mentionRosterCache.removeAll()
         mentionNamesCache.removeAll()
         for lookup in groupMemberDetailsLookups.values {
@@ -1646,32 +1658,84 @@ extension WorkspaceState {
             return cached
         }
         if let lookup = groupMemberDetailsLookups[groupIdHex] {
-            return await lookup.task.value
+            return await lookup.task.value?.members
         }
 
         nextGroupMemberDetailsLookupToken += 1
         let token = nextGroupMemberDetailsLookupToken
         let accountRef = account.accountRef
-        let task = Task { () -> [GroupMemberDetailsFfi]? in
-            guard
-                let details = try? await client.groupDetails(
-                    accountRef: accountRef,
-                    groupIdHex: groupIdHex
-                )
-            else {
-                return nil
-            }
-            return details.members
+        let task = Task { () -> GroupDetailsFfi? in
+            try? await client.groupDetails(
+                accountRef: accountRef,
+                groupIdHex: groupIdHex
+            )
         }
         groupMemberDetailsLookups[groupIdHex] = GroupMemberDetailsLookup(token: token, task: task)
 
-        let members = await task.value
+        let details = await task.value
         if groupMemberDetailsLookups[groupIdHex]?.token == token {
             groupMemberDetailsLookups[groupIdHex] = nil
-            if activeAccountId == account.id, let members {
-                storeGroupMembers(members, for: groupIdHex)
+            if activeAccountId == account.id, let details {
+                storeGroupMembers(
+                    details.members,
+                    welcomerAccountIdHex: details.group.welcomerAccountIdHex,
+                    for: groupIdHex
+                )
             }
         }
-        return members
+        return details?.members
+    }
+
+    /// The account that sent the welcome for `groupIdHex`, once the app has read that group's
+    /// record — `nil` while the roster has not been fetched, and for a group whose local record
+    /// records no welcome sender (one this account created, or one joined before MDK kept it).
+    func inviterAccountIdHex(forGroupIdHex groupIdHex: String) -> String? {
+        groupWelcomerCache[groupIdHex]
+    }
+
+    /// What to call the inviter, resolved through the same precedence every other peer label
+    /// uses: private nickname, then published profile, then the roster entry, then the directory.
+    ///
+    /// `nil` covers both "nobody is recorded as having invited this account" and "someone is,
+    /// but no name for them has arrived yet" — the caller has better fallbacks for a name than
+    /// this does (a direct chat's title is the peer, resolved through the chat-list pipeline),
+    /// and `inviterIdentifierLabel` is the last resort under all of them.
+    func inviterDisplayName(forGroupIdHex groupIdHex: String) -> String? {
+        guard let accountIdHex = inviterAccountIdHex(forGroupIdHex: groupIdHex) else { return nil }
+        if accountIdHex == activeAccount?.accountIdHex { return activeAccount?.displayName }
+
+        if let nickname = contactNickname(forContactAccountIdHex: accountIdHex) {
+            return nickname
+        }
+        let member = groupMemberDetailsCache[groupIdHex]?.first { $0.memberIdHex == accountIdHex }
+        let resolved = peerProfileFFICache[accountIdHex]?.resolved
+        return firstNonBlank([
+            PeerDisplayText.sanitize(resolved?.profileDisplayName),
+            PeerDisplayText.sanitize(resolved?.profileName),
+            member.flatMap { PeerDisplayText.sanitize($0.displayName) },
+            member.flatMap { PeerDisplayText.sanitize($0.account) },
+            PeerDisplayText.sanitize(resolved?.directoryDisplayName),
+        ])
+    }
+
+    /// The shortened npub (or account id) of a known inviter nobody has published a name for.
+    /// Naming them by identifier still tells the user this invite came from a specific account,
+    /// and the profile replaces it in place once it resolves.
+    func inviterIdentifierLabel(forGroupIdHex groupIdHex: String) -> String? {
+        guard let accountIdHex = inviterAccountIdHex(forGroupIdHex: groupIdHex) else { return nil }
+        let member = groupMemberDetailsCache[groupIdHex]?.first { $0.memberIdHex == accountIdHex }
+        return member.map { DisplayText.short($0.npub, head: 12, tail: 8) }
+            ?? DisplayText.short(accountIdHex)
+    }
+
+    /// Fetches the roster — and with it the inviter — for a chat whose invite prompt is on
+    /// screen. The chat list enriches every row it projects, so this normally finds the cache
+    /// already warm; it exists because the invite prompt replaces the composer, which is what
+    /// otherwise pulls a roster in (`ensureMentionRosterLoaded`).
+    func ensureGroupInviterLoaded(forGroupIdHex groupIdHex: String) {
+        guard groupMemberDetailsCache[groupIdHex] == nil,
+            let client, let activeAccount
+        else { return }
+        Task { _ = await cachedGroupMembers(groupIdHex: groupIdHex, account: activeAccount, client: client) }
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -764,6 +764,13 @@ final class WorkspaceState {
     /// need members to identify direct chats and provide member-name fallbacks, so cache just
     /// that membership slice and invalidate it on membership-changing subscription events.
     var groupMemberDetailsCache: [String: [GroupMemberDetailsFfi]] = [:]
+    /// Who sent the welcome that put the local account in each group, from the same
+    /// `groupDetails` read that fills `groupMemberDetailsCache` — the only place the inviter's
+    /// identity is available, since a chat-list row carries no welcomer. Written and invalidated
+    /// with the roster cache, so "this group has no recorded inviter" (one the local account
+    /// created, or an older local record) reads as a missing entry against a *present* roster
+    /// entry, rather than as "not fetched yet".
+    var groupWelcomerCache: [String: String] = [:]
     /// Mention-picker projections derived from `groupMemberDetailsCache`. Kept outside Observation
     /// so reading or populating the cache from a view body does not schedule another render.
     /// Both mention caches fold in the viewer's private nicknames, so both are stamped with the
@@ -963,7 +970,10 @@ final class WorkspaceState {
 
     struct GroupMemberDetailsLookup {
         var token: UInt64
-        var task: Task<[GroupMemberDetailsFfi]?, Never>
+        /// The whole record, not just `members`: the same read is what teaches the app who
+        /// invited the local account (`AppGroupRecordFfi.welcomerAccountIdHex`), and a second
+        /// FFI hop for one string on the chat-list enrichment path would not be worth it.
+        var task: Task<GroupDetailsFfi?, Never>
     }
 
     struct MediaDiskStoreGuard: Equatable {

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -1531,17 +1531,40 @@ struct PendingGroupInviteComposerNotice: View {
         .padding(.vertical, 10)
         .glassCard()
         .accessibilityIdentifier("composer.pendingGroupInvite")
+        // This prompt replaces the composer, so the roster (and with it the inviter) has no
+        // other reason to load for the chat that most needs it.
+        .task(id: chat.id) {
+            workspace.ensureGroupInviterLoaded(forGroupIdHex: chat.id)
+        }
     }
 
     private var inviteMessage: String {
-        String(format: L10n.string("%@ invited you to a secure chat."), inviterName)
+        String(
+            format: L10n.string("%@ invited you to a secure chat."),
+            PeerDisplayText.templateFragment(inviterName)
+        )
     }
 
+    /// Who to name as the inviter, best source first.
+    ///
+    /// The group record's welcome sender is the only authoritative answer — a chat-list row
+    /// carries no welcomer, which is why this used to guess from the preview and land on
+    /// "Someone" for the case an invite is most often seen in: a direct chat with no messages
+    /// yet, whose preview is empty. `directPeerName` covers a record that kept no welcome
+    /// sender: a one-to-one has exactly one other member, so they are the inviter.
     private var inviterName: String {
-        if let previewSender = previewSenderName {
-            return previewSender
-        }
-        return L10n.string("Someone")
+        workspace.inviterDisplayName(forGroupIdHex: chat.id)
+            ?? directPeerName
+            ?? previewSenderName
+            ?? workspace.inviterIdentifierLabel(forGroupIdHex: chat.id)
+            ?? L10n.string("Someone")
+    }
+
+    /// The other party in a direct chat, and only once a peer has actually resolved — a title
+    /// standing in for an unresolved peer is the shortened group id, which names nobody.
+    private var directPeerName: String? {
+        guard chat.isDirect, chat.directPeerAccountIdHex != nil else { return nil }
+        return chat.title.nilIfBlank
     }
 
     private var previewSenderName: String? {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -535,7 +535,7 @@ struct PureValueTests {
 
         let local = mentionMember(id: "self", displayName: "Local", npub: "npub1self", isSelf: true)
         let alice = mentionMember(id: "alice", displayName: "Alice", npub: "npub1alice")
-        state.storeGroupMembers([local, alice], for: group.id)
+        state.storeGroupMembers([local, alice], welcomerAccountIdHex: nil, for: group.id)
 
         #expect(state.mentionRoster().map(\.id) == ["alice"])
         #expect(state.mentionRoster().map(\.id) == ["alice"])
@@ -545,7 +545,7 @@ struct PureValueTests {
         #expect(state.mentionNamesBuildCount == 1)
 
         let bob = mentionMember(id: "bob", displayName: "Bob", npub: "npub1bob")
-        state.storeGroupMembers([local, bob], for: group.id)
+        state.storeGroupMembers([local, bob], welcomerAccountIdHex: nil, for: group.id)
 
         #expect(state.mentionRoster().map(\.id) == ["bob"])
         #expect(state.mentionRosterBuildCount == 2)
@@ -575,6 +575,7 @@ struct PureValueTests {
                 mentionMember(id: "self", displayName: "Local", npub: "npub1self", isSelf: true),
                 mentionMember(id: "alice", displayName: "Alice", npub: "npub1alice"),
             ],
+            welcomerAccountIdHex: nil,
             for: group.id
         )
 
@@ -625,6 +626,7 @@ struct PureValueTests {
         state.selection = .chat(group.id)
         state.storeGroupMembers(
             [mentionMember(id: "alice", displayName: "Alice", npub: "npub1alice")],
+            welcomerAccountIdHex: nil,
             for: group.id
         )
 
@@ -656,7 +658,7 @@ struct PureValueTests {
 
         let local = mentionMember(id: "self", displayName: "Local", npub: "npub1self", isSelf: true)
         let peer = mentionMember(id: "nvk", displayName: "NVK", npub: "npub1nvk")
-        state.storeGroupMembers([local, peer], for: direct.id)
+        state.storeGroupMembers([local, peer], welcomerAccountIdHex: nil, for: direct.id)
 
         #expect(state.mentionRoster().map(\.id) == ["nvk"])
         #expect(state.mentionCandidates(matching: "nv").map(\.displayName) == ["NVK"])
@@ -2248,6 +2250,106 @@ struct PureValueTests {
 
             #expect(snapshot.selfMembership == expected)
         }
+    }
+
+    /// The invite prompt used to guess the inviter from the row preview, which is empty for the
+    /// case it matters most — a direct invite with no messages yet — so it said "Someone". The
+    /// group record's welcome sender is the authoritative answer, and it arrives on the same
+    /// read that fills the roster.
+    @MainActor
+    @Test func inviteRecordsWhoSentTheWelcomeAndNamesThemFromTheRoster() async throws {
+        let welcomer = "alice1234567890alice1234567890alice1234567890alice12345678"
+        let state = WorkspaceState(
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+
+        state.applyGroupDetails(
+            GroupDetailsFfi(
+                group: inviteGroupRecord(groupIdHex: "group", welcomerAccountIdHex: welcomer),
+                members: [
+                    mentionMember(id: welcomer, displayName: "Alice", npub: "npub1alice"),
+                    mentionMember(id: "self", displayName: "Local", npub: "npub1self", isSelf: true),
+                ]
+            ),
+            managementState: inviteManagementState
+        )
+
+        #expect(state.inviterAccountIdHex(forGroupIdHex: "group") == welcomer)
+        #expect(state.inviterDisplayName(forGroupIdHex: "group") == "Alice")
+        // A group nobody welcomed this account into (one it created) names no inviter, and
+        // neither does a group whose roster has never been read.
+        #expect(state.inviterDisplayName(forGroupIdHex: "unfetched") == nil)
+    }
+
+    /// An inviter whose profile has not resolved yet is still someone: naming them by npub beats
+    /// falling back to "Someone", and the published name replaces it in place when it lands. It
+    /// stays a separate lookup from the name so callers with a better fallback of their own —
+    /// a direct chat's title is the peer, already resolved — can rank it below theirs.
+    @MainActor
+    @Test func inviteNamesAnUnresolvedInviterByIdentifier() async throws {
+        let welcomer = "bob1234567890bob1234567890bob1234567890bob1234567890bob123"
+        let state = WorkspaceState(
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+
+        state.applyGroupDetails(
+            GroupDetailsFfi(
+                group: inviteGroupRecord(groupIdHex: "group", welcomerAccountIdHex: welcomer),
+                members: [
+                    GroupMemberDetailsFfi(
+                        memberIdHex: welcomer,
+                        account: nil,
+                        local: false,
+                        isAdmin: false,
+                        isSelf: false,
+                        npub: "npub1bobbobbobbobbobbob",
+                        displayName: nil
+                    )
+                ]
+            ),
+            managementState: inviteManagementState
+        )
+
+        #expect(state.inviterDisplayName(forGroupIdHex: "group") == nil)
+        #expect(
+            state.inviterIdentifierLabel(forGroupIdHex: "group")
+                == DisplayText.short("npub1bobbobbobbobbobbob", head: 12, tail: 8))
+
+        // A roster the app has not read at all cannot name the inviter from a member entry, so
+        // the account id itself is the last thing left to show.
+        state.storeGroupMembers([], welcomerAccountIdHex: welcomer, for: "other")
+        #expect(state.inviterIdentifierLabel(forGroupIdHex: "other") == DisplayText.short(welcomer))
+    }
+
+    /// The inviter is cached with the roster, so it must be dropped with it: a stale welcome
+    /// sender outliving the membership read that produced it would name the wrong account.
+    @MainActor
+    @Test func invalidatingTheRosterForgetsTheInviter() async throws {
+        let welcomer = "carol234567890carol234567890carol234567890carol2345678901"
+        let state = WorkspaceState(
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+
+        state.storeGroupMembers(
+            [mentionMember(id: welcomer, displayName: "Carol", npub: "npub1carol")],
+            welcomerAccountIdHex: welcomer,
+            for: "group"
+        )
+        #expect(state.inviterDisplayName(forGroupIdHex: "group") == "Carol")
+
+        state.invalidateGroupMembers(for: "group")
+        #expect(state.inviterAccountIdHex(forGroupIdHex: "group") == nil)
+
+        // A record that carries no welcome sender leaves no entry behind either, so a later
+        // read of a different group cannot inherit one.
+        state.storeGroupMembers([], welcomerAccountIdHex: "   ", for: "group")
+        #expect(state.inviterAccountIdHex(forGroupIdHex: "group") == nil)
     }
 
     @Test func remoteImageSanitizedURLRejectsPrivateHosts() async throws {
@@ -4802,6 +4904,47 @@ private func mentionMember(
         displayName: displayName
     )
 }
+
+/// A group record whose only interesting field is who sent the welcome.
+private func inviteGroupRecord(groupIdHex: String, welcomerAccountIdHex: String?) -> AppGroupRecordFfi {
+    AppGroupRecordFfi(
+        groupIdHex: groupIdHex,
+        endpoint: "",
+        name: "Test Group",
+        description: "",
+        admins: [],
+        relays: [],
+        nostrGroupIdHex: "",
+        avatarUrl: nil,
+        avatarDim: nil,
+        avatarThumbhash: nil,
+        imageHashHex: nil,
+        encryptedMedia: AppGroupEncryptedMediaComponentFfi(
+            componentId: 0,
+            component: "",
+            required: false,
+            mediaFormat: "",
+            allowedLocatorKinds: [],
+            defaultBlobEndpoints: []
+        ),
+        disappearingMessageSecs: 0,
+        archived: false,
+        pendingConfirmation: true,
+        selfMembership: .member,
+        welcomerAccountIdHex: welcomerAccountIdHex,
+        viaWelcomeMessageIdHex: nil
+    )
+}
+
+private let inviteManagementState = GroupManagementStateFfi(
+    myAccountIdHex: "self",
+    isSelfAdmin: false,
+    isLastAdmin: false,
+    canInvite: false,
+    canLeave: true,
+    requiresSelfDemoteBeforeLeave: false,
+    memberActions: []
+)
 
 private func wideMarkdownTable(columns: Int, rows: Int) -> MarkdownDocumentFfi {
     let header = (0..<columns).map { column in


### PR DESCRIPTION
|Before | After| 
|----|----|
|<img width="359" height="48" alt="Screenshot 2026-08-13 at 11 26 53 AM" src="https://github.com/user-attachments/assets/b96e6def-2a4f-436b-b946-30af8d7d0931" />|<img width="398" height="47" alt="Screenshot 2026-08-13 at 11 25 17 AM" src="https://github.com/user-attachments/assets/5777aed7-106c-4f1a-89f7-2b64cae7f54f" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Group invitations now identify the person who invited you when their name is available.
  - Inviter names are resolved using group details, direct-chat information, or other available identifiers.
  - When no inviter information can be found, invitations display a clear “Someone” fallback.

- **Bug Fixes**
  - Improved inviter information handling when group member data is refreshed or cleared.
  - Group invitation details now remain more consistent across roster updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->