### PR TITLE
Retry a failed send from the bubble

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -666,8 +666,20 @@ extension WorkspaceState {
         copyText(message.body)
     }
 
+    /// Whether the conversation this row belongs to is re-driving its pending sends right now.
+    ///
+    /// Group-scoped like the retry itself: `retryGroupConvergence` re-drives every operation the
+    /// core has committed for the chat, so a retry started from one failed bubble really is
+    /// carrying its neighbours too, and they say so.
+    func isRetryingDelivery(of message: MessageItem) -> Bool {
+        guard let activeAccountId, let selectedChat, selectedChat.id == message.groupIdHex else { return false }
+        return inFlightMessageRetryScopes.contains(
+            Self.messageRetryScope(accountId: activeAccountId, groupIdHex: selectedChat.id)
+        )
+    }
+
     func retryDelivery(of message: MessageItem) async {
-        guard message.canRetryDelivery,
+        guard message.canRetryDelivery(at: .now),
             let client,
             let activeAccount,
             let activeAccountId,
@@ -675,7 +687,7 @@ extension WorkspaceState {
             selectedChat.id == message.groupIdHex
         else { return }
 
-        let retryScope = "\(activeAccountId)\u{1F}\(selectedChat.id)"
+        let retryScope = Self.messageRetryScope(accountId: activeAccountId, groupIdHex: selectedChat.id)
         guard !inFlightMessageRetryScopes.contains(retryScope) else { return }
         inFlightMessageRetryScopes.insert(retryScope)
         defer { inFlightMessageRetryScopes.remove(retryScope) }
@@ -695,6 +707,11 @@ extension WorkspaceState {
         } catch {
             lastError = error.localizedDescription
         }
+    }
+
+    /// Unit separator, so an account id and a group id cannot run together into the same scope.
+    private static func messageRetryScope(accountId: String, groupIdHex: String) -> String {
+        "\(accountId)\u{1F}\(groupIdHex)"
     }
 
     var isTimelineSelectionMode: Bool {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -502,7 +502,11 @@ final class WorkspaceState {
     var selectedTimelineMessageIds: Set<String> = []
     /// Account/group scopes currently re-driving a committed-but-undelivered message.
     /// The core retry is group-scoped, so one guard covers every pending bubble in that chat.
-    @ObservationIgnored var inFlightMessageRetryScopes = Set<String>()
+    ///
+    /// Observed rather than ignored: the failed bubbles in that chat trade their recovery row for a
+    /// progress line while the call runs, which is the only feedback a click on Retry gets — a
+    /// row's delivery marker is derived from `sentAt` and cannot be walked back to "Sending".
+    var inFlightMessageRetryScopes = Set<String>()
     /// Scoped message target whose unified delete-confirmation surface is open, or `nil`. Drives the adaptive
     /// dialog that offers only the scopes `messageDeletionCapability` permits.
     var messagePendingDeletion: MessageDeletionTarget?

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -41698,6 +41698,65 @@
         }
       }
     },
+    "Retrying…": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird erneut versucht…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentando…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle tentative…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuovo tentativo…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tentando novamente…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повтор…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeniden deneniyor…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在重试…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在重試…"
+          }
+        }
+      }
+    },
     "Return to the last conversation selected for this account, both on launch and when you switch accounts.": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2425,8 +2425,14 @@ nonisolated struct MessageItem: Identifiable, Hashable {
             && sourceMessageIdHex == nil
     }
 
-    var canRetryDelivery: Bool {
-        isPendingDelivery
+    /// Whether this row may be re-driven to the relays at `now`.
+    ///
+    /// Time-sensitive on purpose: a send that is still inside `pendingDeliveryGrace` reads as
+    /// "Sending", and offering to retry something the app is telling the user is still going out
+    /// invites a second click on a first attempt that has not finished. Retry appears exactly when
+    /// the bubble starts reading as an error, which is also when the sibling clients offer it.
+    func canRetryDelivery(at now: Date) -> Bool {
+        isPendingDelivery && deliveryIndicator(at: now) == .failed
     }
 
     /// How long an own send may stay unconfirmed before its bubble stops reading as "Sending" and

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -277,6 +277,8 @@ struct MessageBubble: View {
                     MessageReactionDetailsView(message: message, selectedEmoji: $reactionViewerEmoji)
                 }
             }
