### PR TITLE
Show who is not on whitenoise instead of error

### DIFF
--- a/whitenoise-mac/Core/ChatCreationFailure.swift
+++ b/whitenoise-mac/Core/ChatCreationFailure.swift
@@ -1,0 +1,124 @@
+//
+//  ChatCreationFailure.swift
+//  whitenoise-mac
+//
+//  Why a chat or group could not be created, and the invite copy the
+//  compose flow offers instead of an error when the answer is "they
+//  aren't on White Noise yet".
+//
+
+import Foundation
+import MarmotKit
+
+/// Failure taxonomy for the chat/group creation paths. The one distinction that matters to
+/// the person composing is "someone here has no usable messaging setup" — not an error they
+/// can retry away, but an invitation they have to send — versus everything else.
+///
+/// `MarmotKitError.errorDescription` is `String(reflecting:)`, so a raw core error reaching
+/// `lastError` prints `MarmotKit.MarmotKitError.MissingKeyPackage(account: "…")` at the user.
+/// Every creation path maps through here instead.
+nonisolated enum ChatCreationFailure: Equatable {
+    /// A recipient has no usable published KeyPackage. `account` is the single member the core
+    /// named: `create_group` resolves members in order and stops at the first unreachable one, so
+    /// a roster with several needs one attempt per refusal to enumerate (see
+    /// `WorkspaceState.createGroupResolvingEveryRefusal`, which spends them all in one press).
+    /// `nil` when the core reported the condition without naming anyone.
+    case notOnWhiteNoise(account: String?)
+    case other(message: String)
+
+    init(_ error: Error) {
+        guard let marmotError = error as? MarmotKitError else {
+            self = .other(message: error.localizedDescription)
+            return
+        }
+        switch marmotError {
+        case .MissingKeyPackage(let account):
+            let trimmed = account.trimmingCharacters(in: .whitespacesAndNewlines)
+            self = .notOnWhiteNoise(account: trimmed.isEmpty ? nil : trimmed)
+        // A KeyPackage event that exists but cannot be used, and an identity rejected *after*
+        // the recipient already resolved through the new-chat lookup, mean the same thing on
+        // this path: not reachable on White Noise yet. Neither names an account.
+        case .InvalidKeyPackageEvent, .InvalidIdentity:
+            self = .notOnWhiteNoise(account: nil)
+        default:
+            self = .other(message: marmotError.localizedDescription)
+        }
+    }
+
+    /// The recipient the core refused, when the caller has them.
+    ///
+    /// `AppError::MissingKeyPackage` carries a free-form label — an account id hex everywhere on
+    /// the member-resolution path — so it is matched against both identifiers a recipient carries
+    /// rather than parsed into one. A label that matches neither yields `nil`, and every caller
+    /// falls back to an unnamed message rather than showing the raw payload.
+    static func refusedRecipient(named account: String?, among recipients: [NewChatRecipient])
+        -> NewChatRecipient?
+    {
+        guard let account, !account.isEmpty else { return nil }
+        return recipients.first {
+            $0.accountIdHex.caseInsensitiveCompare(account) == .orderedSame
+                || (!$0.npub.isEmpty && $0.npub.caseInsensitiveCompare(account) == .orderedSame)
+        }
+    }
+
+    /// One-line message for a surface with no room to restage the composition — the add-member
+    /// sheet on an existing group, where the user's fix is to deselect and retry. Names the
+    /// recipient when the core named one and the caller knows them.
+    static func message(for error: Error, candidates: [NewChatRecipient]) -> String {
+        switch ChatCreationFailure(error) {
+        case .notOnWhiteNoise(let account):
+            guard let named = refusedRecipient(named: account, among: candidates) else {
+                return L10n.string("Someone you picked isn't on White Noise yet, so they can't be added.")
+            }
+            return String(
+                format: L10n.string("%@ isn't on White Noise yet, so they can't be added."),
+                named.title)
+        case .other(let message):
+            return message
+        }
+    }
+}
+
+/// Which compose surface asked for the chat. The failure lands somewhere different on each, so
+/// this is carried explicitly rather than inferred from the roster size — a group draft whose last
+/// reachable member is refused is still a group draft, and its answer belongs in the panel that is
+/// on screen, not in the direct-chat prompt.
+nonisolated enum ChatCreationSurface {
+    case directChat
+    case groupDraft
+}
+
+/// Shown in place of an error when a one-to-one chat cannot start because the recipient has no
+/// usable messaging setup. There is nothing to retry and nothing to fix in the composition, so
+/// the panel offers the only useful next step: invite them.
+nonisolated struct StartChatInvitePrompt: Equatable {
+    let accountIdHex: String
+    let recipientName: String?
+    /// The trimmed compose query this prompt was raised under — empty when it came from a contact
+    /// row rather than a typed identifier. Visibility is derived from this rather than cleared on
+    /// change (`WorkspaceState.visibleStartChatInvitePrompt`): the resolution path it would have
+    /// to hook is debounced and cancels itself on every keystroke, so an imperative clear does not
+    /// land until typing stops, leaving one recipient's prompt over another's row in the meantime.
+    let query: String
+
+    var detail: String {
+        WhiteNoiseInvite.detail(recipientName: recipientName)
+    }
+}
+
+/// Invite copy shared by the direct-chat prompt and the group-draft notice. Deliberately worded
+/// like the iOS and Flutter clients so someone who has seen one recognizes the other.
+nonisolated enum WhiteNoiseInvite {
+    static var message: String {
+        L10n.string("Let's chat on White Noise — private, secure messaging. Get it at https://whitenoise.chat")
+    }
+
+    static func detail(recipientName: String?) -> String {
+        guard let recipientName, !recipientName.isEmpty else {
+            return L10n.string("They aren't on White Noise yet. Share the app so you can chat securely.")
+        }
+        return String(
+            format: L10n.string("%@ isn't on White Noise yet. Share the app so you can chat securely."),
+            recipientName)
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -500,13 +500,33 @@ extension WorkspaceState {
                     groupIdHex: groupIdHex
                 )
             else { return }
-            lastError = error.localizedDescription
+            // The typed identifier never became a `NewChatRecipient`, so there is no display name
+            // to name — the taxonomy still keeps the raw `MarmotKitError` dump off the screen.
+            lastError = ChatCreationFailure.message(for: error, candidates: [])
         }
     }
 
     /// Invite one or more already-resolved recipients in a single group commit. Recipients carry a
     /// normalized `npub` from the new-chat resolver, so no per-entry re-normalization is needed.
     /// Returns `true` when the commit succeeded so the caller can dismiss only on success.
