### PR TITLE
Let the last member of a chat delete it locally without leaving

### DIFF
--- a/whitenoise-mac/Core/ChatDestructiveActions.swift
+++ b/whitenoise-mac/Core/ChatDestructiveActions.swift
@@ -62,12 +62,17 @@ extension GroupDetailsSnapshot {
     /// inspector and the sidebar row read the same way.
     var isNoLongerMember: Bool { selfMembership != .member }
 
-    /// The destructive action the inspector may offer — the same function the sidebar row uses, so
-    /// the two surfaces agree by construction rather than by convention.
+    /// The destructive action the inspector may offer — the same policy the sidebar row uses, so
+    /// the two surfaces agree by construction rather than by convention. The inspector holds the
+    /// roster and eligibility up front, so it takes the refined form: an account alone in a chat it
+    /// cannot leave is offered the local delete directly, rather than a Leave button whose only
+    /// possible outcome is an explanation.
     var destructiveAction: ChatDestructiveActions.Action? {
         ChatDestructiveActions.action(
             membership: selfMembership,
-            leaveRequestPending: leaveRequestPending
+            leaveRequestPending: leaveRequestPending,
+            leaveBlocker: leaveBlocker,
+            lastAdminResolution: lastAdminResolution
         )
     }
 
@@ -80,14 +85,21 @@ extension GroupDetailsSnapshot {
         ChatDestructiveActions.adminHandoffCandidates(from: members)
     }
 
-    /// What the inspector says beneath the leave button. Prefers the handoff hint over the raw
-    /// `.lastAdmin` blocker, so a sole admin with someone to promote is told leaving *will* work
-    /// rather than that it won't.
+    /// How a `.lastAdmin` block on this chat resolves. Read even when the account is not blocked —
+    /// the functions taking it ignore it unless the blocker is actually `.lastAdmin`.
+    var lastAdminResolution: ChatDestructiveActions.LastAdminResolution {
+        ChatDestructiveActions.lastAdminResolution(members: members)
+    }
+
+    /// What the inspector says beneath the leave button. Prefers the resolution over the raw
+    /// `.lastAdmin` blocker, so a sole admin who can still get out — by promoting someone, or by
+    /// dropping the local copy of a chat nobody else is in — is told what to do rather than that
+    /// they are stuck.
     var leaveGuidance: ChatDestructiveActions.LeaveGuidance? {
         ChatDestructiveActions.leaveGuidance(
             membership: selfMembership,
             eligibility: leaveEligibility,
-            hasAdminHandoffCandidate: !adminHandoffCandidates.isEmpty
+            lastAdminResolution: lastAdminResolution
         )
     }
 }