+
+            sendFailureActions
         }
         .overlay(alignment: message.isOutgoing ? .leading : .trailing) {
             if !usesBubbleSurface {
@@ -388,6 +390,33 @@ struct MessageBubble: View {
                         scale: 0.96,
                         anchor: message.isOutgoing ? .trailing : .leading
                     )))
+        }
+    }
+
+    /// Recovery controls under a failed own send.
+    ///
+    /// The red footer glyph and its tooltip are the whole of the failure story otherwise, and a
+    /// tooltip is not an affordance — the retry lived only in the context menu and the hover
+    /// overflow, both of which the user has to go looking for. This puts the two things worth
+    /// doing about a stranded message where the failure already is. Suppressed during multi-select,
+    /// where the row is a checkbox target rather than a message.
+    @ViewBuilder
+    private var sendFailureActions: some View {
+        if message.isOutgoing, deliveryIndicator == .failed, !workspace.isTimelineSelectionMode {
+            let actions = MessageSendFailureActions(
+                onRetry: message.canRetryDelivery(at: deliveryClock)
+                    ? { Task { await workspace.retryDelivery(of: message) } } : nil,
+                // "Delete", not "Remove": the core committed this message locally before it tried
+                // to publish, so it is part of this device's history and goes out through the same
+                // scoped confirmation every other message deletion uses.
+                discardTitle: L10n.string("Delete"),
+                onDiscard: workspace.canDeleteMessage(message)
+                    ? { workspace.messagePendingDeletion = workspace.messageDeletionTarget(for: message) } : nil,
+                isRetrying: workspace.isRetryingDelivery(of: message)
+            )
+            if !actions.isEmpty {
+                actions.padding(.horizontal, 5)
+            }
         }
     }
 
