### PR TITLE
Add zoom to images

### DIFF
--- a/whitenoise-mac/Core/ImageZoomState.swift
+++ b/whitenoise-mac/Core/ImageZoomState.swift
@@ -1,0 +1,104 @@
+//
+//  ImageZoomState.swift
+//  whitenoise-mac
+//
+//  The zoom and pan transform for the full-screen image viewers, kept as a value
+//  type so the gesture wiring in the views holds no rules of its own.
+//
+
+import CoreGraphics
+import Foundation
+
+/// How far a full-screen image may be magnified, and where it is allowed to sit
+/// once it is.
+///
+/// The numbers match the Flutter client (`lib/widgets/media_image.dart`) so the same
+/// photo behaves the same way on both: a 1x–4x range, and a double-click that jumps
+/// to 2.5x rather than all the way out, which is the magnification that reads a
+/// screenshot's body text without losing the surrounding context.
+///
+/// Positions are held as a *centred* transform — the rendered position of a content
+/// point `u` is `offset + scale * u`, with the origin at the middle of the viewport.
+/// That is exactly what `.scaleEffect(scale).offset(offset)` produces in SwiftUI, so
+/// the view applies this state without doing any arithmetic of its own.
+///
+/// Two sizes are needed for every operation and they are not interchangeable:
+/// `viewport` is the space the viewer occupies, `fitted` is the size the image is
+/// actually drawn at inside it after `.scaledToFit()`. A letterboxed image has a
+/// `fitted` smaller than the `viewport` on one axis, and panning that axis before the
+/// scaled image outgrows the viewport would only drag backdrop into view.
+nonisolated struct ImageZoomState: Equatable {
+    static let minimumScale: CGFloat = 1
+    static let maximumScale: CGFloat = 4
+    static let doubleClickScale: CGFloat = 2.5
+
+    /// Anything within 1% of fit counts as unzoomed. Without the tolerance a trackpad
+    /// twitch that leaves the scale at 1.0000001 would latch the viewer into its zoomed
+    /// mode — which suppresses paging — with nothing on screen to explain why.
+    private static let zoomedTolerance: CGFloat = 0.01
+
+    private(set) var scale: CGFloat = minimumScale
+    private(set) var offset: CGSize = .zero
+
+    var isZoomed: Bool { scale > Self.minimumScale + Self.zoomedTolerance }
+
+    /// Magnifies about `focus`, a point relative to the centre of the viewport.
+    ///
+    /// The content under `focus` stays under it, so a pinch grows the detail being
+    /// pointed at rather than the middle of the picture.
+    mutating func zoom(to proposedScale: CGFloat, focus: CGPoint, viewport: CGSize, fitted: CGSize) {
+        guard proposedScale.isFinite, focus.x.isFinite, focus.y.isFinite else { return }
+        let newScale = min(max(proposedScale, Self.minimumScale), Self.maximumScale)
+        let previousScale = scale
+        guard previousScale > 0 else { return }
+
+        // Solve `focus == newOffset + newScale * u` for the content point `u` that the
+        // old transform placed under the cursor.
+        let ratio = newScale / previousScale
+        let proposedOffset = CGSize(
+            width: focus.x - ratio * (focus.x - offset.width),
+            height: focus.y - ratio * (focus.y - offset.height)
+        )
+
+        scale = newScale
+        offset = Self.clamped(proposedOffset, scale: newScale, viewport: viewport, fitted: fitted)
+    }
+
+    /// Double-click: out to `doubleClickScale` anchored at the pointer, or straight back
+    /// to fit if the image is already magnified. Zooming out ignores `focus` deliberately —
+    /// the gesture that leaves a zoom should always land on the same, centred image.
+    mutating func toggleZoom(at focus: CGPoint, viewport: CGSize, fitted: CGSize) {
+        if isZoomed {
+            reset()
+        } else {
+            zoom(to: Self.doubleClickScale, focus: focus, viewport: viewport, fitted: fitted)
+        }
+    }
+
+    /// Moves the image to `proposedOffset`, stopping at whichever edge it reaches first.
+    mutating func pan(to proposedOffset: CGSize, viewport: CGSize, fitted: CGSize) {
+        offset = Self.clamped(proposedOffset, scale: scale, viewport: viewport, fitted: fitted)
+    }
+
+    mutating func reset() {
+        self = ImageZoomState()
+    }
+
+    /// How far the image may travel from centre before its own edge would come inside the
+    /// viewport. Zero on an axis the scaled image does not yet overflow.
+    private static func clamped(
+        _ proposed: CGSize,
+        scale: CGFloat,
+        viewport: CGSize,
+        fitted: CGSize
+    ) -> CGSize {
+        guard proposed.width.isFinite, proposed.height.isFinite else { return .zero }
+        let limitX = max(0, (fitted.width * scale - viewport.width) / 2)
+        let limitY = max(0, (fitted.height * scale - viewport.height) / 2)
+        guard limitX.isFinite, limitY.isFinite else { return .zero }
+        return CGSize(
+            width: min(max(proposed.width, -limitX), limitX),
+            height: min(max(proposed.height, -limitY), limitY)
+        )
+    }
+}

