### PR TITLE
Preselect the only possible successor in the admin handoff

### DIFF
--- a/whitenoise-mac/Core/ChatDestructiveActions.swift
+++ b/whitenoise-mac/Core/ChatDestructiveActions.swift
@@ -129,6 +129,19 @@ struct ChatAdminHandoffTarget: Equatable, Identifiable {
     let candidates: [GroupMemberItem]
 
     var id: String { groupIdHex }
+
+    /// The successor the picker opens with already chosen, or `nil` when there is a choice to make.
+    ///
+    /// One candidate is not a choice. The core has named exactly one member this account may hand
+    /// the role to, so the click that selects them carries no decision — it is a step between the
+    /// user and the only way out of the group they have. Preselecting it makes the sheet what it
+    /// actually is at that point: a confirmation.
+    ///
+    /// From two candidates up, nothing is preselected on purpose — see the `selectedMemberId`
+    /// comment in `ChatAdminHandoffSheet`.
+    var preselectedSuccessorId: String? {
+        candidates.count == 1 ? candidates.first?.id : nil
+    }
 }
 
 /// Chat awaiting a local-delete confirmation.

--- a/whitenoise-mac/Views/ChatAdminHandoffSheet.swift
+++ b/whitenoise-mac/Views/ChatAdminHandoffSheet.swift
@@ -18,9 +18,15 @@ struct ChatAdminHandoffSheet: View {
 
     let target: ChatAdminHandoffTarget
 
-    /// Nothing is preselected on purpose: handing someone the admin role is a consequential choice,
-    /// and a default would let a distracted return-press pick for them.
+    /// Seeded from `preselectedSuccessorId`, which is the sole candidate when there is only one and
+    /// nothing otherwise: with a real choice on offer, handing someone the admin role is
+    /// consequential, and a default would let a distracted return-press pick for them.
     @State private var selectedMemberId: String?
+
+    init(target: ChatAdminHandoffTarget) {
+        self.target = target
+        _selectedMemberId = State(initialValue: target.preselectedSuccessorId)
+    }
 
     private var selectedMember: GroupMemberItem? {
         target.candidates.first { $0.id == selectedMemberId }

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -4560,6 +4560,21 @@ struct PureValueTests {
         )
     }
 
+    /// A one-row picker asks a question with a single available answer, so the sheet opens with that
+    /// answer chosen and the confirmation is all that is left. Two or more is a decision that stays
+    /// the user's to make.
+    @MainActor
+    @Test func soleSuccessorIsPreselectedWhileARealChoiceIsNot() {
+        let alice = handoffMember(id: "alice", canPromote: true)
+        let bob = handoffMember(id: "bob", canPromote: true)
+
+        #expect(handoffTarget(candidates: [alice]).preselectedSuccessorId == "alice")
+        #expect(handoffTarget(candidates: [alice, bob]).preselectedSuccessorId == nil)
+        // A target is never built with an empty roster — that case is the `.lastAdmin` dead end — but
+        // the property must answer "nobody" rather than invent a successor if one ever is.
+        #expect(handoffTarget(candidates: []).preselectedSuccessorId == nil)
+    }
+
     @Test func nonLastAdminLeavesBySteppingDownFirst() {
         let admin = leaveEligibility(
             canLeave: false,
@@ -5125,6 +5140,10 @@ private func handoffMember(
         canPromote: canPromote,
         canDemote: isAdmin
     )
+}
+
+private func handoffTarget(candidates: [GroupMemberItem]) -> ChatAdminHandoffTarget {
+    ChatAdminHandoffTarget(groupIdHex: "group", title: "Planning", candidates: candidates)
 }
 
 private func destructiveActionChat(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -23566,6 +23566,9 @@ struct whitenoise_macTests {
         #expect(handoff.title == chat.title)
         // Alice only: Bob carries no action state, so the core has not said he may be promoted.
         #expect(handoff.candidates.map(\.npub) == ["npub1alyce"])
+        // And because she is the only one, the picker opens with her already chosen — the sheet is a
+        // confirmation at that point, not a question with one available answer.
+        #expect(handoff.preselectedSuccessorId == handoff.candidates.first?.id)
         // A question, not a commit: nothing about the group has changed, and no blocker was reported.
         #expect(state.chatActionAlert == nil)
         #expect(state.chatPendingLeave == nil)
@@ -23573,6 +23576,44 @@ struct whitenoise_macTests {
         #expect(runtime.leaveGroupCallCount == 0)
         #expect(runtime.selfDemoteAdminDetailedCallCount == 0)
         #expect(state.activeChats.contains { $0.id == chat.id })
+    }
+
+    /// The other side of the preselection: as soon as the core names more than one member this
+    /// account may promote, the choice is real and belongs to the user. Preselecting one of them
+    /// would let a return-press hand the admin role to whoever the roster happens to list first.
+    @MainActor
+    @Test func successorPickerWithMoreThanOneCandidateOpensWithNobodyChosen() async throws {
+        let state = try await leavableChatState(
+            canLeave: false,
+            requiresSelfDemoteBeforeLeave: true,
+            isLastAdmin: true,
+            selfIsAdmin: true,
+            memberActions: [
+                GroupMemberActionStateFfi(
+                    memberIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890",
+                    isSelf: false,
+                    isAdmin: false,
+                    canRemove: true,
+                    canPromote: true,
+                    canDemote: false
+                ),
+                GroupMemberActionStateFfi(
+                    memberIdHex: "bob1234567890bob1234567890bob1234567890bob1234567890bob1",
+                    isSelf: false,
+                    isAdmin: false,
+                    canRemove: true,
+                    canPromote: true,
+                    canDemote: false
+                ),
+            ]
+        )
+        let chat = try #require(state.activeChats.first)
+
+        await state.prepareChatLeave(for: chat)
+
+        let handoff = try #require(state.chatPendingAdminHandoff)
+        #expect(handoff.candidates.map(\.npub) == ["npub1alyce", "npub1p0p"])
+        #expect(handoff.preselectedSuccessorId == nil)
     }
 
     /// The point of the whole flow: one confirmation promotes the successor, steps this account down,


### PR DESCRIPTION
If there is only one other person left in the group, it should be preselected as the admin candidate when leaving the group (in the case the user leaving is the last admin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Automatically preselects the eligible successor when exactly one option is available during admin handoff.
  * Leaves the selection empty when multiple or no eligible successors are available.
* **Bug Fixes**
  * Improved admin handoff selection behavior for clearer and more efficient successor assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->