@@ -2085,14 +2114,22 @@ struct MessageRowAction: Identifiable {
 
     var id: Kind { kind }
 
+    /// `now` resolves the delivery-grace-sensitive actions. Both presentations build their list when
+    /// the menu opens and throw it away when it closes, so reading the clock here is exact rather
+    /// than a snapshot that could go stale under a long-lived view.
     @MainActor
     static func all(
         for message: MessageItem,
         workspace: WorkspaceState,
+        now: Date = .now,
         dismiss: @escaping () -> Void = {}
     ) -> [MessageRowAction] {
         var actions: [MessageRowAction] = []
-        if message.canRetryDelivery {
+        // Dropped rather than disabled while a retry is already running, so this list agrees with
+        // the bubble's own recovery row — which trades Retry for a progress line for that window.
+        // `retryDelivery` would refuse the second call anyway; the point is not to offer a click
+        // that does nothing.
+        if message.canRetryDelivery(at: now), !workspace.isRetryingDelivery(of: message) {
             actions.append(
                 MessageRowAction(
                     kind: .retry,

--- a/whitenoise-mac/Views/MessageSendFailureActions.swift
+++ b/whitenoise-mac/Views/MessageSendFailureActions.swift
@@ -1,0 +1,58 @@
+//
+//  MessageSendFailureActions.swift
+//  whitenoise-mac
+//
+//  The recovery row under a send that did not make it out: run it again, or take it off the
+//  transcript.
+//
+
+import SwiftUI
+
+/// Recovery controls for an outgoing message that failed, rendered under the bubble they act on.
+///
+/// Shared by the two kinds of failed own row so they read as one thing: the locally staged media
+/// message that never published (`PendingOutgoingMessageBubble`) and the core-committed message
+/// stranded before its relay round-trip (`MessageBubble`). This is the macOS answer to the iOS
+/// clients' tap-the-bubble action sheet — on a pointer platform the options belong in the open,
+/// under the row, not behind a gesture and a dialog.
+///
+/// Both actions are optional because the two rows disagree about what a failure allows: an
+/// invalidated message can only be removed, and a message in a conversation the account may not act
+/// in can only be retried. A row with neither action left renders nothing.
+struct MessageSendFailureActions: View {
+    let onRetry: (() -> Void)?
+    let discardTitle: String
+    let onDiscard: (() -> Void)?
+    /// Swaps the controls for a progress line while the retry runs. The only feedback the click
+    /// gets on a core-committed row: its delivery marker is derived from `sentAt`, so it cannot be
+    /// walked back to "Sending" the way the sibling clients walk back an optimistic one.
+    var isRetrying = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if isRetrying {
+                ProgressView()
+                    .controlSize(.mini)
+                Text(L10n.string("Retrying…"))
+                    .wnFont(.medium10)
+                    .foregroundStyle(WNColor.backgroundContentTertiary)
+            } else {
+                if let onRetry {
+                    Button(L10n.string("Retry"), systemImage: "arrow.clockwise", action: onRetry)
+                }
+                if let onDiscard {
+                    Button(discardTitle, systemImage: "trash", action: onDiscard)
+                }
+            }
+        }
+        .buttonStyle(.link)
+        .wnFont(.medium10)
+        .labelStyle(.titleOnly)
+    }
+
+    /// Nothing to offer — the caller should leave the row out entirely rather than reserve empty
+    /// space under the bubble.
+    var isEmpty: Bool {
+        !isRetrying && onRetry == nil && onDiscard == nil
+    }
+}

--- a/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
+++ b/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
@@ -28,8 +28,11 @@ struct PendingOutgoingMessageBubble: View {
             content
 
             if message.state == .failed {
-                PendingOutgoingMessageFailureActions(
+                // "Remove", not "Delete": nothing has been committed anywhere yet, so dropping the
+                // bubble takes the message with it rather than hiding a message the group has.
+                MessageSendFailureActions(
                     onRetry: { workspace.retryPendingOutgoingMediaMessage(message.id) },
+                    discardTitle: L10n.string("Remove"),
                     onDiscard: { workspace.discardPendingOutgoingMediaMessage(message.id) }
                 )
             }
@@ -167,21 +170,6 @@ private struct PendingOutgoingMessageMetadata: View {
     /// what retired the `isOnBubbleFill` flag this used to branch on.
     private var tint: Color {
         WNColor.backgroundContentTertiary
-    }
-}
-
-private struct PendingOutgoingMessageFailureActions: View {
-    let onRetry: () -> Void
-    let onDiscard: () -> Void
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Button(L10n.string("Retry"), systemImage: "arrow.clockwise", action: onRetry)
-            Button(L10n.string("Remove"), systemImage: "trash", action: onDiscard)
-        }
-        .buttonStyle(.link)
-        .wnFont(.medium10)
-        .labelStyle(.titleOnly)
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6072,12 +6072,20 @@ struct whitenoise_macTests {
             isOutgoing: true
         )
 
+        let sentAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let failed = sentAt.addingTimeInterval(MessageItem.pendingDeliveryGrace + 1)
+
         #expect(pending.isPendingDelivery)
-        #expect(pending.canRetryDelivery)
+        #expect(pending.canRetryDelivery(at: failed))
         #expect(pending.statusLabel == "Not delivered")
         #expect(!delivered.isPendingDelivery)
-        #expect(!delivered.canRetryDelivery)
+        #expect(!delivered.canRetryDelivery(at: failed))
         #expect(delivered.statusLabel == "Sent")
+
+        // Retry is withheld while the bubble still reads "Sending": offering it there asks the
+        // user to re-drive a first attempt the app has just told them is still going out.
+        #expect(pending.deliveryIndicator(at: sentAt.addingTimeInterval(1)) == .sending)
+        #expect(!pending.canRetryDelivery(at: sentAt.addingTimeInterval(1)))
     }
 
     @MainActor
@@ -17502,6 +17510,9 @@ struct whitenoise_macTests {
         let state = WorkspaceState(clientFactory: { runtime })
         await state.bootstrap()
 
+        // Sent far enough back that the row has already stopped reading as "Sending" — retry is
+        // gated on the grace window having passed, so a fixed literal date would decide the
+        // outcome by whichever side of it the test host's clock happens to be on.
         let pending = MessageItem(
             id: "pending",
             groupIdHex: "direct-group",
@@ -17509,7 +17520,7 @@ struct whitenoise_macTests {
             senderAccountIdHex: account.accountIdHex,
             senderName: "Desktop Account",
             body: "Do not duplicate me",
-            sentAt: Date(timeIntervalSince1970: 1_800_000_000),
+            sentAt: .now.addingTimeInterval(-(MessageItem.pendingDeliveryGrace + 1)),
             isOutgoing: true
         )
         await state.retryDelivery(of: pending)
@@ -17517,6 +17528,133 @@ struct whitenoise_macTests {
         #expect(runtime.retryGroupConvergenceCallCount == 1)
         #expect(runtime.retriedGroupIdHex == "direct-group")
         #expect(runtime.sendTextCallCount == 0)
+        #expect(state.inFlightMessageRetryScopes.isEmpty)
+    }
+
+    @MainActor
+    @Test func retryDeliveryIsRefusedWhileTheSendIsStillInsideItsGraceWindow() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        // A send this young still shows the clock glyph, so neither the bubble's recovery row nor
+        // the context menu offers Retry — and the workspace refuses it if one somehow fires.
+        let justSent = MessageItem(
+            id: "just-sent",
+            groupIdHex: "direct-group",
+            sourceMessageIdHex: nil,
+            senderAccountIdHex: account.accountIdHex,
+            senderName: "Desktop Account",
+            body: "Still on its way",
+            sentAt: .now,
+            isOutgoing: true
+        )
+        await state.retryDelivery(of: justSent)
+
+        #expect(runtime.retryGroupConvergenceCallCount == 0)
+    }
+
+    @MainActor
+    @Test func retryDeliveryMarksTheConversationRetryingWhileTheConvergenceRuns() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            directGroup(),
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+            otherDisplayName: "Alice",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice",
+                about: nil,
+                picture: nil,
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let pending = MessageItem(
+            id: "pending",
+            groupIdHex: "direct-group",
+            sourceMessageIdHex: nil,
+            senderAccountIdHex: account.accountIdHex,
+            senderName: "Desktop Account",
+            body: "Say something while I work",
+            sentAt: .now.addingTimeInterval(-(MessageItem.pendingDeliveryGrace + 1)),
+            isOutgoing: true
+        )
+
+        #expect(MessageRowAction.all(for: pending, workspace: state).contains { $0.kind == .retry })
+
+        // Hold the convergence at the FFI gate: this is the window the bubble spends showing
+        // "Retrying…" instead of its Retry/Delete row, and it is the only feedback the click gets.
+        runtime.messageActionGateEnabled = true
+        let retry = Task { await state.retryDelivery(of: pending) }
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+
+        #expect(state.isRetryingDelivery(of: pending))
+
+        // The context menu and hover overflow drop Retry for that window too, rather than offering
+        // a click `retryDelivery` would refuse.
+        #expect(!MessageRowAction.all(for: pending, workspace: state).contains { $0.kind == .retry })
+
+        // Group-scoped, like the core call it wraps: a second failed row in the same chat is being
+        // carried by this same retry and says so.
+        let sibling = MessageItem(
+            id: "sibling",
+            groupIdHex: "direct-group",
+            sourceMessageIdHex: nil,
+            senderAccountIdHex: account.accountIdHex,
+            senderName: "Desktop Account",
+            body: "Me too",
+            sentAt: .now.addingTimeInterval(-(MessageItem.pendingDeliveryGrace + 1)),
+            isOutgoing: true
+        )
+        #expect(state.isRetryingDelivery(of: sibling))
+
+        // A second click during that window must not mint a second convergence.
+        await state.retryDelivery(of: sibling)
+        #expect(runtime.retryGroupConvergenceCallCount == 1)
+
+        runtime.releaseMessageActionGate()
+        await retry.value
+
+        #expect(!state.isRetryingDelivery(of: pending))
+        #expect(runtime.retryGroupConvergenceCallCount == 1)
+        // Retry comes back once the window closes — the in-flight scope was what withheld it, not
+        // the row losing its claim to a retry.
+        #expect(MessageRowAction.all(for: pending, workspace: state).contains { $0.kind == .retry })
     }
 
     @MainActor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry and remove controls for failed outgoing messages.
  * Added progress feedback while a message retry is running.
  * Added localized “Retrying…” text in multiple languages.

* **Bug Fixes**
  * Retry actions now appear only after the delivery grace period.
  * Prevented duplicate retries and accurately cleared retry status after completion.
  * Improved retry state updates across conversations.

* **Tests**
  * Expanded coverage for retry timing, progress state, duplicate prevention, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->