+    /// Staged recipients the core hasn't refused, in the order the sheet lists them.
+    func reachableInviteRecipients(_ recipients: [NewChatRecipient]) -> [NewChatRecipient] {
+        recipients.filter { !unreachableInviteMemberIdHexes.contains($0.accountIdHex.lowercased()) }
+    }
+
+    /// Staged recipients the core has refused, so the sheet can show them apart rather than drop
+    /// them without saying so.
+    func unreachableInviteRecipients(_ recipients: [NewChatRecipient]) -> [NewChatRecipient] {
+        recipients.filter { unreachableInviteMemberIdHexes.contains($0.accountIdHex.lowercased()) }
+    }
+
+    /// Called when the add-members sheet opens: a new staging session asks the core again rather
+    /// than inheriting marks from whoever was staged last time.
+    func resetInviteRefusals() {
+        unreachableInviteMemberIdHexes = []
+        hasUnnamedInviteRefusal = false
+    }
+
     @discardableResult
     func inviteMembers(_ recipients: [NewChatRecipient]) async -> Bool {
         guard let client,
@@ -514,57 +534,195 @@ extension WorkspaceState {
             let snapshot = groupDetailsSnapshot,
             !hasInFlightGroupCommit
         else { return false }
-        let memberRefs = recipients.map(\.npub).filter { !$0.isEmpty }
-        guard !memberRefs.isEmpty else { return false }
+        // Members the core has already refused are left out, exactly as the compose draft leaves
+        // them out of the next create: the sheet dims them and says why, so the invite being sent
+        // is the one the user is looking at.
+        var candidates = reachableInviteRecipients(recipients)
+        guard !candidates.isEmpty else { return false }
         let accountId = activeAccount.id
         let groupIdHex = snapshot.groupIdHex
         let generation = beginGroupDetailsMutation()
 
         lastError = nil
+        hasUnnamedInviteRefusal = false
         isInvitingGroupMember = true
         defer { isInvitingGroupMember = false }
 
-        do {
-            let result = try await client.inviteMembersDetailed(
-                accountRef: activeAccount.accountRef,
-                groupIdHex: groupIdHex,
-                memberRefs: memberRefs
-            )
-            guard
-                isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
-            else { return false }
-            applyGroupMutationResult(result)
-            await reloadChats(forceFreshSnapshot: true)
-            return true
-        } catch {
-            guard
-                isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
-            else { return false }
-            // `inviteMembersDetailed` can throw while reading post-commit details *after* the MLS
-            // invite already published. Refresh the roster and reconcile: if every recipient is now
-            // a member, the invite succeeded despite the read error — report success so the sheet
-            // dismisses and a retry doesn't hit "already a member".
-            await reloadChats(forceFreshSnapshot: true)
-            // Every await here suspends the actor, so re-validate the full presentation context
-            // after each one — not just the snapshot: a switch to another chat leaves the old
-            // snapshot temporarily intact (`loadGroupDetails` early-returns for a deselected
-            // group), and this error must not land in whatever the user is looking at now.
-            guard isInviteReconciliationTargetCurrent(accountId: accountId, groupIdHex: groupIdHex) else {
-                return false
-            }
-            await loadGroupDetails(groupIdHex: groupIdHex)
-            guard isInviteReconciliationTargetCurrent(accountId: accountId, groupIdHex: groupIdHex) else {
-                return false
-            }
-            let currentMemberIds = Set(groupDetailsSnapshot?.members.map(\.id) ?? [])
-            if !currentMemberIds.isEmpty,
-                recipients.allSatisfy({ currentMemberIds.contains($0.accountIdHex) })
-            {
+        // `invite_members` resolves every member's KeyPackage before it commits anything and stops
+        // at the first one it can't, naming that account alone. Learning them one press at a time
+        // meant the sheet answered "who can't be added" with one name while several were at fault,
+        // so the refusals are chased down here the way `createGroupResolvingEveryRefusal` does:
+        // the member just refused rides along at the end of each follow-up, which keeps that
+        // follow-up failing in resolution — before any commit — while the roster ahead of it is
+        // checked. Keep the two in step.
+        var pinnedRefusal: NewChatRecipient?
+        // Collected and published in one go on the way out. Marking them as they arrive let the
+        // sheet render each partial answer — one name, then two, then three — which reads as the
+        // sheet changing its mind rather than as the single answer this press has.
+        var discovered: Set<String> = []
+        defer { unreachableInviteMemberIdHexes.formUnion(discovered) }
+        while !candidates.isEmpty {
+            let attempt = candidates + (pinnedRefusal.map { [$0] } ?? [])
+            do {
+                let result = try await client.inviteMembersDetailed(
+                    accountRef: activeAccount.accountRef,
+                    groupIdHex: groupIdHex,
+                    memberRefs: attempt.map(\.npub).filter { !$0.isEmpty }
+                )
+                guard
+                    isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
+                else { return false }
+                applyGroupMutationResult(result)
+                await reloadChats(forceFreshSnapshot: true)
                 return true
+            } catch {
+                guard
+                    isCurrentGroupDetailsMutation(generation: generation, accountId: accountId, groupIdHex: groupIdHex)
+                else { return false }
+                if case .notOnWhiteNoise(let account) = ChatCreationFailure(error),
+                    let refused = ChatCreationFailure.refusedRecipient(named: account, among: attempt),
+                    let index = candidates.firstIndex(where: {
+                        $0.accountIdHex.caseInsensitiveCompare(refused.accountIdHex) == .orderedSame
+                    })
+                {
+                    // A named refusal aborts resolution before the commit, so there is nothing to
+                    // reconcile — only someone to mark and a roster to keep checking.
+                    discovered.insert(refused.accountIdHex.lowercased())
+                    candidates.remove(at: index)
+                    pinnedRefusal = refused
+                    // Everyone ahead of a refusal resolved; a refusal at the end of the roster
+                    // leaves nobody behind it to ask about.
+                    guard index < candidates.count else { return false }
+                    continue
+                }
+                let outcome = await reconcileOrAttributeInviteFailure(
+                    error,
+                    attempted: attempt,
+                    candidates: candidates,
+                    pin: pinnedRefusal ?? unreachableInviteRecipients(recipients).first,
+                    recipients: recipients,
+                    client: client,
+                    activeAccount: activeAccount,
+                    groupIdHex: groupIdHex,
+                    accountId: accountId
+                )
+                discovered.formUnion(outcome.marks)
+                return outcome.didInvite
             }
-            lastError = error.localizedDescription
-            return false
         }
+        return false
+    }
+
+    /// What `reconcileOrAttributeInviteFailure` concluded: whether the invite turned out to have
+    /// gone through, and who it managed to name along the way.
+    private struct InviteFailureOutcome {
+        let didInvite: Bool
+        var marks: Set<String> = []
+    }
+
+    /// An invite failure that named nobody in the staged roster: either the commit went through and
+    /// only the read of it failed, or one member is failing in a way the error doesn't attribute.
+    ///
+    /// Sorts the two out in that order — a published invite must never be reported as a refusal —
+    /// then asks about the remaining members one at a time, exactly as the compose draft does, so
+    /// the sheet can name everyone rather than the first person the core happened to mention.
+    private func reconcileOrAttributeInviteFailure(
+        _ error: Error,
+        attempted: [NewChatRecipient],
+        candidates: [NewChatRecipient],
+        pin: NewChatRecipient?,
+        recipients: [NewChatRecipient],
+        client: any MarmotRuntime,
+        activeAccount: AccountItem,
+        groupIdHex: String,
+        accountId: String
+    ) async -> InviteFailureOutcome {
+        // `inviteMembersDetailed` can throw while reading post-commit details *after* the MLS
+        // invite already published. Refresh the roster and reconcile: if every member of this
+        // attempt is now in the group, the invite succeeded despite the read error — report success
+        // so the sheet dismisses and a retry doesn't hit "already a member".
+        await reloadChats(forceFreshSnapshot: true)
+        // Every await here suspends the actor, so re-validate the full presentation context
+        // after each one — not just the snapshot: a switch to another chat leaves the old
+        // snapshot temporarily intact (`loadGroupDetails` early-returns for a deselected
+        // group), and this error must not land in whatever the user is looking at now.
+        guard isInviteReconciliationTargetCurrent(accountId: accountId, groupIdHex: groupIdHex) else {
+            return InviteFailureOutcome(didInvite: false)
+        }
+        await loadGroupDetails(groupIdHex: groupIdHex)
+        guard isInviteReconciliationTargetCurrent(accountId: accountId, groupIdHex: groupIdHex) else {
+            return InviteFailureOutcome(didInvite: false)
+        }
+        let currentMemberIds = Set(groupDetailsSnapshot?.members.map(\.id) ?? [])
+        if !currentMemberIds.isEmpty,
+            attempted.allSatisfy({ currentMemberIds.contains($0.accountIdHex) })
+        {
+            return InviteFailureOutcome(didInvite: true)
+        }
+
+        // Nothing was committed, so this is about the people. `[candidate, pin]` is a question the
+        // core answers by refusing: the pin is already known to have no usable KeyPackage, and
+        // resolution stops at the first member it can't resolve — the candidate, who goes first.
+        var marks: Set<String> = []
+        // The core named a member at some point in this pass — evidence that it is naming them at
+        // all, without which an unnamed answer says nothing about the candidate it was asked about.
+        var didNameAnyone = false
+        var unattributed: [NewChatRecipient] = []
+        if let pin {
+            for candidate in candidates {
+                do {
+                    let result = try await client.inviteMembersDetailed(
+                        accountRef: activeAccount.accountRef,
+                        groupIdHex: groupIdHex,
+                        memberRefs: [candidate, pin].map(\.npub).filter { !$0.isEmpty }
+                    )
+                    // The pin resolved between attempts, so this invited both — which is what the
+                    // user staged them for.
+                    guard isInviteReconciliationTargetCurrent(accountId: accountId, groupIdHex: groupIdHex)
+                    else { return InviteFailureOutcome(didInvite: false) }
+                    unreachableInviteMemberIdHexes.remove(pin.accountIdHex.lowercased())
+                    applyGroupMutationResult(result)
+                    await reloadChats(forceFreshSnapshot: true)
+                    return InviteFailureOutcome(didInvite: true)
+                } catch {
+                    // Guarded on the presentation context rather than the mutation generation the
+                    // caller captured: the reconciliation above reloads the group details, which
+                    // supersedes that generation by design.
+                    guard isInviteReconciliationTargetCurrent(accountId: accountId, groupIdHex: groupIdHex)
+                    else { return InviteFailureOutcome(didInvite: false, marks: marks) }
+                    var named: NewChatRecipient?
+                    if case .notOnWhiteNoise(let account) = ChatCreationFailure(error) {
+                        named = ChatCreationFailure.refusedRecipient(named: account, among: [candidate, pin])
+                    }
+                    guard let named else {
+                        unattributed.append(candidate)
+                        continue
+                    }
+                    didNameAnyone = true
+                    if named.accountIdHex.caseInsensitiveCompare(pin.accountIdHex) == .orderedSame {
+                        continue
+                    }
+                    marks.insert(candidate.accountIdHex.lowercased())
+                }
+            }
+            // Only convict on an unnamed answer where the core has shown it names members at all
+            // this pass; otherwise the failure is as likely to be about the group or the relays,
+            // and marking everyone would empty the sheet of people who are perfectly reachable.
+            if didNameAnyone {
+                for candidate in unattributed {
+                    marks.insert(candidate.accountIdHex.lowercased())
+                }
+            }
+        }
+        guard marks.isEmpty else { return InviteFailureOutcome(didInvite: false, marks: marks) }
+        if case .notOnWhiteNoise = ChatCreationFailure(error) {
+            // Nobody could be named, so the sheet says there is someone rather than blaming a
+            // person the core never mentioned.
+            hasUnnamedInviteRefusal = true
+            return InviteFailureOutcome(didInvite: false)
+        }
+        lastError = ChatCreationFailure.message(for: error, candidates: recipients)
+        return InviteFailureOutcome(didInvite: false)
     }
 
     func acceptGroupInvite(for chat: ChatItem) async {

--- a/whitenoise-mac/Core/WorkspaceState+Navigation.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Navigation.swift
@@ -90,6 +90,10 @@ extension WorkspaceState {
         newChatQuery = ""
         newChatRecipient = nil
         lastError = nil
+        // Scoped to the row that failed, so it goes with the results. The group draft's
+        // unreachable marks are *not* cleared here — they survive chooseMembers ↔ nameGroup
+        // hops exactly like the rest of the draft.
+        startChatInvitePrompt = nil
     }
 
     func showSettings(_ page: SettingsPage = .profile) {

--- a/whitenoise-mac/Core/WorkspaceState+NewChat.swift
+++ b/whitenoise-mac/Core/WorkspaceState+NewChat.swift
@@ -145,11 +145,16 @@ extension WorkspaceState {
             return false
         }
         newChatRecipients.append(recipient)
+        // An unnamed refusal belongs to the roster it was raised on. Editing that roster is exactly
+        // what the notice asks for, so the claim goes with the edit rather than following a draft
+        // that no longer contains whoever it was about.
+        hasUnnamedGroupDraftRefusal = false
         return true
     }
 
     func removeNewChatRecipient(_ recipient: NewChatRecipient) {
         newChatRecipients.removeAll { $0.accountIdHex == recipient.accountIdHex }
+        hasUnnamedGroupDraftRefusal = false
     }
 
     func createNewChat() async {
@@ -159,6 +164,7 @@ extension WorkspaceState {
         // resolve below). Otherwise two rapid submits both pass the `!isCreatingChat`
         // guard while suspended and each reach `createGroup`, creating duplicate chats.
         lastError = nil
+        startChatInvitePrompt = nil
         isCreatingChat = true
         defer { isCreatingChat = false }
 
@@ -236,7 +242,8 @@ extension WorkspaceState {
             beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
             await loadMessages(groupIdHex: groupIdHex)
         } catch {
-            lastError = error.localizedDescription
+            guard activeAccountId == accountId else { return }
+            applyChatCreationFailure(error, recipients: recipients, surface: isDirect ? .directChat : .groupDraft)
         }
     }
 
@@ -283,6 +290,9 @@ extension WorkspaceState {
         newChatRecipient = nil
         newChatRecipients = []
         groupDraftRetentionSecs = 0
+        unreachableDraftMemberIdHexes = []
+        hasUnnamedGroupDraftRefusal = false
+        startChatInvitePrompt = nil
         creatingDirectChatIdHex = nil
     }
 
@@ -569,6 +579,7 @@ extension WorkspaceState {
         }
         guard let client, let activeAccount, !isCreatingChat else { return }
         lastError = nil
+        startChatInvitePrompt = nil
         isCreatingChat = true
         creatingDirectChatIdHex = recipient.accountIdHex
         defer {
@@ -600,8 +611,40 @@ extension WorkspaceState {
             beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
             await loadMessages(groupIdHex: groupIdHex)
         } catch {
-            lastError = error.localizedDescription
+            guard activeAccountId == accountId else { return }
+            applyChatCreationFailure(error, recipients: [recipient], surface: .directChat)
         }
+    }
+
+    /// The invite prompt to render, or `nil` when it belongs to a query the user has since edited.
+    ///
+    /// Derived rather than cleared on change, because the only hook a clear could use — the
+    /// debounced `resolveNewChatQueryIfReady()` — cancels itself on every keystroke and so does not
+    /// run until typing settles, which is exactly when a stale prompt is most visible. Comparing
+    /// against the live query costs nothing and cannot be forgotten by a future code path. A
+    /// contact-row failure records the empty query it was raised under, so it hides the moment the
+    /// user starts typing and returns if they clear the field again — the person is still not
+    /// reachable, so re-showing it is honest.
+    var visibleStartChatInvitePrompt: StartChatInvitePrompt? {
+        guard let startChatInvitePrompt,
+            startChatInvitePrompt.query == newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return nil }
+        return startChatInvitePrompt
+    }
+
+    /// Members of the group draft the core has not (yet) refused. The `unreachable` split is
+    /// derived from the live roster rather than stored alongside it, so removing someone from
+    /// the draft drops their mark with them and no stale entry can outlive the recipient. Marks
+    /// survive a remove-then-re-add within the same draft, which is the wanted behaviour: the
+    /// core has not changed its mind, and the panel says so without another failed attempt.
+    var reachableDraftMembers: [NewChatRecipient] {
+        newChatRecipients.filter { !unreachableDraftMemberIdHexes.contains($0.accountIdHex.lowercased()) }
+    }
+
+    /// Draft members the core named as having no usable KeyPackage. These are shown apart in the
+    /// name-group panel and left out of the next create attempt.
+    var unreachableDraftMembers: [NewChatRecipient] {
+        newChatRecipients.filter { unreachableDraftMemberIdHexes.contains($0.accountIdHex.lowercased()) }
     }
 
     /// Create the group from the compose-flow draft (chosen members, required name, timer).
@@ -609,49 +652,313 @@ extension WorkspaceState {
     func createGroupFromDraft() async {
         guard let client, let activeAccount, !isCreatingChat else { return }
         let name = newChatName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let members = newChatRecipients
-        guard !name.isEmpty, !members.isEmpty else { return }
+        // Members the core has already refused are left out of the attempt. This is not a silent
+        // drop: the panel lists them under "Not on White Noise yet" and the Create button names
+        // the exclusion, so the composition being submitted is the one the user is looking at.
+        guard !name.isEmpty, !reachableDraftMembers.isEmpty else { return }
         lastError = nil
+        startChatInvitePrompt = nil
+        // Whatever this press learns replaces what the last one did, marks included: an
+        // unattributed refusal that has since been pinned on a member must not keep claiming
+        // there is someone else on top of the ones the panel now names.
+        hasUnnamedGroupDraftRefusal = false
         isCreatingChat = true
         defer { isCreatingChat = false }
         let accountId = activeAccount.id
         let retentionSecs = groupDraftRetentionSecs
-        do {
-            let groupIdHex = try await client.createGroup(
-                accountRef: activeAccount.accountRef,
+        guard
+            let groupIdHex = await createGroupResolvingEveryRefusal(
                 name: name,
-                memberRefs: members.map { $0.memberRef.isEmpty ? $0.accountIdHex : $0.memberRef },
-                description: nil
+                client: client,
+                activeAccount: activeAccount,
+                accountId: accountId
             )
-            if retentionSecs > 0 {
-                do {
-                    try await client.updateMessageRetention(
-                        accountRef: activeAccount.accountRef,
-                        groupIdHex: groupIdHex,
-                        disappearingMessageSecs: retentionSecs
-                    )
-                } catch {
-                    if activeAccountId == accountId {
-                        backgroundStatus = L10n.string(
-                            "The group was created, but disappearing messages could not be turned on.")
-                    }
+        else { return }
+
+        if retentionSecs > 0 {
+            do {
+                try await client.updateMessageRetention(
+                    accountRef: activeAccount.accountRef,
+                    groupIdHex: groupIdHex,
+                    disappearingMessageSecs: retentionSecs
+                )
+            } catch {
+                if activeAccountId == accountId {
+                    backgroundStatus = L10n.string(
+                        "The group was created, but disappearing messages could not be turned on.")
                 }
             }
-            await reloadChats(forceFreshSnapshot: true)
-            guard activeAccountId == accountId else { return }
-            insertCreatedChatIfNeeded(
-                groupIdHex: groupIdHex,
-                title: name,
-                avatarSeed: groupIdHex,
-                pictureURL: nil,
-                isDirect: false
-            )
-            selection = .chat(groupIdHex)
-            closeNewChatComposer()
-            beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
-            await loadMessages(groupIdHex: groupIdHex)
-        } catch {
-            lastError = error.localizedDescription
+        }
+        await reloadChats(forceFreshSnapshot: true)
+        guard activeAccountId == accountId else { return }
+        insertCreatedChatIfNeeded(
+            groupIdHex: groupIdHex,
+            title: name,
+            avatarSeed: groupIdHex,
+            pictureURL: nil,
+            isDirect: false
+        )
+        selection = .chat(groupIdHex)
+        closeNewChatComposer()
+        beginTimelineInitialLoadIfNeeded(groupIdHex: groupIdHex)
+        await loadMessages(groupIdHex: groupIdHex)
+    }
+
+    /// Create the group, but not before every member the core will refuse is known.
+    ///
+    /// `create_group` resolves the roster in list order and reports only the *first* member with no
+    /// usable KeyPackage, so one attempt per refusal is the only way to learn the whole set — there
+    /// is no FFI that asks whether a given person has a published KeyPackage. Spending those
+    /// attempts one press at a time revealed a draft's unreachable members one by one, and the last
+    /// press — the one whose roster the core finally accepted — created the group before the user
+    /// had ever seen the full list.
+    ///
+    /// So this spends them in a single press, and pins the member the core just refused to the end
+    /// of every follow-up attempt. That member is known-unreachable, which makes each follow-up
+    /// guaranteed to fail: nothing can be created while members are still being checked. And
+    /// because the core reports the first refusal *in list order*, an error naming someone else is
+    /// a new refusal, while an error naming the pinned member means everyone ahead of them
+    /// resolved. Discovery therefore ends on a refusal with nothing created, the panel lists every
+    /// excluded member at once, and the Create the user presses next submits the composition they
+    /// are looking at.
+    ///
+    /// Should the core ever name an arbitrary failing member rather than the first, this degrades
+    /// to the old behaviour — fewer refusals learned per press — and still never creates a group
+    /// mid-discovery, because a pinned refusal keeps every follow-up attempt failing regardless of
+    /// which member the error names.
+    ///
+    /// Returns the new group id, or `nil` when nothing was created: either members were refused
+    /// (they are marked, and the panel explains) or the failure was one `applyChatCreationFailure`
+    /// routes to the error line.
+    private func createGroupResolvingEveryRefusal(
+        name: String,
+        client: any MarmotRuntime,
+        activeAccount: AccountItem,
+        accountId: String
+    ) async -> String? {
+        var candidates = reachableDraftMembers
+        // The most recently refused member, carried into the next attempt to keep it failing.
+        var pinnedRefusal: NewChatRecipient?
+        // Refusals are collected here and published in one go on the way out. Marking them as they
+        // arrive let the panel render each partial answer — one name, then two, then three — which
+        // reads as the panel changing its mind about who can't be added. The press has one answer,
+        // so it says it once.
+        var discovered: Set<String> = []
+        defer { unreachableDraftMemberIdHexes.formUnion(discovered) }
+        while !candidates.isEmpty {
+            let attempt = candidates + (pinnedRefusal.map { [$0] } ?? [])
+            do {
+                let groupIdHex = try await client.createGroup(
+                    accountRef: activeAccount.accountRef,
+                    name: name,
+                    memberRefs: attempt.map { $0.memberRef.isEmpty ? $0.accountIdHex : $0.memberRef },
+                    description: nil
+                )
+                // Only the first attempt is expected to reach here. A later one can succeed only if
+                // the pinned member published a KeyPackage between two attempts, and then they are
+                // in the group the core just created — which is the roster the user asked for, and
+                // the mark taken moments earlier goes out with the rest of the draft when the
+                // caller closes the composer.
+                return groupIdHex
+            } catch {
+                guard activeAccountId == accountId else { return nil }
+                let failure = ChatCreationFailure(error)
+                let refused: NewChatRecipient?
+                if case .notOnWhiteNoise(let account) = failure {
+                    refused = ChatCreationFailure.refusedRecipient(named: account, among: attempt)
+                } else {
+                    refused = nil
+                }
+                guard let refused else {
+                    // Nobody to pin this on. Either the refusal named no account — a KeyPackage that
+                    // exists but can't be used — or the member stopping the create fails some other
+                    // way entirely, which reads as a group-wide error while it is really one person.
+                    // Both are answerable by asking about the members one at a time.
+                    switch await attributeRefusalMemberByMember(
+                        among: candidates,
+                        pin: pinnedRefusal ?? unreachableDraftMembers.first,
+                        name: name,
+                        client: client,
+                        activeAccount: activeAccount,
+                        accountId: accountId
+                    ) {
+                    case .created(let groupIdHex):
+                        return groupIdHex
+                    case .attributed(let marks):
+                        discovered.formUnion(marks)
+                        return nil
+                    case .unattributed:
+                        // Nothing owned up to it, so this is reported as what it looked like: a
+                        // refusal the panel can't name, or an error that belongs on the error line.
+                        if case .notOnWhiteNoise = failure {
+                            hasUnnamedGroupDraftRefusal = true
+                        } else {
+                            applyChatCreationFailure(error, recipients: attempt, surface: .groupDraft)
+                        }
+                        return nil
+                    }
+                }
+                // The refusal names someone who is not up for checking — the pinned member, whose
+                // failure is the signal that everyone ahead of them resolved. There is nothing left
+                // to learn and nothing to create until the user presses Create again.
+                guard
+                    let index = candidates.firstIndex(where: {
+                        $0.accountIdHex.caseInsensitiveCompare(refused.accountIdHex) == .orderedSame
+                    })
+                else { return nil }
+                discovered.insert(refused.accountIdHex.lowercased())
+                candidates.remove(at: index)
+                pinnedRefusal = refused
+                // Everyone ahead of a refusal resolved, so only the members behind it are still
+                // unknown. A refusal at the end of the roster leaves none — the common
+                // one-unreachable-member draft therefore costs exactly the one attempt it always
+                // did, and no follow-up is spent confirming what the same error already said.
+                guard index < candidates.count else { return nil }
+            }
+        }
+        return nil
+    }
+
+    /// What a member-by-member pass concluded about a failure no member could be pinned on.
+    enum RefusalAttribution {
+        /// The pin resolved between attempts, so the create the probe asked for went through.
+        case created(String)
+        /// At least one member was named. Carries their account ids for the caller to publish with
+        /// the rest of the press's findings.
+        case attributed(Set<String>)
+        /// Nobody owned up to it. The caller reports the failure as it arrived.
+        case unattributed
+    }
+
+    /// Work out which member a failure belongs to, by asking about one at a time.
+    ///
+    /// `MissingKeyPackage` carries the account it is about, but a KeyPackage that exists and cannot
+    /// be used (`InvalidKeyPackageEvent`, `InvalidIdentity`) names no one — and the core still stops
+    /// the whole create over it. Left there, the panel showed the members it *had* named alongside a
+    /// red line about an unnamed someone, which is two different accounts of the same draft.
+    ///
+    /// Failures of other kinds arrive here too. Member resolution can fail for reasons that look
+    /// nothing like a missing KeyPackage — a person with no relay list to fetch one from, say — and
+    /// those stopped the whole search, leaving the panel naming the one member it had learned about
+    /// before the roster ran into somebody who fails differently.
+    ///
+    /// `pin` is a member already known to be refused, so `[candidate, pin]` cannot create anything:
+    /// an error naming the pin clears that candidate, and any other refusal — named or not — is
+    /// about the candidate, because the core reports the first failure in list order and the
+    /// candidate goes first. Without a pin (an unnamed refusal on the first attempt of the first
+    /// press) there is no safe way to ask, so the notice says as much and names no one.
+    ///
+    /// The pass is exhaustive rather than a bisection: every member is checked, so it also settles
+    /// the members behind the one at fault and the next press has nothing left to discover. What it
+    /// will not do is convict on its own say-so — see the corroboration rule at the end.
+    private func attributeRefusalMemberByMember(
+        among candidates: [NewChatRecipient],
+        pin: NewChatRecipient?,
+        name: String,
+        client: any MarmotRuntime,
+        activeAccount: AccountItem,
+        accountId: String
+    ) async -> RefusalAttribution {
+        guard let pin else { return .unattributed }
+        // Collected rather than published as they are found: the caller reports this press's
+        // findings in one update, so the panel never counts them out loud.
+        var marks: Set<String> = []
+        // The core named a member at some point in this pass — evidence that it is naming them at
+        // all, without which an unnamed probe says nothing about the candidate it was asked about.
+        var didNameAnyone = false
+        // Refusals that named nobody, held back until that evidence arrives.
+        var unattributed: [NewChatRecipient] = []
+        for candidate in candidates {
+            do {
+                let groupIdHex = try await client.createGroup(
+                    accountRef: activeAccount.accountRef,
+                    name: name,
+                    memberRefs: [candidate, pin].map { $0.memberRef.isEmpty ? $0.accountIdHex : $0.memberRef },
+                    description: nil
+                )
+                // The pin resolved after all, so this asked the core to create a real group and it
+                // did. Hand it back rather than leave it unowned; the caller selects it, and the
+                // draft it came from closes with it.
+                return .created(groupIdHex)
+            } catch {
+                // The composer belongs to another account now: stop, and leave the caller with
+                // nothing to report into it.
+                guard activeAccountId == accountId else { return .attributed(marks) }
+                let named: NewChatRecipient?
+                if case .notOnWhiteNoise(let account) = ChatCreationFailure(error) {
+                    named = ChatCreationFailure.refusedRecipient(named: account, among: [candidate, pin])
+                } else {
+                    // A failure of another kind, for a question that only had two members in it and
+                    // resolves them in order. It says the same thing an unnamed refusal does.
+                    named = nil
+                }
+                guard let named else {
+                    unattributed.append(candidate)
+                    continue
+                }
+                didNameAnyone = true
+                if named.accountIdHex.caseInsensitiveCompare(pin.accountIdHex) == .orderedSame {
+                    // The pin is what failed, which it always does — so the candidate ahead of it
+                    // resolved.
+                    continue
+                }
+                marks.insert(candidate.accountIdHex.lowercased())
+            }
+        }
+        // A pass where the core never named anyone is a pass that proves nothing about anyone: the
+        // failure is as likely to be about this account, or the relays, as about the member being
+        // asked after. Marking every candidate on that evidence would empty the group and blame
+        // people who are perfectly reachable, so the notice says there is someone and names no one.
+        if didNameAnyone {
+            for candidate in unattributed {
+                marks.insert(candidate.accountIdHex.lowercased())
+            }
+        }
+        return marks.isEmpty ? .unattributed : .attributed(marks)
+    }
+
+    /// Route a creation failure to the surface that can act on it.
+    ///
+    /// A one-to-one attempt becomes an invite prompt naming the recipient: the composition is
+    /// already minimal, so the only move left is to invite them. A group draft instead pins the
+    /// refusal on the member the core named, which moves them into the panel's "Not on White
+    /// Noise yet" section and takes them out of the next attempt. Anything the taxonomy doesn't
+    /// recognize falls back to the error line, as before.
+    ///
+    /// The group path reaches here only for a refusal that names nobody the draft knows;
+    /// `createGroupResolvingEveryRefusal` handles the named ones itself, because learning them one
+    /// per press was the bug it exists to fix.
+    ///
+    /// Every caller must re-check `activeAccountId` first, the same way the success paths do
+    /// (whitenoise-mac#229): each of them suspends across `createGroup`, so a mid-await A→B
+    /// switch would otherwise land account A's refusal in account B's composer. The draft half of
+    /// that is latent today — the switch closes the composer, and `resetNewChatComposer()` clears
+    /// both fields — but `lastError` survives a close, so the guard closes a real leak and stops
+    /// the rest from depending on teardown order.
+    func applyChatCreationFailure(
+        _ error: Error,
+        recipients: [NewChatRecipient],
+        surface: ChatCreationSurface
+    ) {
+        switch ChatCreationFailure(error) {
+        case .other(let message):
+            lastError = message
+        case .notOnWhiteNoise(let account):
+            if surface == .directChat, let recipient = recipients.first {
+                startChatInvitePrompt = StartChatInvitePrompt(
+                    accountIdHex: recipient.accountIdHex,
+                    recipientName: recipient.displayName,
+                    query: newChatQuery.trimmingCharacters(in: .whitespacesAndNewlines))
+                return
+            }
+            // Without a member to pin it on — an unusable KeyPackage event rather than a missing
+            // one — the panel says there is someone it can't name, in the same notice that lists
+            // the ones it can. A red line beside that notice was two answers to one question.
+            guard let refused = ChatCreationFailure.refusedRecipient(named: account, among: recipients) else {
+                hasUnnamedGroupDraftRefusal = true
+                return
+            }
+            unreachableDraftMemberIdHexes.insert(refused.accountIdHex.lowercased())
         }
     }
 

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -393,6 +393,29 @@ final class WorkspaceState {
     /// Disappearing-message timer chosen on the name-group panel. Not a `createGroup`
     /// parameter, so it is applied right after creation.
     var groupDraftRetentionSecs: UInt64 = 0
+    /// Draft members the core has named as having no usable KeyPackage, by lowercased account
+    /// id. `create_group` stops at the first unreachable member, so an attempt names at most one;
+    /// `createGroupResolvingEveryRefusal` spends as many attempts as it takes to fill this in
+    /// completely. The name-group panel lists them apart and the next attempt leaves them out.
+    var unreachableDraftMemberIdHexes: Set<String> = []
+    /// Staged add-members recipients the core has named as having no usable KeyPackage, by
+    /// lowercased account id. The add-members sheet is the compose draft's twin — `invite_members`
+    /// resolves the roster the same way `create_group` does and reports the same one refusal per
+    /// attempt — so it splits its staged list the same way rather than naming one person per press.
+    var unreachableInviteMemberIdHexes: Set<String> = []
+    /// The add-members counterpart of `hasUnnamedGroupDraftRefusal`.
+    var hasUnnamedInviteRefusal = false
+    /// Set when a group-draft attempt was refused for want of a usable KeyPackage and no draft
+    /// member could be held responsible — a KeyPackage that exists but can't be used names nobody,
+    /// and one can turn up before this press has a refused member to probe with.
+    ///
+    /// It feeds the same notice `unreachableDraftMemberIdHexes` does rather than `lastError`,
+    /// because a red line contradicting the notice above it ("2 people here aren't on White
+    /// Noise") is how the panel came to state two different counts at once.
+    var hasUnnamedGroupDraftRefusal = false
+    /// Shown instead of `lastError` when a one-to-one chat can't start because the recipient
+    /// isn't on White Noise yet — there is nothing to retry, only someone to invite.
+    var startChatInvitePrompt: StartChatInvitePrompt?
     @ObservationIgnored var composeContactsGeneration: UInt64 = 0
     /// People the web-of-trust search found for the current compose query. Deliberately separate
     /// from `composeContacts`: a search result is not a relationship, so nothing here is ever

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -840,6 +840,138 @@
         }
       }
     },
+    "%@ isn't on White Noise yet, so they can't be added.": {
+      "comment": "Shown when the core refuses a member because they have no usable KeyPackage.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist noch nicht bei White Noise und kann nicht hinzugefügt werden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ isn't on White Noise yet, so they can't be added."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ todavía no está en White Noise, así que no se puede añadir."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ n'est pas encore sur White Noise : impossible de l'ajouter pour l'instant."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ non è ancora su White Noise, quindi non si può aggiungere."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ainda não está no White Noise, por isso não é possível adicionar essa pessoa."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ пока не в White Noise, поэтому добавить не получится."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ henüz White Noise'da değil, bu yüzden eklenemiyor."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 还没有加入 White Noise，因此无法添加。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 還沒有加入 White Noise，因此無法新增。"
+          }
+        }
+      }
+    },
+    "%@ isn't on White Noise yet. Share the app so you can chat securely.": {
+      "comment": "Direct-chat invite prompt naming the recipient.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist noch nicht bei White Noise. Teile die App, damit ihr sicher chatten könnt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ isn't on White Noise yet. Share the app so you can chat securely."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ todavía no está en White Noise. Comparte la app para poder chatear de forma segura."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ n'est pas encore sur White Noise. Partagez l'app pour discuter en toute sécurité."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ non è ancora su White Noise. Condividi l'app per chattare in modo sicuro."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ainda não está no White Noise. Compartilhe o app para vocês conversarem com segurança."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ пока не в White Noise. Поделитесь приложением, чтобы общаться защищённо."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ henüz White Noise'da değil. Güvenli sohbet edebilmek için uygulamayı paylaşın."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 还没有加入 White Noise。分享这个应用，你们就能安全聊天了。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 還沒有加入 White Noise。分享這個應用程式，你們就能安全聊天了。"
+          }
+        }
+      }
+    },
     "%@ joined": {
       "extractionState": "manual",
       "localizations": {
@@ -3444,6 +3576,286 @@
                     "stringUnit": {
                       "state": "translated",
                       "value": "%lld 位成員"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld people here aren't on White Noise yet, so they can't be added.": {
+      "comment": "Headline of the group-draft invite notice when several members were refused.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld Person hier ist noch nicht bei White Noise und kann nicht hinzugefügt werden."
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld Personen hier sind noch nicht bei White Noise und können nicht hinzugefügt werden."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld person here isn't on White Noise yet, so they can't be added."
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld people here aren't on White Noise yet, so they can't be added."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld persona de aquí todavía no está en White Noise, así que no se puede añadir."
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld personas de aquí todavía no están en White Noise, así que no se pueden añadir."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld personne ici n'est pas encore sur White Noise et ne peut pas être ajoutée."
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld personnes ici ne sont pas encore sur White Noise et ne peuvent pas être ajoutées."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld persona qui non è ancora su White Noise, quindi non può essere aggiunta."
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld persone qui non sono ancora su White Noise, quindi non possono essere aggiunte."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld pessoa aqui ainda não está no White Noise, por isso não pode ser adicionada."
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld pessoas aqui ainda não estão no White Noise, por isso não podem ser adicionadas."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "few": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld человека здесь пока не в White Noise, поэтому добавить их не получится."
+                    }
+                  },
+                  "many": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld человек здесь пока не в White Noise, поэтому добавить их не получится."
+                    }
+                  },
+                  "one": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld человек здесь пока не в White Noise, поэтому добавить его не получится."
+                    }
+                  },
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "%lld человека здесь пока не в White Noise, поэтому добавить их не получится."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "Buradaki %lld kişi henüz White Noise'da değil, bu yüzden eklenemiyor."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "这里有 %lld 人还没有加入 White Noise，因此无法添加。"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%#@count@"
+          },
+          "substitutions": {
+            "count": {
+              "argNum": 1,
+              "formatSpecifier": "lld",
+              "variations": {
+                "plural": {
+                  "other": {
+                    "stringUnit": {
+                      "state": "translated",
+                      "value": "這裡有 %lld 人還沒有加入 White Noise，因此無法新增。"
                     }
                   }
                 }
@@ -24585,6 +24997,72 @@
         }
       }
     },
