### PR TITLE
Improve qr modal

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -17339,65 +17339,6 @@
         }
       }
     },
-    "Done": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fertig"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Listo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminé"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fine"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concluído"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Готово"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bitti"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成"
-          }
-        }
-      }
-    },
     "Downloaded attachments stored on this Mac.": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -771,9 +771,10 @@ extension View {
 /// either way; raising that ring is a separate change because it also restyles the composer.
 struct GlassCircleCloseButton: View {
     enum Appearance {
-        /// The glass disc. For a ✕ that dismisses.
+        /// The glass disc. For a ✕ that dismisses and is meant to read as prominent.
         case glass
-        /// The palette's outline circle. For a ‹ that navigates back.
+        /// The palette's outline circle. For a ‹ that navigates back, or a ✕ that should not
+        /// compete with the content it sits above.
         case outline
     }
 

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -359,7 +359,9 @@ struct PublicIdentityQRCodeSheet: View {
 
                 Spacer()
 
-                GlassCircleCloseButton {
+                // Outline rather than glass: the ✕ is the only way out of this sheet, but it is
+                // not the thing to look at — the code is. See `GlassCircleCloseButton.Appearance`.
+                GlassCircleCloseButton(appearance: .outline) {
                     dismiss()
                 }
             }
@@ -380,32 +382,24 @@ struct PublicIdentityQRCodeSheet: View {
                     .stroke(WNColor.borderTertiary, lineWidth: 1)
             }
 
-            Text(DisplayText.short(npub, head: 24, tail: 24))
-                .font(.system(.callout, design: .monospaced))
-                .foregroundStyle(WNColor.backgroundContentSecondary)
-                .multilineTextAlignment(.center)
-                .textSelection(.enabled)
-                .lineLimit(2)
-                .truncationMode(.middle)
-                .frame(maxWidth: .infinity)
+            // Head and tail are cut to what fits beside the copy glyph on one line at this
+            // sheet's width; the button still copies the whole npub. Same shape as
+            // `CopyableKeyLabel`, which cannot be reused here because the sheet is handed a
+            // resolved npub rather than an account id.
+            HStack(spacing: 8) {
+                Text(DisplayText.short(npub, head: 20, tail: 16))
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
 
-            HStack(spacing: 10) {
                 CopyToClipboardButton(value: npub, actionDescription: L10n.string("Copy npub")) { isConfirming in
-                    Label(
-                        isConfirming ? L10n.string("Copied") : L10n.string("Copy npub"),
-                        systemImage: isConfirming ? "checkmark" : "doc.on.doc"
-                    )
+                    Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
+                        .foregroundStyle(
+                            isConfirming ? WNColor.intentionSuccessContent : WNColor.backgroundContentSecondary)
                 }
-                .buttonStyle(.wnSecondary)
-
-                Spacer()
-
-                Button {
-                    dismiss()
-                } label: {
-                    Label(L10n.string("Done"), systemImage: "checkmark")
-                }
-                .nativeGlassProminentButtonStyle()
+                .buttonStyle(.borderless)
             }
         }
         .padding(22)


### PR DESCRIPTION
This modal could be simpler: done button is unnecesary (X does the same). Also, the npub having a copy icon at the right would be enough. Also, the X shouldn't be primary, closing is not a primary action.

|Before| After|
|----|----|
|<img width="432" height="534" alt="Screenshot 2026-08-13 at 2 56 28 PM" src="https://github.com/user-attachments/assets/d20a8b44-357c-405a-9aa1-033b73f0b8c3" />|<img width="453" height="501" alt="Screenshot 2026-08-13 at 2 55 48 PM" src="https://github.com/user-attachments/assets/72bf7afd-56b4-4656-b905-e2e05053115f" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the public identity QR sheet with a more compact identity display and copy control.
  * Shortened the visible npub to keep it on one line while preserving full-value copying.
  * Replaced the previous close action with a streamlined outline-style button.
* **Documentation**
  * Clarified when to use prominent versus non-competing close button styles.
* **Localization**
  * Removed unused “Done” translation entries across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->