--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -319,12 +319,42 @@ nonisolated enum DownsampledImageSizing {
         max(1, ceil(maxPixelSize))
     }
 
+    /// Ceiling on the zoom-driven half of the gallery budget. A 4x pinch on a large window
+    /// would otherwise ask ImageIO to materialize a bitmap several times the size of anything
+    /// a chat photo actually contains, for detail the source does not have.
+    static let maximumGalleryPixelSize: CGFloat = 8192
+
     /// Buckets continuously-changing gallery sizes so drag-resizing a window does not create a
     /// fresh decoded cache entry for every pixel delta. Rounds up to avoid under-resolving.
-    static func galleryPixelSize(for pointSize: CGSize, displayScale: CGFloat) -> CGFloat {
+    ///
+    /// `zoomScale` raises the budget while the viewer is magnified. Without it a zoom would
+    /// simply enlarge the fit-sized decode and go soft exactly when the user is looking closest.
+    static func galleryPixelSize(
+        for pointSize: CGSize,
+        displayScale: CGFloat,
+        zoomScale: CGFloat = 1
+    ) -> CGFloat {
         let rawPixels = max(pointSize.width, pointSize.height) * max(1, displayScale)
         let bucketSize: CGFloat = 128
-        return max(bucketSize, ceil(rawPixels / bucketSize) * bucketSize)
+        let fitted = max(bucketSize, ceil(rawPixels / bucketSize) * bucketSize)
+        guard zoomScale > 1 else { return fitted }
+        // `max(fitted, …)` keeps the cap from ever *lowering* resolution on a display whose
+        // fitted decode is already past it: the ceiling bounds growth, it is not a target.
+        return max(fitted, min(fitted * zoomPixelMultiplier(for: zoomScale), maximumGalleryPixelSize))
+    }
+
+    /// Rounds a live zoom scale to the handful of resolutions worth decoding at.
+    ///
+    /// Feeding the raw scale in would cross a new 128px bucket several dozen times over a
+    /// single pinch, re-decoding at each one. Powers of two mean at most two refinements
+    /// between fit and 4x, and every step stays a multiple of the bucket size.
+    static func zoomPixelMultiplier(for zoomScale: CGFloat) -> CGFloat {
+        guard zoomScale.isFinite else { return 1 }
+        switch zoomScale {
+        case ..<1.5: return 1
+        case ..<3: return 2
+        default: return 4
+        }
     }
 
     /// Wraps a downsampled `CGImage` in an `NSImage` that reports the CGImage's *true* pixel

--- a/whitenoise-mac/Views/GroupSharedMediaViews.swift
+++ b/whitenoise-mac/Views/GroupSharedMediaViews.swift
@@ -278,25 +278,11 @@ private struct SharedMediaThumbnail: View {
 private struct SharedMediaImagePreviewView: View {
     let payload: DownloadedMediaPayload
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.displayScale) private var displayScale
+    @State private var zoom = ImageZoomState()
 
     var body: some View {
-        GeometryReader { proxy in
-            DownsampledDataImage(
-                payload: payload,
-                maxPixelSize: DownsampledImageSizing.galleryPixelSize(
-                    for: proxy.size,
-                    displayScale: displayScale
-                )
-            ) { image in
-                image
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } placeholder: {
-                ContentUnavailableView(L10n.string("Couldn't open image"), systemImage: "photo")
-            }
-            .frame(width: proxy.size.width, height: proxy.size.height)
+        ZoomableMediaImage(payload: payload, zoom: $zoom) {
+            ContentUnavailableView(L10n.string("Couldn't open image"), systemImage: "photo")
         }
         .frame(minWidth: 480, minHeight: 360)
         .background(WNColor.shadow.opacity(0.85))

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1700,6 +1700,7 @@ struct MessageImageGalleryOverlay: View {
     let presentation: MessageImageGalleryPresentation
     let onClose: () -> Void
     @State private var selectedIndex: Int
+    @State private var zoom = ImageZoomState()
 
     init(presentation: MessageImageGalleryPresentation, onClose: @escaping () -> Void) {
         self.presentation = presentation
@@ -1771,7 +1772,7 @@ struct MessageImageGalleryOverlay: View {
                         navigationButton(
                             systemName: "chevron.left",
                             accessibilityLabel: L10n.string("Previous image"),
-                            isEnabled: selectedIndex > 0
+                            isEnabled: selectedIndex > 0 && !zoom.isZoomed
                         ) {
                             selectedIndex = max(0, selectedIndex - 1)
                         }
@@ -1783,6 +1784,7 @@ struct MessageImageGalleryOverlay: View {
                             systemName: "chevron.right",
                             accessibilityLabel: L10n.string("Next image"),
                             isEnabled: selectedIndex < presentation.imageAttachments.count - 1
+                                && !zoom.isZoomed
                         ) {
                             selectedIndex = min(presentation.imageAttachments.count - 1, selectedIndex + 1)
                         }
@@ -1793,6 +1795,10 @@ struct MessageImageGalleryOverlay: View {
             }
         }
         .onExitCommand(perform: onClose)
+        // Paging out of a magnified photo would drop the next one in at someone else's
+        // zoom, so each image starts fitted. Flutter suppresses paging entirely while
+        // zoomed; the chevrons above disable for the same reason.
+        .onChange(of: selectedIndex) { zoom.reset() }
     }
 
     @ViewBuilder
@@ -1800,7 +1806,8 @@ struct MessageImageGalleryOverlay: View {
         MessageImageGalleryContent(
             downloadState: workspace.mediaDownloadStateStore(for: presentation.message, attachment: selectedAttachment),
             message: presentation.message,
-            attachment: selectedAttachment
+            attachment: selectedAttachment,
+            zoom: $zoom
         )
     }
 
@@ -1830,6 +1837,7 @@ struct MessageImageGalleryContent: View {
     let downloadState: MediaDownloadStateStore
     let message: MessageItem
     let attachment: MessageMediaAttachment
+    @Binding var zoom: ImageZoomState
 
     var body: some View {
         Group {
@@ -1852,7 +1860,7 @@ struct MessageImageGalleryContent: View {
                 }
                 .foregroundStyle(WNColor.fillContentQuaternary)
             case .loaded(let download):
-                DownsampledMessageGalleryImage(download: download, attachment: attachment)
+                DownsampledMessageGalleryImage(download: download, attachment: attachment, zoom: $zoom)
             }
         }
         .autoDownloadMediaAttachment(
@@ -1865,31 +1873,20 @@ struct MessageImageGalleryContent: View {
 }
 
 struct DownsampledMessageGalleryImage: View {
-    @Environment(\.displayScale) private var displayScale
     let download: MessageMediaDownload
     let attachment: MessageMediaAttachment
+    @Binding var zoom: ImageZoomState
 
     var body: some View {
-        GeometryReader { proxy in
-            DownsampledDataImage(
-                payload: download.payload,
-                maxPixelSize: DownsampledImageSizing.galleryPixelSize(
-                    for: proxy.size,
-                    displayScale: displayScale
-                )
-            ) { image in
-                image
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .accessibilityLabel(attachment.fileName)
-            } placeholder: {
-                Text(L10n.string("Image unavailable"))
-                    .wnFont(.semiBold12)
-                    .foregroundStyle(WNColor.fillContentQuaternary)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-            .frame(width: proxy.size.width, height: proxy.size.height)
+        ZoomableMediaImage(
+            payload: download.payload,
+            zoom: $zoom,
+            accessibilityLabel: attachment.fileName
+        ) {
+            Text(L10n.string("Image unavailable"))
+                .wnFont(.semiBold12)
+                .foregroundStyle(WNColor.fillContentQuaternary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }

--- a/whitenoise-mac/Views/ZoomableImageView.swift
+++ b/whitenoise-mac/Views/ZoomableImageView.swift
@@ -1,0 +1,176 @@
+//
+//  ZoomableImageView.swift
+//  whitenoise-mac
+//
+//  The magnifiable image used by both full-screen viewers: the chat gallery overlay
+//  and the shared-media preview sheet.
+//
+
+import SwiftUI
+
+/// A decrypted attachment rendered to fit, that the pointer can magnify.
+///
+/// Three gestures, matching the Flutter client: pinch to scale, double-click to jump to
+/// `ImageZoomState.doubleClickScale` at the pointer (and again to return to fit), and drag
+/// to pan once the image is larger than the space it sits in.
+///
+/// The gestures hang off the drawn image rather than the surrounding frame on purpose. A
+/// letterboxed photo leaves backdrop either side of it, and both viewers close when that
+/// backdrop is clicked — giving the whole frame a hit shape would quietly take that away.
+struct ZoomableMediaImage<Placeholder: View>: View {
+    let payload: DownloadedMediaPayload
+    @Binding var zoom: ImageZoomState
+    var accessibilityLabel: String?
+    @ViewBuilder var placeholder: () -> Placeholder
+
+    @Environment(\.displayScale) private var displayScale
+
+    /// The size the image is actually drawn at, which is what decides how far it may pan.
+    /// It is not the frame size: `.scaledToFit()` letterboxes anything that does not share
+    /// the frame's aspect ratio.
+    @State private var fittedSize: CGSize = .zero
+    @State private var pointerLocation: CGPoint?
+    @State private var panOrigin: CGSize?
+    @State private var magnifyBaseScale: CGFloat?
+
+    /// Flutter animates zoom over 250ms of `Curves.easeOutCubic`; this is the same curve
+    /// expressed as its bezier, so a double-click settles identically on both clients.
+    private static var zoomAnimation: Animation {
+        .timingCurve(0.215, 0.61, 0.355, 1, duration: 0.25)
+    }
+
+    /// Computed rather than stored because `ZoomableMediaImage` is generic over its
+    /// placeholder, and generic types cannot hold static stored properties.
+    private static var coordinateSpace: String { "zoomableMediaImage" }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let viewport = proxy.size
+
+            DownsampledDataImage(
+                payload: payload,
+                maxPixelSize: DownsampledImageSizing.galleryPixelSize(
+                    for: viewport,
+                    displayScale: displayScale,
+                    zoomScale: zoom.scale
+                )
+            ) { image in
+                labelled(
+                    image
+                        .resizable()
+                        .scaledToFit()
+                        .onGeometryChange(for: CGSize.self) {
+                            $0.size
+                        } action: {
+                            fittedSize = $0
+                        }
+                        .scaleEffect(zoom.scale)
+                        .offset(zoom.offset)
+                )
+                .pointerStyle(zoom.isZoomed ? .grabIdle : .zoomIn)
+                // Pinch runs alongside the click/drag pair rather than competing with it:
+                // a trackpad magnify and a pointer drag are separate inputs and either may
+                // arrive first.
+                .simultaneousGesture(magnifyGesture(viewport: viewport))
+                .gesture(
+                    doubleClickGesture(viewport: viewport)
+                        .exclusively(before: panGesture(viewport: viewport))
+                )
+            } placeholder: {
+                placeholder()
+            }
+            .frame(width: viewport.width, height: viewport.height)
+            .coordinateSpace(.named(Self.coordinateSpace))
+            .onContinuousHover(coordinateSpace: .named(Self.coordinateSpace)) { phase in
+                switch phase {
+                case .active(let location): pointerLocation = location
+                case .ended: pointerLocation = nil
+                }
+            }
+            // A resize moves the pan limits under an offset that was legal a moment ago, so
+            // re-clamp rather than leaving the image parked past its own edge. Both inputs
+            // matter: `viewport` appears in the limits directly, and it also changes the size
+            // the image fits to. Watching only `viewport` would always run a step early —
+            // SwiftUI measures the child after the parent, so `fittedSize` is still the old
+            // one at that point.
+            .onChange(of: viewport) { reclampOffset(viewport: viewport) }
+            .onChange(of: fittedSize) { reclampOffset(viewport: viewport) }
+        }
+    }
+
+    /// Trackpad pinch. `MagnifyGesture.magnification` is cumulative from the start of the
+    /// gesture, so it is applied to the scale captured when the fingers went down instead of
+    /// compounding against a scale this same gesture already changed.
+    private func magnifyGesture(viewport: CGSize) -> some Gesture {
+        MagnifyGesture()
+            .onChanged { value in
+                let base = magnifyBaseScale ?? zoom.scale
+                magnifyBaseScale = base
+                zoom.zoom(
+                    to: base * value.magnification,
+                    focus: focus(at: pointerLocation, viewport: viewport),
+                    viewport: viewport,
+                    fitted: fittedSize
+                )
+            }
+            .onEnded { _ in magnifyBaseScale = nil }
+    }
+
+    private func doubleClickGesture(viewport: CGSize) -> some Gesture {
+        SpatialTapGesture(count: 2, coordinateSpace: .named(Self.coordinateSpace))
+            .onEnded { value in
+                withAnimation(Self.zoomAnimation) {
+                    zoom.toggleZoom(
+                        at: focus(at: value.location, viewport: viewport),
+                        viewport: viewport,
+                        fitted: fittedSize
+                    )
+                }
+            }
+    }
+
+    /// Drag to pan, but only once there is something to pan to — otherwise a stray drag on a
+    /// fitted image would be swallowed here instead of reaching the viewer behind it.
+    private func panGesture(viewport: CGSize) -> some Gesture {
+        DragGesture(coordinateSpace: .named(Self.coordinateSpace))
+            .onChanged { value in
+                guard zoom.isZoomed else { return }
+                let origin = panOrigin ?? zoom.offset
+                panOrigin = origin
+                zoom.pan(
+                    to: CGSize(
+                        width: origin.width + value.translation.width,
+                        height: origin.height + value.translation.height
+                    ),
+                    viewport: viewport,
+                    fitted: fittedSize
+                )
+            }
+            .onEnded { _ in panOrigin = nil }
+    }
+
+    /// Pulls the current offset back inside whatever the limits have just become. A no-op for
+    /// an offset that is still legal, which is most geometry changes.
+    private func reclampOffset(viewport: CGSize) {
+        zoom.pan(to: zoom.offset, viewport: viewport, fitted: fittedSize)
+    }
+
+    /// Labels the image only when the caller has a name for it. The shared-media sheet does
+    /// not, and an empty label reads worse to VoiceOver than an unlabelled decorative image.
+    @ViewBuilder
+    private func labelled(_ image: some View) -> some View {
+        if let accessibilityLabel {
+            image.accessibilityLabel(accessibilityLabel)
+        } else {
+            image
+        }
+    }
+
+    /// Converts a point in the viewer's coordinate space to the centre-relative one
+    /// `ImageZoomState` works in. A pinch with the pointer outside the view (or off-screen)
+    /// falls back to the centre.
+    private func focus(at location: CGPoint?, viewport: CGSize) -> CGPoint {
+        guard let location else { return .zero }
+        return CGPoint(x: location.x - viewport.width / 2, y: location.y - viewport.height / 2)
+    }
+}

--- a/whitenoise-macTests/ImageZoomTests.swift
+++ b/whitenoise-macTests/ImageZoomTests.swift
@@ -1,0 +1,250 @@
+//
+//  ImageZoomTests.swift
+//  whitenoise-macTests
+//
+//  The zoom/pan contract for the full-screen image viewers. These mirror the
+//  Flutter client's `InteractiveViewer` tests, which likewise assert against the
+//  transformation state rather than rendered pixels.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import whitenoise_mac
+
+@Suite(.serialized)
+struct ImageZoomTests {
+    /// A landscape image letterboxed into a taller viewport: fitted is narrower than
+    /// the viewport is tall, so the two pan axes bottom out at different scales.
+    private let viewport = CGSize(width: 1000, height: 800)
+    private let fitted = CGSize(width: 1000, height: 500)
+
+    @Test func startsFittedAndUnzoomed() {
+        let zoom = ImageZoomState()
+
+        #expect(zoom.scale == 1)
+        #expect(zoom.offset == .zero)
+        #expect(!zoom.isZoomed)
+    }
+
+    @Test func doubleClickZoomsInToTheDoubleClickScale() {
+        var zoom = ImageZoomState()
+
+        zoom.toggleZoom(at: .zero, viewport: viewport, fitted: fitted)
+
+        #expect(zoom.scale == ImageZoomState.doubleClickScale)
+        #expect(zoom.isZoomed)
+    }
+
+    @Test func doubleClickWhileZoomedReturnsToFit() {
+        var zoom = ImageZoomState()
+
+        zoom.toggleZoom(at: CGPoint(x: 200, y: 100), viewport: viewport, fitted: fitted)
+        #expect(zoom.isZoomed)
+
+        // A second double-click resets regardless of where it lands, matching Flutter's
+        // "double-tap when zoomed resets to identity".
+        zoom.toggleZoom(at: CGPoint(x: -300, y: 50), viewport: viewport, fitted: fitted)
+
+        #expect(zoom.scale == 1)
+        #expect(zoom.offset == .zero)
+        #expect(!zoom.isZoomed)
+    }
+
+    @Test func doubleClickKeepsThePointUnderTheCursorInPlace() {
+        var zoom = ImageZoomState()
+        // Left of centre, and within the fitted image so the anchor is not clamped away.
+        let focus = CGPoint(x: -200, y: 0)
+
+        zoom.toggleZoom(at: focus, viewport: viewport, fitted: fitted)
+
+        // Screen position of a content point u is `offset + scale * u`. The content point
+        // that sat under the cursor before the zoom must still sit under it after.
+        let contentUnderCursor = CGPoint(x: focus.x, y: focus.y)
+        let screenX = zoom.offset.width + zoom.scale * contentUnderCursor.x
+        let screenY = zoom.offset.height + zoom.scale * contentUnderCursor.y
+
+        #expect(abs(screenX - focus.x) < 0.001)
+        #expect(abs(screenY - focus.y) < 0.001)
+    }
+
+    @Test func zoomClampsToTheAllowedRange() {
+        var zoom = ImageZoomState()
+
+        zoom.zoom(to: 99, focus: .zero, viewport: viewport, fitted: fitted)
+        #expect(zoom.scale == ImageZoomState.maximumScale)
+
+        zoom.zoom(to: 0.1, focus: .zero, viewport: viewport, fitted: fitted)
+        #expect(zoom.scale == ImageZoomState.minimumScale)
+    }
+
+    @Test func pinchingBackToFitRecentresTheImage() {
+        var zoom = ImageZoomState()
+
+        zoom.zoom(to: 4, focus: CGPoint(x: -400, y: -200), viewport: viewport, fitted: fitted)
+        #expect(zoom.offset != .zero)
+
+        // Returning to fit must leave no residual offset, or the image would sit
+        // off-centre in its own letterbox with no way to nudge it back.
+        zoom.zoom(to: 1, focus: CGPoint(x: -400, y: -200), viewport: viewport, fitted: fitted)
+        #expect(zoom.offset == .zero)
+    }
+
+    @Test func panningIsRefusedWhileTheImageStillFits() {
+        var zoom = ImageZoomState()
+
+        zoom.pan(to: CGSize(width: 250, height: 250), viewport: viewport, fitted: fitted)
+
+        #expect(zoom.offset == .zero)
+    }
+
+    @Test func panningStopsAtTheImageEdge() {
+        var zoom = ImageZoomState()
+        zoom.zoom(to: 2, focus: .zero, viewport: viewport, fitted: fitted)
+
+        zoom.pan(to: CGSize(width: 10_000, height: 10_000), viewport: viewport, fitted: fitted)
+
+        // Scaled image is 2000x1000 inside a 1000x800 viewport, so the image may travel
+        // (2000-1000)/2 = 500 horizontally and (1000-800)/2 = 100 vertically.
+        #expect(zoom.offset.width == 500)
+        #expect(zoom.offset.height == 100)
+
+        zoom.pan(to: CGSize(width: -10_000, height: -10_000), viewport: viewport, fitted: fitted)
+        #expect(zoom.offset.width == -500)
+        #expect(zoom.offset.height == -100)
+    }
+
+    @Test func theLetterboxedAxisNeverPansWhileTheImageFitsIt() {
+        var zoom = ImageZoomState()
+        // At 1.5x the 500pt-tall fitted image is 750pt — still inside the 800pt viewport,
+        // so vertical panning would only expose backdrop.
+        zoom.zoom(to: 1.5, focus: .zero, viewport: viewport, fitted: fitted)
+
+        zoom.pan(to: CGSize(width: 10_000, height: 10_000), viewport: viewport, fitted: fitted)
+
+        #expect(zoom.offset.height == 0)
+        #expect(zoom.offset.width == 250)
+    }
+
+    @Test func zoomingOutPullsTheImageBackInsideItsBounds() {
+        var zoom = ImageZoomState()
+        zoom.zoom(to: 4, focus: .zero, viewport: viewport, fitted: fitted)
+        zoom.pan(to: CGSize(width: 10_000, height: 10_000), viewport: viewport, fitted: fitted)
+        #expect(zoom.offset.width == 1500)
+
+        // Shrinking the image must re-clamp the offset it was already holding, otherwise
+        // the previous pan would leave a gap at the trailing edge.
+        zoom.zoom(to: 2, focus: .zero, viewport: viewport, fitted: fitted)
+
+        #expect(zoom.offset.width <= 500)
+        #expect(zoom.offset.height <= 100)
+    }
+
+    @Test func reClampingAfterTheImageFitsSmallerPullsItBackInside() {
+        var zoom = ImageZoomState()
+        zoom.zoom(to: 4, focus: .zero, viewport: viewport, fitted: fitted)
+        zoom.pan(to: CGSize(width: 10_000, height: 10_000), viewport: viewport, fitted: fitted)
+        #expect(zoom.offset.width == 1500)
+
+        // A window resize re-fits the image, which moves the pan limits under an offset that
+        // was legal a moment ago. Re-panning to the current offset is how the viewer re-clamps.
+        let smallerFit = CGSize(width: 600, height: 300)
+        zoom.pan(to: zoom.offset, viewport: viewport, fitted: smallerFit)
+
+        // 600*4 = 2400 wide in a 1000pt viewport leaves (2400-1000)/2 = 700 of travel.
+        #expect(zoom.offset.width == 700)
+    }
+
+    @Test func reClampingIsIdempotentForAnOffsetThatIsAlreadyLegal() {
+        var zoom = ImageZoomState()
+        zoom.zoom(to: 2, focus: .zero, viewport: viewport, fitted: fitted)
+        zoom.pan(to: CGSize(width: 120, height: 40), viewport: viewport, fitted: fitted)
+        let settled = zoom
+
+        // The viewer re-clamps on every geometry change, most of which move nothing.
+        zoom.pan(to: zoom.offset, viewport: viewport, fitted: fitted)
+
+        #expect(zoom == settled)
+    }
+
+    @Test func isZoomedIgnoresFloatingPointDust() {
+        var zoom = ImageZoomState()
+
+        zoom.zoom(to: 1.005, focus: .zero, viewport: viewport, fitted: fitted)
+
+        // Flutter treats anything at or below a 1% overshoot as "not zoomed" so that a
+        // stray trackpad twitch does not silently disable paging.
+        #expect(!zoom.isZoomed)
+    }
+
+    @Test func resetReturnsToTheInitialState() {
+        var zoom = ImageZoomState()
+        zoom.zoom(to: 3, focus: CGPoint(x: 100, y: 100), viewport: viewport, fitted: fitted)
+
+        zoom.reset()
+
+        #expect(zoom == ImageZoomState())
+    }
+
+    @Test func degenerateGeometryIsIgnoredRatherThanProducingNaN() {
+        var zoom = ImageZoomState()
+
+        zoom.zoom(to: 2, focus: .zero, viewport: .zero, fitted: .zero)
+        #expect(zoom.offset.width.isFinite)
+        #expect(zoom.offset.height.isFinite)
+
+        zoom.zoom(to: .nan, focus: .zero, viewport: viewport, fitted: fitted)
+        #expect(zoom.scale.isFinite)
+    }
+
+    // MARK: - Pixel budget
+
+    @Test func zoomBucketsThePixelBudgetSoAPinchDoesNotRedecodeContinuously() {
+        // Fit and anything near it keeps the fitted-resolution decode.
+        #expect(DownsampledImageSizing.zoomPixelMultiplier(for: 1) == 1)
+        #expect(DownsampledImageSizing.zoomPixelMultiplier(for: 1.4) == 1)
+        // Then at most two refinements across the whole 1x-4x range.
+        #expect(DownsampledImageSizing.zoomPixelMultiplier(for: 2) == 2)
+        #expect(DownsampledImageSizing.zoomPixelMultiplier(for: 4) == 4)
+    }
+
+    @Test func zoomedGalleryAsksForMorePixelsThanTheFittedDecode() {
+        let size = CGSize(width: 800, height: 600)
+        let fittedBudget = DownsampledImageSizing.galleryPixelSize(for: size, displayScale: 2)
+        let zoomedBudget = DownsampledImageSizing.galleryPixelSize(for: size, displayScale: 2, zoomScale: 4)
+
+        // Without this the viewer would simply magnify the fit-sized bitmap and go soft.
+        #expect(zoomedBudget > fittedBudget)
+        #expect(zoomedBudget == fittedBudget * 4)
+    }
+
+    @Test func theZoomedPixelBudgetStaysBounded() {
+        let large = CGSize(width: 1600, height: 1200)
+        let budget = DownsampledImageSizing.galleryPixelSize(for: large, displayScale: 2, zoomScale: 4)
+
+        // 3200 fitted pixels would otherwise ask ImageIO for a 12800px decode at 4x.
+        #expect(budget == DownsampledImageSizing.maximumGalleryPixelSize)
+    }
+
+    @Test func theBoundNeverShrinksABudgetThatIsAlreadyThatLarge() {
+        // On a display whose fitted decode already exceeds the cap, zooming must not
+        // *reduce* resolution — the cap bounds zoom-driven growth, nothing else.
+        let enormous = CGSize(width: 6000, height: 6000)
+        let fittedBudget = DownsampledImageSizing.galleryPixelSize(for: enormous, displayScale: 2)
+        let zoomedBudget = DownsampledImageSizing.galleryPixelSize(for: enormous, displayScale: 2, zoomScale: 4)
+
+        #expect(fittedBudget > DownsampledImageSizing.maximumGalleryPixelSize)
+        #expect(zoomedBudget == fittedBudget)
+    }
+
+    @Test func anUnzoomedGalleryBudgetIsUnchangedFromBefore() {
+        let size = CGSize(width: 800, height: 600)
+
+        // The default argument must keep every existing call site byte-identical in behaviour.
+        #expect(
+            DownsampledImageSizing.galleryPixelSize(for: size, displayScale: 2)
+                == DownsampledImageSizing.galleryPixelSize(for: size, displayScale: 2, zoomScale: 1)
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added zoomable image previews with trackpad pinch, double-click zoom, pointer-focused scaling, and drag-to-pan support.
  * Added zooming to shared media and image galleries, with automatic reset when switching images.
  * Improved image detail during magnified viewing while enforcing safe size limits.

* **Bug Fixes**
  * Prevented images from panning beyond their visible bounds.
  * Improved handling of resizing, invalid zoom values, and unavailable media.

* **Tests**
  * Added comprehensive coverage for zoom behavior, panning, image sizing, limits, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->