+    "Invite them to White Noise, then add them to the group once they're set up.": {
+      "comment": "Secondary line of the group-draft invite notice.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lade sie zu White Noise ein und füge sie der Gruppe hinzu, sobald sie eingerichtet sind."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invite them to White Noise, then add them to the group once they're set up."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invítalos a White Noise y añádelos al grupo cuando ya lo tengan configurado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invitez-les sur White Noise, puis ajoutez-les au groupe une fois qu'ils sont installés."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invitali su White Noise e aggiungili al gruppo quando avranno completato la configurazione."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Convide-os para o White Noise e adicione-os ao grupo assim que estiverem configurados."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пригласите их в White Noise и добавьте в группу, когда они всё настроят."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onları White Noise'a davet edin, kurulumu tamamladıklarında gruba ekleyin."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "邀请他们加入 White Noise，等他们设置好后再添加到群组。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "邀請他們加入 White Noise，等他們設定好後再加入群組。"
+          }
+        }
+      }
+    },
     "Invited %lld members": {
       "extractionState": "manual",
       "localizations": {
@@ -26296,6 +26774,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "已離開"
+          }
+        }
+      }
+    },
+    "Let's chat on White Noise — private, secure messaging. Get it at https://whitenoise.chat": {
+      "comment": "The invite message shared from the compose flow.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lass uns auf White Noise chatten – private, sichere Nachrichten. Hier gibt es die App: https://whitenoise.chat"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Let's chat on White Noise — private, secure messaging. Get it at https://whitenoise.chat"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chateemos en White Noise: mensajería privada y segura. Descárgala en https://whitenoise.chat"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discutons sur White Noise — messagerie privée et sécurisée. À télécharger sur https://whitenoise.chat"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chattiamo su White Noise: messaggistica privata e sicura. Scaricala da https://whitenoise.chat"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vamos conversar no White Noise — mensagens privadas e seguras. Baixe em https://whitenoise.chat"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Давай общаться в White Noise — приватные и защищённые сообщения. Скачать: https://whitenoise.chat"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "White Noise'da sohbet edelim — özel ve güvenli mesajlaşma. İndirmek için: https://whitenoise.chat"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来 White Noise 聊天吧——私密、安全的消息应用。下载地址：https://whitenoise.chat"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來 White Noise 聊天吧——私密、安全的訊息應用程式。下載網址：https://whitenoise.chat"
           }
         }
       }