@@ -232,11 +244,13 @@ nonisolated enum ChatDestructiveActions {
         /// The account is the group's only admin. MIP-03 §149/§150 forbids an admin self-removal
         /// that would deplete the admin set, so leaving requires promoting another member first.
         ///
-        /// As a *blocker* this is the dead end only: the app resolves the ordinary case itself by
-        /// offering the successor picker (`LeaveGuidance.adminHandoffRequired`), so this reaches the
-        /// user only when there is nobody to promote — an admin alone in the group, or one whose
-        /// only companions the core refuses to let it promote. Hence the wording, which asks for a
-        /// member rather than for a promotion.
+        /// As a *blocker* this is the dead end only, and the dead end is now narrow: the app
+        /// resolves both ordinary cases itself, offering the successor picker
+        /// (`LeaveGuidance.adminHandoffRequired`) when someone can take the role over and the local
+        /// delete (`LeaveGuidance.localDeleteInstead`) when nobody else is in the group at all. What
+        /// is left — the only shape that reaches the user — is a sole admin whose companions the
+        /// core refuses to let it promote. Hence the wording, which asks for a member rather than
+        /// for a promotion: the members present are unusable as successors.
         case lastAdmin
         /// Ordinary group actions are disabled (the group is disbanding, or its lifecycle is
         /// terminal). Reachable from remote admin action even though this app never initiates a
@@ -260,16 +274,38 @@ nonisolated enum ChatDestructiveActions {
 
     }
 
+    /// How a `.lastAdmin` leave block resolves, decided from the roster the block applies to.
+    ///
+    /// The core reports one flag for three quite different situations, and conflating them is what
+    /// produced the dead end this type exists to remove — a user alone in a chat, told to invite
+    /// someone before leaving.
+    enum LastAdminResolution: Equatable {
+        /// Someone else may take the admin role: promote them, then leave. The group survives and
+        /// the departure still reaches it, which is why this is preferred whenever it is available.
+        case handOffAdmin
+        /// Nobody else is in the group at all, so there is no successor to promote *and* nobody the
+        /// leave would inform. See `action(membership:leaveRequestPending:leaveBlocker:lastAdminResolution:)`
+        /// for why the local delete is safe here and nowhere else.
+        case deleteLocally
+        /// Others remain, but the core will not let this account promote any of them — the genuine
+        /// dead end, and the only one reported as a `.lastAdmin` blocker.
+        case blocked
+    }
+
     /// What a surface says about leaving beyond offering the button — the inspector's footer today.
     ///
-    /// Distinguishing the two `.lastAdmin` outcomes is the whole point: a sole admin with a
-    /// promotable member is not blocked, they are one extra step away, and telling them "you can't
-    /// leave" would be wrong.
+    /// Distinguishing the `.lastAdmin` outcomes is the whole point: a sole admin with a promotable
+    /// member is not blocked, they are one extra step away, and a sole admin with nobody left at all
+    /// is not blocked either — they need a different action. Telling either "you can't leave" would
+    /// be wrong.
     enum LeaveGuidance: Equatable {
         /// Leaving cannot proceed, for a reason no action in this app resolves.
         case blocked(LeaveBlocker)
         /// Leaving works, but routes through the successor picker first.
         case adminHandoffRequired
+        /// Leaving is impossible and pointless — nobody else is in the chat — so the surface offers
+        /// the local delete in its place.
+        case localDeleteInstead
 
         var message: String {
             switch self {
@@ -277,6 +313,10 @@ nonisolated enum ChatDestructiveActions {
                 return blocker.message
             case .adminHandoffRequired:
                 return L10n.string("You're the only admin. You'll pick who takes over before you leave.")
+            case .localDeleteInstead:
+                return L10n.string(
+                    "You're the only one left in this chat, so there's no one to hand admin to. Remove it from this device to close it out."
+                )
             }
         }
     }
@@ -315,6 +355,32 @@ nonisolated enum ChatDestructiveActions {
         action(membership: chat.selfMembership, leaveRequestPending: chat.leaveRequestPending)
     }
 
+    /// The roster-aware refinement, for surfaces holding eligibility and the roster up front — the
+    /// inspector today.
+    ///
+    /// It can only ever turn `.leave` into `.deleteLocally`, and only for the one shape where the
+    /// rule above has nothing left to protect: an account the core refuses to let leave *because it
+    /// is the last admin*, in a group where it is also the last member. Leaving is otherwise the
+    /// only way out precisely so the rest of the group learns this account stopped reading — but
+    /// here there is no rest of the group to tell, and no leave the core will accept. The local
+    /// delete strands nobody, and it is the only way to close the chat out.
+    ///
+    /// Every other blocker keeps the plain answer. In particular `.blocked` — others present, none
+    /// promotable — stays a `.leave`, because those others *would* be stranded.
+    static func action(
+        membership: ChatSelfMembership,
+        leaveRequestPending: Bool,
+        leaveBlocker: LeaveBlocker?,
+        lastAdminResolution: LastAdminResolution
+    ) -> Action? {
+        let action = action(membership: membership, leaveRequestPending: leaveRequestPending)
+        guard action == .leave,
+            leaveBlocker == .lastAdmin,
+            lastAdminResolution == .deleteLocally
+        else { return action }
+        return .deleteLocally
+    }
+
     /// Whether a leave would do anything, counting the self-demote-first path as available.
     static func canLeave(_ eligibility: ChatLeaveEligibility) -> Bool {
         eligibility.canLeave || shouldSelfDemoteBeforeLeave(eligibility)
@@ -344,29 +410,27 @@ nonisolated enum ChatDestructiveActions {
         return eligibility.isLastAdmin ? .lastAdmin : .unavailable
     }
 
-    /// Whether the `.lastAdmin` block is the resolvable kind — the one the successor picker exists
-    /// for. `false` for every other blocker, including a `.lastAdmin` with nobody to promote.
-    static func offersAdminHandoff(
-        _ blocker: LeaveBlocker?,
-        hasAdminHandoffCandidate: Bool
-    ) -> Bool {
-        blocker == .lastAdmin && hasAdminHandoffCandidate
-    }
-
     /// The blocker a surface should explain, refined by whether the app can resolve it in-flow.
     /// `nil` when leaving is plain and needs no explanation.
+    ///
+    /// `.lastAdmin` is the only blocker a roster can say anything about: a pending leave and a
+    /// disabled group are unaffected by who else is present, so `lastAdminResolution` is ignored for
+    /// them rather than allowed to invent a way out they don't have.
     static func leaveGuidance(
         membership: ChatSelfMembership,
         eligibility: ChatLeaveEligibility,
-        hasAdminHandoffCandidate: Bool
+        lastAdminResolution: LastAdminResolution
     ) -> LeaveGuidance? {
         guard let blocker = leaveBlocker(membership: membership, eligibility: eligibility) else {
             return nil
         }
-        if offersAdminHandoff(blocker, hasAdminHandoffCandidate: hasAdminHandoffCandidate) {
-            return .adminHandoffRequired
+        guard blocker == .lastAdmin else { return .blocked(blocker) }
+
+        switch lastAdminResolution {
+        case .handOffAdmin: return .adminHandoffRequired
+        case .deleteLocally: return .localDeleteInstead
+        case .blocked: return .blocked(.lastAdmin)
         }
-        return .blocked(blocker)
     }
 }
 
@@ -383,5 +447,30 @@ extension ChatDestructiveActions {
     @MainActor
     static func adminHandoffCandidates(from members: [GroupMemberItem]) -> [GroupMemberItem] {
         members.filter { !$0.isSelf && !$0.isAdmin && $0.canPromote }
+    }
+
+    /// True when nobody but this account is left in the group — the last member of a group everyone
+    /// else left, or the remaining half of a DM whose peer is gone.
+    ///
+    /// Asks whether any *other* member exists rather than comparing a count, so an empty roster
+    /// answers true as well: a group with nobody in it has nobody to strand either, and the exotic
+    /// case where the core returns no members at all should not fall through to the dead end.
+    @MainActor
+    static func isSoleRemainingMember(_ members: [GroupMemberItem]) -> Bool {
+        !members.contains { !$0.isSelf }
+    }
+
+    /// Which way out of a `.lastAdmin` block this roster allows.
+    ///
+    /// Handing the role over comes first whenever it is possible: it keeps the group alive and puts
+    /// the departure on the wire, which the local delete cannot do. Only once there is no successor
+    /// does being alone matter — and being alone is checked *specifically*, not inferred from the
+    /// candidate list being empty. The two are not the same thing: a sole admin whose companions the
+    /// core refuses to promote also has no candidates, and dropping the local copy there would
+    /// strand the members still in the group.
+    @MainActor
+    static func lastAdminResolution(members: [GroupMemberItem]) -> LastAdminResolution {
+        if !adminHandoffCandidates(from: members).isEmpty { return .handOffAdmin }
+        return isSoleRemainingMember(members) ? .deleteLocally : .blocked
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -796,16 +796,9 @@ extension WorkspaceState {
             // `LeavingGroupBadge` instead.
             await reloadChats(forceFreshSnapshot: true)
         case .lastAdmin:
-            // The one blocker the app can clear on the user's behalf: offer the successor picker,
-            // and only report the dead end when there is nobody to hand admin to.
-            //
-            // `handingOffAdminChatId` is the re-entrancy guard. `confirmChatAdminHandoff` runs the
-            // leave through `confirmChatLeave`, which re-reads eligibility; if the promotion
-            // committed but the core still reports this account as the last admin, reopening the
-            // picker the user just used would loop. Report the blocker instead.
-            if handingOffAdminChatId != groupIdHex,
-                await presentChatAdminHandoff(groupIdHex: groupIdHex, title: title, state: state)
-            {
+            // The one blocker the app can clear on the user's behalf — in one of two ways, decided
+            // by who is left in the group. Only the genuine dead end falls through to the alert.
+            if await resolveLastAdminLeaveBlock(groupIdHex: groupIdHex, title: title, state: state) {
                 return
             }
             chatActionAlert = .leaveBlocked(blocker)
@@ -814,14 +807,23 @@ extension WorkspaceState {
         }
     }
 
-    /// Open the successor picker for a sole admin who wants to leave. Returns false when the roster
-    /// is unreadable or holds nobody this account may promote, leaving the caller to report the
-    /// blocker.
+    /// Clear a sole-admin leave block using the group's roster, or report that it cannot be cleared.
+    /// Returns false only for the genuine dead end — an unreadable roster, or members present whom
+    /// the core refuses to let this account promote — leaving the caller to report the blocker.
+    ///
+    /// Which of the two resolutions applies is `ChatDestructiveActions`' decision, not this method's:
+    ///
+    /// * **A successor exists** → open the picker; the leave runs once the promotion commits.
+    /// * **Nobody else is in the group** → offer the local delete. Leaving is normally the only way
+    ///   out of a group *because the others have to learn this account stopped reading*; with nobody
+    ///   left there is no one to tell, and no leave the core will accept either. This is the only
+    ///   case in the app where a member is offered a local delete — see
+    ///   `ChatDestructiveActions.action(membership:leaveRequestPending:leaveBlocker:lastAdminResolution:)`.
     ///
     /// The roster comes from a fresh `groupDetails` read rather than from `groupDetailsSnapshot`: the
-    /// leave can be started from a sidebar row while an entirely different chat is open, and the
-    /// promotion has to name a member of *this* group.
-    private func presentChatAdminHandoff(
+    /// leave can be started from a sidebar row while an entirely different chat is open, so both
+    /// resolutions have to be about *this* group.
+    private func resolveLastAdminLeaveBlock(
         groupIdHex: String,
         title: String,
         state: GroupManagementStateFfi
@@ -840,15 +842,32 @@ extension WorkspaceState {
         // nicknames, avatars and admin badges as the member list — and reads `canPromote` from the
         // same `memberActions` the core just returned.
         let members = groupDetailsSnapshot(from: details, managementState: state).members
-        let candidates = ChatDestructiveActions.adminHandoffCandidates(from: members)
-        guard !candidates.isEmpty else { return false }
 
-        chatPendingAdminHandoff = ChatAdminHandoffTarget(
-            groupIdHex: groupIdHex,
-            title: title,
-            candidates: candidates
-        )
-        return true
+        switch ChatDestructiveActions.lastAdminResolution(members: members) {
+        case .handOffAdmin:
+            // `handingOffAdminChatId` is the re-entrancy guard. `confirmChatAdminHandoff` runs the
+            // leave through `confirmChatLeave`, which re-reads eligibility; if the promotion
+            // committed but the core still reports this account as the last admin, reopening the
+            // picker the user just used would loop. Report the blocker instead.
+            guard handingOffAdminChatId != groupIdHex else { return false }
+            chatPendingAdminHandoff = ChatAdminHandoffTarget(
+                groupIdHex: groupIdHex,
+                title: title,
+                candidates: ChatDestructiveActions.adminHandoffCandidates(from: members)
+            )
+            return true
+
+        case .deleteLocally:
+            // True even if the request is dropped by its own re-entrancy guard (a local delete
+            // already confirming or running). The resolution was still correct, and a suppressed
+            // duplicate dialog is far better than falling through to a `.lastAdmin` alert telling
+            // someone alone in a chat to invite a member — which is the bug this branch removes.
+            requestChatLocalDelete(groupIdHex: groupIdHex, title: title)
+            return true
+
+        case .blocked:
+            return false
+        }
     }
 
     /// Promote `successor`, then run the leave the promotion unblocked.

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -54828,6 +54828,65 @@
         }
       }
     },
+    "You're the only one left in this chat, so there's no one to hand admin to. Remove it from this device to close it out.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du bist die letzte Person in diesem Chat, es gibt also niemanden, der die Adminrolle übernehmen könnte. Entferne ihn von diesem Gerät, um ihn abzuschließen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eres la única persona que queda en este chat, así que no hay a quién pasarle la administración. Quítalo de este dispositivo para cerrarlo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous êtes la seule personne restante dans ce chat, il n'y a donc personne à qui confier le rôle d'administrateur. Retirez-le de cet appareil pour le clôturer."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei l'unica persona rimasta in questa chat, quindi non c'è nessuno a cui passare il ruolo di amministratore. Rimuovila da questo dispositivo per chiuderla."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você é a única pessoa que restou neste bate-papo, então não há ninguém para assumir a administração. Remova-o deste dispositivo para encerrá-lo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы единственный участник, оставшийся в этом чате, поэтому передать роль администратора некому. Удалите его с этого устройства, чтобы закрыть."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu sohbette kalan tek kişisin, bu yüzden yöneticiliği devredebileceğin kimse yok. Kapatmak için bu cihazdan kaldır."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你是此聊天中剩下的唯一成员，没有人可以接手管理员。将其从此设备移除即可关闭。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你是此聊天中剩下的唯一成員，沒有人可以接手管理員。將其從此裝置移除即可關閉。"
+          }
+        }
+      }
+    },
     "You: %@": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Views/ChatDestructiveActionsConfirmation.swift
+++ b/whitenoise-mac/Views/ChatDestructiveActionsConfirmation.swift
@@ -82,6 +82,8 @@ private struct ChatDestructiveActionsConfirmationModifier: ViewModifier {
             ) { _ in
                 // No local-delete alternative here on purpose: dropping the local copy while the
                 // group still counts you as a member would silently strand everyone else's messages.
+                // The one case where that argument does not apply — nobody else left in the chat —
+                // never reaches this alert; it opens the local-delete confirmation above instead.
                 Button(L10n.string("OK"), role: .cancel) {}
             } message: { alert in
                 Text(alert.message)

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -475,10 +475,13 @@ struct GroupDetailsSheet: View {
                             }
 
                             // Leave / Delete come from the same policy the sidebar row menu uses, so
-                            // the two surfaces cannot disagree on which is legal. Membership is the
-                            // whole rule: a member is offered the leave even when eligibility will
-                            // block it, and `prepareSelectedChatLeave` either explains the block or —
-                            // for a sole admin — opens the successor picker that resolves it.
+                            // the two surfaces cannot disagree on which is legal. Membership is
+                            // very nearly the whole rule: a member is offered the leave even when
+                            // eligibility will block it, and `prepareSelectedChatLeave` either
+                            // explains the block or resolves it — with the successor picker for a
+                            // sole admin who has someone to promote. The one exception is an account
+                            // alone in a chat it cannot leave, which this inspector can see from the
+                            // roster and so offers the local delete outright.
                             switch snapshot.destructiveAction {
                             case .leave:
                                 Button(role: .destructive) {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -4012,11 +4012,27 @@ struct PureValueTests {
         )
     }
 
-    /// The load-bearing invariant: **no leave eligibility, however bad, ever produces a local
-    /// delete for someone the group still counts as a member.** Deleting locally while a member
-    /// would strand every later message the group sends, with nothing on the wire to say so, so
-    /// membership alone decides — across the whole eligibility cross product.
-    @Test func noEligibilityStateOffersLocalDeleteWhileStillAMember() {
+    /// The load-bearing invariant: **no leave eligibility, however bad, produces a local delete for
+    /// someone the group still counts as a member — while anyone else is still in the group.**
+    /// Deleting locally with others present would strand every later message they send, with nothing
+    /// on the wire to say so, so eligibility never decides it.
+    ///
+    /// Crosses both forms over the whole eligibility product: the membership-only one, which is all a
+    /// sidebar row can evaluate and which never yields a delete for a member at all, and the
+    /// roster-aware one, held here to a roster with a second member present. The single shape allowed
+    /// to deviate — nobody left in the group — is pinned in
+    /// `soleRemainingMemberBlockedAsLastAdminIsOfferedTheLocalDelete`, and the reason it is safe there
+    /// is exactly the reason it is forbidden here.
+    @MainActor
+    @Test func noEligibilityStateOffersLocalDeleteWhileOthersRemainInTheGroup() {
+        let othersPresent = ChatDestructiveActions.lastAdminResolution(
+            members: [
+                handoffMember(id: "self", isSelf: true, isAdmin: true),
+                handoffMember(id: "still-here", canPromote: false),
+            ]
+        )
+        #expect(othersPresent == .blocked)
+
         for pending in [false, true] {
             for canLeave in [false, true] {
                 for requiresSelfDemote in [false, true] {
@@ -4034,11 +4050,22 @@ struct PureValueTests {
                         #expect(action != .deleteLocally)
                         // Blocked or not, a member is only ever offered the leave.
                         #expect(action == (pending ? nil : .leave))
-                        // And the blocker only ever explains itself — it carries no delete.
-                        if let blocker = ChatDestructiveActions.leaveBlocker(
+
+                        let blocker = ChatDestructiveActions.leaveBlocker(
                             membership: .member,
                             eligibility: eligibility
-                        ) {
+                        )
+                        // Same answer from the roster-aware form while someone else is present.
+                        #expect(
+                            ChatDestructiveActions.action(
+                                membership: .member,
+                                leaveRequestPending: pending,
+                                leaveBlocker: blocker,
+                                lastAdminResolution: othersPresent
+                            ) == action
+                        )
+                        // And the blocker only ever explains itself — it carries no delete.
+                        if let blocker {
                             #expect(!ChatActionAlert.leaveBlocked(blocker).message.isEmpty)
                         }
                     }
@@ -4062,10 +4089,11 @@ struct PureValueTests {
             ChatDestructiveActions.leaveBlocker(membership: .member, eligibility: lastAdmin)
                 == .lastAdmin
         )
-        // The answer is still Leave, and it is deliberately *not* swapped for a local delete: the
-        // group has to learn that this account stopped reading, and only a leave tells them. What
-        // happens next depends on whether anyone can take the admin role over — see
-        // `soleAdminWithASuccessorIsGuidedToTheHandoffRatherThanBlocked`.
+        // From membership alone the answer is still Leave, and deliberately *not* a local delete:
+        // the group has to learn that this account stopped reading, and only a leave tells them.
+        // What happens next depends on who is left — a successor to promote
+        // (`soleAdminWithASuccessorIsGuidedToTheHandoffRatherThanBlocked`), nobody at all
+        // (`soleRemainingMemberBlockedAsLastAdminIsOfferedTheLocalDelete`), or this dead end.
         #expect(
             ChatDestructiveActions.action(membership: .member, leaveRequestPending: false) == .leave
         )
@@ -4091,14 +4119,14 @@ struct PureValueTests {
             ChatDestructiveActions.leaveGuidance(
                 membership: .member,
                 eligibility: lastAdmin,
-                hasAdminHandoffCandidate: true
+                lastAdminResolution: .handOffAdmin
             ) == .adminHandoffRequired
         )
         #expect(
             ChatDestructiveActions.leaveGuidance(
                 membership: .member,
                 eligibility: lastAdmin,
-                hasAdminHandoffCandidate: false
+                lastAdminResolution: .blocked
             ) == .blocked(.lastAdmin)
         )
         // One promises the leave will happen, the other says it cannot — sharing wording would make
@@ -4115,31 +4143,127 @@ struct PureValueTests {
         let pending = leaveEligibility(canLeave: false, leaveRequestPending: true, isLastAdmin: true)
         let unavailable = leaveEligibility(canLeave: false, isLastAdmin: false)
 
+        // No roster answer may soften either one — not the successor that resolves `.lastAdmin`, and
+        // not the empty group that redirects it to a local delete.
         for eligibility in [pending, unavailable] {
             let blocker = ChatDestructiveActions.leaveBlocker(
                 membership: .member,
                 eligibility: eligibility
             )
-            #expect(!ChatDestructiveActions.offersAdminHandoff(blocker, hasAdminHandoffCandidate: true))
-            #expect(
-                ChatDestructiveActions.leaveGuidance(
-                    membership: .member,
-                    eligibility: eligibility,
-                    hasAdminHandoffCandidate: true
-                ) == blocker.map(ChatDestructiveActions.LeaveGuidance.blocked)
-            )
+            for resolution: ChatDestructiveActions.LastAdminResolution in [
+                .handOffAdmin, .deleteLocally, .blocked,
+            ] {
+                #expect(
+                    ChatDestructiveActions.leaveGuidance(
+                        membership: .member,
+                        eligibility: eligibility,
+                        lastAdminResolution: resolution
+                    ) == blocker.map(ChatDestructiveActions.LeaveGuidance.blocked)
+                )
+                #expect(
+                    ChatDestructiveActions.action(
+                        membership: .member,
+                        leaveRequestPending: eligibility.leaveRequestPending,
+                        leaveBlocker: blocker,
+                        lastAdminResolution: resolution
+                    ) != .deleteLocally
+                )
+            }
         }
 
-        // And a leave with nothing wrong with it needs no footer at all, candidates or not.
-        for hasCandidate in [false, true] {
+        // And a leave with nothing wrong with it needs no footer at all, whoever is in the roster.
+        for resolution: ChatDestructiveActions.LastAdminResolution in [
+            .handOffAdmin, .deleteLocally, .blocked,
+        ] {
             #expect(
                 ChatDestructiveActions.leaveGuidance(
                     membership: .member,
                     eligibility: leaveEligibility(canLeave: true),
-                    hasAdminHandoffCandidate: hasCandidate
+                    lastAdminResolution: resolution
                 ) == nil
             )
         }
+    }
+
+    /// The dead end this flow used to produce: alone in a chat, blocked for being the last admin,
+    /// and advised to invite someone before leaving. There is nobody to invite and nobody to hand the
+    /// role to, so the leave can never happen — the local delete is the only way to close the chat,
+    /// and it is safe precisely because there is no one left to strand.
+    @MainActor
+    @Test func soleRemainingMemberBlockedAsLastAdminIsOfferedTheLocalDelete() {
+        let alone = [handoffMember(id: "self", isSelf: true, isAdmin: true, canPromote: true)]
+        #expect(ChatDestructiveActions.isSoleRemainingMember(alone))
+        #expect(ChatDestructiveActions.lastAdminResolution(members: alone) == .deleteLocally)
+
+        let lastAdmin = leaveEligibility(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: true
+        )
+        #expect(
+            ChatDestructiveActions.leaveGuidance(
+                membership: .member,
+                eligibility: lastAdmin,
+                lastAdminResolution: .deleteLocally
+            ) == .localDeleteInstead
+        )
+        #expect(
+            ChatDestructiveActions.action(
+                membership: .member,
+                leaveRequestPending: false,
+                leaveBlocker: .lastAdmin,
+                lastAdminResolution: .deleteLocally
+            ) == .deleteLocally
+        )
+        // Its own wording: neither the handoff promise nor the "invite someone" dead end applies.
+        let message = ChatDestructiveActions.LeaveGuidance.localDeleteInstead.message
+        #expect(message != ChatDestructiveActions.LeaveGuidance.adminHandoffRequired.message)
+        #expect(message != ChatDestructiveActions.LeaveBlocker.lastAdmin.message)
+        #expect(
+            message
+                == L10n.string(
+                    "You're the only one left in this chat, so there's no one to hand admin to. Remove it from this device to close it out."
+                )
+        )
+    }
+
+    /// The line the escape must not cross. "Nobody to promote" and "nobody left at all" are
+    /// different facts, and only the second one makes a local delete safe: a sole admin whose
+    /// companions the core refuses to promote is just as stuck, but deleting locally there would
+    /// strand the members still in the group — the exact harm the membership rule exists to prevent.
+    @MainActor
+    @Test func soleAdminWithUnpromotableCompanionsStaysBlockedRatherThanDeleting() {
+        let stuckWithOthers = [
+            handoffMember(id: "self", isSelf: true, isAdmin: true, canPromote: true),
+            handoffMember(id: "not-promotable", canPromote: false),
+        ]
+        #expect(!ChatDestructiveActions.isSoleRemainingMember(stuckWithOthers))
+        #expect(ChatDestructiveActions.adminHandoffCandidates(from: stuckWithOthers).isEmpty)
+        #expect(ChatDestructiveActions.lastAdminResolution(members: stuckWithOthers) == .blocked)
+        #expect(
+            ChatDestructiveActions.action(
+                membership: .member,
+                leaveRequestPending: false,
+                leaveBlocker: .lastAdmin,
+                lastAdminResolution: .blocked
+            ) == .leave
+        )
+
+        // A successor keeps precedence over both: it is the only resolution that puts the departure
+        // on the wire, so it is never traded for a local delete.
+        let withSuccessor = [
+            handoffMember(id: "self", isSelf: true, isAdmin: true, canPromote: true),
+            handoffMember(id: "successor", canPromote: true),
+        ]
+        #expect(ChatDestructiveActions.lastAdminResolution(members: withSuccessor) == .handOffAdmin)
+        #expect(
+            ChatDestructiveActions.action(
+                membership: .member,
+                leaveRequestPending: false,
+                leaveBlocker: .lastAdmin,
+                lastAdminResolution: .handOffAdmin
+            ) == .leave
+        )
     }
 
     /// `canPromote` is the core's verdict on whether the promotion would commit, so it decides who

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -22476,6 +22476,9 @@ struct whitenoise_macTests {
         leaveRequestPending: Bool = false,
         selfIsAdmin: Bool = false,
         openingInspector: Bool = false,
+        // Leaves this account alone in the group, so a `.lastAdmin` block has neither a successor to
+        // promote nor anyone the departure would inform.
+        soleMember: Bool = false,
         // Empty by default, which is also the "nobody can be promoted" case the sole-admin dead end
         // needs. Pass actions when the test is about who may take the admin role over.
         memberActions: [GroupMemberActionStateFfi] = []
@@ -22483,7 +22486,11 @@ struct whitenoise_macTests {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroupDetails(
-            groupDetailsFixture(selfAccountIdHex: account.accountIdHex, selfIsAdmin: selfIsAdmin),
+            groupDetailsFixture(
+                selfAccountIdHex: account.accountIdHex,
+                selfIsAdmin: selfIsAdmin,
+                soleMember: soleMember
+            ),
             managementState: GroupManagementStateFfi(
                 myAccountIdHex: account.accountIdHex,
                 isSelfAdmin: selfIsAdmin,
@@ -23087,6 +23094,11 @@ struct whitenoise_macTests {
     /// would empty the admin set, so leaving is blocked until another member is promoted. The report
     /// says exactly that and offers no local delete: dropping the local copy while the group still
     /// counts this account as a member would strand every message they send afterwards.
+    ///
+    /// This is now the *narrow* dead end, and the fixture roster is what keeps it here: Alice and Bob
+    /// are still in the group, so somebody would be stranded. Empty that roster and the same
+    /// eligibility resolves to a local delete instead — see
+    /// `lastMemberBlockedAsLastAdminIsOfferedTheLocalDeleteInsteadOfADeadEnd`.
     @MainActor
     @Test func lastAdminLeaveIsReportedWithoutOfferingALocalDelete() async throws {
         let state = try await leavableChatState(
@@ -23245,6 +23257,65 @@ struct whitenoise_macTests {
         #expect(runtime.promoteAdminDetailedCallCount == 1)
         #expect(runtime.groupMutationOrder == ["promote", "selfDemote", "leave"])
         #expect(state.chatActionAlert == nil)
+    }
+
+    /// The last one out of a DM or group: alone, and refused the leave for being the last admin.
+    ///
+    /// Before this existed the row menu's Leave landed on an alert telling the user to invite
+    /// someone before leaving — advice with nobody to follow it about, and no way out of the chat.
+    /// The leave genuinely cannot happen, so the local delete takes its place: with no one else in
+    /// the group there is nobody the departure would have informed and nobody left to strand.
+    @MainActor
+    @Test func lastMemberBlockedAsLastAdminIsOfferedTheLocalDeleteInsteadOfADeadEnd() async throws {
+        let state = try await leavableChatState(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: true,
+            selfIsAdmin: true,
+            soleMember: true
+        )
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+
+        // No dead-end alert, and no successor picker with nobody to put in it.
+        #expect(state.chatActionAlert == nil)
+        #expect(state.chatPendingAdminHandoff == nil)
+        #expect(state.chatPendingLeave == nil)
+        let target = try #require(state.chatPendingLocalDelete)
+        #expect(target.groupIdHex == chat.id)
+        #expect(target.title == chat.title)
+
+        // Nothing was sent on the user's behalf while resolving the block.
+        #expect(runtime.leaveGroupCallCount == 0)
+        #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
+        #expect(runtime.promoteAdminDetailedCallCount == 0)
+
+        await state.confirmChatLocalDelete(target)
+        #expect(runtime.locallyDeletedGroupIds == [chat.id])
+        #expect(state.chatActionAlert == nil)
+    }
+
+    /// The inspector holds the roster up front, so it must not offer a Leave whose only outcome is an
+    /// explanation — it offers the delete directly, with a footer saying why.
+    @MainActor
+    @Test func inspectorOffersTheLocalDeleteToTheLastMemberOfAChatItCannotLeave() async throws {
+        let state = try await leavableChatState(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: true,
+            selfIsAdmin: true,
+            openingInspector: true,
+            soleMember: true
+        )
+        let snapshot = try #require(state.groupDetailsSnapshot)
+
+        #expect(snapshot.members.count == 1)
+        #expect(snapshot.leaveBlocker == .lastAdmin)
+        #expect(snapshot.lastAdminResolution == .deleteLocally)
+        #expect(snapshot.destructiveAction == .deleteLocally)
+        #expect(snapshot.leaveGuidance == .localDeleteInstead)
     }
 
     /// The sole admin of a fixture group in which Alice — and only Alice — may be promoted.
@@ -33839,7 +33910,10 @@ private func soleRemainingSelfMember(accountIdHex: String) -> GroupMemberDetails
 private func groupDetailsFixture(
     selfAccountIdHex: String,
     selfIsAdmin: Bool = true,
-    otherIsAdmin: Bool = false
+    otherIsAdmin: Bool = false,
+    /// Drops Alice and Bob, leaving this account alone in the group — the last member of a group
+    /// everyone else left, or the remaining half of a DM whose peer is gone.
+    soleMember: Bool = false
 ) -> GroupDetailsFfi {
     var group = messageGroup()
     group.description = "Original room"
@@ -33848,18 +33922,22 @@ private func groupDetailsFixture(
         selfIsAdmin ? selfAccountIdHex : nil,
         otherIsAdmin ? aliceIdHex : nil,
     ].compactMap(\.self)
+    let selfMember = GroupMemberDetailsFfi(
+        memberIdHex: selfAccountIdHex,
+        account: "Desktop Account",
+        local: true,
+        isAdmin: selfIsAdmin,
+        isSelf: true,
+        npub: "npub1self",
+        displayName: "Desktop Account"
+    )
+    if soleMember {
+        return GroupDetailsFfi(group: group, members: [selfMember])
+    }
     return GroupDetailsFfi(
         group: group,
         members: [
-            GroupMemberDetailsFfi(
-                memberIdHex: selfAccountIdHex,
-                account: "Desktop Account",
-                local: true,
-                isAdmin: selfIsAdmin,
-                isSelf: true,
-                npub: "npub1self",
-                displayName: "Desktop Account"
-            ),
+            selfMember,
             GroupMemberDetailsFfi(
                 memberIdHex: aliceIdHex,
                 account: nil,


### PR DESCRIPTION
Last member from a group ended in a weird situation where it couldn't leave the chat or delete it locally cause deletion required leaving first, but leaving required not being the last admin. Now, for the last member of a group, it is permitted to delete the group locally without leaving