### PR TITLE
Open the inviter's profile from a pending invite

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+PendingInviteInviter.swift
+++ b/whitenoise-mac/Core/WorkspaceState+PendingInviteInviter.swift
@@ -1,0 +1,75 @@
+//
+//  WorkspaceState+PendingInviteInviter.swift
+//  whitenoise-mac
+//
+//  The identity behind the name in a pending invite: whose avatar the notice draws, and whose
+//  profile it opens when that avatar is clicked.
+//
+//  Naming the inviter is `inviterDisplayName(forGroupIdHex:)`'s job, and the notice keeps it —
+//  this only answers "who is that, exactly", which a name cannot: the avatar to draw, and the
+//  npub the contact pane needs so the invitee can compare a key before accepting rather than
+//  taking a display name at face value.
+//
+//  Everything here reads caches the invite has already filled. `groupWelcomerCache` and
+//  `groupMemberDetailsCache` are written together by `storeGroupMembers`, which the notice's
+//  `ensureGroupInviterLoaded` triggers, and the picture comes from the observed peer-profile
+//  cache the roster's kind:0 pull populates — so a profile that lands after the notice is drawn
+//  reaches the avatar without re-projecting anything.
+//
+
+import Foundation
+import MarmotKit
+
+@MainActor
+extension WorkspaceState {
+    /// Who sent a pending invite, in the terms an avatar and a profile need.
+    struct PendingInviteInviterIdentity: Hashable {
+        let accountIdHex: String
+        /// Empty until the roster resolves; the contact pane falls back to the hex key.
+        let npub: String
+        let pictureURL: String?
+        /// Already through `RemoteImageURLPolicy`; the view still applies `loadRemoteImages`.
+        let sanitizedPictureURL: URL?
+    }
+
+    /// The inviter of `chat`, or nil when this is not a pending invite, when nobody is recorded
+    /// as having sent it, or when the invite came from this account (nothing to look up).
+    ///
+    /// The direct-chat fallback matches how the notice names an inviter it has no welcomer for:
+    /// a one-to-one has exactly one other member, so they are the person who invited you.
+    func pendingInviteInviterIdentity(for chat: ChatItem) -> PendingInviteInviterIdentity? {
+        guard chat.pendingConfirmation else { return nil }
+        let welcomer = inviterAccountIdHex(forGroupIdHex: chat.id)
+        guard let accountIdHex = (welcomer ?? chat.directPeerAccountIdHex)?.nilIfBlank,
+            accountIdHex != activeAccount?.accountIdHex
+        else { return nil }
+
+        let member = groupMemberDetailsCache[chat.id]?.first { $0.memberIdHex == accountIdHex }
+        let pictureURL = peerProfileFFICache[accountIdHex]?.resolved.profilePicture
+        return PendingInviteInviterIdentity(
+            accountIdHex: accountIdHex,
+            npub: member?.npub.nilIfBlank ?? "",
+            pictureURL: pictureURL,
+            sanitizedPictureURL: RemoteImageURLPolicy.sanitizedURL(from: pictureURL)
+        )
+    }
+
+    /// Opens the inviter's profile, the way a group-details member row or a message avatar does.
+    ///
+    /// `name` is what the notice calls them, so the pane opens on the name the user just read
+    /// rather than blanking until the profile re-resolves.
+    func showContactDetails(
+        for inviter: PendingInviteInviterIdentity,
+        named name: String,
+        invitedTo chat: ChatItem
+    ) async {
+        await showContactDetails(
+            accountIdHex: inviter.accountIdHex,
+            npub: inviter.npub,
+            displayName: name,
+            pictureURL: inviter.pictureURL,
+            // The invite has not been accepted, so the group it is for is not a group in common.
+            excludingGroupIdHex: chat.id
+        )
+    }
+}

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -1464,11 +1464,20 @@ struct PendingGroupInviteComposerNotice: View {
     let chat: ChatItem
 
     var body: some View {
+        let inviter = workspace.pendingInviteInviterIdentity(for: chat)
+
         VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .firstTextBaseline, spacing: 10) {
-                Image(systemName: "lock.shield.fill")
-                    .wnFont(.semiBold14)
-                    .foregroundStyle(WNColor.intentionInfoContent)
+            // Once the inviter resolves, their avatar leads the notice and opens their profile:
+            // the invitee's one chance to check who this is — npub included — before answering.
+            // The lock stands in until then, so the row never has an empty leading slot.
+            HStack(alignment: inviter == nil ? .firstTextBaseline : .center, spacing: 10) {
+                if let inviter {
+                    PendingInviteInviterAvatar(chat: chat, inviter: inviter, name: inviterName)
+                } else {
+                    Image(systemName: "lock.shield.fill")
+                        .wnFont(.semiBold14)
+                        .foregroundStyle(WNColor.intentionInfoContent)
+                }
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text(inviteMessage)
@@ -1576,6 +1585,43 @@ struct PendingGroupInviteComposerNotice: View {
             candidate != chat.title
         else { return nil }
         return candidate
+    }
+}
+
+/// The inviter's avatar in the pending-invite notice, opening their profile.
+///
+/// Drawn and wired like the transcript's sender avatar — same control, same contact pane — so
+/// "the picture beside a name is how you look that person up" holds here too. A touch larger
+/// than the transcript's 28pt, because here it stands beside the notice's two lines of text.
+///
+/// `name` is the notice's own `inviterName`, so the avatar's monogram and label always read as
+/// the sentence beside them, whichever rung of that ladder answered.
+private struct PendingInviteInviterAvatar: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let chat: ChatItem
+    let inviter: WorkspaceState.PendingInviteInviterIdentity
+    let name: String
+
+    var body: some View {
+        Button {
+            Task { await workspace.showContactDetails(for: inviter, named: name, invitedTo: chat) }
+        } label: {
+            ProfileImageAvatarView(
+                seed: inviter.accountIdHex,
+                initials: name,
+                sanitizedPictureURL: inviter.sanitizedPictureURL,
+                size: 32,
+                isSelected: false
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(viewContactLabel)
+        .accessibilityIdentifier("composer.pendingGroupInvite.inviter")
+        .help(viewContactLabel)
+    }
+
+    private var viewContactLabel: String {
+        String(format: L10n.string("View contact %@"), name)
     }
 }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -2466,6 +2466,62 @@ struct PureValueTests {
         #expect(state.inviterAccountIdHex(forGroupIdHex: "group") == nil)
     }
 
+    /// Naming the inviter is one thing; being able to check who they actually are is another.
+    /// The avatar in the invite prompt opens their profile, and that needs the npub — the whole
+    /// point of looking before accepting is comparing a key rather than trusting a display name.
+    @MainActor
+    @Test func pendingInviteInviterIdentityCarriesTheNpubTheProfileNeeds() async throws {
+        let welcomer = "alice1234567890alice1234567890alice1234567890alice12345678"
+        let state = WorkspaceState(
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+        let invite = pendingInviteChat(id: "group")
+        state.storeGroupMembers(
+            [mentionMember(id: welcomer, displayName: "Alice", npub: "npub1alice")],
+            welcomerAccountIdHex: welcomer,
+            for: "group"
+        )
+
+        let identity = try #require(state.pendingInviteInviterIdentity(for: invite))
+        #expect(identity.accountIdHex == welcomer)
+        #expect(identity.npub == "npub1alice")
+
+        // An answered invite has no inviter to offer: an accepted group is just a group.
+        let accepted = pendingInviteChat(id: "group", pendingConfirmation: false)
+        #expect(state.pendingInviteInviterIdentity(for: accepted) == nil)
+    }
+
+    /// A record that kept no welcome sender still has an inviter in a one-to-one: the single
+    /// other member. This is the same fallback the prompt's own name ladder makes, so the avatar
+    /// cannot end up naming one person and opening another.
+    @MainActor
+    @Test func pendingDirectInviteFallsBackToThePeerAsInviter() async throws {
+        let peer = "bob1234567890bob1234567890bob1234567890bob1234567890bob123"
+        let state = WorkspaceState(
+            localNotificationCenter: NoopLocalNotificationCenter(),
+            appActivityProvider: { false },
+            conversationWindowVisibilityProvider: { false }
+        )
+        let invite = pendingInviteChat(id: "direct-group", avatarSeed: peer, isDirect: true)
+        state.storeGroupMembers(
+            [mentionMember(id: peer, displayName: "Bob", npub: "npub1bob")],
+            welcomerAccountIdHex: nil,
+            for: "direct-group"
+        )
+
+        #expect(state.inviterAccountIdHex(forGroupIdHex: "direct-group") == nil)
+        let identity = try #require(state.pendingInviteInviterIdentity(for: invite))
+        #expect(identity.accountIdHex == peer)
+        #expect(identity.npub == "npub1bob")
+
+        // A direct chat whose peer has not resolved seeds `avatarSeed` with the group id, which
+        // is nobody — offering that as a profile would open a page for a group id.
+        let unresolved = pendingInviteChat(id: "direct-group", avatarSeed: "direct-group", isDirect: true)
+        #expect(state.pendingInviteInviterIdentity(for: unresolved) == nil)
+    }
+
     @Test func remoteImageSanitizedURLRejectsPrivateHosts() async throws {
         // The string entry point used by the UI must also reject internal destinations.
         #expect(RemoteImageURLPolicy.sanitizedURL(from: "https://192.168.1.1/x.png") == nil)
@@ -5140,6 +5196,27 @@ private func mentionMember(
         isSelf: isSelf,
         npub: npub,
         displayName: displayName
+    )
+}
+
+/// A chat row for an invite nobody has answered yet — the state the invite prompt draws in.
+private func pendingInviteChat(
+    id: String,
+    avatarSeed: String? = nil,
+    isDirect: Bool = false,
+    pendingConfirmation: Bool = true
+) -> ChatItem {
+    ChatItem(
+        id: id,
+        title: "Test Group",
+        subtitle: "",
+        preview: "",
+        updatedAt: nil,
+        avatarSeed: avatarSeed ?? id,
+        pictureURL: nil,
+        unreadCount: 0,
+        isDirect: isDirect,
+        pendingConfirmation: pendingConfirmation
     )
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -22511,6 +22511,58 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func pendingInviteAvatarOpensTheInvitersProfileWithTheirNpub() async throws {
+        // End to end for the invite prompt's avatar: the roster read that names the inviter also
+        // has to leave enough behind to *open* them — the npub above all, since checking the key
+        // is why someone looks at a profile before accepting an invite from a name they may not
+        // recognise.
+        let account = desktopAccount()
+        let aliceIdHex = "alice1234567890alice1234567890alice1234567890alice1234567890"
+        var details = groupDetailsFixture(selfAccountIdHex: account.accountIdHex)
+        details.group.pendingConfirmation = true
+        details.group.welcomerAccountIdHex = aliceIdHex
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(details)
+        runtime.installProfile(
+            accountIdHex: aliceIdHex,
+            profile: UserProfileMetadataFfi(
+                name: "alice",
+                displayName: "Alice Inviter",
+                about: nil,
+                picture: "https://example.com/alice.png",
+                nip05: nil,
+                lud16: nil
+            )
+        )
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        let groupChat = try #require(state.activeChats.first)
+        #expect(groupChat.pendingConfirmation)
+
+        _ = await state.cachedGroupMembers(
+            groupIdHex: groupChat.id,
+            account: try #require(state.activeAccount),
+            client: runtime
+        )
+        await state.settlePeerProfileRefreshQueueForTesting()
+
+        let inviter = try #require(state.pendingInviteInviterIdentity(for: groupChat))
+        #expect(inviter.accountIdHex == aliceIdHex)
+        #expect(inviter.npub == "npub1alyce")
+        // The avatar draws the published picture, so it is recognisably them and not a monogram.
+        #expect(inviter.sanitizedPictureURL == URL(string: "https://example.com/alice.png"))
+
+        let name = try #require(state.inviterDisplayName(forGroupIdHex: groupChat.id))
+        await state.showContactDetails(for: inviter, named: name, invitedTo: groupChat)
+
+        let target = try #require(state.contactDetailsTarget)
+        #expect(target.accountIdHex == aliceIdHex)
+        #expect(target.npub == "npub1alyce")
+        #expect(target.displayName == "Alice Inviter")
+    }
+
+    @MainActor
     @Test func acceptGroupInviteDropsOverlappingDuplicateAfterClosingDetails() async throws {
         let account = desktopAccount()
         var details = groupDetailsFixture(selfAccountIdHex: account.accountIdHex)


### PR DESCRIPTION
Currently the name of the inviter is shown "X invited you.." but there is no easy way to access to the profile from that message. Now that changed to show the avatar and when clicking it it redirects to a profile sheet