### PR TITLE
Add speed options for audio player

### DIFF
--- a/whitenoise-mac/Core/Media/AudioPlaybackSpeed.swift
+++ b/whitenoise-mac/Core/Media/AudioPlaybackSpeed.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// The rates an audio message can be played back at.
+///
+/// Mirrors the iOS client, whose audio bubble cycles a single badge through 1x, 1.5x and 2x and
+/// wraps back round. Keeping the same three rates in the same order means a voice note sounds the
+/// same on both clients, and the badge reads the same way to someone who moves between them.
+nonisolated enum AudioPlaybackSpeed: CaseIterable, Sendable {
+    case normal
+    case oneAndAHalf
+    case double
+
+    /// What a row starts at, and what the cycle wraps back to.
+    static let initial = AudioPlaybackSpeed.normal
+
+    /// The `AVAudioPlayer.rate` this speed asks for.
+    ///
+    /// `AVAudioPlayer` only honours a rate other than `1` when `enableRate` was set *before*
+    /// `prepareToPlay()`, which is why `MessageAudioAttachmentPlayer` arms it while preparing the
+    /// player rather than when the badge is first clicked.
+    var rate: Float {
+        switch self {
+        case .normal: 1
+        case .oneAndAHalf: 1.5
+        case .double: 2
+        }
+    }
+
+    /// How the rate is written: one fraction digit at most, so 1 and 2 stay whole rather than
+    /// showing a pointless `.0`, and 1.5 keeps its half.
+    private static let rateStyle = FloatingPointFormatStyle<Float>.number.precision(.fractionLength(0...1))
+
+    /// The badge's text, in `locale`'s notation.
+    ///
+    /// Not a catalog string — the only part that varies between languages is the decimal separator,
+    /// and seven of the nine we ship write 1.5 as `1,5`. A format style takes that from the locale's
+    /// own data, which is both correct everywhere and one fewer numeral for a translator to get
+    /// wrong. The `x` multiplier suffix is shown verbatim in every language, as it is on iOS.
+    func label(locale: Locale) -> String {
+        "\(rate.formatted(Self.rateStyle.locale(locale)))x"
+    }
+
+    /// The speed one click on the badge moves to, wrapping from the last case back to the first.
+    var next: AudioPlaybackSpeed {
+        let speeds = Self.allCases
+        guard let index = speeds.firstIndex(of: self) else { return Self.initial }
+        return speeds[(index + 1) % speeds.count]
+    }
+}

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -35842,6 +35842,65 @@
         }
       }
     },
+    "Playback speed": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiedergabegeschwindigkeit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocidad de reproducción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitesse de lecture"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocità di riproduzione"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocidade de reprodução"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скорость воспроизведения"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oynatma hızı"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "播放速度"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "播放速度"
+          }
+        }
+      }
+    },
     "Please choose an image file.": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -630,6 +630,18 @@ private extension View {
             }
     }
 