@@ -33925,6 +34469,138 @@
           "stringUnit": {
             "state": "translated",
             "value": "未交付"
+          }
+        }
+      }
+    },
+    "Not on White Noise yet": {
+      "comment": "Heading over the draft members who cannot be added.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch nicht bei White Noise"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not on White Noise yet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todavía no está en White Noise"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore sur White Noise"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non ancora su White Noise"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não está no White Noise"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока не в White Noise"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Henüz White Noise'da değil"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未加入 White Noise"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未加入 White Noise"
+          }
+        }
+      }
+    },
+    "Not on White Noise yet — they won't be added to this group.": {
+      "comment": "Tooltip on a dimmed draft member row.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch nicht bei White Noise – wird dieser Gruppe nicht hinzugefügt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not on White Noise yet — they won't be added to this group."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todavía no está en White Noise: no se añadirá a este grupo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore sur White Noise — cette personne ne sera pas ajoutée au groupe."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non ancora su White Noise: non si può aggiungere a questo gruppo."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não está no White Noise — essa pessoa não será adicionada ao grupo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пока не в White Noise — в эту группу не попадёт."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Henüz White Noise'da değil — bu gruba eklenmeyecek."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未加入 White Noise——不会被添加到这个群组。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未加入 White Noise——不會被加入這個群組。"
           }
         }
       }
@@ -47238,6 +47914,138 @@
         }
       }
     },
