### PR TITLE
Show success toasts on copy

### DIFF
--- a/whitenoise-mac/ContentView.swift
+++ b/whitenoise-mac/ContentView.swift
@@ -30,6 +30,10 @@ struct ContentView: View {
             // Attached here, not on the conversation pane: a chat-list delete is most likely with
             // no chat selected, and the sidebar row menu cannot host its own dialog.
             .chatDestructiveActionsConfirmation()
+            // The window-wide surface for quiet successes (copies, above all). Sheets that host
+            // one of those actions install their own surface on top of this one, because a sheet
+            // draws above every part of its parent window.
+            .successToastSurface(workspace.successToasts)
             // App-wide default: static text is selectable, so anything on screen — a startup
             // failure message, a relay URL, an npub, a profile field — can be selected and
             // copied without the view having to opt in. `.textSelection` propagates through the

--- a/whitenoise-mac/Core/SuccessToastPresenter.swift
+++ b/whitenoise-mac/Core/SuccessToastPresenter.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Transient success feedback for an action whose only other evidence is invisible — a pasteboard
+/// write, above all. macOS raises no system-level confirmation when an app writes to the
+/// pasteboard, so without this the user cannot tell a copy that landed from a click that missed.
+///
+/// Mirrors the Flutter client's `WnSystemNotice` in its temporary variant: a second action replaces
+/// the notice in place rather than queueing behind it, and the notice clears itself after
+/// `defaultDuration`.
+///
+/// State lives here rather than in the view for two reasons. The auto-hide window is unit-testable
+/// this way; and an action buried in a context menu or an overflow popover — neither of which
+/// reliably inherits an injected environment value in this app — can raise a notice that a
+/// container several levels up draws.
+@Observable
+final class SuccessToastPresenter {
+    /// How long a notice stays up. Matches the Flutter client's temporary-notice auto-hide window.
+    static let defaultDuration = Duration.seconds(3)
+
+    /// The notice on screen, or `nil` when nothing is showing.
+    private(set) var message: String?
+
+    /// Containers that can draw a notice, in the order they installed themselves.
+    ///
+    /// Only the last one draws. A sheet installs its own surface on top of the window's, and macOS
+    /// draws a sheet in a child window above every part of its parent — so without this ordering a
+    /// copy made inside a sheet would paint the toast twice: once inside the sheet and once on the
+    /// window behind it, where the sheet does not cover it.
+    private(set) var surfaces: [UUID] = []
+
+    private let duration: Duration
+    private var dismissTask: Task<Void, Never>?
+
+    init(duration: Duration = SuccessToastPresenter.defaultDuration) {
+        self.duration = duration
+    }
+
+    /// The surface responsible for drawing the current notice: the most recently installed one.
+    var drawingSurface: UUID? { surfaces.last }
+
+    /// Shows `message` and schedules its clear. A second call restarts the window rather than
+    /// letting the earlier call's pending clear blank the newer notice out from under the user.
+    func show(_ message: String) {
+        dismissTask?.cancel()
+        self.message = message
+        dismissTask = Task { [duration] in
+            try? await Task.sleep(for: duration)
+            guard !Task.isCancelled else { return }
+            self.message = nil
+        }
+    }
+
+    /// Clears the notice now, cancelling any pending auto-hide.
+    func dismiss() {
+        dismissTask?.cancel()
+        dismissTask = nil
+        message = nil
+    }
+
+    /// Registers a container as able to draw notices. Idempotent, because a view's `onAppear` can
+    /// run again without an intervening `onDisappear`.
+    func installSurface(_ id: UUID) {
+        guard !surfaces.contains(id) else { return }
+        surfaces.append(id)
+    }
+
+    func removeSurface(_ id: UUID) {
+        surfaces.removeAll { $0 == id }
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -663,7 +663,7 @@ extension WorkspaceState {
 
     func copyText(of message: MessageItem) {
         guard message.canCopyText else { return }
-        copyText(message.body)
+        copyText(message.body, notice: L10n.string("Message copied to clipboard"))
     }
 
     /// Whether the conversation this row belongs to is re-driving its pending sends right now.
@@ -848,7 +848,7 @@ extension WorkspaceState {
         cancelMessageSelection()
     }
 
-    /// Copies `text` to the system pasteboard.
+    /// Copies `text` to the system pasteboard and confirms it with the success toast.
     ///
     /// Every value copied from this app is private-messenger content — decrypted message
     /// bodies, full conversation transcripts, and Nostr identity keys — so copies default to
@@ -856,8 +856,14 @@ extension WorkspaceState {
     /// marker (see `copyToGeneralPasteboard`), which clipboard-history managers honor to avoid
     /// persisting the value and which discourages Universal Clipboard (Handoff) from syncing it
     /// to the user's other devices.
-    func copyText(_ text: String, concealed: Bool = true) {
+    ///
+    /// `notice` is what the toast says, e.g. "Public key copied to clipboard". It has no default on
+    /// purpose: macOS gives no feedback of its own for a pasteboard write, so a copy affordance
+    /// that raises nothing is a copy the user cannot confirm — and this way one cannot be written
+    /// without the compiler asking for the confirmation.
+    func copyText(_ text: String, concealed: Bool = true, notice: String) {
         copyTextHandler(text, concealed)
+        successToasts.show(notice)
     }
 
     /// Ordered edit history (oldest first) for `message` in the selected conversation, or empty

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -141,6 +141,11 @@ final class WorkspaceState {
     /// just did, so they are surfaced on a non-modal global banner instead of the
     /// per-screen error view, preventing misattribution and clobbering of `lastError`.
     var backgroundStatus: String?
+    /// The counterpart of `lastError` for actions that succeed quietly — a pasteboard write above
+    /// all. Kept here rather than in the environment because the actions that raise it sit in
+    /// context menus, overflow popovers and sheets, none of which reliably inherit an injected
+    /// environment value; `workspace` is threaded into all three already.
+    let successToasts = SuccessToastPresenter()
 
     /// Profile reference from a marmot:// deep link that arrived before the workspace
     /// reached `.ready` (cold start or signed out). Never read by a view body; flushed
@@ -1762,8 +1767,22 @@ final class WorkspaceState {
         telemetryBuildConfigProvider()
     }
 
+    /// The re-configure pass started by `refreshObservabilityRuntime()`, or `nil` when none is in
+    /// flight. Retained for two reasons: a newer refresh can supersede the one already running
+    /// instead of racing it, and a caller that needs the new configuration in place — an account
+    /// switch's, above all — has something to await.
+    @ObservationIgnored private(set) var observabilityRefreshTask: Task<Void, Never>?
+
+    /// Re-configure observability for whatever the active account and build config now are,
+    /// without making the caller wait.
+    ///
+    /// Two passes running together are not harmful — they converge on the same configuration —
+    /// but they do both bump `observabilityRuntimeGeneration`, so the one that bumps first
+    /// abandons its write when it finds the generation moved. Cancelling the pass already in
+    /// flight keeps that to the single pass whose inputs are freshest.
     func refreshObservabilityRuntime() {
-        Task { [weak self] in
+        observabilityRefreshTask?.cancel()
+        observabilityRefreshTask = Task { [weak self] in
             await self?.configureObservabilityRuntimeBestEffort()
         }
     }

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -28813,6 +28813,65 @@
         }
       }
     },
+    "Message copied to clipboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nachricht in Zwischenablage kopiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensaje copiado al portapapeles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message copié dans le presse-papiers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Messaggio copiato negli appunti"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mensagem copiada para a área de transferência"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщение скопировано в буфер обмена"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mesaj panoya kopyalandı"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消息已复制到剪贴板"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "訊息已複製到剪貼簿"
+          }
+        }
+      }
+    },
     "Message deleted": {
       "extractionState": "manual",
       "localizations": {
@@ -36316,6 +36375,65 @@
         }
       }
     },
