### PR TITLE
Fix audio loading ui

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+PendingOutgoingMedia.swift
+++ b/whitenoise-mac/Core/WorkspaceState+PendingOutgoingMedia.swift
@@ -57,6 +57,9 @@ extension WorkspaceState {
             let client
         else { return }
         pendingOutgoingMediaMessagesByConversation[draftKey]?[index].state = .uploading
+        // The retry re-uploads from scratch, so last attempt's digests describe nothing that is on
+        // its way out any more. Left behind, they would hide the bubble the retry just relit.
+        pendingOutgoingMediaMessagesByConversation[draftKey]?[index].publishedPlaintextSHAs = []
         pendingOutgoingMediaSendTasks[id]?.cancel()
         pendingOutgoingMediaSendTasks[id] = Task { [weak self] in
             await self?.completePendingOutgoingMediaSend(
@@ -138,6 +141,15 @@ extension WorkspaceState {
         pendingOutgoingMediaUploadTasks[id] = nil
         guard !Task.isCancelled, pendingOutgoingMediaMessage(id, in: draftKey) != nil else { return }
 
+        // Stamped before the publish, not after it: the core commits an own send locally as part of
+        // publishing, so the real row can reach the transcript through the subscription while we
+        // are still awaiting the relay. These digests are what let it hide this bubble on arrival
+        // instead of leaving the two stacked for the length of the round-trip.
+        setPendingOutgoingMediaPublishedDigests(
+            Set(references.map { $0.plaintextSha256.lowercased() }),
+            for: id,
+            in: draftKey
+        )
         setPendingOutgoingMediaMessageState(.publishing, for: id, in: draftKey)
 
         // We are holding the plaintext that produced these references, so the sender's own bubble
@@ -233,6 +245,16 @@ extension WorkspaceState {
         guard let index = pendingOutgoingMediaMessagesByConversation[draftKey]?.firstIndex(where: { $0.id == id })
         else { return }
         pendingOutgoingMediaMessagesByConversation[draftKey]?[index].state = state
+    }
+
+    private func setPendingOutgoingMediaPublishedDigests(
+        _ digests: Set<String>,
+        for id: PendingOutgoingMediaMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) {
+        guard let index = pendingOutgoingMediaMessagesByConversation[draftKey]?.firstIndex(where: { $0.id == id })
+        else { return }
+        pendingOutgoingMediaMessagesByConversation[draftKey]?[index].publishedPlaintextSHAs = digests
     }
 
     private func removePendingOutgoingMediaMessage(

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1618,9 +1618,35 @@ final class WorkspaceState {
 
     /// Media messages sent from the selected conversation that are still uploading or publishing,
     /// oldest first — the loading bubbles the transcript appends after its real rows.
+    ///
+    /// A message whose blobs are already on screen is withheld even though its publish has not
+    /// returned yet: the core commits an own send locally *inside* that call, so the real row can
+    /// arrive through the timeline subscription while the relay round-trip is still going, and both
+    /// rows would render at once for the length of it. Only in-flight messages are withheld — a
+    /// failed one keeps its bubble so its retry and remove actions stay reachable.
     var selectedPendingOutgoingMediaMessages: [PendingOutgoingMediaMessage] {
         guard let selectedComposerDraftKey else { return [] }
-        return pendingOutgoingMediaMessagesByConversation[selectedComposerDraftKey] ?? []
+        let pending = pendingOutgoingMediaMessagesByConversation[selectedComposerDraftKey] ?? []
+        // Nothing has been uploaded yet in the common case, so the timeline is never walked.
+        guard pending.contains(where: { $0.state.isInFlight && !$0.publishedPlaintextSHAs.isEmpty }) else {
+            return pending
+        }
+        let published = publishedOutgoingMediaDigestsInSelectedTimeline
+        return pending.filter { message in
+            guard message.state.isInFlight, !message.publishedPlaintextSHAs.isEmpty else { return true }
+            return !message.publishedPlaintextSHAs.isSubset(of: published)
+        }
+    }
+
+    /// Plaintext digests of every blob the selected transcript already renders as an own send.
+    private var publishedOutgoingMediaDigestsInSelectedTimeline: Set<String> {
+        var digests: Set<String> = []
+        for message in selectedMessages where message.isOutgoing {
+            for attachment in message.mediaAttachments {
+                digests.insert(attachment.reference.plaintextSha256.lowercased())
+            }
+        }
+        return digests
     }
 
     var showsMessengerChrome: Bool {

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -897,6 +897,14 @@ nonisolated struct PendingOutgoingMediaMessage: Identifiable, Hashable, Sendable
     let caption: String
     let createdAt: Date
     var state: PendingOutgoingMediaMessageState
+    /// The plaintext digests of this message's blobs, stamped once every upload has handed back a
+    /// reference and empty until then.
+    ///
+    /// The published row carries the same digests, which is what lets the transcript retire this
+    /// bubble the moment the row it became is on screen. It has to: the core commits an own send
+    /// locally *inside* the publish call, so the real row can arrive through the timeline
+    /// subscription while the relay round-trip is still in flight — and until then both rendered.
+    var publishedPlaintextSHAs: Set<String> = []
 
     init(
         id: UUID = UUID(),
@@ -920,6 +928,18 @@ nonisolated struct PendingOutgoingMediaMessage: Identifiable, Hashable, Sendable
 
     var nonvisualAttachments: [PendingMediaAttachment] {
         attachments.filter { $0.kind == .audio || $0.kind == .file }
+    }
+
+    /// The one audio attachment that carries this message's loading state inside its own row, or
+    /// `nil` when the bubble has to fall back to the centered overlay.
+    ///
+    /// An audio row has a natural home for progress — the circular well the play button lands in,
+    /// which `MessageAudioRow` reserves at the same size whatever the row's state. A grid of tiles
+    /// and a document row do not, so a message carrying either keeps the overlay; lighting up both
+    /// treatments would give one Send press two loading indicators.
+    var inlineLoadingAudioAttachment: PendingMediaAttachment? {
+        guard attachments.count == 1, let only = attachments.first, only.kind == .audio else { return nil }
+        return only
     }
 }
 

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -1220,7 +1220,7 @@ struct MessageAttachmentStatusRow: View {
                     .lineLimit(1)
                 Text(detail)
                     .wnFont(.medium10)
-                    .foregroundStyle(AttachmentRowPalette.detailContent)
+                    .foregroundStyle(AttachmentRowPalette.detailContent(isOutgoing: isOutgoing))
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -1245,6 +1245,8 @@ struct MessageAttachmentStatusRow: View {
 /// download finishes — only the control's glyph changes. Nothing here shows the file name; an
 /// audio attachment is almost always a voice recording whose name the sender never chose.
 struct MessageAudioRow<Control: View, SpeedControl: View>: View {
+    static var waveformHeight: CGFloat { 24 }
+
     let bars: [ComposerAudioWaveformBar]
     let progress: CGFloat
     let durationLabel: String
@@ -1253,7 +1255,12 @@ struct MessageAudioRow<Control: View, SpeedControl: View>: View {
     @ViewBuilder let speedControl: SpeedControl
 
     var body: some View {
-        HStack(spacing: 10) {
+        // Aligned on the waveform's own midline rather than on the row box. The duration label
+        // hangs below the bars, so the box's centre sits about half a line lower than they do —
+        // enough that a centred play button read as riding low against the waveform beside it.
+        // Only the middle column needs to state its guide; the control and the badge fall back to
+        // their own centres, which is exactly where they should meet the bars.
+        HStack(alignment: .audioRowWaveformCenter, spacing: 10) {
             control
 
             VStack(alignment: .leading, spacing: 5) {
@@ -1263,19 +1270,34 @@ struct MessageAudioRow<Control: View, SpeedControl: View>: View {
                     barColor: AttachmentRowPalette.waveformBar(isOutgoing: isOutgoing),
                     playedColor: AttachmentRowPalette.waveformPlayedBar(isOutgoing: isOutgoing)
                 )
-                .frame(height: 24)
+                .frame(height: Self.waveformHeight)
 
                 Text(durationLabel)
                     .wnFont(.medium10.monospacedDigit())
-                    .foregroundStyle(AttachmentRowPalette.detailContent)
+                    .foregroundStyle(AttachmentRowPalette.detailContent(isOutgoing: isOutgoing))
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .alignmentGuide(.audioRowWaveformCenter) { _ in Self.waveformHeight / 2 }
 
             speedControl
         }
         .attachmentRowChrome(isOutgoing: isOutgoing)
     }
+}
+
+/// `nonisolated` because `AlignmentID.defaultValue` is: the module defaults to MainActor
+/// isolation, which would otherwise isolate the conformance and the alignment constant with it.
+nonisolated extension VerticalAlignment {
+    /// The midline of an audio row's waveform, so the play control and the speed badge sit level
+    /// with the bars instead of with the box the bars and their duration label share.
+    private enum AudioRowWaveformCenter: AlignmentID {
+        static func defaultValue(in context: ViewDimensions) -> CGFloat {
+            context[VerticalAlignment.center]
+        }
+    }
+
+    static let audioRowWaveformCenter = VerticalAlignment(AudioRowWaveformCenter.self)
 }
 
 /// The `1x` / `1.5x` / `2x` pill at the trailing edge of an audio row.
@@ -1299,25 +1321,34 @@ struct MessageAudioSpeedBadge: View {
     }
 }
 
-/// An audio attachment whose payload has not arrived yet.
+/// An audio attachment with no payload to play yet — one still downloading, or one still on its
+/// way out.
 ///
-/// It stands in for `MessageAudioAttachmentPlayer` at exactly the same size, showing the same
-/// flat fallback bars the player itself starts with and a `--:--` duration, because neither the
-/// real waveform nor the real duration is known before the download — the mac's imeta reference
-/// carries only `dim` and `thumbhash`. Audio deliberately does not fall back to
-/// `MessageAttachmentStatusRow`: that row leads with the file name and the raw media type, which
-/// is the wrong thing to show for a voice message and reflows the bubble once playback is ready.
+/// It stands in for `MessageAudioAttachmentPlayer` at exactly the same size, which is the whole
+/// point: the spinner sits in the well the play button lands in, so the row swaps a glyph rather
+/// than reflowing when the payload arrives. A download defaults to flat fallback bars and a `--:--`
+/// duration because neither the real waveform nor the real duration is known before it lands — the
+/// mac's imeta reference carries only `dim` and `thumbhash`. A send passes both in: the sender
+/// recorded the audio, so this client already knows them.
+///
+/// Audio deliberately does not fall back to `MessageAttachmentStatusRow`: that row leads with the
+/// file name and the raw media type, which is the wrong thing to show for a voice message and
+/// reflows the bubble once playback is ready.
 struct MessageAudioAttachmentPlaceholder: View {
     let isOutgoing: Bool
     let accessibilityLabel: String
-    /// `nil` while the download is still in flight; set once it has failed and can be retried.
+    var bars: [ComposerAudioWaveformBar] = ComposerAudioWaveformPresentation.fallbackPlaybackBars
+    var durationLabel: String = MediaDurationLabel.placeholder
+    /// `nil` while the payload is still in flight; set once it has failed and can be retried.
     var retryAction: (() -> Void)?
+    /// What the retry control's tooltip says. A download is retried; a send that never left is not.
+    var retryHelp: String = L10n.string("Retry download")
 
     var body: some View {
         MessageAudioRow(
-            bars: ComposerAudioWaveformPresentation.fallbackPlaybackBars,
+            bars: bars,
             progress: 0,
-            durationLabel: MediaDurationLabel.placeholder,
+            durationLabel: durationLabel,
             isOutgoing: isOutgoing,
             control: {
                 if let retryAction {
@@ -1327,7 +1358,7 @@ struct MessageAudioAttachmentPlaceholder: View {
                             .audioRowControlChrome(isOutgoing: isOutgoing)
                     }
                     .buttonStyle(.plain)
-                    .help(L10n.string("Retry download"))
+                    .help(retryHelp)
                 } else {
                     ProgressView()
                         .controlSize(.small)

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -270,22 +270,45 @@ nonisolated enum AttachmentRowPalette {
     /// content color so it steps away from the fill in whichever direction that fill has room —
     /// the alternative, a fixed white or black wash, is only correct in one of the four
     /// fill × appearance combinations.
+    ///
+    /// The opacities below are set against measured contrast, not by eye. `content` over `fill` is
+    /// a ~14:1 pair in all four fill × appearance combinations, so an opacity here reads almost
+    /// directly as a fraction of that: 0.14 left the disc at 1.4:1, invisible enough that the well
+    /// the play button sits in read as an artifact of the fill rather than as a control.
+    static let controlFillOpacity = 0.24
+
     static func controlFill(isOutgoing: Bool) -> Color {
-        content(isOutgoing: isOutgoing).opacity(0.14)
+        content(isOutgoing: isOutgoing).opacity(controlFillOpacity)
     }
+
+    /// 0.58 is the iOS client's own figure for this bar, and it is the step that clears 3:1
+    /// against every bubble fill — 0.42 held only where the content color was the light one
+    /// (4.05:1 outgoing in light appearance) and fell to 2.84:1 where it was the dark one, which
+    /// is how a waveform came to read as washed-out grey on half the rows in the app.
+    static let waveformBarOpacity = 0.58
 
     static func waveformBar(isOutgoing: Bool) -> Color {
-        content(isOutgoing: isOutgoing).opacity(0.42)
+        content(isOutgoing: isOutgoing).opacity(waveformBarOpacity)
     }
+
+    static let waveformPlayedBarOpacity = 0.9
 
     static func waveformPlayedBar(isOutgoing: Bool) -> Color {
-        content(isOutgoing: isOutgoing).opacity(0.9)
+        content(isOutgoing: isOutgoing).opacity(waveformPlayedBarOpacity)
     }
 
-    /// Detail text inside an attachment row — file size, duration. `backgroundContentTertiary` is
-    /// what the other clients use for de-emphasized text inside a bubble, in *both* directions:
-    /// the `400`/`500` neutral step is the one that clears both bubble fills.
-    static let detailContent = WNColor.backgroundContentTertiary
+    /// Detail text inside an attachment row — file size, duration.
+    ///
+    /// Derived from the row's own content, like every other value here, because the fill it is
+    /// drawn on is the row's — not the window's. The flat `backgroundContentTertiary` this used to
+    /// be is a *background* token, and pairing it with a bubble fill is the crossover this palette
+    /// exists to prevent: it measured 7.85:1 on the outgoing bubble in light appearance and 2.31:1
+    /// on the incoming one, the same label failing in one place and shouting in another.
+    static let detailContentOpacity = 0.72
+
+    static func detailContent(isOutgoing: Bool) -> Color {
+        content(isOutgoing: isOutgoing).opacity(detailContentOpacity)
+    }
 }
 
 /// How an `@mention` is set off from the text around it: **bold, in the app's one blue**, with no

--- a/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
+++ b/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
@@ -56,6 +56,11 @@ struct PendingOutgoingMessageBubble: View {
             // alone rather than on the whole row — a caption or the timestamp footer below the
             // grid would otherwise drag the overlay's midpoint down off the image. The dim is
             // applied per part instead of to the stack so it does not fade the spinner with it.
+            //
+            // An audio-only message opts out of both: its row shows the wait in the well the play
+            // button lands in (`inlineLoadingAudioAttachment`), which is where a listener already
+            // looks. A large spinner floated over that single short row on top of it would be the
+            // same send announced twice, and the dim would fade the inline one along with the row.
             attachments
                 .opacity(dimsForSend ? 0.55 : 1)
                 .overlay(alignment: .center) {
@@ -78,7 +83,7 @@ struct PendingOutgoingMessageBubble: View {
     }
 
     private var dimsForSend: Bool {
-        message.state.isInFlight
+        message.state.isInFlight && message.inlineLoadingAudioAttachment == nil
     }
 
     /// The visual body of the bubble: the grid, then any audio/document rows. Never empty — a
@@ -86,12 +91,20 @@ struct PendingOutgoingMessageBubble: View {
     @ViewBuilder
     private var attachments: some View {
         VStack(alignment: .trailing, spacing: 6) {
-            if !message.visualAttachments.isEmpty {
-                PendingOutgoingMediaGrid(attachments: message.visualAttachments)
-            }
+            if let audio = message.inlineLoadingAudioAttachment {
+                PendingOutgoingAudioRow(
+                    attachment: audio,
+                    isFailed: message.state == .failed,
+                    onRetry: { workspace.retryPendingOutgoingMediaMessage(message.id) }
+                )
+            } else {
+                if !message.visualAttachments.isEmpty {
+                    PendingOutgoingMediaGrid(attachments: message.visualAttachments)
+                }
 
-            ForEach(message.nonvisualAttachments) { attachment in
-                PendingOutgoingMediaAttachmentRow(attachment: attachment)
+                ForEach(message.nonvisualAttachments) { attachment in
+                    PendingOutgoingMediaAttachmentRow(attachment: attachment)
+                }
             }
         }
     }
@@ -293,49 +306,57 @@ private struct PendingOutgoingMediaTile: View {
     }
 }
 
-/// Audio and document attachments, which never enter the grid. Kept intentionally plain: the
-/// message is still going out, so there is nothing to play or reveal yet.
+/// A lone audio attachment on its way out, wearing the delivered player's exact geometry with a
+/// spinner where the play button will be.
+///
+/// It renders through `MessageAudioAttachmentPlaceholder` — the same row a not-yet-downloaded
+/// audio uses — rather than a shape of its own, which is the only way the row is guaranteed not to
+/// resize when the published message replaces it. The waveform and duration are the real ones: the
+/// sender recorded this audio, so unlike a download this side already knows both.
+private struct PendingOutgoingAudioRow: View {
+    let attachment: PendingMediaAttachment
+    let isFailed: Bool
+    let onRetry: () -> Void
+
+    var body: some View {
+        MessageAudioAttachmentPlaceholder(
+            isOutgoing: true,
+            accessibilityLabel: isFailed ? L10n.string("Not delivered") : L10n.string("Sending"),
+            bars: bars,
+            durationLabel: attachment.durationSeconds.map(MediaDurationLabel.string(for:))
+                ?? MediaDurationLabel.placeholder,
+            retryAction: isFailed ? onRetry : nil,
+            retryHelp: L10n.string("Retry")
+        )
+    }
+
+    /// An audio *file* the user attached carries no samples — nothing analysed it — so it falls
+    /// back to the same flat bars a download shows until its payload lands.
+    private var bars: [ComposerAudioWaveformBar] {
+        attachment.waveformSamples.isEmpty
+            ? ComposerAudioWaveformPresentation.fallbackPlaybackBars
+            : ComposerAudioWaveformPresentation.bars(for: attachment.waveformSamples, mode: .playback)
+    }
+}
+
+/// Document attachments, and audio travelling alongside them, which never enter the grid. Kept
+/// intentionally plain: the message is still going out, so there is nothing to play or reveal yet.
+///
+/// A recording never reaches here — it takes the composer over on its own, so it is always the
+/// message's only attachment and always renders as `PendingOutgoingAudioRow`.
 private struct PendingOutgoingMediaAttachmentRow: View {
     let attachment: PendingMediaAttachment
 
     var body: some View {
-        Group {
-            if attachment.isVoiceMessage {
-                voiceMessageRow
-            } else {
-                fileRow
+        fileRow
+            .foregroundStyle(AttachmentRowPalette.outgoingContent)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(width: 260, alignment: .leading)
+            .background {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(MessagesPalette.sentBubble)
             }
-        }
-        .foregroundStyle(AttachmentRowPalette.outgoingContent)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .frame(width: 260, alignment: .leading)
-        .background {
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(MessagesPalette.sentBubble)
-        }
-    }
-
-    /// A recording keeps its waveform on the way out, the way the voice-draft bar showed it and
-    /// the way the delivered bubble will show it. Its file name is a generated `voice-<uuid>.m4a`
-    /// the user never chose, so naming it here would be worse than saying nothing.
-    private var voiceMessageRow: some View {
-        HStack(spacing: 10) {
-            Image(systemName: "mic.fill")
-                .wnFont(.semiBold14)
-
-            ComposerAudioWaveformView(
-                samples: attachment.waveformSamples,
-                progress: 0,
-                barColor: AttachmentRowPalette.waveformBar(isOutgoing: true),
-                playedColor: AttachmentRowPalette.waveformPlayedBar(isOutgoing: true)
-            )
-            .frame(height: 24)
-
-            Text(MediaDurationLabel.string(for: attachment.durationSeconds ?? 0))
-                .wnFont(.semiBold10.monospacedDigit())
-                .foregroundStyle(AttachmentRowPalette.detailContent)
-        }
     }
 
     private var fileRow: some View {
@@ -350,7 +371,7 @@ private struct PendingOutgoingMediaAttachmentRow: View {
                     .truncationMode(.middle)
                 Text(attachment.durationLabel ?? attachment.sizeLabel)
                     .wnFont(.medium10.monospacedDigit())
-                    .foregroundStyle(AttachmentRowPalette.detailContent)
+                    .foregroundStyle(AttachmentRowPalette.detailContent(isOutgoing: true))
             }
 
             Spacer(minLength: 0)

--- a/whitenoise-macTests/SemanticPaletteTests.swift
+++ b/whitenoise-macTests/SemanticPaletteTests.swift
@@ -145,6 +145,53 @@ struct SemanticPaletteTests {
     /// `fillPrimary` and `backgroundPrimary` run in opposite directions, and so do their
     /// content tokens. That inversion is the reason the two families cannot be mixed, so it
     /// is asserted directly rather than left implicit in the contrast table.
+    /// The attachment row derives its waveform and its detail text from the row's *own* content at
+    /// a reduced opacity, so each has to be measured against the row's own fill — the surface the
+    /// rest of the table works from is the window, which is not what these are drawn on.
+    ///
+    /// Both fills invert between appearances while the content inverts with them, so a single
+    /// opacity has to clear four combinations at once. That is what the old values missed: an
+    /// unplayed bar at 0.42 measured 4.05 on the outgoing bubble in light appearance and 2.84 on
+    /// the incoming one, and the duration label — drawn in the flat *background* token
+    /// `backgroundContentTertiary` rather than in the row's content — ran from 7.85 down to 2.31.
+    @Test func attachmentRowTonesClearTheRowFillTheyAreDrawnOn() throws {
+        // Row fill paired with the content every tone in the row is derived from.
+        let rows: [(name: String, fill: NSColor, content: NSColor)] = [
+            ("outgoing", WNNSColor.fillPrimary, WNNSColor.fillContentPrimary),
+            ("incoming", WNNSColor.backgroundMessageIncoming, WNNSColor.backgroundContentPrimary),
+        ]
+        // The unplayed waveform is a graphical object, so it takes WCAG's non-text bar; the
+        // duration label is small text and takes the body-text one. The disc behind the play
+        // control is deliberately absent: it is a locator for a glyph that carries its own
+        // contrast, so a threshold on it would be a number invented to be met.
+        let tones: [(name: String, opacity: Double, minimum: Double)] = [
+            ("waveform bar", AttachmentRowPalette.waveformBarOpacity, 3.0),
+            ("played waveform bar", AttachmentRowPalette.waveformPlayedBarOpacity, 4.5),
+            ("duration label", AttachmentRowPalette.detailContentOpacity, 4.5),
+        ]
+
+        for appearance in try Self.appearances() {
+            for row in rows {
+                for tone in tones {
+                    let drawn = try Self.blended(
+                        row.content,
+                        opacity: tone.opacity,
+                        over: row.fill,
+                        in: appearance
+                    )
+                    let ratio = try Self.contrast(drawn, row.fill, in: appearance)
+                    #expect(
+                        ratio >= tone.minimum,
+                        """
+                        \(row.name) \(tone.name) contrast \(ratio) < \(tone.minimum) \
+                        in \(appearance.name.rawValue)
+                        """
+                    )
+                }
+            }
+        }
+    }
+
     @Test func fillAndBackgroundFamiliesInvertRelativeToEachOther() throws {
         for appearance in try Self.appearances() {
             // The fill is the *opposite* of the surface it sits on…
@@ -412,6 +459,31 @@ struct SemanticPaletteTests {
         let first = relativeLuminance(of: a)
         let second = relativeLuminance(of: b)
         return (max(first, second) + 0.05) / (min(first, second) + 0.05)
+    }
+
+    /// `color` laid over `background` at `opacity`, resolved in `appearance` — what a
+    /// `.opacity()` modifier actually puts on screen, which is the thing worth measuring when a
+    /// tone is derived from its own surface's content rather than named outright.
+    private static func blended(
+        _ color: NSColor,
+        opacity: Double,
+        over background: NSColor,
+        in appearance: NSAppearance
+    ) throws -> NSColor {
+        var blended: NSColor?
+        appearance.performAsCurrentDrawingAppearance {
+            guard
+                let foreground = color.usingColorSpace(.sRGB),
+                let base = background.usingColorSpace(.sRGB)
+            else { return }
+            blended = NSColor(
+                srgbRed: foreground.redComponent * opacity + base.redComponent * (1 - opacity),
+                green: foreground.greenComponent * opacity + base.greenComponent * (1 - opacity),
+                blue: foreground.blueComponent * opacity + base.blueComponent * (1 - opacity),
+                alpha: 1
+            )
+        }
+        return try #require(blended)
     }
 
     /// The sRGB hex a token resolves to under `appearance`, for asserting that a token does —

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -10324,6 +10324,57 @@ struct whitenoise_macTests {
         }
     }
 
+    @Test func audioRowAlignsItsControlsOnTheWaveformRatherThanOnTheRowBox() throws {
+        // The duration label hangs below the bars inside the middle column, so the column's centre
+        // — and with it the row box's — sits about half a line below the bars themselves. Aligning
+        // on `.center` therefore hangs the play control and the speed badge low against the
+        // waveform they belong to. Nothing observable from a unit test reports a stack's alignment,
+        // so the guide is pinned against the source, like the player's rate ordering below.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+        let start = try #require(source.range(of: "struct MessageAudioRow<"))
+        let rest = source[start.upperBound...]
+        let end = try #require(rest.range(of: "\n}\n\n")?.upperBound)
+        let normalizedBody = String(rest[..<end]).components(separatedBy: .whitespacesAndNewlines).joined()
+
+        #expect(normalizedBody.contains("HStack(alignment:.audioRowWaveformCenter"))
+        // Half the waveform's own height, not a literal: the guide has to follow the band it names.
+        #expect(normalizedBody.contains(".alignmentGuide(.audioRowWaveformCenter){_inSelf.waveformHeight/2}"))
+    }
+
+    @Test func aSendingAudioShowsItsWaitInThePlayButtonRatherThanUnderAnOverlay() throws {
+        // Same geometry contract as the test above, across the other axis: a voice note is one row
+        // from the moment Send is pressed to the moment it is playable, so the wait belongs in the
+        // well the play button lands in. Rendering it through the shared placeholder is what makes
+        // that a guarantee instead of two hand-matched layouts — and the message-wide dimmer has to
+        // stand down for it, or the send announces itself twice and the inline spinner fades along
+        // with the row it sits in.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("PendingOutgoingMessageViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+
+        #expect(
+            source.contains("MessageAudioAttachmentPlaceholder("),
+            "a pending audio row must render through the shared audio placeholder"
+        )
+        let normalizedSource = source.components(separatedBy: .whitespacesAndNewlines).joined()
+        #expect(
+            normalizedSource.contains("message.state.isInFlight&&message.inlineLoadingAudioAttachment==nil"),
+            "the centered overlay must stand down for a row that carries its own spinner"
+        )
+    }
+
     @Test func audioPlayerArmsRateControlBeforePreparingAndReappliesItAroundPlay() throws {
         // Two `AVAudioPlayer` traps, both of which fail silently — the badge would keep cycling and
         // keep reading 2x while playback stayed at 1x, with nothing in the UI to show it:
@@ -16471,6 +16522,163 @@ struct whitenoise_macTests {
         #expect(runtime.sentMediaAttachments.last?.fileNames == ["voice-note.m4a"])
         #expect(runtime.sentMediaAttachments.last?.caption == nil)
         #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+    }
+
+    @MainActor
+    @Test func pendingBubbleGivesWayTheMomentItsPublishedRowLands() async throws {
+        // The core commits an own send locally *inside* `sendMediaAttachments`, so the real row can
+        // reach the transcript through the timeline subscription while the relay round-trip is
+        // still in flight. The pending bubble is only dropped once that call returns, so for the
+        // length of the publish the same voice note rendered twice — one loading bubble stacked
+        // under the real one. Matching on the uploaded blob's plaintext digest retires the
+        // placeholder as soon as the row it became is on screen.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        let recording = recordedVoiceMessage()
+        state.appendPendingMediaAttachment(recording, for: draftKey)
+        await Self.settleComposerMediaUploads(state)
+
+        // Arm the gate only now, so it holds the publish rather than the upload.
+        runtime.messageActionGateEnabled = true
+        await state.sendDraft()
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+        #expect(state.selectedPendingOutgoingMediaMessages.map(\.state) == [.publishing])
+
+        runtime.installTimelinePage(
+            TimelinePageFfi(
+                messages: [
+                    timelineMessage(
+                        id: "published-voice",
+                        direction: "outbound",
+                        groupIdHex: "group",
+                        sender: account.accountIdHex,
+                        plaintext: "",
+                        recordedAt: 1_700_000_000,
+                        media: [
+                            mediaAttachmentReference(
+                                mediaType: "audio/mp4",
+                                fileName: "voice-note.m4a",
+                                plaintextSha256: hexSHA256(recording.data)
+                            )
+                        ]
+                    )
+                ],
+                hasMoreBefore: false,
+                hasMoreAfter: false
+            ),
+            groupIdHex: "group"
+        )
+        let activeAccount = try #require(state.activeAccount)
+        await state.refreshSelectedTimelineAfterSend(
+            groupIdHex: "group",
+            account: activeAccount,
+            client: runtime
+        )
+
+        // One bubble, not two: the real row is on screen and the loading one is already gone, even
+        // though the publish has not returned yet.
+        #expect(state.selectedMessages.map(\.id) == ["published-voice"])
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+        // Hidden, not cancelled — the send still owns the message until its publish returns, which
+        // is what lets a failure put the bubble back with its retry actions.
+        #expect(state.pendingOutgoingMediaMessagesByConversation[draftKey]?.count == 1)
+
+        runtime.releaseMessageActionGate()
+        await Self.settlePendingOutgoingMediaSends(state)
+        #expect(state.pendingOutgoingMediaMessagesByConversation.isEmpty)
+    }
+
+    @MainActor
+    @Test func pendingBubbleStaysUpWhileADifferentAudioIsPublished() async throws {
+        // The suppression is keyed on the blob the message actually uploaded. A neighbouring audio
+        // row in the same transcript must not retire a bubble whose own publish is still climbing.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        state.appendPendingMediaAttachment(recordedVoiceMessage(), for: draftKey)
+        await Self.settleComposerMediaUploads(state)
+        runtime.messageActionGateEnabled = true
+        await state.sendDraft()
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+
+        runtime.installTimelinePage(
+            TimelinePageFfi(
+                messages: [
+                    timelineMessage(
+                        id: "someone-elses-voice",
+                        groupIdHex: "group",
+                        sender: "alice1234567890alice1234567890alice1234567890alice1234567890",
+                        plaintext: "",
+                        recordedAt: 1_700_000_000,
+                        media: [
+                            mediaAttachmentReference(
+                                mediaType: "audio/mp4",
+                                fileName: "other.m4a",
+                                plaintextSha256: hexSHA256(Data("someone else".utf8))
+                            )
+                        ]
+                    )
+                ],
+                hasMoreBefore: false,
+                hasMoreAfter: false
+            ),
+            groupIdHex: "group"
+        )
+        let activeAccount = try #require(state.activeAccount)
+        await state.refreshSelectedTimelineAfterSend(
+            groupIdHex: "group",
+            account: activeAccount,
+            client: runtime
+        )
+
+        #expect(state.selectedPendingOutgoingMediaMessages.map(\.state) == [.publishing])
+
+        runtime.releaseMessageActionGate()
+        await Self.settlePendingOutgoingMediaSends(state)
+    }
+
+    @Test func onlyAnAudioOnlyMessageCarriesItsLoadingStateInsideTheRow() {
+        // The inline spinner lives in the well the play button lands in, which only exists on an
+        // audio row. A message that also carries tiles or a document row has no such well, so it
+        // keeps the centered overlay — and a message that had both would show one Send press two
+        // loading indicators.
+        let voice = PendingMediaAttachment(
+            fileName: "voice-note.m4a",
+            mediaType: "audio/mp4",
+            data: Data("recorded audio".utf8),
+            dim: nil,
+            durationSeconds: 4,
+            waveformSamples: [0.2, 0.7, 0.4],
+            isVoiceMessage: true
+        )
+        let photo = PendingMediaAttachment(
+            fileName: "photo.png",
+            mediaType: "image/png",
+            data: Data("png".utf8),
+            dim: "120x80"
+        )
+
+        #expect(
+            PendingOutgoingMediaMessage(attachments: [voice], caption: "")
+                .inlineLoadingAudioAttachment == voice
+        )
+        #expect(
+            PendingOutgoingMediaMessage(attachments: [voice, photo], caption: "")
+                .inlineLoadingAudioAttachment == nil
+        )
+        #expect(
+            PendingOutgoingMediaMessage(attachments: [photo], caption: "")
+                .inlineLoadingAudioAttachment == nil
+        )
     }
 
     @MainActor


### PR DESCRIPTION
Loading when sending an audio was like in an overlay above instead of using the same space. Also, sometimes it looked double

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate pending media messages from appearing after uploads are published.
  * Improved retry handling for failed media uploads.
  * Kept unrelated pending messages visible while suppressing completed ones.

* **UI Improvements**
  * Added inline loading states for audio-only messages.
  * Improved audio waveform alignment, status details, retry controls, and contrast across appearances.
  * Enhanced attachment styling for incoming and outgoing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->