+    "Someone in this group isn't on White Noise yet, so it can't be created.": {
+      "comment": "Group-create failure the app could not pin on a specific member.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jemand in dieser Gruppe ist noch nicht bei White Noise, deshalb kann sie nicht erstellt werden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Someone in this group isn't on White Noise yet, so it can't be created."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alguien de este grupo todavía no está en White Noise, así que no se puede crear."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une personne de ce groupe n'est pas encore sur White Noise, il est donc impossible de le créer."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una persona di questo gruppo non è ancora su White Noise, quindi il gruppo non può essere creato."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alguém neste grupo ainda não está no White Noise, por isso ele não pode ser criado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кто-то в этой группе пока не в White Noise, поэтому создать её не получится."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu gruptaki biri henüz White Noise'da değil, bu yüzden grup oluşturulamıyor."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这个群组里有人还没有加入 White Noise，因此无法创建。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這個群組裡有人還沒有加入 White Noise，因此無法建立。"
+          }
+        }
+      }
+    },
+    "Someone you picked isn't on White Noise yet, so they can't be added.": {
+      "comment": "Add-member failure when the app has no display name for the refused recipient.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jemand, den du ausgewählt hast, ist noch nicht bei White Noise und kann nicht hinzugefügt werden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Someone you picked isn't on White Noise yet, so they can't be added."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alguien que elegiste todavía no está en White Noise, así que no se puede añadir."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une personne que vous avez choisie n'est pas encore sur White Noise et ne peut pas être ajoutée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una persona che hai scelto non è ancora su White Noise, quindi non può essere aggiunta."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alguém que você escolheu ainda não está no White Noise, por isso não pode ser adicionado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кто-то из выбранных пока не в White Noise, поэтому добавить не получится."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçtiğiniz kişilerden biri henüz White Noise'da değil, bu yüzden eklenemiyor."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你选择的某个人还没有加入 White Noise，因此无法添加。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你選擇的某個人還沒有加入 White Noise，因此無法新增。"
+          }
+        }
+      }
+    },
     "Something went wrong": {
       "extractionState": "manual",
       "localizations": {
@@ -50601,6 +51409,72 @@
           "stringUnit": {
             "state": "translated",
             "value": "主題"
+          }
+        }
+      }
+    },
+    "They aren't on White Noise yet. Share the app so you can chat securely.": {
+      "comment": "Direct-chat invite prompt when the recipient has no display name.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Person ist noch nicht bei White Noise. Teile die App, damit ihr sicher chatten könnt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "They aren't on White Noise yet. Share the app so you can chat securely."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todavía no está en White Noise. Comparte la app para poder chatear de forma segura."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette personne n'est pas encore sur White Noise. Partagez l'app pour discuter en toute sécurité."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non è ancora su White Noise. Condividi l'app per chattare in modo sicuro."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não está no White Noise. Compartilhe o app para vocês conversarem com segurança."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот человек пока не в White Noise. Поделитесь приложением, чтобы общаться защищённо."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu kişi henüz White Noise'da değil. Güvenli sohbet edebilmek için uygulamayı paylaşın."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对方还没有加入 White Noise。分享这个应用，你们就能安全聊天了。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "對方還沒有加入 White Noise。分享這個應用程式，你們就能安全聊天了。"
           }
         }
       }