+    "Private key copied to clipboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privater Schlüssel in Zwischenablage kopiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Llave privada copiada al portapapeles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé privée copiée dans le presse-papiers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiave privata copiata negli appunti"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chave privada copiada para a área de transferência"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приватный ключ скопирован в буфер обмена"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özel anahtar panoya kopyalandı"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私钥已复制到剪贴板"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "私鑰已複製到剪貼簿"
+          }
+        }
+      }
+    },
     "Private-key export is not exposed by MarmotKit in this build": {
       "extractionState": "manual",
       "localizations": {
@@ -37142,6 +37260,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "公鑰"
+          }
+        }
+      }
+    },
+    "Public key copied to clipboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffentlicher Schlüssel in Zwischenablage kopiert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Llave pública copiada al portapapeles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé publique copiée dans le presse-papiers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiave pubblica copiata negli appunti"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chave pública copiada para a área de transferência"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Публичный ключ скопирован в буфер обмена"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açık anahtar panoya kopyalandı"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公钥已复制到剪贴板"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公鑰已複製到剪貼簿"
           }
         }
       }

--- a/whitenoise-mac/Views/CopyToClipboardButton.swift
+++ b/whitenoise-mac/Views/CopyToClipboardButton.swift
@@ -1,65 +1,32 @@
 import SwiftUI
 
