### PR TITLE
Show group name in 2 member groups

### DIFF
--- a/whitenoise-mac/Core/MarmotMapping.swift
+++ b/whitenoise-mac/Core/MarmotMapping.swift
@@ -58,9 +58,20 @@ extension ChatItem {
         lastSenderNickname: String? = nil
     ) {
         let groupName = PeerDisplayText.sanitize(row.groupName) ?? ""
-        let peerName = PeerDisplayText.sanitize(directPeer?.displayName)
+        // MDK classifies any conversation carrying a group name as a group whatever its member
+        // count (`conversation_kind`: a non-blank name returns `Group` before member count is even
+        // consulted). Naming a two-person chat is the user saying "this is the group Book club",
+        // not "this is my DM with Alice" — so a named row drops the direct-peer projection its
+        // one-other-member roster resolves, which would otherwise win `resolvedTitle` and replace
+        // the name they typed with the other member's name.
+        //
+        // Keyed on the name rather than on `.group`: MDK also reports `.group` for a conversation
+        // whose roster has emptied out, and that case is exactly where the remembered/recovered
+        // peer is the only thing left that can name the chat.
+        let peer = groupName.isEmpty ? directPeer : nil
+        let peerName = PeerDisplayText.sanitize(peer?.displayName)
         let projectedTitle = PeerDisplayText.sanitize(row.title) ?? ""
-        let fallbackId = directPeer?.accountIdHex ?? row.groupIdHex
+        let fallbackId = peer?.accountIdHex ?? row.groupIdHex
         let title = Self.resolvedTitle(
             peerName: peerName,
             projectedTitle: projectedTitle,
@@ -68,7 +79,7 @@ extension ChatItem {
             fallbackId: fallbackId
         )
 
-        let publishedTitle = directPeer?.publishedDisplayName?.nilIfBlank.map { peerPublishedName in
+        let publishedTitle = peer?.publishedDisplayName?.nilIfBlank.map { peerPublishedName in
             Self.resolvedTitle(
                 peerName: PeerDisplayText.sanitize(peerPublishedName),
                 projectedTitle: projectedTitle,
@@ -88,7 +99,7 @@ extension ChatItem {
         // writes and must not make a conversation jump in the sidebar.
         let timestamp = row.activitySortAt > 0 ? row.activitySortAt : row.conversationCreatedAt
         let updatedAt = timestamp > 0 ? Date(timeIntervalSince1970: TimeInterval(timestamp)) : nil
-        let isDirect = row.conversationKind == .direct || directPeer != nil
+        let isDirect = row.conversationKind == .direct || peer != nil
         let subtitle: String
         if row.archived {
             subtitle = L10n.string("Archived")
@@ -111,8 +122,8 @@ extension ChatItem {
             previewAttachmentKind: preview?.attachmentKind,
             previewAttribution: preview?.attribution,
             updatedAt: updatedAt,
-            avatarSeed: directPeer?.accountIdHex ?? row.groupIdHex,
-            pictureURL: directPeer?.pictureURL ?? groupAvatarURL,
+            avatarSeed: peer?.accountIdHex ?? row.groupIdHex,
+            pictureURL: peer?.pictureURL ?? groupAvatarURL,
             groupImagePayload: isDirect ? nil : groupImagePayload,
             groupImageHashHex: isDirect ? nil : row.avatar?.imageHashHex.nilIfBlank,
             unreadCount: Int(clamping: row.unreadCount),

--- a/whitenoise-mac/Core/WorkspaceState+ChatList.swift
+++ b/whitenoise-mac/Core/WorkspaceState+ChatList.swift
@@ -725,15 +725,29 @@ extension WorkspaceState {
                 from: members,
                 nicknames: contactNicknames(forOwnerAccountIdHex: account.accountIdHex)
             )
-            directPeer = await directPeerProfile(
-                from: members,
-                groupIdHex: row.groupIdHex,
-                activeAccount: account,
-                client: client
-            )
+            // A named conversation is a group however few members it has, so it takes no peer
+            // projection — `ChatItem.init(row:)` drops one anyway. Skipping the resolve here also
+            // saves the profile FFI hop and keeps `directPeerProfile` from recording a remembered
+            // peer for a named group, which a later rename to a blank name could resurface as the
+            // title.
+            let isNamedConversation = PeerDisplayText.sanitize(row.groupName) != nil
+            if isNamedConversation {
+                // Naming the conversation is what makes it a group, so a peer remembered from when
+                // it held two people no longer describes it. Dropped here for the same reason
+                // `directPeerProfile` drops one when the roster grows: clearing the name later must
+                // not resurface that peer as the title. A no-op when nothing was recorded.
+                forgetDirectPeer(groupIdHex: row.groupIdHex, accountId: account.id)
+            } else {
+                directPeer = await directPeerProfile(
+                    from: members,
+                    groupIdHex: row.groupIdHex,
+                    activeAccount: account,
+                    client: client
+                )
+            }
             if directPeer == nil,
-                Self.otherMembers(in: members, activeAccount: account).isEmpty,
-                PeerDisplayText.sanitize(row.groupName) == nil
+                !isNamedConversation,
+                Self.otherMembers(in: members, activeAccount: account).isEmpty
             {
                 // Nobody is left to name this conversation and it never had a group name, so MDK
                 // projects the shortened group id as its title. Fall back to whoever this chat was

--- a/whitenoise-mac/Core/WorkspaceState+PeerProfiles.swift
+++ b/whitenoise-mac/Core/WorkspaceState+PeerProfiles.swift
@@ -430,6 +430,13 @@ extension WorkspaceState {
                 // FFI resolve per group row on every pass is the cost this guard removes.
                 guard Self.otherMembers(in: members, activeAccount: account).count == 1 else { continue }
 
+                // A named two-person conversation is a group (MDK's `conversation_kind`), and its
+                // title is the name its members gave it — projecting a peer profile onto it would
+                // put the other member's name back over that name on every profile refresh. Rows
+                // whose kind MDK did not supply stay eligible, since they are the legacy
+                // roster-enriched ones this pass exists for.
+                guard chat.isDirect || !chat.hasAuthoritativeConversationKind else { continue }
+
                 // `readStateMetadataEnrichmentAttempts` is a permanent per-group "tried once"
                 // flag, so a group whose single enrichment pass ran before this peer's
                 // metadata landed could never re-enrich from the read-state path. Clearing it

--- a/whitenoise-macTests/MarmotKitFixtureCompatibility.swift
+++ b/whitenoise-macTests/MarmotKitFixtureCompatibility.swift
@@ -159,7 +159,8 @@ nonisolated extension ChatListRowFfi {
         lastReadTimelineAt: UInt64?,
         updatedAt: UInt64,
         selfMembership: SelfMembershipFfi,
-        leaveRequestPending: Bool = false
+        leaveRequestPending: Bool = false,
+        conversationKind: ChatConversationKindFfi? = nil
     ) {
         let previewTimelineAt = lastMessage?.timelineAt ?? 0
         let activitySortAt = previewTimelineAt > 0 ? previewTimelineAt : updatedAt
@@ -189,7 +190,11 @@ nonisolated extension ChatListRowFfi {
             activitySortAt: activitySortAt,
             updatedAt: updatedAt,
             selfMembership: selfMembership,
-            conversationKind: .unknown,
+            // Mirrors mdk's `conversation_kind`: a non-blank group name is a group before the
+            // member count is even consulted. A blank name stays `.unknown` here because this
+            // shim carries no member count — which is what mdk returns in that case too.
+            conversationKind: conversationKind
+                ?? (groupName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .unknown : .group),
             muted: false,
             mutedUntilMs: nil,
             leaveRequestPending: leaveRequestPending,

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -1154,6 +1154,66 @@ struct PureValueTests {
         #expect(own.relabelingPreviewSender(accountIdHex: "self", nickname: "Me") == own)
     }
 
+    /// A conversation the user named keeps that name even when it has exactly one other member.
+    ///
+    /// The roster of a two-person group resolves a direct peer, and that peer's profile used to win
+    /// the row title — so a group created as "Book club" with one other member came back titled
+    /// "Alice". mdk classifies any named conversation as a group whatever its member count, and the
+    /// name the user typed is the whole point of having typed it.
+    @Test func namedTwoMemberGroupKeepsItsNameOverTheOtherMembersProfile() async throws {
+        let selfIdHex = String(repeating: "5", count: 64)
+        let peer = ChatPeerProfile(
+            accountIdHex: aliceIdHex,
+            displayName: "Alice",
+            pictureURL: "https://example.com/alice.png"
+        )
+
+        let named = ChatItem(
+            row: chatRow(groupName: "Book club", sender: aliceIdHex, senderDisplayName: "Alice", plaintext: "Hi"),
+            activeAccountIdHex: selfIdHex,
+            directPeer: peer,
+            groupAvatarURL: "https://example.com/group.png"
+        )
+
+        #expect(named.title == "Book club")
+        #expect(!named.isDirect)
+        #expect(named.subtitle == "Book club")
+        // The group's own avatar, not the other member's: seeded by group id so the initials
+        // fallback draws the group name, and picturing the peer would read as a DM.
+        #expect(named.avatarSeed == "group")
+        #expect(named.pictureURL == "https://example.com/group.png")
+        // Nothing to reveal behind a private label, because no peer name is on display.
+        #expect(named.publishedTitle == nil)
+        #expect(named.directPeerAccountIdHex == nil)
+
+        // A private nickname for that member cannot retitle it either.
+        let nicknamed = ChatItem(
+            row: chatRow(groupName: "Book club", sender: aliceIdHex, senderDisplayName: "Alice", plaintext: "Hi"),
+            activeAccountIdHex: selfIdHex,
+            directPeer: ChatPeerProfile(
+                accountIdHex: aliceIdHex,
+                displayName: "Mum",
+                publishedDisplayName: "Alice",
+                pictureURL: nil
+            )
+        )
+        #expect(nicknamed.title == "Book club")
+        #expect(nicknamed.publishedTitle == nil)
+
+        // A real DM carries no name of its own, so the peer is still the only thing that titles it.
+        let direct = ChatItem(
+            row: chatRow(groupName: "", sender: aliceIdHex, senderDisplayName: "Alice", plaintext: "Hi"),
+            activeAccountIdHex: selfIdHex,
+            directPeer: peer
+        )
+        #expect(direct.title == "Alice")
+        #expect(direct.isDirect)
+        #expect(direct.subtitle == L10n.string("Direct message"))
+        #expect(direct.avatarSeed == aliceIdHex)
+        #expect(direct.pictureURL == "https://example.com/alice.png")
+        #expect(direct.directPeerAccountIdHex == aliceIdHex)
+    }
+
     @Test func chatListRowClampsOversizedUnreadCounts() async throws {
         // Regression for whitenoise-mac#242: unread counts cross the FFI boundary as
         // UInt64, and Int(value) traps above Int.max while mapping the chat list.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -19178,6 +19178,71 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func namedGroupWithOneOtherMemberKeepsItsNameThroughEnrichment() async throws {
+        // Regression: naming a chat with a single other member left it titled with that member's
+        // name. Chat-list enrichment resolves a direct peer for any two-person roster, and the peer
+        // projection outranked the group name — so "Book club" came back as "Alice Actual". mdk
+        // classifies a named conversation as a group whatever its member count, and the name the
+        // user typed is what the row has to say.
+        let account = desktopAccount()
+        let aliceId = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("whitenoise-named-group-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        let store = DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory)
+
+        // A record left from an era when this conversation was a nameless two-person chat. Naming it
+        // makes the record wrong, so enrichment has to drop it — otherwise clearing the name later
+        // would put Alice back in the title.
+        try store.write(
+            ["book-club": RememberedDirectPeer(accountIdHex: aliceId, displayName: "Alice Actual", pictureURL: nil)],
+            forAccountId: account.label
+        )
+
+        var namedGroup = messageGroup()
+        namedGroup.groupIdHex = "book-club"
+        namedGroup.name = "Book club"
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installDirectGroup(
+            namedGroup,
+            selfAccountIdHex: account.accountIdHex,
+            otherAccountIdHex: aliceId,
+            otherDisplayName: "Alice Cached",
+            otherProfile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Actual",
+                about: nil,
+                picture: "https://example.com/alice.png",
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(directPeerMemoryStore: store, clientFactory: { runtime })
+
+        await state.bootstrap()
+        // The roster fetch is the enrichment pass this test is about, so wait for it rather than
+        // for a title change — with the fix there is no change to observe.
+        let didEnrich = await waitFor { (runtime.groupDetailsCallCounts["book-club"] ?? 0) >= 1 }
+        #expect(didEnrich)
+        // Bounded negative check: the buggy path retitles the row from the peer profile.
+        let didRetitleFromPeer = await waitFor { state.activeChats.first?.title == "Alice Actual" }
+        #expect(!didRetitleFromPeer)
+
+        let chat = try #require(state.activeChats.first)
+        #expect(chat.title == "Book club")
+        #expect(chat.isDirect == false)
+        #expect(chat.subtitle == "Book club")
+        #expect(chat.avatarSeed == "book-club")
+        #expect(chat.pictureURL == nil)
+        // No peer was recorded either: a remembered peer for a named group would resurface as its
+        // title the moment the roster emptied out.
+        let accountId = try #require(state.activeAccountId)
+        #expect(try store.loadAll()[accountId]?["book-club"] == nil)
+        #expect(!runtime.refreshedProfileIds.contains(aliceId))
+    }
+
+    @MainActor
     @Test func newLastMessageChatRowPreservesDirectChatMetadataWithoutReenrichment() async throws {
         // Regression for #40/#251: a `.newLastMessage` single-row delta is metadata-invariant,
         // so it takes the `shouldEnrich: false` fast path (no per-row FFI fan-out). The
@@ -19498,8 +19563,13 @@ struct whitenoise_macTests {
         let store = DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory)
 
         let runtime = FakeMarmotRuntime(accounts: [account])
+        // The conversation is nameless while it holds two people — that is the only shape that is
+        // titled from a peer, and so the only one that records one. It is named in the second phase
+        // below, which is the sequence a real group takes to get here.
+        var namelessGroup = messageGroup()
+        namelessGroup.name = ""
         runtime.installDirectGroup(
-            messageGroup(),
+            namelessGroup,
             selfAccountIdHex: account.accountIdHex,
             otherAccountIdHex: aliceId,
             otherDisplayName: "Alice Cached",
@@ -19553,8 +19623,12 @@ struct whitenoise_macTests {
         let store = DirectPeerMemoryFileStore(fileManager: fileManager, directoryURL: directory)
 
         let runtime = FakeMarmotRuntime(accounts: [account])
+        // Nameless while it is a two-person chat: only that shape is titled from a peer, and so only
+        // that shape records one for the growth below to drop.
+        var namelessGroup = messageGroup()
+        namelessGroup.name = ""
         runtime.installDirectGroup(
-            messageGroup(),
+            namelessGroup,
             selfAccountIdHex: account.accountIdHex,
             otherAccountIdHex: aliceId,
             otherDisplayName: "Alice Cached",


### PR DESCRIPTION
When I created a group with just one person (2 members, me and the other person), despite adding a name, the group is shown with the other person name (like a DM). This PR fixes that.