--- a/whitenoise-mac/Views/ComposeFlowViews.swift
+++ b/whitenoise-mac/Views/ComposeFlowViews.swift
@@ -37,6 +37,16 @@ struct NewChatPanelView: View {
             .debouncedNewChatQueryResolution(for: workspace.newChatQuery)
             .userDiscovery(for: workspace.newChatQuery)
 
+            // Above the list, not inside it: the row that failed can be anywhere in a long
+            // contact list, and a prompt appended below the results would land off screen.
+            // `visible…` rather than the raw prompt so editing the query hides it immediately,
+            // without waiting on the resolution debounce.
+            if let prompt = workspace.visibleStartChatInvitePrompt {
+                StartChatInviteNotice(prompt: prompt)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 12)
+            }
+
             GlassSeparator(axis: .horizontal)
 
             ScrollView {
@@ -342,15 +352,7 @@ struct NameGroupPanelView: View {
 
                     disappearingRow
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(L10n.plural("%lld members", Int64(workspace.newChatRecipients.count)))
-                            .wnFont(MessagesType.sectionHeader)
-                            .foregroundStyle(WNColor.backgroundContentSecondary)
-                        ForEach(workspace.newChatRecipients, id: \.accountIdHex) { member in
-                            memberRow(member)
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    GroupDraftMembersSection()
 
                     if let lastError = workspace.lastError {
                         Text(lastError)
@@ -363,6 +365,21 @@ struct NameGroupPanelView: View {
             }
 
             GlassSeparator(axis: .horizontal)
+
+            // Pinned above the button rather than left in the scrolling list: this is the one
+            // thing the user must see before pressing Create, and the members list can be
+            // scrolled away. It deliberately does *not* live in the button's title — a primary
+            // action whose label rewrites itself between presses reads as a different button
+            // each time. The first press that meets a refusal fills this in completely and
+            // creates nothing, so it is never a partial account of who was left out.
+            if !workspace.unreachableDraftMembers.isEmpty || workspace.hasUnnamedGroupDraftRefusal {
+                GroupDraftInviteNotice(
+                    members: workspace.unreachableDraftMembers,
+                    hasUnnamedRefusal: workspace.hasUnnamedGroupDraftRefusal
+                )
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+            }
 
             HStack {
                 Spacer()
@@ -380,7 +397,7 @@ struct NameGroupPanelView: View {
                     }
                 }
                 .nativeGlassProminentButtonStyle()
-                .disabled(trimmedName.isEmpty || workspace.isCreatingChat)
+                .disabled(trimmedName.isEmpty || workspace.isCreatingChat || workspace.reachableDraftMembers.isEmpty)
                 .accessibilityIdentifier("compose.create")
             }
             .padding(12)
@@ -435,7 +452,55 @@ struct NameGroupPanelView: View {
         .glassCard()
     }
 
-    private func memberRow(_ member: NewChatRecipient) -> some View {
+}
+
+// MARK: - Group draft members
+
+/// The chosen members, split by whether the core will accept them. Everyone stays on screen: a
+/// member the core refused is dimmed under its own heading rather than dropped, because "who do I
+/// still need to invite" is the whole question this panel has to answer.
+private struct GroupDraftMembersSection: View {
+    @Environment(WorkspaceState.self) private var workspace
+
+    var body: some View {
+        let reachable = workspace.reachableDraftMembers
+        let unreachable = workspace.unreachableDraftMembers
+
+        VStack(alignment: .leading, spacing: 16) {
+            if !reachable.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(L10n.plural("%lld members", Int64(reachable.count)))
+                        .wnFont(MessagesType.sectionHeader)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
+                    ForEach(reachable, id: \.accountIdHex) { member in
+                        GroupDraftMemberRow(member: member)
+                    }
+                }
+            }
+
+            if !unreachable.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(L10n.string("Not on White Noise yet"))
+                        .wnFont(MessagesType.sectionHeader)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
+                    ForEach(unreachable, id: \.accountIdHex) { member in
+                        GroupDraftMemberRow(member: member, isExcluded: true)
+                    }
+                    // The explanation and the invite action live in the pinned footer notice, so
+                    // this section stays a plain roster and the two never disagree.
+                }
+                .accessibilityIdentifier("compose.notOnWhiteNoise")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct GroupDraftMemberRow: View {
+    let member: NewChatRecipient
+    var isExcluded = false
+
+    var body: some View {
         HStack(spacing: 10) {
             ProfileImageAvatarView(
                 seed: member.accountIdHex,
@@ -457,6 +522,103 @@ struct NameGroupPanelView: View {
             Spacer(minLength: 0)
         }
         .padding(.vertical, 4)
+        // Dimming is how the other clients mark an excluded member, and it carries here without
+        // a second colour: the row keeps its own tokens, it just recedes.
+        .opacity(isExcluded ? 0.55 : 1)
+        .help(isExcluded ? L10n.string("Not on White Noise yet — they won't be added to this group.") : "")
+    }
+}
+
+/// Why the dimmed members can't join, and the one action that changes it. Also the only place the
+/// panel speaks about a refusal it could not pin on anyone: two claims in two styles — a red error
+/// line over this notice — read as two different answers about the same draft.
+private struct GroupDraftInviteNotice: View {
+    let members: [NewChatRecipient]
+    /// The core refused someone it did not name and no member could be held responsible.
+    var hasUnnamedRefusal = false
+
+    var body: some View {
+        // Text block over the action, the shape `PendingGroupInviteComposerNotice` already uses:
+        // the compose drawer is narrow, and a button parked beside two wrapping lines squeezes
+        // both. `.firstTextBaseline` sits the icon on the headline rather than the box.
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Image(systemName: "person.badge.plus")
+                    .wnFont(.semiBold14)
+                    .foregroundStyle(WNColor.intentionInfoContent)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(headline)
+                        .wnFont(.semiBold12)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(L10n.string("Invite them to White Noise, then add them to the group once they're set up."))
+                        .wnFont(.medium10)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            ShareLink(item: WhiteNoiseInvite.message) {
+                Text(L10n.string("Invite"))
+            }
+            .buttonStyle(.wnSecondary)
+            .accessibilityIdentifier("compose.invite")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .glassCard()
+    }
+
+    private var headline: String {
+        // A refusal nobody owned up to outranks the count. It means there is someone here beyond
+        // the rows already dimmed above, so a headline claiming a number would be claiming the
+        // wrong one — and a count next to "and also someone else" is the pair of answers that made
+        // this panel confusing in the first place.
+        guard let first = members.first, !hasUnnamedRefusal else {
+            return L10n.string("Someone in this group isn't on White Noise yet, so it can't be created.")
+        }
+        guard members.count > 1 else {
+            return String(
+                format: L10n.string("%@ isn't on White Noise yet, so they can't be added."),
+                first.title)
+        }
+        return L10n.plural("%lld people here aren't on White Noise yet, so they can't be added.", Int64(members.count))
+    }
+}
+
+/// The one-to-one counterpart: nothing to restage, so the panel drops the error and offers the
+/// invite directly.
+private struct StartChatInviteNotice: View {
+    let prompt: StartChatInvitePrompt
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Image(systemName: "person.badge.plus")
+                    .wnFont(.semiBold14)
+                    .foregroundStyle(WNColor.intentionInfoContent)
+
+                Text(prompt.detail)
+                    .wnFont(.semiBold12)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: 0)
+            }
+
+            ShareLink(item: WhiteNoiseInvite.message) {
+                Text(L10n.string("Invite"))
+            }
+            .buttonStyle(.wnSecondary)
+            .accessibilityIdentifier("compose.invite")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .glassCard()
+        .accessibilityIdentifier("compose.startChatInvite")
     }
 }
 

--- a/whitenoise-mac/Views/GroupAddMembersSheet.swift
+++ b/whitenoise-mac/Views/GroupAddMembersSheet.swift
@@ -18,6 +18,8 @@ struct GroupAddMembersSheet: View {
     @State private var staged: [NewChatRecipient] = []
     @State private var isResolving = false
     @State private var resolveError: String?
+    /// Who the core refused, said once, under the roster that shows them dimmed.
+    @State private var unreachableNotice: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -32,12 +34,27 @@ struct GroupAddMembersSheet: View {
                     .padding(.horizontal, 16)
                     .padding(.bottom, 6)
             }
+            // Deliberately not the destructive style, and never shown alongside a red line saying
+            // something different: who can't be added is an answer, not an error.
+            if let unreachableNotice {
+                Text(unreachableNotice)
+                    .wnFont(.medium10)
+                    .foregroundStyle(WNColor.backgroundContentSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 6)
+                    .accessibilityIdentifier("addMembers.notOnWhiteNoise")
+            }
             Divider()
             stagedList
             Divider()
             footer
         }
         .frame(width: 420, height: 460)
+        // A fresh staging session asks the core again rather than inheriting marks from the last
+        // sheet, which may have been a different group or a different day.
+        .task { workspace.resetInviteRefusals() }
     }
 
     private var header: some View {
@@ -99,7 +116,9 @@ struct GroupAddMembersSheet: View {
     }
 
     private func recipientRow(_ recipient: NewChatRecipient) -> some View {
-        HStack(spacing: 10) {
+        let isExcluded = workspace.unreachableInviteMemberIdHexes.contains(
+            recipient.accountIdHex.lowercased())
+        return HStack(spacing: 10) {
             ProfileImageAvatarView(
                 seed: recipient.accountIdHex,
                 initials: recipient.title,
@@ -111,10 +130,16 @@ struct GroupAddMembersSheet: View {
                 Text(recipient.title)
                     .wnFont(.medium12)
                     .lineLimit(1)
-                Text(DisplayText.short(recipient.npub))
-                    .wnFont(.medium10)
-                    .foregroundStyle(WNColor.backgroundContentSecondary)
-                    .lineLimit(1)
+                // The key gives way to the reason: someone who can't be added needs explaining
+                // more than they need identifying a second time.
+                Text(
+                    isExcluded
+                        ? L10n.string("Not on White Noise yet")
+                        : DisplayText.short(recipient.npub)
+                )
+                .wnFont(.medium10)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
+                .lineLimit(1)
             }
             Spacer(minLength: 8)
             Button {
@@ -127,6 +152,10 @@ struct GroupAddMembersSheet: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 6)
+        // Dimmed rather than dropped, the way the compose panel marks them: "who do I still need to
+        // invite" is the question this sheet has to answer.
+        .opacity(isExcluded ? 0.55 : 1)
+        .help(isExcluded ? L10n.string("Not on White Noise yet — they won't be added to this group.") : "")
     }
 
     private var footer: some View {
@@ -148,12 +177,17 @@ struct GroupAddMembersSheet: View {
         !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// Staged people the core hasn't refused — the roster an invite would actually carry.
+    private var reachableStaged: [NewChatRecipient] {
+        workspace.reachableInviteRecipients(staged)
+    }
+
     private var canInvite: Bool {
-        !staged.isEmpty || pendingQuery
+        !reachableStaged.isEmpty || pendingQuery
     }
 
     private var inviteLabel: String {
-        let count = staged.count + (pendingQuery && !staged.isEmpty ? 1 : 0)
+        let count = reachableStaged.count + (pendingQuery && !reachableStaged.isEmpty ? 1 : 0)
         return count <= 1 ? L10n.string("Invite") : String(format: L10n.string("Invite %lld"), count)
     }
 
@@ -164,12 +198,33 @@ struct GroupAddMembersSheet: View {
             await resolveAndStage()
             guard resolveError == nil else { return }
         }
-        guard !staged.isEmpty else { return }
+        guard !reachableStaged.isEmpty else { return }
+        resolveError = nil
+        unreachableNotice = nil
         if await workspace.inviteMembers(staged) {
             dismiss()
-        } else {
+            return
+        }
+        // One press learns every refusal, so this names all of them at once — and the plain error
+        // line is kept for failures that aren't about who these people are.
+        let refused = workspace.unreachableInviteRecipients(staged)
+        unreachableNotice = unreachableMessage(for: refused)
+        if unreachableNotice == nil {
             resolveError = workspace.lastError ?? L10n.string("Couldn't add members.")
         }
+    }
+
+    private func unreachableMessage(for refused: [NewChatRecipient]) -> String? {
+        if refused.count > 1 {
+            return L10n.plural(
+                "%lld people here aren't on White Noise yet, so they can't be added.", Int64(refused.count))
+        }
+        if let only = refused.first {
+            return String(
+                format: L10n.string("%@ isn't on White Noise yet, so they can't be added."), only.title)
+        }
+        guard workspace.hasUnnamedInviteRefusal else { return nil }
+        return L10n.string("Someone you picked isn't on White Noise yet, so they can't be added.")
     }
 
     private func resolveAndStage() async {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -209,6 +209,14 @@ private final class BlockingFfiGate: @unchecked Sendable {
 /// Async twin of `BlockingFfiGate`: suspends the first armed call on a continuation, with all
 /// gate state lock-guarded so arming, polling, and releasing from other threads cannot race the
 /// suspension — a release that wins the race resumes the parked call immediately.
+/// Snapshots of how many people the panel or sheet was showing as unreachable, taken while a press
+/// was still working through the roster. A press that publishes its findings as it goes leaves a
+/// rising sequence here; one that publishes them together leaves zeros.
+@MainActor
+private final class MidPressMarkCounts {
+    var counts: [Int] = []
+}
+
 private final class AsyncFfiGate: @unchecked Sendable {
     private let lock = NSLock()
     private var enabled = false
@@ -23667,6 +23675,86 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func invitingMembersNamesEveryoneWithoutAKeyPackageInOneAttempt() async throws {
+        // The add-members sheet had the compose draft's old bug: `invite_members` names one refused
+        // member per attempt, so staging three people with no KeyPackage named the first and left
+        // the user to deselect and press again to meet the next.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1carol"] = Self.carolAccountIdHex
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let staged = [Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient()]
+
+        let invited = await state.inviteMembers(staged)
+
+        #expect(!invited)
+        #expect(
+            state.unreachableInviteRecipients(staged).map(\.accountIdHex)
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex])
+        #expect(state.reachableInviteRecipients(staged).map(\.accountIdHex) == [Self.aliceAccountIdHex])
+        #expect(state.lastError == nil)
+        #expect(!state.hasUnnamedInviteRefusal)
+        // Bob rode along at the end of the follow-up, which keeps it failing in resolution — so
+        // Carol was found without anything being committed.
+        #expect(
+            runtime.inviteMemberRefAttempts == [
+                ["npub1alyce", "npub1p0p", "npub1carol"],
+                ["npub1alyce", "npub1carol", "npub1p0p"],
+            ])
+        #expect(runtime.invitedMemberRefs.isEmpty)
+
+        // The next press carries the roster the sheet has been showing all along.
+        let retried = await state.inviteMembers(staged)
+        #expect(retried)
+        #expect(runtime.invitedMemberRefs == ["npub1alyce"])
+    }
+
+    @MainActor
+    @Test func invitingMembersNamesAMemberWhoseRefusalNamesNobody() async throws {
+        // A KeyPackage that exists but can't be used names no account, and the invite still stops
+        // over it. Asking about each staged person with the refused one alongside settles who.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.invalidKeyPackageMemberRefs = ["npub1carol"]
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let staged = [Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient()]
+
+        let invited = await state.inviteMembers(staged)
+
+        #expect(!invited)
+        #expect(
+            state.unreachableInviteRecipients(staged).map(\.accountIdHex)
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex])
+        #expect(state.lastError == nil)
+        #expect(!state.hasUnnamedInviteRefusal)
+        #expect(runtime.invitedMemberRefs.isEmpty)
+    }
+
+    @MainActor
+    @Test func invitingMembersSaysSomeoneWhenTheFirstRefusalNamesNobody() async throws {
+        // Nothing refused yet, so there is no known-unreachable member to ask alongside — and
+        // asking about one person alone would invite them. The sheet says what it knows.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        runtime.invalidKeyPackageMemberRefs = ["npub1carol"]
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let staged = [Self.carolDraftRecipient(), Self.aliceDraftRecipient()]
+
+        let invited = await state.inviteMembers(staged)
+
+        #expect(!invited)
+        #expect(state.hasUnnamedInviteRefusal)
+        #expect(state.unreachableInviteRecipients(staged).isEmpty)
+        #expect(state.lastError == nil)
+        #expect(runtime.invitedMemberRefs.isEmpty)
+    }
+
+    @MainActor
     @Test func inviteMemberDropsWhileProfileSaveIsInFlight() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
@@ -26902,6 +26990,657 @@ struct whitenoise_macTests {
         #expect(state.selection == .chat("created-group"))
         #expect(!state.isNewChatComposerVisible)
         #expect(state.activeChats.map(\.id) == ["created-group"])
+    }
+
+    @MainActor
+    @Test func groupDraftNamesTheMemberWithoutAKeyPackageInsteadOfShowingTheCoreError() async throws {
+        // The core stops at the first member it can't resolve and throws `MissingKeyPackage`,
+        // whose `errorDescription` is `String(reflecting:)`. Letting that reach `lastError`
+        // printed a Swift enum dump at the user and never said who was at fault.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [Self.aliceDraftRecipient(), Self.bobDraftRecipient()]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        #expect(state.lastError == nil)
+        #expect(state.unreachableDraftMembers.map(\.accountIdHex) == [Self.bobAccountIdHex])
+        #expect(state.reachableDraftMembers.map(\.accountIdHex) == [Self.aliceAccountIdHex])
+        // Nothing was created, and the draft is still on screen for a second, informed attempt.
+        #expect(runtime.createdGroupMemberRefs.isEmpty)
+        #expect(state.isNewChatComposerVisible)
+        // The refusal named the last member of the roster, so everyone else had already resolved
+        // and there was nothing left to check: one refusal still costs exactly one attempt.
+        #expect(runtime.createGroupAttempts == [["npub1alyce", "npub1p0p"]])
+    }
+
+    @MainActor
+    @Test func groupDraftNamesEveryMemberWithoutAKeyPackageInOneAttempt() async throws {
+        // The core reports only the *first* member it can't resolve, so a draft with two of them
+        // used to reveal one per press — the panel claimed a complete answer while naming half of
+        // it. One press now chases every refusal down before anything is created.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1carol"] = Self.carolAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [
+            Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient(),
+        ]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        #expect(state.lastError == nil)
+        #expect(
+            state.unreachableDraftMembers.map(\.accountIdHex)
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex])
+        #expect(state.reachableDraftMembers.map(\.accountIdHex) == [Self.aliceAccountIdHex])
+        // Bob was refused first; the follow-up carries him at the end, which keeps it failing —
+        // so Carol's refusal is learned without any attempt being able to create the group.
+        #expect(
+            runtime.createGroupAttempts == [
+                ["npub1alyce", "npub1p0p", "npub1carol"],
+                ["npub1alyce", "npub1carol", "npub1p0p"],
+            ])
+        #expect(runtime.createdGroupMemberRefs.isEmpty)
+        #expect(state.selection == nil)
+        #expect(state.isNewChatComposerVisible)
+    }
+
+    @MainActor
+    @Test func groupDraftNamesAMemberWhoseRefusalNamesNobody() async throws {
+        // Four picked, three unreachable, and the middle one refused over a KeyPackage that exists
+        // but can't be used — a refusal that names no account. That one used to land on the red
+        // error line while the notice above it counted the two the core *had* named, so the panel
+        // stated two different things about one draft. It is now asked about member by member.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.invalidKeyPackageMemberRefs = ["npub1carol"]
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1dave"] = Self.daveAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [
+            Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient(),
+            Self.daveDraftRecipient(),
+        ]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        #expect(
+            state.unreachableDraftMembers.map(\.accountIdHex)
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex, Self.daveAccountIdHex])
+        #expect(state.reachableDraftMembers.map(\.accountIdHex) == [Self.aliceAccountIdHex])
+        // One notice, one account of the draft: no red line, and nothing left unexplained.
+        #expect(state.lastError == nil)
+        #expect(!state.hasUnnamedGroupDraftRefusal)
+        #expect(runtime.createdGroupMemberRefs.isEmpty)
+        #expect(state.isNewChatComposerVisible)
+
+        await state.createGroupFromDraft()
+        #expect(runtime.createdGroupMemberRefs == ["npub1alyce"])
+        #expect(state.selection == .chat("created-group"))
+    }
+
+    @MainActor
+    @Test func groupDraftSaysSomeoneRatherThanNothingWhenTheFirstRefusalNamesNobody() async throws {
+        // Nothing has been refused yet, so there is no known-unreachable member to ask alongside —
+        // and asking about one member alone would create a chat with them. The panel says what it
+        // knows in the notice it always uses, and never on a second, contradictory line.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.invalidKeyPackageMemberRefs = ["npub1carol"]
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [Self.carolDraftRecipient(), Self.aliceDraftRecipient()]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        #expect(state.hasUnnamedGroupDraftRefusal)
+        #expect(state.unreachableDraftMembers.isEmpty)
+        #expect(state.lastError == nil)
+        #expect(runtime.createGroupAttempts.count == 1)
+        #expect(runtime.createdGroupMemberRefs.isEmpty)
+
+        // Editing the roster is what the notice asks for, so the claim doesn't outlive the draft
+        // it was made about.
+        state.removeNewChatRecipient(Self.carolDraftRecipient())
+        #expect(!state.hasUnnamedGroupDraftRefusal)
+    }
+
+    @MainActor
+    @Test func groupDraftNamesAMemberWhoFailsForSomeOtherReason() async throws {
+        // Not every unreachable member fails as a missing KeyPackage: one with no relay list to
+        // fetch one from fails in a way that reads as a group-wide error. That stopped the search
+        // at the first member, so the panel named one and went quiet about the rest.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.unresolvableMemberRefs = ["npub1carol"]
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [
+            Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient(),
+        ]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        #expect(
+            state.unreachableDraftMembers.map(\.accountIdHex)
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex])
+        #expect(state.reachableDraftMembers.map(\.accountIdHex) == [Self.aliceAccountIdHex])
+        #expect(state.lastError == nil)
+        #expect(!state.hasUnnamedGroupDraftRefusal)
+        #expect(runtime.createdGroupMemberRefs.isEmpty)
+    }
+
+    @MainActor
+    @Test func groupDraftKeepsARealErrorOnTheErrorLineWhenNoMemberOwnsIt() async throws {
+        // The same kind of failure, but this one is about the send rather than a member: asking
+        // about each member reproduces it every time and names no one, so it stays what it is —
+        // an error on the error line, with nobody marked for it.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.createGroupFailure = MarmotKitError.Publish(details: "relay refused")
+        runtime.createGroupFailureAfterAttempts = 1
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [
+            Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient(),
+        ]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        #expect(state.unreachableDraftMembers.map(\.accountIdHex) == [Self.bobAccountIdHex])
+        #expect(
+            state.reachableDraftMembers.map(\.accountIdHex)
+                == [Self.aliceAccountIdHex, Self.carolAccountIdHex])
+        #expect(state.lastError?.contains("relay refused") == true)
+        #expect(!state.hasUnnamedGroupDraftRefusal)
+    }
+
+    @MainActor
+    @Test func groupDraftBlamesNobodyWhenAFailureIsNotAboutAnyMember() async throws {
+        // A refusal that starts *after* the roster resolves — this account, not these people. Every
+        // member-by-member question then comes back unnamed, and marking each one would empty the
+        // group of people who are perfectly reachable.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.createGroupFailure = MarmotKitError.InvalidIdentity(details: "identity rejected")
+        runtime.createGroupFailureAfterAttempts = 1
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [
+            Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient(),
+        ]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        // Bob was named before the account-level failure began; Alice and Carol keep their place,
+        // and the notice reports someone it cannot name rather than convicting them both.
+        #expect(state.hasUnnamedGroupDraftRefusal)
+        #expect(state.unreachableDraftMembers.map(\.accountIdHex) == [Self.bobAccountIdHex])
+        #expect(
+            state.reachableDraftMembers.map(\.accountIdHex)
+                == [Self.aliceAccountIdHex, Self.carolAccountIdHex])
+        #expect(state.lastError == nil)
+        #expect(runtime.createdGroupMemberRefs.isEmpty)
+    }
+
+    @MainActor
+    @Test func groupDraftShowsWhoCantBeAddedOnceRatherThanCountingUpToIt() async throws {
+        // Discovery spends an attempt per refusal, so publishing each one as it lands rendered the
+        // answer growing on screen — one name, then two — which reads as the panel correcting
+        // itself. The press has a single answer and says it when it has all of it.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1carol"] = Self.carolAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [
+            Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient(),
+        ]
+        state.newChatName = "Project Room"
+
+        // What the panel would have been rendering at the start of each attempt.
+        let visible = MidPressMarkCounts()
+        runtime.onMemberResolutionAttempt = { @Sendable in
+            await MainActor.run { visible.counts.append(state.unreachableDraftMembers.count) }
+        }
+        await state.createGroupFromDraft()
+
+        #expect(visible.counts == [0, 0])
+        #expect(
+            state.unreachableDraftMembers.map(\.accountIdHex)
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex])
+    }
+
+    @MainActor
+    @Test func addMembersSheetShowsWhoCantBeAddedOnceRatherThanCountingUpToIt() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1carol"] = Self.carolAccountIdHex
+        let state = try await openInstalledGroupDetails(runtime: runtime)
+        let staged = [Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient()]
+
+        let visible = MidPressMarkCounts()
+        runtime.onMemberResolutionAttempt = { @Sendable in
+            await MainActor.run { visible.counts.append(state.unreachableInviteRecipients(staged).count) }
+        }
+        await state.inviteMembers(staged)
+
+        #expect(visible.counts == [0, 0])
+        #expect(
+            state.unreachableInviteRecipients(staged).map(\.accountIdHex)
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex])
+    }
+
+    @MainActor
+    @Test func groupDraftCreatesTheGroupOnTheNextPressAfterEveryRefusalIsShown() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1carol"] = Self.carolAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [
+            Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient(),
+        ]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+        await state.createGroupFromDraft()
+
+        #expect(runtime.createdGroupMemberRefs == ["npub1alyce"])
+        #expect(state.selection == .chat("created-group"))
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
+    @Test func groupDraftWhereNobodyIsReachableMarksThemAllAndCreatesNothing() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1carol"] = Self.carolAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [Self.bobDraftRecipient(), Self.carolDraftRecipient()]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        #expect(
+            state.unreachableDraftMembers.map(\.accountIdHex)
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex])
+        #expect(state.reachableDraftMembers.isEmpty)
+        #expect(runtime.createdGroupMemberRefs.isEmpty)
+        #expect(state.lastError == nil)
+        #expect(state.isNewChatComposerVisible)
+    }
+
+    @MainActor
+    @Test func groupDraftKeepsAMemberWhoBecomesReachableWhileTheRestAreBeingChecked() async throws {
+        // The pinned member is what keeps a follow-up attempt failing, so the one way a follow-up
+        // can succeed is that they published a KeyPackage between two attempts. They are then in
+        // the group the core just created, and the mark taken moments earlier is stale.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1carol"] = Self.carolAccountIdHex
+        runtime.forgetsMissingKeyPackagesAfterAttempts = 1
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [
+            Self.aliceDraftRecipient(), Self.bobDraftRecipient(), Self.carolDraftRecipient(),
+        ]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        // Everyone the user picked is in the group, Bob included — a follow-up that goes through
+        // carries the pinned member, so it creates the roster the draft asked for rather than one
+        // missing whoever was refused a moment earlier.
+        #expect(runtime.createdGroupMemberRefs == ["npub1alyce", "npub1carol", "npub1p0p"])
+        #expect(state.selection == .chat("created-group"))
+        #expect(state.unreachableDraftMembers.isEmpty)
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
+    @Test func groupDraftRetryExcludesTheNamedMemberAndCreatesTheGroup() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [Self.aliceDraftRecipient(), Self.bobDraftRecipient()]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+        await state.createGroupFromDraft()
+
+        #expect(runtime.createdGroupMemberRefs == ["npub1alyce"])
+        #expect(state.selection == .chat("created-group"))
+        #expect(state.lastError == nil)
+    }
+
+    @MainActor
+    @Test func aMemberAddedAfterARefusalIsCheckedOnTheNextAttempt() async throws {
+        // The core names one refused member per attempt, so the split has to keep up with a draft
+        // that is still being edited. Someone added *after* an earlier refusal carries no mark, so
+        // the next attempt must include them — and refuse them in turn — rather than treating the
+        // roster as settled once the first refusal landed.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1carol"] = Self.carolAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [Self.aliceDraftRecipient(), Self.bobDraftRecipient()]
+        state.newChatName = "Project Room"
+
+        await state.createGroupFromDraft()
+        #expect(state.unreachableDraftMembers.map(\.accountIdHex) == [Self.bobAccountIdHex])
+
+        // Add Carol, who is also unreachable, after Bob was already marked.
+        state.appendNewChatRecipient(Self.carolDraftRecipient())
+        #expect(state.reachableDraftMembers.map(\.accountIdHex) == [Self.aliceAccountIdHex, Self.carolAccountIdHex])
+
+        await state.createGroupFromDraft()
+        #expect(
+            Set(state.unreachableDraftMembers.map(\.accountIdHex))
+                == [Self.bobAccountIdHex, Self.carolAccountIdHex])
+        #expect(runtime.createdGroupMemberRefs.isEmpty)
+
+        // Only once every refusal is known does the attempt go through, with the roster the panel
+        // has been showing all along.
+        await state.createGroupFromDraft()
+        #expect(runtime.createdGroupMemberRefs == ["npub1alyce"])
+        #expect(state.selection == .chat("created-group"))
+    }
+
+    @MainActor
+    @Test func removingARefusedMemberDropsItsMarkWithIt() async throws {
+        // The split is derived from the live roster, so a mark can never outlive the recipient
+        // it belongs to and reappear against someone re-added later.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        let bob = Self.bobDraftRecipient()
+        state.newChatRecipients = [Self.aliceDraftRecipient(), bob]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+        #expect(state.unreachableDraftMembers.count == 1)
+
+        state.removeNewChatRecipient(bob)
+
+        #expect(state.unreachableDraftMembers.isEmpty)
+        #expect(state.reachableDraftMembers.map(\.accountIdHex) == [Self.aliceAccountIdHex])
+    }
+
+    @MainActor
+    @Test func closingTheComposerClearsTheRefusedDraftMembers() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [Self.aliceDraftRecipient(), Self.bobDraftRecipient()]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+        #expect(!state.unreachableDraftMemberIdHexes.isEmpty)
+
+        state.closeNewChatComposer()
+
+        #expect(state.unreachableDraftMemberIdHexes.isEmpty)
+        #expect(state.startChatInvitePrompt == nil)
+    }
+
+    @MainActor
+    @Test func editingTheQueryHidesAStaleInvitePrompt() async throws {
+        // The prompt names the person a previous attempt failed on and renders above the results,
+        // so leaving it up while the user searches for someone else pins "Bob isn't on White
+        // Noise yet" over Alice's row.
+        //
+        // Asserted on the *derived* property with no await in between: the only clear hook
+        // available is the 250 ms debounced resolution, which cancels itself on every keystroke,
+        // so a prompt cleared imperatively would stay on screen for as long as the user keeps
+        // typing — the case that matters most.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        await state.startDirectChat(with: Self.bobDraftRecipient())
+        #expect(state.visibleStartChatInvitePrompt?.accountIdHex == Self.bobAccountIdHex)
+
+        // Mid-typing, before any debounce could fire.
+        state.newChatQuery = "a"
+        #expect(state.visibleStartChatInvitePrompt == nil)
+        state.newChatQuery = "alice"
+        #expect(state.visibleStartChatInvitePrompt == nil)
+
+        // Clearing the field puts the user back where the prompt was raised, and the recipient is
+        // still unreachable, so showing it again is accurate rather than stale.
+        state.newChatQuery = ""
+        #expect(state.visibleStartChatInvitePrompt?.accountIdHex == Self.bobAccountIdHex)
+    }
+
+    @MainActor
+    @Test func aTypedIdentifierInvitePromptBelongsToThatIdentifier() async throws {
+        // Raised from the identifier branch rather than a contact row, so the prompt is scoped to
+        // the npub that produced it and must not survive into a different one.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatQuery = "npub1p0p"
+        await state.startDirectChat(with: Self.bobDraftRecipient())
+        #expect(state.visibleStartChatInvitePrompt?.query == "npub1p0p")
+
+        state.newChatQuery = "npub1carol"
+        #expect(state.visibleStartChatInvitePrompt == nil)
+    }
+
+    @MainActor
+    @Test func groupCreateFailureUnderASupersededAccountStaysOutOfTheNewAccount() async throws {
+        // Issue #229's rule applied to the failure path: `createGroupFromDraft()` suspends across
+        // `createGroup`, so a mid-await A→B switch must not land account A's failure in account
+        // B's context. Asserted on `lastError` specifically because it is the one field the
+        // switch does *not* clear — `closeNewChatComposer()` resets the draft and the prompt, so
+        // only this one can prove the call-site guard is doing the work.
+        let accountA = desktopAccount()
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.createGroupFailure = MarmotKitError.Publish(details: "relay refused")
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == "Desktop Account")
+        state.showNewChat()
+        state.newChatRecipients = [Self.aliceDraftRecipient(), Self.bobDraftRecipient()]
+        state.newChatName = "Project Room"
+
+        runtime.createGroupGateEnabled = true
+        async let pendingCreate: Void = state.createGroupFromDraft()
+        while !runtime.didReachCreateGroupGate {
+            await Task.yield()
+        }
+
+        let backupAccount = try #require(state.accounts.first { $0.id == "Backup Account" })
+        state.selectAccountFromSettings(backupAccount)
+        #expect(state.activeAccountId == "Backup Account")
+
+        runtime.releaseCreateGroupGate()
+        _ = await pendingCreate
+
+        #expect(state.lastError == nil)
+        #expect(state.startChatInvitePrompt == nil)
+        #expect(state.unreachableDraftMemberIdHexes.isEmpty)
+    }
+
+    @MainActor
+    @Test func directChatWithSomeoneNotOnWhiteNoiseOffersAnInviteInsteadOfAnError() async throws {
+        // One recipient means there is no composition left to fix, so the panel drops the error
+        // line entirely and offers the only useful next step.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.missingKeyPackageAccountIdHexByMemberRef["npub1p0p"] = Self.bobAccountIdHex
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        await state.startDirectChat(with: Self.bobDraftRecipient())
+
+        #expect(state.lastError == nil)
+        #expect(state.startChatInvitePrompt?.accountIdHex == Self.bobAccountIdHex)
+        #expect(state.startChatInvitePrompt?.recipientName == "Bob")
+        #expect(state.startChatInvitePrompt?.detail.contains("Bob") == true)
+    }
+
+    @MainActor
+    @Test func groupCreateFailureThatNamesNobodyFallsBackToAnUnnamedMessage() async throws {
+        // `InvalidKeyPackageEvent` carries a detail string, not an account. Marking nobody would
+        // leave the panel unchanged and make the press look like a no-op, so it is reported — in
+        // the notice the panel already uses for this, never as a red line beside it, and never as
+        // the raw `MarmotKitError` dump.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.createGroupFailure = MarmotKitError.InvalidKeyPackageEvent(details: "unsupported ciphersuite")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showNewChat()
+        state.newChatRecipients = [Self.aliceDraftRecipient(), Self.bobDraftRecipient()]
+        state.newChatName = "Project Room"
+        await state.createGroupFromDraft()
+
+        #expect(state.unreachableDraftMembers.isEmpty)
+        #expect(state.hasUnnamedGroupDraftRefusal)
+        #expect(state.lastError == nil)
+    }
+
+    @Test func chatCreationFailureKeepsUnrelatedCoreErrorsIntact() {
+        let failure = ChatCreationFailure(MarmotKitError.Publish(details: "relay refused"))
+        guard case .other(let message) = failure else {
+            Issue.record("expected .other, got \(failure)")
+            return
+        }
+        #expect(message.contains("relay refused"))
+    }
+
+    @Test func chatCreationFailureMatchesTheRefusedRecipientByEitherIdentifier() {
+        let alice = Self.aliceDraftRecipient()
+        #expect(
+            ChatCreationFailure.refusedRecipient(named: Self.aliceAccountIdHex.uppercased(), among: [alice])?
+                .accountIdHex == Self.aliceAccountIdHex)
+        #expect(ChatCreationFailure.refusedRecipient(named: "npub1alyce", among: [alice])?.npub == "npub1alyce")
+        #expect(ChatCreationFailure.refusedRecipient(named: "someone else", among: [alice]) == nil)
+        #expect(ChatCreationFailure.refusedRecipient(named: nil, among: [alice]) == nil)
+    }
+
+    private static let aliceAccountIdHex =
+        "a11ce1234567890aa11ce1234567890aa11ce1234567890aa11ce1234567890a"
+    private static let bobAccountIdHex =
+        "b0b1234567890abb0b1234567890abb0b1234567890abb0b1234567890abb0b1"
+    private static let carolAccountIdHex =
+        "ca401234567890ddca401234567890ddca401234567890ddca401234567890dd"
+
+    private static func aliceDraftRecipient() -> NewChatRecipient {
+        NewChatRecipient(
+            sourceQuery: "npub1alyce",
+            memberRef: "npub1alyce",
+            accountIdHex: aliceAccountIdHex,
+            npub: "npub1alyce",
+            displayName: "Alice",
+            pictureURL: nil
+        )
+    }
+
+    private static func bobDraftRecipient() -> NewChatRecipient {
+        NewChatRecipient(
+            sourceQuery: "npub1p0p",
+            memberRef: "npub1p0p",
+            accountIdHex: bobAccountIdHex,
+            npub: "npub1p0p",
+            displayName: "Bob",
+            pictureURL: nil
+        )
+    }
+
+    private static func carolDraftRecipient() -> NewChatRecipient {
+        NewChatRecipient(
+            sourceQuery: "npub1carol",
+            memberRef: "npub1carol",
+            accountIdHex: carolAccountIdHex,
+            npub: "npub1carol",
+            displayName: "Carol",
+            pictureURL: nil
+        )
+    }
+
+    private static let daveAccountIdHex =
+        "da7e1234567890eeda7e1234567890eeda7e1234567890eeda7e1234567890ee"
+
+    private static func daveDraftRecipient() -> NewChatRecipient {
+        NewChatRecipient(
+            sourceQuery: "npub1dave",
+            memberRef: "npub1dave",
+            accountIdHex: daveAccountIdHex,
+            npub: "npub1dave",
+            displayName: "Dave",
+            pictureURL: nil
+        )
     }
 
     @MainActor