-/// The transient "Copied" state behind a copy affordance.
-///
-/// Kept out of the view so the reset window is unit-testable, and so one copy action can flip
-/// several elements (glyph, title, tint) from a single source of truth.
-@Observable
-final class CopyConfirmation {
-    /// How long the confirmation stays up. Matches the iOS client's copy affordance.
-    static let defaultDuration = Duration.seconds(1.5)
-
-    private(set) var isConfirming = false
-
-    private let duration: Duration
-    private var resetTask: Task<Void, Never>?
-
-    init(duration: Duration = CopyConfirmation.defaultDuration) {
-        self.duration = duration
-    }
-
-    /// Shows the confirmation and schedules its reset. A repeated copy restarts the window rather
-    /// than letting the earlier call's pending reset clear it out from under the new copy.
-    func confirm() {
-        resetTask?.cancel()
-        withAnimation(.smooth(duration: 0.15)) { isConfirming = true }
-        resetTask = Task { [duration] in
-            try? await Task.sleep(for: duration)
-            guard !Task.isCancelled else { return }
-            withAnimation(.smooth(duration: 0.2)) { isConfirming = false }
-        }
-    }
-}
-
-/// A copy-to-clipboard button that confirms the copy in place: the glyph flips to a green
-/// checkmark for ~1.5s, matching the iOS client.
+/// A copy-to-clipboard button that confirms the copy with the app's green success toast.
 ///
 /// macOS raises no system-level confirmation when an app writes to the pasteboard, so a bare copy