+    /// The pill behind an audio row's playback-speed label, a capsule counterpart to
+    /// `audioRowControlChrome`. Its width is fixed rather than hugging the label because the three
+    /// labels are not the same width: at the 10pt rung `1x` lays out at 12pt and `1.5x` at 22pt, so
+    /// a self-sizing pill would shove the waveform sideways on every click of the badge.
+    func audioRowSpeedChrome(isOutgoing: Bool) -> some View {
+        frame(width: 34, height: 22)
+            .background {
+                Capsule()
+                    .fill(AttachmentRowPalette.controlFill(isOutgoing: isOutgoing))
+            }
+    }
+
     func autoDownloadMediaAttachment(
         _ downloadState: MediaDownloadStateStore,
         attachment: MessageMediaAttachment,
@@ -1203,12 +1215,13 @@ struct MessageAttachmentStatusRow: View {
 /// The placeholder and the loaded player both render through this so the row cannot reflow as a
 /// download finishes — only the control's glyph changes. Nothing here shows the file name; an
 /// audio attachment is almost always a voice recording whose name the sender never chose.
-struct MessageAudioRow<Control: View>: View {
+struct MessageAudioRow<Control: View, SpeedControl: View>: View {
     let bars: [ComposerAudioWaveformBar]
     let progress: CGFloat
     let durationLabel: String
     let isOutgoing: Bool
     @ViewBuilder let control: Control
+    @ViewBuilder let speedControl: SpeedControl
 
     var body: some View {
         HStack(spacing: 10) {
@@ -1229,8 +1242,31 @@ struct MessageAudioRow<Control: View>: View {
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+
+            speedControl
         }
         .attachmentRowChrome(isOutgoing: isOutgoing)
+    }
+}
+
+/// The `1x` / `1.5x` / `2x` pill at the trailing edge of an audio row.
+///
+/// Rendered by `MessageAudioAttachmentPlayer` as a button's label and by
+/// `MessageAudioAttachmentPlaceholder` as inert text, so a finished download turns the badge live
+/// without moving anything around it — the same reason both rows share `MessageAudioRow` itself.
+struct MessageAudioSpeedBadge: View {
+    let speed: AudioPlaybackSpeed
+    let isOutgoing: Bool
+    // Read here rather than passed in so the badge re-renders on a language switch: the decimal
+    // separator in `1.5x` is language-specific, and the environment locale is the only form of the
+    // preference SwiftUI tracks as a dependency.
+    @Environment(\.locale) private var locale
+
+    var body: some View {
+        Text(speed.label(locale: locale))
+            .wnFont(.bold10)
+            .lineLimit(1)
+            .audioRowSpeedChrome(isOutgoing: isOutgoing)
     }
 }
 
@@ -1253,23 +1289,29 @@ struct MessageAudioAttachmentPlaceholder: View {
             bars: ComposerAudioWaveformPresentation.fallbackPlaybackBars,
             progress: 0,
             durationLabel: MediaDurationLabel.placeholder,
-            isOutgoing: isOutgoing
-        ) {
-            if let retryAction {
-                Button(action: retryAction) {
-                    Image(systemName: "arrow.clockwise")
-                        .wnFont(.bold14)
+            isOutgoing: isOutgoing,
+            control: {
+                if let retryAction {
+                    Button(action: retryAction) {
+                        Image(systemName: "arrow.clockwise")
+                            .wnFont(.bold14)
+                            .audioRowControlChrome(isOutgoing: isOutgoing)
+                    }
+                    .buttonStyle(.plain)
+                    .help(L10n.string("Retry download"))
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(AttachmentRowPalette.content(isOutgoing: isOutgoing))
                         .audioRowControlChrome(isOutgoing: isOutgoing)
                 }
-                .buttonStyle(.plain)
-                .help(L10n.string("Retry download"))
-            } else {
-                ProgressView()
-                    .controlSize(.small)
-                    .tint(AttachmentRowPalette.content(isOutgoing: isOutgoing))
-                    .audioRowControlChrome(isOutgoing: isOutgoing)
+            },
+            // Inert until the payload arrives: there is no player to set a rate on yet, and the
+            // badge is here so the finished download does not reflow the row around it.
+            speedControl: {
+                MessageAudioSpeedBadge(speed: .initial, isOutgoing: isOutgoing)
             }
-        }
+        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
     }
@@ -1292,6 +1334,7 @@ final class MessageAudioPlayerDelegate: NSObject, AVAudioPlayerDelegate {
 struct MessageAudioAttachmentPlayer: View {
     let download: MessageMediaDownload
     let isOutgoing: Bool
+    @Environment(\.locale) private var locale
     @State private var player: AVAudioPlayer?
     @State private var isPlaying = false
     @State private var playbackPreparationID: UUID?
@@ -1301,6 +1344,9 @@ struct MessageAudioAttachmentPlayer: View {
     @State private var waveformBars = ComposerAudioWaveformPresentation.fallbackPlaybackBars
     @State private var playbackMonitor: Task<Void, Never>?
     @State private var audioPlayerDelegate = MessageAudioPlayerDelegate()
+    /// Per-row, like the iOS client's bubble: the speed a listener picked for one voice note is
+    /// their reading of that note, not a preference to carry across the transcript.
+    @State private var speed = AudioPlaybackSpeed.initial
 
     private var isPreparingPlayback: Bool {
         playbackPreparationID != nil
@@ -1311,18 +1357,28 @@ struct MessageAudioAttachmentPlayer: View {
             bars: visibleWaveformBars,
             progress: playbackProgress,
             durationLabel: durationLabel,
-            isOutgoing: isOutgoing
-        ) {
-            Button {
-                Task { await togglePlayback() }
-            } label: {
-                Image(systemName: isPlaying || isPreparingPlayback ? "stop.fill" : "play.fill")
-                    .wnFont(.bold14)
-                    .audioRowControlChrome(isOutgoing: isOutgoing)
+            isOutgoing: isOutgoing,
+            control: {
+                Button {
+                    Task { await togglePlayback() }
+                } label: {
+                    Image(systemName: isPlaying || isPreparingPlayback ? "stop.fill" : "play.fill")
+                        .wnFont(.bold14)
+                        .audioRowControlChrome(isOutgoing: isOutgoing)
+                }
+                .buttonStyle(.plain)
+                .help(isPlaying || isPreparingPlayback ? L10n.string("Stop") : L10n.string("Play"))
+            },
+            speedControl: {
+                Button(action: cycleSpeed) {
+                    MessageAudioSpeedBadge(speed: speed, isOutgoing: isOutgoing)
+                }
+                .buttonStyle(.plain)
+                .help(L10n.string("Playback speed"))
+                .accessibilityLabel(L10n.string("Playback speed"))
+                .accessibilityValue(speed.label(locale: locale))
             }
-            .buttonStyle(.plain)
-            .help(isPlaying || isPreparingPlayback ? L10n.string("Stop") : L10n.string("Play"))
-        }
+        )
         // Transcript rows are intentionally eager, so scrolling this tile out of the viewport
         // does not trigger onDisappear. Stop playback here as well so the AVAudioPlayer and
         // progress monitor do not keep running offscreen.
@@ -1396,6 +1452,10 @@ struct MessageAudioAttachmentPlayer: View {
                 playbackPreparationID = nextPreparationID
                 let preparedPlayer = try await Task.detached(priority: .userInitiated) {
                     let audioPlayer = try AVAudioPlayer(data: data)
+                    // `rate` is only honoured when rate control is armed before the player
+                    // prepares its buffers, so the speed badge has to be enabled here — doing it
+                    // on the first click of the badge is too late and leaves playback at 1x.
+                    audioPlayer.enableRate = true
                     audioPlayer.prepareToPlay()
                     return PreparedMessageAudioPlayer(player: audioPlayer)
                 }.value.player
@@ -1405,7 +1465,9 @@ struct MessageAudioAttachmentPlayer: View {
                 preparedPlayer.delegate = audioPlayerDelegate
             }
             audioPlayerDelegate.onDidFinishPlaying = handlePlaybackFinished
+            applyPlaybackSpeed()
             player?.play()
+            applyPlaybackSpeed()
             isPlaying = true
             updatePlaybackProgress()
             monitorPlaybackProgress()
@@ -1415,6 +1477,26 @@ struct MessageAudioAttachmentPlayer: View {
                 isPlaying = false
             }
         }
+    }
+
+    /// Advance the badge one step, wrapping 2x back to 1x, and make the new rate audible at once.
+    ///
+    /// Nothing is loaded on the first click of a row that has never played, and that is fine: the
+    /// selection is remembered in `speed` and `startPlayback` applies it to the player it prepares.
+    private func cycleSpeed() {
+        speed = speed.next
+        applyPlaybackSpeed()
+        guard isPlaying else { return }
+        // A rate assigned to an already-playing `AVAudioPlayer` does not always take until the
+        // player is told to play again, and `play()` in turn can reset the rate to 1 — so the new
+        // speed is applied on both sides of the call. Without this the change is inaudible until
+        // the listener stops and restarts the note.
+        player?.play()
+        applyPlaybackSpeed()
+    }
+
+    private func applyPlaybackSpeed() {
+        player?.rate = speed.rate
     }
 
     private func stopPlayback() {

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -820,6 +820,60 @@ struct PureValueTests {
         )
     }
 
+    @Test func audioPlaybackSpeedCyclesThroughTheIOSRatesAndWrapsBackToNormal() {
+        // Parity with the iOS client's audio bubble, which cycles one badge through exactly these
+        // three rates in this order. A fourth rate, a different order, or a cycle that stopped at
+        // 2x instead of wrapping would make the same voice note behave differently on each client.
+        #expect(AudioPlaybackSpeed.allCases == [.normal, .oneAndAHalf, .double])
+        #expect(AudioPlaybackSpeed.initial == .normal)
+
+        #expect(AudioPlaybackSpeed.normal.next == .oneAndAHalf)
+        #expect(AudioPlaybackSpeed.oneAndAHalf.next == .double)
+        #expect(AudioPlaybackSpeed.double.next == .normal)
+
+        // Cycling once per case returns to where it started, whatever the case count grows to.
+        var speed = AudioPlaybackSpeed.initial
+        for _ in AudioPlaybackSpeed.allCases {
+            speed = speed.next
+        }
+        #expect(speed == .initial)
+    }
+
+    @Test func audioPlaybackSpeedRatesAndLabelsAgree() {
+        // The badge is the only thing a listener sees, so its text has to name the rate the player
+        // is actually set to. `1` matters especially: it is what `AVAudioPlayer` plays at natively,
+        // so a mislabelled normal speed would look like a broken control rather than a wrong rate.
+        #expect(AudioPlaybackSpeed.normal.rate == 1)
+        #expect(AudioPlaybackSpeed.oneAndAHalf.rate == 1.5)
+        #expect(AudioPlaybackSpeed.double.rate == 2)
+
+        #expect(AudioPlaybackSpeed.normal.label(locale: Locale(identifier: "en")) == "1x")
+        #expect(AudioPlaybackSpeed.oneAndAHalf.label(locale: Locale(identifier: "en")) == "1.5x")
+        #expect(AudioPlaybackSpeed.double.label(locale: Locale(identifier: "en")) == "2x")
+    }
+
+    @Test func audioPlaybackSpeedLabelsUseEachLanguagesDecimalSeparator() {
+        // `1.5x` is not language-neutral: seven of the nine languages the app ships write it `1,5x`.
+        // The separator is asserted from the locale's own data rather than spelled out here, so this
+        // stays true if CLDR revises one — the point is that the label never hardcodes a `.`.
+        // The whole rates must also stay whole: `1,0x` would be a worse regression than `1.5x`.
+        for identifier in ["en", "es", "de", "fr", "it", "pt", "ru", "tr", "zh-Hans", "zh-Hant"] {
+            let locale = Locale(identifier: identifier)
+            let separator = locale.decimalSeparator ?? "."
+
+            #expect(AudioPlaybackSpeed.normal.label(locale: locale) == "1x")
+            #expect(AudioPlaybackSpeed.oneAndAHalf.label(locale: locale) == "1\(separator)5x")
+            #expect(AudioPlaybackSpeed.double.label(locale: locale) == "2x")
+        }
+
+        // The seven comma languages really are reached above, rather than every locale quietly
+        // resolving to a dot and the loop passing for the wrong reason.
+        let commaLanguages = ["es", "de", "fr", "it", "pt", "ru", "tr"]
+        for identifier in commaLanguages {
+            #expect(AudioPlaybackSpeed.oneAndAHalf.label(locale: Locale(identifier: identifier)) == "1,5x")
+        }
+    }
+
     @Test func composerAudioWaveformSelectsLoadedBarsForMatchingPayload() async throws {
         // The metadata-loaded path stores bars once, then playback progress should only
         // recolor those loaded bars. Stale or missing metadata keeps showing fallback.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10183,7 +10183,43 @@ struct whitenoise_macTests {
 
             #expect(body.contains("MessageAudioRow("), "\(typeName) must render through MessageAudioRow")
             #expect(!body.contains("fileName"), "\(typeName) must not show the attachment file name")
+            // The speed badge is part of that shared geometry: it sits at the row's trailing edge
+            // and takes width from the waveform, so a row that showed it only once the download
+            // finished would reflow the bubble on the very swap this test exists to prevent.
+            #expect(
+                body.contains("MessageAudioSpeedBadge("),
+                "\(typeName) must reserve the playback-speed badge"
+            )
         }
+    }
+
+    @Test func audioPlayerArmsRateControlBeforePreparingAndReappliesItAroundPlay() throws {
+        // Two `AVAudioPlayer` traps, both of which fail silently — the badge would keep cycling and
+        // keep reading 2x while playback stayed at 1x, with nothing in the UI to show it:
+        //   1. `rate` is ignored unless `enableRate` was set *before* `prepareToPlay()`.
+        //   2. `play()` can reset `rate`, so the selected speed has to be applied after it too.
+        // Neither is observable from a unit test — nothing reports the audible rate back — so the
+        // ordering is pinned against the source, the same way the teardown paths above are.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+        let playerStart = try #require(source.range(of: "struct MessageAudioAttachmentPlayer: View {"))
+        let rest = source[playerStart.upperBound...]
+        let playerEnd = try #require(rest.range(of: "\nstruct MessageVideoAttachmentPlayer: View {")?.lowerBound)
+        let playerSource = String(source[playerStart.lowerBound..<playerEnd])
+
+        let enableRate = try #require(playerSource.range(of: "audioPlayer.enableRate = true"))
+        let prepareToPlay = try #require(playerSource.range(of: "audioPlayer.prepareToPlay()"))
+        #expect(enableRate.upperBound < prepareToPlay.lowerBound)
+
+        let normalizedSource = playerSource.components(separatedBy: .whitespacesAndNewlines).joined()
+        #expect(normalizedSource.contains("applyPlaybackSpeed()player?.play()applyPlaybackSpeed()"))
+        #expect(normalizedSource.contains("privatefuncapplyPlaybackSpeed(){player?.rate=speed.rate}"))
     }
 
     @MainActor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added playback-speed controls for audio attachments with Normal, 1.5×, and 2× options.
  * Speed selection is retained for each audio item and cycles back to Normal after 2×.
  * Added localized “Playback speed” labels in multiple languages.
  * Added consistent speed badges to audio rows, including loading states.

* **Bug Fixes**
  * Selected playback speed now applies reliably before and during audio playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->