@@ -31566,8 +32305,38 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private var mediaDownloadsByPlaintextSha256: [String: MediaDownloadResultFfi] = [:]
     private var chatListUpdates: [ChatListSubscriptionUpdateFfi] = []
     private(set) var createdGroupMemberRefs: [String] = []
+    /// Every `createGroup` call in order, refused ones included — `createdGroupMemberRefs` records
+    /// only the roster that went through, so it cannot show how a refusal was chased down.
+    private(set) var createGroupAttempts: [[String]] = []
+    /// Run at the top of every member-resolving call, before it refuses or commits. A test can read
+    /// the workspace from here to see what the UI would have been rendering *while* a press is still
+    /// working through the roster.
+    var onMemberResolutionAttempt: (@Sendable () async -> Void)?
     private(set) var createdGroupName: String?
     private(set) var createdGroupDescription: String?
+    /// Member refs the core would refuse for want of a published KeyPackage. `createGroup` mirrors
+    /// the real member-resolution order: it stops at the *first* one it finds in `memberRefs` and
+    /// throws `MissingKeyPackage` naming that account, so a roster with several surfaces them one
+    /// attempt at a time. Keyed by member ref, valued by the account id hex the core reports.
+    var missingKeyPackageAccountIdHexByMemberRef: [String: String] = [:]
+    /// Member refs the core would refuse over a KeyPackage that exists but cannot be used. Unlike
+    /// `missingKeyPackageAccountIdHexByMemberRef`, `InvalidKeyPackageEvent` names no account, so a
+    /// roster containing one of these is refused without saying who is at fault. Resolution order
+    /// is shared with the missing-KeyPackage set: whichever comes first in `memberRefs` wins.
+    var invalidKeyPackageMemberRefs: Set<String> = []
+    /// Member refs whose resolution fails in a way that has nothing to do with KeyPackages — a
+    /// person with no relay list to fetch one from, say. Shares the same resolution order: an error
+    /// like this still stops the whole create at the member it belongs to.
+    var unresolvableMemberRefs: Set<String> = []
+    /// Thrown by `createGroup` regardless of the roster, for failures that name nobody.
+    var createGroupFailure: Error?
+    /// Holds `createGroupFailure` back until this many attempts have been made, posing as a failure
+    /// that is about the account rather than any member and only starts once resolution gets past
+    /// the roster.
+    var createGroupFailureAfterAttempts = 0
+    /// Forgets every missing KeyPackage once this many `createGroup` attempts have been made, posing
+    /// as a member who publishes one *between* two attempts of the same press.
+    var forgetsMissingKeyPackagesAfterAttempts: Int?
     private(set) var repliedMessage: SentReply?
     private(set) var reactedMessage: SentReaction?
     private(set) var deletedMessage: DeletedMessage?