-/// button leaves the user unable to tell a successful copy from a click that missed. `label`
-/// receives `true` while the confirmation is showing, so each call site keeps its own styling and
-/// decides whether to also swap its title.
+/// button leaves the user unable to tell a successful copy from a click that missed. The
+/// confirmation is a toast rather than a glyph swap on the button itself, matching how every other
+/// White Noise client reports a quiet success — and unlike an in-place checkmark it is legible from
+/// wherever on the surface the user is actually looking.
 struct CopyToClipboardButton<Label: View>: View {
     @Environment(WorkspaceState.self) private var workspace
 
     /// The full value written to the pasteboard.
     let value: String
     /// Localized description of the action, e.g. "Copy npub". Used for the tooltip and the
-    /// accessibility label, both of which must stay stable while the glyph is a checkmark.
+    /// accessibility label.
     let actionDescription: String
-    /// Whether the value is private-messenger content; see `WorkspaceState.copyText(_:concealed:)`.
+    /// Localized confirmation the toast carries, e.g. "Public key copied to clipboard". Names the
+    /// value rather than the control, because the toast is read away from the button.
+    let successMessage: String
+    /// Whether the value is private-messenger content; see `WorkspaceState.copyText(_:concealed:notice:)`.
     var concealed = true
-    @ViewBuilder var label: (Bool) -> Label
-
-    @State private var confirmation = CopyConfirmation()
+    @ViewBuilder var label: () -> Label
 
     var body: some View {
         Button {
-            workspace.copyText(value, concealed: concealed)
-            confirmation.confirm()
-            // The checkmark is invisible to VoiceOver, so announce the same result it conveys.
-            AccessibilityNotification.Announcement(L10n.string("Copied")).post()
+            workspace.copyText(value, concealed: concealed, notice: successMessage)
         } label: {
-            label(confirmation.isConfirming)
+            label()
         }
         .help(actionDescription)
         .accessibilityLabel(actionDescription)

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -690,7 +690,6 @@ struct GroupDetailsSheet: View {
 }
 
 struct GroupDiagnosticsValueRow: View {
-    @Environment(WorkspaceState.self) private var workspace
     let title: String
     let value: String
     var lineLimit = 2
@@ -716,14 +715,18 @@ struct GroupDiagnosticsValueRow: View {
             }
 
             if copyable && !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                Button {
-                    workspace.copyText(value)
-                } label: {
+                // Deliberately not "<title> copied": the diagnostics titles are interpolated, and
+                // a value name cannot be dropped into a sentence in the languages this app ships
+                // without breaking agreement. The generic confirmation is correct in all of them.
+                CopyToClipboardButton(
+                    value: value,
+                    actionDescription: String(format: L10n.string("Copy %@"), title),
+                    successMessage: L10n.string("Copied to clipboard")
+                ) {
                     Image(systemName: "doc.on.doc")
                         .frame(width: 24, height: 24)
                 }
                 .buttonStyle(.wnSecondary)
-                .help(String(format: L10n.string("Copy %@"), title))
             }
         }
     }
@@ -918,13 +921,14 @@ struct ContactDetailsView: View {
                             .textSelection(.enabled)
                     }
 
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(
-                            contact.npub.isEmpty ? contact.accountIdHex : contact.npub,
-                            forType: .string
-                        )
-                    } label: {
+                    // Routed through `copyText` rather than writing the pasteboard here, so this
+                    // copy confirms itself and carries the same concealed marker as every other
+                    // copy in the app.
+                    CopyToClipboardButton(
+                        value: contact.npub.isEmpty ? contact.accountIdHex : contact.npub,
+                        actionDescription: L10n.string("Copy Public Key"),
+                        successMessage: L10n.string("Public key copied to clipboard")
+                    ) {
                         Label(L10n.string("Copy Public Key"), systemImage: "doc.on.doc")
                     }
                     .buttonStyle(.wnSecondary)

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -341,6 +341,7 @@ struct PublicIdentityQRCodeButton: View {
 }
 
 struct PublicIdentityQRCodeSheet: View {
+    @Environment(WorkspaceState.self) private var workspace
     @Environment(\.dismiss) private var dismiss
     let displayName: String
     let npub: String
@@ -394,10 +395,13 @@ struct PublicIdentityQRCodeSheet: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
 
-                CopyToClipboardButton(value: npub, actionDescription: L10n.string("Copy npub")) { isConfirming in
-                    Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
-                        .foregroundStyle(
-                            isConfirming ? WNColor.intentionSuccessContent : WNColor.backgroundContentSecondary)
+                CopyToClipboardButton(
+                    value: npub,
+                    actionDescription: L10n.string("Copy npub"),
+                    successMessage: L10n.string("Public key copied to clipboard")
+                ) {
+                    Image(systemName: "doc.on.doc")
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
                 .buttonStyle(.borderless)
             }
@@ -407,6 +411,9 @@ struct PublicIdentityQRCodeSheet: View {
         .background {
             LiquidGlassBackground()
         }
+        // The sheet draws in a child window above the whole parent, so the window's own surface
+        // could not show this sheet's copy confirmation.
+        .successToastSurface(workspace.successToasts)
     }
 }
 
@@ -836,13 +843,11 @@ struct IdentityKeysSettingsView: View {
 
                             CopyToClipboardButton(
                                 value: npub,
-                                actionDescription: L10n.string("Copy npub")
-                            ) { isConfirming in
-                                Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
-                                    .foregroundStyle(
-                                        isConfirming
-                                            ? WNColor.intentionSuccessContent
-                                            : WNColor.backgroundContentPrimary)
+                                actionDescription: L10n.string("Copy npub"),
+                                successMessage: L10n.string("Public key copied to clipboard")
+                            ) {
+                                Image(systemName: "doc.on.doc")
+                                    .foregroundStyle(WNColor.backgroundContentPrimary)
                             }
                             .buttonStyle(.borderless)
 
@@ -991,13 +996,11 @@ struct PrivateKeyBackupSheet: View {
                         Spacer(minLength: 8)
                         CopyToClipboardButton(
                             value: revealedSecret,
-                            actionDescription: L10n.string("Copy")
-                        ) { isConfirming in
-                            Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
-                                .foregroundStyle(
-                                    isConfirming
-                                        ? WNColor.intentionSuccessContent
-                                        : WNColor.backgroundContentPrimary)
+                            actionDescription: L10n.string("Copy"),
+                            successMessage: L10n.string("Private key copied to clipboard")
+                        ) {
+                            Image(systemName: "doc.on.doc")
+                                .foregroundStyle(WNColor.backgroundContentPrimary)
                         }
                         .buttonStyle(.borderless)
                     }
@@ -1027,6 +1030,9 @@ struct PrivateKeyBackupSheet: View {
         }
         .padding(20)
         .frame(width: 420)
+        // The sheet draws in a child window above the whole parent, so the window's own surface
+        // could not show this sheet's copy confirmation.
+        .successToastSurface(workspace.successToasts)
     }
 
     private var backupTypeSelector: some View {
@@ -1104,11 +1110,14 @@ struct CopyableKeyLabel: View {
                 .textSelection(.enabled)
 
             if showsCopyButton {
-                CopyToClipboardButton(value: npub, actionDescription: L10n.string("Copy npub")) { isConfirming in
-                    Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
+                CopyToClipboardButton(
+                    value: npub,
+                    actionDescription: L10n.string("Copy npub"),
+                    successMessage: L10n.string("Public key copied to clipboard")
+                ) {
+                    Image(systemName: "doc.on.doc")
                         .wnFont(.medium10)
-                        .foregroundStyle(
-                            isConfirming ? WNColor.intentionSuccessContent : WNColor.backgroundContentSecondary)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
                 }
                 .buttonStyle(.borderless)
             }

--- a/whitenoise-mac/Views/WNSuccessToast.swift
+++ b/whitenoise-mac/Views/WNSuccessToast.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// The green success notice, drawn from the same two semantic tokens the Flutter client's
+/// `WnSystemNotice` uses for its success type: `intentionSuccessContent` for the glyph and the
+/// title, over `intentionSuccessBackground`. Both are dynamic, so this reads correctly in either
+/// appearance without the view consulting `\.colorScheme`.
+///
+/// Presented by `successToastSurface(_:)`, which owns the placement and the transition. This struct
+/// is only the card, so it can also be rendered on its own for a visual check.
+struct WNSuccessToast: View {
+    let message: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .wnFont(.semiBold14)
+            Text(message)
+                .wnFont(.bold14)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .foregroundStyle(WNColor.intentionSuccessContent)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        // One width for every notice, leading-aligned, the shape the Flutter client's notice bar
+        // has: repeated copies of different things then raise a card that stays put instead of one
+        // that resizes under the cursor. A message too long for it wraps rather than widening it.
+        //
+        // 440 rather than a rounder number because it is what keeps the longest of these notices
+        // on one line in every language the app ships — Portuguese sets
+        // "Chave privada copiada para a área de transferência" at ~372pt, and the glyph and the
+        // horizontal padding take 54 of the card's width before the label gets any.
+        .frame(maxWidth: 440, alignment: .leading)
+        .background {
+            WNColor.intentionSuccessBackground
+        }
+        .clipShape(.rect(cornerRadius: 10, style: .continuous))
+        .shadow(color: WNColor.shadow.opacity(0.1), radius: 12, y: 4)
+        // The card carries no dismiss control (it clears itself), so nothing in it is
+        // interactive. VoiceOver is told the same thing sighted users see.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(message)
+    }
+}
+
+extension View {
+    /// Installs this container as the surface that draws `presenter`'s success notices.
+    ///
+    /// Attach it to every surface a copy — or any other quietly-successful action — can be
+    /// triggered from: the window root, plus each sheet that hosts one of those actions, since a
+    /// sheet draws in a child window above its parent and would otherwise leave the notice hidden
+    /// behind itself. Nesting is safe: the innermost installed surface is the only one that draws.
+    func successToastSurface(_ presenter: SuccessToastPresenter) -> some View {
+        modifier(SuccessToastSurfaceModifier(presenter: presenter))
+    }
+}
+
+private struct SuccessToastSurfaceModifier: ViewModifier {
+    let presenter: SuccessToastPresenter
+
+    @State private var surfaceID = UUID()
+
+    func body(content: Content) -> some View {
+        content
+            // Bottom, not top: the window's top edge already belongs to
+            // `BackgroundStatusBanner`, and a transient confirmation must not land on top of a
+            // standing warning about a background failure.
+            .overlay(alignment: .bottom) {
+                if let message = presenter.message, presenter.drawingSurface == surfaceID {
+                    WNSuccessToast(message: message)
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 16)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        // Purely informational, and it floats over the composer: it must never
+                        // swallow a click meant for whatever is underneath it.
+                        .allowsHitTesting(false)
+                        // The card is not in the focus order, so its arrival is silent to
+                        // VoiceOver unless announced.
+                        .onAppear {
+                            AccessibilityNotification.Announcement(message).post()
+                        }
+                }
+            }
+            .animation(.smooth(duration: 0.2), value: presenter.message)
+            .onAppear { presenter.installSurface(surfaceID) }
+            .onDisappear { presenter.removeSurface(surfaceID) }
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        WNSuccessToast(message: L10n.string("Public key copied to clipboard"))
+        WNSuccessToast(message: L10n.string("Copied to clipboard"))
+    }
+    .padding(24)
+}

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -18412,7 +18412,7 @@ struct whitenoise_macTests {
         var copiedConcealed = false
         let state = WorkspaceState(copyTextHandler: { _, concealed in copiedConcealed = concealed })
 
-        state.copyText("anything-copied-from-this-app")
+        state.copyText("anything-copied-from-this-app", notice: "Copied to clipboard")
 
         #expect(copiedConcealed)
     }
@@ -18450,38 +18450,103 @@ struct whitenoise_macTests {
         var copiedText = ""
         let state = WorkspaceState(copyTextHandler: { text, _ in copiedText = text })
 
-        state.copyText("public-key-value")
+        state.copyText("public-key-value", notice: "Public key copied to clipboard")
 
         #expect(copiedText == "public-key-value")
     }
 
     @MainActor
-    @Test func copyConfirmationShowsThenClearsItself() async throws {
-        let confirmation = CopyConfirmation(duration: .milliseconds(30))
+    @Test func copyingTextRaisesItsSuccessNotice() async throws {
+        let state = WorkspaceState(copyTextHandler: { _, _ in })
 
-        #expect(!confirmation.isConfirming)
-        confirmation.confirm()
-        // macOS gives no system-level copy confirmation, so the checkmark is the only signal the
-        // user gets that the click landed — it has to be up immediately, not after an await.
-        #expect(confirmation.isConfirming)
+        #expect(state.successToasts.message == nil)
+        state.copyText("public-key-value", notice: "Public key copied to clipboard")
 
-        try await Task.sleep(for: .milliseconds(300))
-
-        #expect(!confirmation.isConfirming)
+        // macOS gives no system-level copy confirmation, so the toast is the only signal the user
+        // gets that the click landed — it has to be up immediately, not after an await.
+        #expect(state.successToasts.message == "Public key copied to clipboard")
     }
 
     @MainActor
-    @Test func repeatedCopyRestartsTheConfirmationWindow() async throws {
-        let confirmation = CopyConfirmation(duration: .milliseconds(200))
+    @Test func copyingAMessageBodyNamesTheMessageInItsNotice() async throws {
+        let state = WorkspaceState(copyTextHandler: { _, _ in })
 
-        confirmation.confirm()
+        state.copyText(
+            of: MessageItem(
+                id: "message",
+                senderName: "Alice",
+                body: "Copy this",
+                sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+                isOutgoing: false
+            ))
+
+        #expect(state.successToasts.message == L10n.string("Message copied to clipboard"))
+    }
+
+    @MainActor
+    @Test func aCopyThatIsRefusedRaisesNoNotice() async throws {
+        let state = WorkspaceState(copyTextHandler: { _, _ in })
+
+        state.copyText(
+            of: MessageItem(
+                id: "deleted",
+                senderName: "Alice",
+                body: "Message deleted",
+                sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+                isDeleted: true,
+                isOutgoing: false
+            ))
+
+        // Nothing reached the pasteboard, so claiming a successful copy would be a lie.
+        #expect(state.successToasts.message == nil)
+    }
+
+    @MainActor
+    @Test func successToastShowsThenClearsItself() async throws {
+        let presenter = SuccessToastPresenter(duration: .milliseconds(30))
+
+        #expect(presenter.message == nil)
+        presenter.show("Copied to clipboard")
+        #expect(presenter.message == "Copied to clipboard")
+
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(presenter.message == nil)
+    }
+
+    @MainActor
+    @Test func repeatedSuccessRestartsTheToastWindow() async throws {
+        let presenter = SuccessToastPresenter(duration: .milliseconds(200))
+
+        presenter.show("Public key copied to clipboard")
         try await Task.sleep(for: .milliseconds(120))
-        // Second copy mid-window: the first reset must not fire and blank the confirmation while
-        // the user is still looking at the result of the newer copy.
-        confirmation.confirm()
+        // Second copy mid-window: the first clear must not fire and blank the toast while the user
+        // is still looking at the result of the newer copy.
+        presenter.show("Private key copied to clipboard")
         try await Task.sleep(for: .milliseconds(120))
 
-        #expect(confirmation.isConfirming)
+        #expect(presenter.message == "Private key copied to clipboard")
+    }
+
+    @MainActor
+    @Test func onlyTheInnermostSurfaceDrawsTheSuccessToast() async throws {
+        let presenter = SuccessToastPresenter()
+        let window = UUID()
+        let sheet = UUID()
+
+        presenter.installSurface(window)
+        #expect(presenter.drawingSurface == window)
+
+        // A sheet draws in a child window above every part of its parent, so once one is up it is
+        // the only surface whose toast the user could see. Drawing on both would paint it twice.
+        presenter.installSurface(sheet)
+        #expect(presenter.drawingSurface == sheet)
+
+        // Re-entering `onAppear` without an intervening `onDisappear` must not stack a duplicate,
+        // which would survive the matching removal and strand the toast on the dismissed sheet.
+        presenter.installSurface(sheet)
+        presenter.removeSurface(sheet)
+        #expect(presenter.drawingSurface == window)
     }
 
     @Test func globalMessageSearchTextNormalizesOrderedTokensAndBoundsSnippets() {
@@ -28231,6 +28296,12 @@ struct whitenoise_macTests {
 
         let secondaryItem = try #require(state.accounts.first { $0.id == secondary.label })
         state.prepareForActiveAccountSwitch(to: secondaryItem, preservingMessageCacheFor: nil)
+        // The switch starts its own re-configure pass. Await it instead of racing it: both it and
+        // the call below bump `observabilityRuntimeGeneration`, so whichever bumps first abandons
+        // its write — and when the loser was the awaited call, the assertions below read whatever
+        // the unawaited pass had managed to land. It usually landed in time locally and did not
+        // under CI load, which is the whole of this test's flakiness.
+        await state.observabilityRefreshTask?.value
         try await state.configureObservabilityRuntime()
         runtime.releaseTelemetryInstallIdGate()
         try await stalePrimaryConfiguration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added success toast notifications for clipboard actions across the app.
  * Toasts appear consistently across windows, sheets, popovers, and context menus, with automatic dismissal and replacement for repeated actions.
  * Added accessible, VoiceOver-friendly confirmation messages with localized translations.
  * Copy actions now provide clear confirmations for messages, private keys, and public keys.
* **Bug Fixes**
  * Improved reliability of notifications during repeated copies and refreshed workspace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->