### PR TITLE
Fix profile image in  edit profile form

### DIFF
--- a/whitenoise-mac/Core/RemoteImageDisplayPolicy.swift
+++ b/whitenoise-mac/Core/RemoteImageDisplayPolicy.swift
@@ -1,0 +1,47 @@
+//
+//  RemoteImageDisplayPolicy.swift
+//  whitenoise-mac
+//
+//  Whether an avatar that lives at a remote URL may be fetched and drawn at all.
+//  The URL-safety half of this decision is `RemoteImageURLPolicy`; this is the
+//  consent half.
+//
+
+import Foundation
+
+/// Decides whether a *sanitized* remote avatar URL may actually be loaded, given the viewer's
+/// "Load Remote Profile Images" preference.
+///
+/// `WorkspaceState.loadRemoteImages` is off by default, and Privacy & Security states exactly why:
+/// "Profile pictures come from URLs **other people** control, so loading them reveals your IP
+/// address and when you're online to whoever sent them." That reasoning covers every avatar the
+/// viewer did not choose — and none of the one they did.
+///
+/// The account's own picture is the case the preference was never written for. The viewer picked it
+/// in the profile editor, the app uploaded it to the Blossom server *the app* chose, and the URL is
+/// what that upload returned. Fetching it discloses the viewer's address to a host they have just
+/// handed the image to, so drawing it leaks nothing the upload did not already leak.
+///
+/// Gating it made the profile editor look broken rather than private: the upload succeeded, the
+/// draft took the new URL, `saveProfile()` published it — and the 96pt avatar at the top of the form
+/// kept drawing initials, with no error to explain why. From the outside that is indistinguishable
+/// from "I can't set a profile image."
+///
+/// So: your own avatar always draws, everyone else's waits for the preference. Pass
+/// `isOwnAccountImage: true` only where the URL provably belongs to an account **signed in** on
+/// this Mac — the profile editor, its picker, Identity & Keys, and the account switcher. Peer
+/// avatars (chat rows, message senders, member lists, search results) must keep the default.
+///
+/// "Signed in" is load-bearing rather than decorative. The first three of those sites render
+/// `activeAccount`, which `restoreOrSelectFirstAccount()` guarantees is never a signed-out account,
+/// so they can pass a literal `true`. The switcher's row list is the one site that also shows
+/// signed-out identities, and it passes `!account.signedOut`: sign-out deactivates an identity and
+/// drops its relay key packages, so the app should not then fetch its avatar and put traffic on the
+/// wire on its behalf. That is a narrower argument than the preference's own — a signed-out account
+/// is still yours, not a peer's — but the exemption should stay as small as the bug it exists to
+/// fix.
+nonisolated enum RemoteImageDisplayPolicy {
+    static func loadsRemoteImage(isOwnAccountImage: Bool, preferenceEnabled: Bool) -> Bool {
+        isOwnAccountImage || preferenceEnabled
+    }
+}

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -1629,9 +1629,13 @@ struct ProfileImageAvatarView: View {
     @Environment(WorkspaceState.self) private var workspace
     let seed: String
     let initials: String
-    /// Already passed through `RemoteImageURLPolicy`; body only checks the user preference.
+    /// Already passed through `RemoteImageURLPolicy`; body only checks consent to load it.
     let sanitizedPictureURL: URL?
     let localImagePayload: DownloadedMediaPayload?
+    /// Whether `sanitizedPictureURL` is an account signed in on this Mac rather than a peer's.
+    /// Own-account avatars ignore the "Load Remote Profile Images" preference — see
+    /// `RemoteImageDisplayPolicy` for why, and for the four call sites allowed to pass `true`.
+    let isOwnAccountImage: Bool
     let size: CGFloat
     let isSelected: Bool
 
@@ -1640,6 +1644,7 @@ struct ProfileImageAvatarView: View {
         initials: String,
         sanitizedPictureURL: URL?,
         localImagePayload: DownloadedMediaPayload? = nil,
+        isOwnAccountImage: Bool = false,
         size: CGFloat,
         isSelected: Bool
     ) {
@@ -1647,6 +1652,7 @@ struct ProfileImageAvatarView: View {
         self.initials = initials
         self.sanitizedPictureURL = sanitizedPictureURL
         self.localImagePayload = localImagePayload
+        self.isOwnAccountImage = isOwnAccountImage
         self.size = size
         self.isSelected = isSelected
     }
@@ -1661,7 +1667,7 @@ struct ProfileImageAvatarView: View {
                 } placeholder: {
                     AvatarView(seed: seed, initials: initials, size: size, isSelected: isSelected, drawsChrome: false)
                 }
-            } else if workspace.loadRemoteImages, let imageURL = sanitizedPictureURL {
+            } else if loadsRemoteImage, let imageURL = sanitizedPictureURL {
                 DownsampledAsyncImage(url: imageURL, maxPixelSize: size * 2) { image in
                     image
                         .resizable()
@@ -1678,11 +1684,20 @@ struct ProfileImageAvatarView: View {
         .modifier(AvatarChromeModifier(isSelected: isSelected, ringColor: ringColor))
     }
 
+    /// Whether a remote picture may be fetched: the viewer's preference, or an own-account
+    /// exemption from it.
+    private var loadsRemoteImage: Bool {
+        RemoteImageDisplayPolicy.loadsRemoteImage(
+            isOwnAccountImage: isOwnAccountImage,
+            preferenceEnabled: workspace.loadRemoteImages
+        )
+    }
+
     /// A picture keeps the neutral hairline; the initials fallback wears its accent border, whose
     /// pale fill needs the ring to read as an object. Keyed on whether an image will be *attempted*
     /// rather than on whether one has decoded, so the ring does not change color mid-load.
     private var ringColor: Color {
-        let showsPicture = localImagePayload != nil || (workspace.loadRemoteImages && sanitizedPictureURL != nil)
+        let showsPicture = localImagePayload != nil || (loadsRemoteImage && sanitizedPictureURL != nil)
         return showsPicture ? AvatarChromeModifier.neutralRing : AvatarPalette.colors(for: seed).border
     }
 }

--- a/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/SettingsAccountSwitcherViews.swift
@@ -37,6 +37,7 @@ struct SettingsAccountSwitcherCard: View {
                         seed: account.accountIdHex,
                         initials: account.initials,
                         sanitizedPictureURL: account.sanitizedPictureURL,
+                        isOwnAccountImage: true,
                         size: 34,
                         isSelected: false
                     )
@@ -259,6 +260,12 @@ struct AccountSwitcherRow: View {
                         seed: account.accountIdHex,
                         initials: account.initials,
                         sanitizedPictureURL: account.sanitizedPictureURL,
+                        // Every row here is one of this Mac's own accounts, but a signed-out one is
+                        // an identity the user has deliberately deactivated — sign-out even drops
+                        // its relay key packages. Fetching its avatar would put traffic on the wire
+                        // for an identity that is supposed to be off, so it drops back to initials
+                        // (the row is already dimmed to 0.4). Signed-in rows are unaffected.
+                        isOwnAccountImage: !account.signedOut,
                         size: 32,
                         isSelected: isActive
                     )

--- a/whitenoise-mac/Views/SettingsViews.swift
+++ b/whitenoise-mac/Views/SettingsViews.swift
@@ -819,6 +819,7 @@ struct ProfileIdentityHeaderView: View {
                         seed: account.accountIdHex,
                         initials: displayName,
                         sanitizedPictureURL: workspace.profileDraft.sanitizedPictureURL,
+                        isOwnAccountImage: true,
                         size: avatarSize,
                         isSelected: false
                     )
@@ -873,6 +874,7 @@ struct ProfileImagePickerSheet: View {
                         seed: account.accountIdHex,
                         initials: account.displayName,
                         sanitizedPictureURL: workspace.profileDraft.sanitizedPictureURL,
+                        isOwnAccountImage: true,
                         size: 46,
                         isSelected: false
                     )
@@ -1013,6 +1015,7 @@ struct IdentityKeysSettingsView: View {
                             seed: account.accountIdHex,
                             initials: account.initials,
                             sanitizedPictureURL: account.sanitizedPictureURL,
+                            isOwnAccountImage: true,
                             size: 52,
                             isSelected: false
                         )

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -19,6 +19,32 @@ import UserNotifications
 
 @Suite(.serialized)
 struct PureValueTests {
+    @Test func ownAccountAvatarLoadsItsPictureWithTheRemoteImagePreferenceOff() {
+        // The bug this pins: "Load Remote Profile Images" is off by default, and the profile
+        // editor's 96pt avatar went through the same gate as a stranger's. Picking an image
+        // uploaded it and updated the draft, then drew initials anyway — no picture, no error,
+        // indistinguishable from a broken picker. Your own avatar is not remote content you were
+        // sent, so the preference must not reach it.
+        #expect(
+            RemoteImageDisplayPolicy.loadsRemoteImage(isOwnAccountImage: true, preferenceEnabled: false)
+        )
+        #expect(
+            RemoteImageDisplayPolicy.loadsRemoteImage(isOwnAccountImage: true, preferenceEnabled: true)
+        )
+    }
+
+    @Test func peerAvatarStillWaitsForTheRemoteImagePreference() {
+        // The other half of the rule, and the reason the exemption is a per-call-site flag rather
+        // than a default: a peer's `picture` is a URL they chose, so fetching it hands them the
+        // viewer's IP address and presence. That stays gated.
+        #expect(
+            !RemoteImageDisplayPolicy.loadsRemoteImage(isOwnAccountImage: false, preferenceEnabled: false)
+        )
+        #expect(
+            RemoteImageDisplayPolicy.loadsRemoteImage(isOwnAccountImage: false, preferenceEnabled: true)
+        )
+    }
+
     @MainActor
     @Test func primaryButtonLargeIsBiggerThanMediumOnEveryAxisItControls() {
         // The whole point of the `large` size is that it reads as the one action on the screen.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -21638,6 +21638,9 @@ struct whitenoise_macTests {
         #expect(runtime.uploadedProfileImageMediaType == "image/jpeg")
         #expect(runtime.uploadedProfileImageBlossomServer == nil)
         #expect(state.profileDraft.picture == runtime.uploadedProfileImageURL)
+        // The avatar draws `sanitizedPictureURL`, not `picture`. Asserting only the raw string
+        // leaves the form free to show initials for an image that uploaded perfectly well.
+        #expect(state.profileDraft.sanitizedPictureURL?.absoluteString == runtime.uploadedProfileImageURL)
         #expect(!state.isProfileImagePickerPresented)
     }
 
@@ -21666,6 +21669,7 @@ struct whitenoise_macTests {
         #expect(runtime.uploadedProfileImageData?.isEmpty == false)
         #expect(runtime.uploadedProfileImageMediaType == "image/jpeg")
         #expect(state.profileDraft.picture == runtime.uploadedProfileImageURL)
+        #expect(state.profileDraft.sanitizedPictureURL?.absoluteString == runtime.uploadedProfileImageURL)
         #expect(!state.isProfileImagePickerPresented)
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Your own profile images now load even when remote image loading is disabled.
  * Remote images from other accounts continue to follow your remote-image preference.

* **Bug Fixes**
  * Improved consistency for profile avatars across account switching, settings, and profile views.

* **Tests**
  * Added coverage for account-specific remote image loading and uploaded profile image URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->