@@ -31681,6 +32450,9 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     private(set) var declinedInviteGroupIds: [String] = []
     private(set) var declineGroupInviteCallCount = 0
     private(set) var invitedMemberRefs: [String] = []
+    /// Every invite call in order, refused ones included — `invitedMemberRefs` records only the
+    /// roster that committed, so it cannot show how a refusal was chased down.
+    private(set) var inviteMemberRefAttempts: [[String]] = []
     private(set) var inviteMembersDetailedCallCount = 0
     private(set) var promotedAdminRef: String?
     private(set) var promoteAdminDetailedCallCount = 0
@@ -32702,6 +33474,39 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     func createGroup(accountRef: String, name: String, memberRefs: [String], description: String?) async throws
         -> String
     {
+        createGroupAttempts.append(memberRefs)
+        await onMemberResolutionAttempt?()
+        if let forgetsMissingKeyPackagesAfterAttempts,
+            createGroupAttempts.count > forgetsMissingKeyPackagesAfterAttempts
+        {
+            missingKeyPackageAccountIdHexByMemberRef = [:]
+        }
+        // Member resolution runs in list order and stops at the first member it can't resolve,
+        // whichever way that member fails.
+        let refusedMemberRef = memberRefs.first {
+            missingKeyPackageAccountIdHexByMemberRef[$0] != nil || invalidKeyPackageMemberRefs.contains($0)
+                || unresolvableMemberRefs.contains($0)
+        }
+        let pendingFailure =
+            createGroupAttempts.count > createGroupFailureAfterAttempts ? createGroupFailure : nil
+        if pendingFailure != nil || refusedMemberRef != nil {
+            // Pass the gate before throwing so a test can hold a *failing* create in flight and
+            // switch accounts under it. Deliberately ahead of every mutation below, so a refused
+            // create still records nothing — the success path keeps its own gate at the end.
+            await createGroupGate.passIfArmed()
+            if let pendingFailure {
+                throw pendingFailure
+            }
+            if let refusedMemberRef {
+                if let accountIdHex = missingKeyPackageAccountIdHexByMemberRef[refusedMemberRef] {
+                    throw MarmotKitError.MissingKeyPackage(account: accountIdHex)
+                }
+                if unresolvableMemberRefs.contains(refusedMemberRef) {
+                    throw MarmotKitError.Publish(details: "no relay list for member")
+                }
+                throw MarmotKitError.InvalidKeyPackageEvent(details: "unusable key package event")
+            }
+        }
         createdGroupMemberRefs = memberRefs
         createdGroupName = name
         createdGroupDescription = description
@@ -32811,6 +33616,18 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     {
         inviteMembersDetailedCallCount += 1
         await groupMutationGate.passIfArmed()
+        inviteMemberRefAttempts.append(memberRefs)
+        await onMemberResolutionAttempt?()
+        // Invites resolve every member's KeyPackage before committing anything and stop at the
+        // first one they can't, exactly as `createGroup` does.
+        if let refusedMemberRef = memberRefs.first(where: {
+            missingKeyPackageAccountIdHexByMemberRef[$0] != nil || invalidKeyPackageMemberRefs.contains($0)
+        }) {
+            if let accountIdHex = missingKeyPackageAccountIdHexByMemberRef[refusedMemberRef] {
+                throw MarmotKitError.MissingKeyPackage(account: accountIdHex)
+            }
+            throw MarmotKitError.InvalidKeyPackageEvent(details: "unusable key package event")
+        }
         invitedMemberRefs = memberRefs
         guard var details = groupDetailsById[groupIdHex] else {
             throw FakeMarmotRuntimeError.unused


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance when chat invitations cannot be completed.
  * Group creation now identifies unavailable members, lets you invite them, and supports creating groups with reachable members only.
  * Direct-chat attempts can display an invitation prompt for people not yet on White Noise.
  * Added localized messaging, including singular and plural forms across supported languages.

* **Bug Fixes**
  * Improved invite failure handling and retry behavior without creating partial groups.
  * Draft and composer state now reset correctly after failed or canceled chat creation.
  * Prevented stale invitation prompts and unavailable-member indicators from appearing during new chat flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->