### PR TITLE
Add the three dots menu to failed media sends

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -678,6 +678,23 @@ extension WorkspaceState {
         )
     }
 
+    /// The delivery marker a row should wear at `now`, with an in-flight retry folded in.
+    ///
+    /// A retry puts the send back in the state a first attempt is in, so the row goes back to
+    /// reading "Sending" — the clock in the bubble's own footer — rather than keeping the failure
+    /// marker and announcing the retry in a line underneath it. That also takes the recovery row
+    /// down for the length of the retry, since it is gated on the same marker: there is nothing to
+    /// retry or delete while the retry is the thing running.
+    ///
+    /// Group-scoped through `isRetryingDelivery`, like the core call: every failed row in the chat
+    /// is being carried by this retry, so they all go back to "Sending" together. Rows that are not
+    /// failed are left exactly as they were.
+    func deliveryIndicator(for message: MessageItem, at now: Date) -> MessageDeliveryIndicator {
+        let indicator = message.deliveryIndicator(at: now)
+        guard indicator == .failed, isRetryingDelivery(of: message) else { return indicator }
+        return .sending
+    }
+
     func retryDelivery(of message: MessageItem) async {
         guard message.canRetryDelivery(at: .now),
             let client,

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2473,8 +2473,15 @@ nonisolated struct MessageItem: Identifiable, Hashable {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Whether the row carries real content the user can act on.
+    ///
+    /// Invalidated rows count. Convergence retired them, but they are still drawn with their own
+    /// content and their own failure marker, so to the reader they are a failed message like any
+    /// other — and a failed message the app refuses to retry, forward, edit, copy or delete is a
+    /// bubble the user is simply stuck with. Only a deleted row, whose body is a placeholder rather
+    /// than anything the user wrote, is excluded.
     private var isActionableContent: Bool {
-        !isDeleted && invalidationStatus == nil
+        !isDeleted
     }
 
     private var isActionableChatBubble: Bool {
@@ -2497,12 +2504,18 @@ nonisolated struct MessageItem: Identifiable, Hashable {
 
     /// Whether this row may be re-driven to the relays at `now`.
     ///
-    /// Time-sensitive on purpose: a send that is still inside `pendingDeliveryGrace` reads as
-    /// "Sending", and offering to retry something the app is telling the user is still going out
-    /// invites a second click on a first attempt that has not finished. Retry appears exactly when
-    /// the bubble starts reading as an error, which is also when the sibling clients offer it.
+    /// Keyed on the marker the bubble is actually wearing, so retry appears exactly when the row
+    /// starts reading as an error and never before. That is time-sensitive on purpose: a send still
+    /// inside `pendingDeliveryGrace` reads as "Sending", and offering to retry something the app is
+    /// telling the user is still going out invites a second click on a first attempt that has not
+    /// finished.
+    ///
+    /// Invalidated rows qualify too — they wear the same marker, so refusing them here would be the
+    /// app showing a failure and then declining to do the one thing a failure asks for. The retry
+    /// is `retryGroupConvergence`, which re-drives what the core is holding for the conversation.
     func canRetryDelivery(at now: Date) -> Bool {
-        isPendingDelivery && deliveryIndicator(at: now) == .failed
+        guard presentation.isChatBubble, isOutgoing, !isDeleted else { return false }
+        return deliveryIndicator(at: now) == .failed
     }
 
     /// How long an own send may stay unconfirmed before its bubble stops reading as "Sending" and

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -420,30 +420,27 @@ struct MessageBubble: View {
         }
     }
 
-    /// Recovery controls under a failed own send.
+    /// Retry under a failed own send.
     ///
     /// The red footer glyph and its tooltip are the whole of the failure story otherwise, and a
-    /// tooltip is not an affordance — the retry lived only in the context menu and the hover
-    /// overflow, both of which the user has to go looking for. This puts the two things worth
-    /// doing about a stranded message where the failure already is. Suppressed during multi-select,
-    /// where the row is a checkbox target rather than a message.
+    /// tooltip is not an affordance. Retry is in the row's ⋯ menu too, where every other thing that
+    /// can be done to a message lives — but a failure is worth answering without making the user go
+    /// looking, so this one action is answered twice on purpose. Delete is not: it is destructive
+    /// and belongs with the rest of the menu. Suppressed during multi-select, where the row is a
+    /// checkbox target rather than a message.
+    ///
+    /// Gated on `deliveryIndicator`, which reads `.sending` again while a retry runs — so this
+    /// stands down for that window and the bubble shows the same clock a first attempt shows,
+    /// inside its own footer, instead of a progress line hanging underneath it.
     @ViewBuilder
     private var sendFailureActions: some View {
-        if message.isOutgoing, deliveryIndicator == .failed, !workspace.isTimelineSelectionMode {
-            let actions = MessageSendFailureActions(
-                onRetry: message.canRetryDelivery(at: deliveryClock)
-                    ? { Task { await workspace.retryDelivery(of: message) } } : nil,
-                // "Delete", not "Remove": the core committed this message locally before it tried
-                // to publish, so it is part of this device's history and goes out through the same
-                // scoped confirmation every other message deletion uses.
-                discardTitle: L10n.string("Delete"),
-                onDiscard: workspace.canDeleteMessage(message)
-                    ? { workspace.messagePendingDeletion = workspace.messageDeletionTarget(for: message) } : nil,
-                isRetrying: workspace.isRetryingDelivery(of: message)
-            )
-            if !actions.isEmpty {
-                actions.padding(.horizontal, 5)
+        if message.canRetryDelivery(at: deliveryClock), deliveryIndicator == .failed,
+            !workspace.isTimelineSelectionMode
+        {
+            MessageSendFailureActions {
+                Task { await workspace.retryDelivery(of: message) }
             }
+            .padding(.horizontal, 5)
         }
     }
 
@@ -591,7 +588,7 @@ struct MessageBubble: View {
     }
 
     private var deliveryIndicator: MessageDeliveryIndicator {
-        message.deliveryIndicator(at: deliveryClock)
+        workspace.deliveryIndicator(for: message, at: deliveryClock)
     }
 
     /// Hover text for the failure glyph. The bubble keeps the message's own text now, so this
@@ -2349,6 +2346,35 @@ struct MessageRowAction: Identifiable {
         }
         return actions
     }
+
+    /// The same two recovery actions for a media message that never reached the core: the bubble
+    /// the transcript renders while a send is on its way out, once that send has failed.
+    ///
+    /// Deliberately the same type the committed rows build, so both open `MessageOverflowMenu` and
+    /// a failed row's actions live in one place whichever half of the send it is stranded in. The
+    /// list is empty until then — the core has no cancellation story for a publish in flight, so
+    /// neither action would do anything.
+    @MainActor
+    static func all(
+        for message: PendingOutgoingMediaMessage,
+        workspace: WorkspaceState,
+        dismiss: @escaping () -> Void = {}
+    ) -> [MessageRowAction] {
+        guard message.state == .failed else { return [] }
+        return [
+            MessageRowAction(kind: .retry, title: L10n.string("Retry"), systemImage: "arrow.clockwise", role: nil) {
+                dismiss()
+                workspace.retryPendingOutgoingMediaMessage(message.id)
+            },
+            // "Remove", not "Delete": nothing has been committed anywhere yet, so dropping the
+            // bubble takes the message with it rather than hiding a message the group has. It also
+            // skips the deletion confirmation the committed rows go through, for the same reason.
+            MessageRowAction(kind: .delete, title: L10n.string("Remove"), systemImage: "trash", role: .destructive) {
+                dismiss()
+                workspace.discardPendingOutgoingMediaMessage(message.id)
+            },
+        ]
+    }
 }
 
 struct MessageOverflowPopover: View {
@@ -2357,7 +2383,21 @@ struct MessageOverflowPopover: View {
     let dismiss: () -> Void
 
     var body: some View {
-        let actions = MessageRowAction.all(for: message, workspace: workspace, dismiss: dismiss)
+        MessageOverflowMenu(actions: MessageRowAction.all(for: message, workspace: workspace, dismiss: dismiss))
+    }
+}
+
+/// The popover body behind the ⋯ control: a list of `MessageRowAction`s in the transcript's own
+/// menu chrome.
+///
+/// Split from `MessageOverflowPopover` so the staged-media bubble
+/// (`PendingOutgoingMessageOverflowButton`) opens the same menu rather than a lookalike — it
+/// builds its actions from a message the core has never seen, but a failed row is a failed row and
+/// the two must not drift into different shapes.
+struct MessageOverflowMenu: View {
+    let actions: [MessageRowAction]
+
+    var body: some View {
         VStack(spacing: 0) {
             ForEach(Array(actions.enumerated()), id: \.element.id) { index, action in
                 if index > 0 { Divider() }

--- a/whitenoise-mac/Views/MessageSendFailureActions.swift
+++ b/whitenoise-mac/Views/MessageSendFailureActions.swift
@@ -2,57 +2,34 @@
 //  MessageSendFailureActions.swift
 //  whitenoise-mac
 //
-//  The recovery row under a send that did not make it out: run it again, or take it off the
-//  transcript.
+//  The recovery control under a send that did not make it out: run it again.
 //
 
 import SwiftUI
 
-/// Recovery controls for an outgoing message that failed, rendered under the bubble they act on.
+/// Retry for an outgoing message that failed, rendered under the bubble it acts on.
 ///
 /// Shared by the two kinds of failed own row so they read as one thing: the locally staged media
 /// message that never published (`PendingOutgoingMessageBubble`) and the core-committed message
 /// stranded before its relay round-trip (`MessageBubble`). This is the macOS answer to the iOS
-/// clients' tap-the-bubble action sheet — on a pointer platform the options belong in the open,
-/// under the row, not behind a gesture and a dialog.
+/// clients' tap-the-bubble action sheet — on a pointer platform the one thing worth doing about a
+/// failure belongs in the open, under the row, not behind a gesture and a dialog.
 ///
-/// Both actions are optional because the two rows disagree about what a failure allows: an
-/// invalidated message can only be removed, and a message in a conversation the account may not act
-/// in can only be retried. A row with neither action left renders nothing.
+/// Only retry. Deleting a failed message is not a recovery — it is the same destructive action
+/// every other row has, and it lives where every other row keeps it: the ⋯ menu
+/// (`MessageRowAction.all`). Putting it here as well made the one control under a failure a
+/// two-way choice, with the destructive half a click away from the one the user came for.
+///
+/// Nothing here covers a retry that is already running: both rows put the bubble back into their
+/// respective sending state for that window — clock in the footer, or the staged bubble's own
+/// spinner — so this control is simply not rendered while one is in flight.
 struct MessageSendFailureActions: View {
-    let onRetry: (() -> Void)?
-    let discardTitle: String
-    let onDiscard: (() -> Void)?
-    /// Swaps the controls for a progress line while the retry runs. The only feedback the click
-    /// gets on a core-committed row: its delivery marker is derived from `sentAt`, so it cannot be
-    /// walked back to "Sending" the way the sibling clients walk back an optimistic one.
-    var isRetrying = false
+    let onRetry: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
-            if isRetrying {
-                ProgressView()
-                    .controlSize(.mini)
-                Text(L10n.string("Retrying…"))
-                    .wnFont(.medium10)
-                    .foregroundStyle(WNColor.backgroundContentTertiary)
-            } else {
-                if let onRetry {
-                    Button(L10n.string("Retry"), systemImage: "arrow.clockwise", action: onRetry)
-                }
-                if let onDiscard {
-                    Button(discardTitle, systemImage: "trash", action: onDiscard)
-                }
-            }
-        }
-        .buttonStyle(.link)
-        .wnFont(.medium10)
-        .labelStyle(.titleOnly)
-    }
-
-    /// Nothing to offer — the caller should leave the row out entirely rather than reserve empty
-    /// space under the bubble.
-    var isEmpty: Bool {
-        !isRetrying && onRetry == nil && onDiscard == nil
+        Button(L10n.string("Retry"), systemImage: "arrow.clockwise", action: onRetry)
+            .buttonStyle(.link)
+            .wnFont(.medium10)
+            .labelStyle(.titleOnly)
     }
 }

--- a/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
+++ b/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
@@ -16,6 +16,9 @@ private let pendingMediaThumbnailOversample: CGFloat = 1.5
 
 struct PendingOutgoingMessageBubble: View {
     @Environment(WorkspaceState.self) private var workspace
+    @State private var isHovering = false
+    @State private var isOverflowPresented = false
+    @State private var overflowWidth: CGFloat = 0
     let message: PendingOutgoingMediaMessage
     let timestampReferenceDate: Date
     let timestampLocale: Locale
@@ -28,21 +31,73 @@ struct PendingOutgoingMessageBubble: View {
             content
 
             if message.state == .failed {
-                // "Remove", not "Delete": nothing has been committed anywhere yet, so dropping the
-                // bubble takes the message with it rather than hiding a message the group has.
-                MessageSendFailureActions(
-                    onRetry: { workspace.retryPendingOutgoingMediaMessage(message.id) },
-                    discardTitle: L10n.string("Remove"),
-                    onDiscard: { workspace.discardPendingOutgoingMediaMessage(message.id) }
-                )
+                // Retry only, and in both places deliberately: the ⋯ has to be reached for, and a
+                // failed send is worth answering where the failure already is. Remove stays in the
+                // menu with the other destructive actions.
+                MessageSendFailureActions {
+                    workspace.retryPendingOutgoingMediaMessage(message.id)
+                }
             }
         }
+        .overlay(alignment: .leading) { overflowControl }
+        .animation(.smooth(duration: 0.12), value: showsOverflowControl)
         .frame(maxWidth: maxContentWidth, alignment: .trailing)
         .frame(maxWidth: .infinity, alignment: .trailing)
         .padding(.leading, bubbleGutter)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel)
+        // The whole row is the hover target, matching `MessageBubble`: the ⋯ appears when the
+        // pointer is anywhere on the message, not only over the media itself.
+        .contentShape(.rect)
+        .onHover { isHovering = $0 }
     }
+
+    /// The recovery menu for a send that never reached the core, in the ⋯ control every other row
+    /// in the transcript carries. This was the one failed row with no ⋯ at all, whichever way its
+    /// retry went: a failed retry lands it back on `.failed`, so it stayed a bubble whose only
+    /// actions were the link row under it.
+    ///
+    /// Revealed on hover, and held open while its popover is: the pointer leaves the row to reach
+    /// the menu it just opened.
+    @ViewBuilder
+    private var overflowControl: some View {
+        if showsOverflowControl {
+            Button {
+                isOverflowPresented = true
+            } label: {
+                MessageInlineActionIcon(systemName: "ellipsis", label: L10n.string("More"))
+            }
+            .buttonStyle(.plain)
+            .help(L10n.string("More"))
+            .popover(isPresented: $isOverflowPresented, arrowEdge: .bottom) {
+                MessageOverflowMenu(
+                    actions: MessageRowAction.all(for: message, workspace: workspace) {
+                        isOverflowPresented = false
+                    }
+                )
+            }
+            // Pushed clear of the bubble by the width SwiftUI measured, the way `MessageBubble`
+            // places its own hover strip — `.alignmentGuide` does not survive the `ViewBuilder`
+            // conditional above it, and would leave the control drawn on top of the message.
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { width in
+                overflowWidth = width
+            }
+            .offset(x: -(overflowWidth + Self.overflowBubbleGap))
+            .opacity(overflowWidth > 0 ? 1 : 0)
+            .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .trailing)))
+        }
+    }
+
+    /// Failed sends only: a message still on its way out has nothing to retry and no cancellation
+    /// story in the core, so an open menu would offer two actions that do nothing.
+    private var showsOverflowControl: Bool {
+        message.state == .failed && (isHovering || isOverflowPresented)
+    }
+
+    /// Breathing room between the ⋯ control and the bubble edge, matching `MessageBubble`.
+    private static let overflowBubbleGap: CGFloat = 8
 
     private var accessibilityLabel: String {
         message.state == .failed ? L10n.string("Not delivered") : L10n.string("Sending")

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -6645,9 +6645,10 @@ struct whitenoise_macTests {
         // the pending-delivery grace window.
         #expect(messages.allSatisfy { $0.deliveryIndicator(at: sentAt) == .failed })
         #expect(messages.allSatisfy { $0.statusLabel(for: .failed) == "Did not reach group" })
-        // Convergence-lost content stays read-only — reacting to or replying to a message the
-        // group never accepted would address a branch that no longer exists.
-        #expect(messages.allSatisfy { !$0.supportsChatActions })
+        // Convergence-lost content is still actionable: it carries the user's own words and a
+        // failure marker, so it gets the same menu every other row has rather than being a bubble
+        // nothing can be done about.
+        #expect(messages.allSatisfy { $0.supportsChatActions })
     }
 
     @MainActor
@@ -7271,13 +7272,22 @@ struct whitenoise_macTests {
         #expect(incomingMediaOnly.canReply)
         #expect(!incomingMediaOnly.canDelete)
 
-        for message in [deleted, failed] {
-            #expect(!message.supportsChatActions)
-            #expect(!message.canCopyText)
-            #expect(!message.canReact)
-            #expect(!message.canReply)
-            #expect(!message.canDelete)
-        }
+        #expect(!deleted.supportsChatActions)
+        #expect(!deleted.canCopyText)
+        #expect(!deleted.canReact)
+        #expect(!deleted.canReply)
+        #expect(!deleted.canDelete)
+
+        // An invalidated row keeps every action a live one has. It is drawn with its own content
+        // and its own failure marker, so to the reader it is a failed message like any other, and
+        // a failed message the app refuses to act on is a bubble the user is stuck with.
+        #expect(failed.supportsChatActions)
+        #expect(failed.canCopyText)
+        #expect(failed.canReact)
+        #expect(failed.canReply)
+        #expect(failed.canDelete)
+        // Including the one a failure actually asks for.
+        #expect(failed.canRetryDelivery(at: sentAt))
 
         #expect(!systemNotice.supportsChatActions)
         #expect(systemNotice.canCopyText)
@@ -17700,6 +17710,332 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func failedOutgoingMediaBubbleOffersRetryAndRemoveInItsOverflowMenu() async throws {
+        // The staged-media bubble used to carry its recovery as a link row under itself and had no
+        // ⋯ control at all, so it was the one failed row in the transcript whose actions lived
+        // somewhere other than the overflow menu every other row uses.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(
+                fileName: "notes.txt",
+                mediaType: "text/plain",
+                data: Data("hello media".utf8),
+                dim: nil
+            ),
+            for: draftKey
+        )
+        await Self.settleComposerMediaUploads(state)
+
+        runtime.sendMediaAttachmentsError = FakeMarmotRuntimeError.mediaUploadFailed
+        await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        let failed = try #require(state.selectedPendingOutgoingMediaMessages.first)
+        let actions = MessageRowAction.all(for: failed, workspace: state)
+        #expect(actions.map(\.kind) == [.retry, .delete])
+        // "Remove", not "Delete": nothing has been committed anywhere yet.
+        #expect(actions.map(\.title) == [L10n.string("Retry"), L10n.string("Remove")])
+        #expect(actions.last?.role == .destructive)
+
+        runtime.sendMediaAttachmentsError = nil
+        try #require(actions.first { $0.kind == .retry }).run()
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        #expect(runtime.sendMediaAttachmentsCallCount == 2)
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+    }
+
+    @MainActor
+    @Test func outgoingMediaBubbleOverflowMenuIsEmptyWhileTheSendIsStillGoingOut() async throws {
+        // Nothing to retry and nothing to remove until it has failed: the core has no cancellation
+        // story for a publish in flight, so both actions would be a lie.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let sending = PendingOutgoingMediaMessage(
+            attachments: [
+                PendingMediaAttachment(
+                    fileName: "notes.txt",
+                    mediaType: "text/plain",
+                    data: Data("hello media".utf8),
+                    dim: nil
+                )
+            ],
+            caption: "",
+            state: .uploading
+        )
+
+        #expect(MessageRowAction.all(for: sending, workspace: state).isEmpty)
+    }
+
+    @MainActor
+    @Test func failedOutgoingMediaBubbleRoutesRemoveThroughTheOverflowMenu() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(
+                fileName: "notes.txt",
+                mediaType: "text/plain",
+                data: Data("hello media".utf8),
+                dim: nil
+            ),
+            for: draftKey
+        )
+        await Self.settleComposerMediaUploads(state)
+
+        runtime.sendMediaAttachmentsError = FakeMarmotRuntimeError.mediaUploadFailed
+        await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        let failed = try #require(state.selectedPendingOutgoingMediaMessages.first)
+        var dismissed = false
+        let actions = MessageRowAction.all(for: failed, workspace: state) { dismissed = true }
+        try #require(actions.first { $0.kind == .delete }).run()
+
+        #expect(dismissed)
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+        #expect(state.pendingOutgoingMediaMessagesByConversation.isEmpty)
+    }
+
+    @Test func failedOutgoingMediaBubbleCarriesTheSharedOverflowControl() throws {
+        // Source contract: the pending bubble's recovery is offered twice on purpose — the link row
+        // under the bubble, where the failure already is, and the ⋯ menu every other row uses. This
+        // guards both, since the bubble had only the first for as long as it existed.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("PendingOutgoingMessageViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+
+        #expect(source.contains("MessageInlineActionIcon(systemName: \"ellipsis\""))
+        #expect(source.contains("MessageOverflowMenu("))
+        #expect(source.contains("MessageRowAction.all(for: message, workspace: workspace)"))
+        #expect(source.contains("MessageSendFailureActions {"))
+        // Retry only under the bubble — Remove belongs in the menu with the other destructive
+        // actions, and reintroducing it here is the regression this guards.
+        #expect(!source.contains("discardPendingOutgoingMediaMessage"))
+    }
+
+    @MainActor
+    @Test func invalidatedRowGetsTheSameOverflowMenuAsALiveOne() async throws {
+        // An invalidated row used to have no ⋯ at all — `supportsChatActions` refused everything,
+        // so a bubble wearing the same red failure marker as any other failed send offered nothing,
+        // not even Delete. It now carries the whole menu, retry included: it is drawn with the
+        // user's own words, and a failure the app declines to act on is a bubble they are stuck
+        // with.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        func message(id: String, invalidated: Bool) -> MessageItem {
+            MessageItem(
+                id: id,
+                groupIdHex: "group",
+                sourceMessageIdHex: "source-\(id)",
+                senderAccountIdHex: account.accountIdHex,
+                senderName: "Desktop Account",
+                body: "Meet at seven",
+                sentAt: .now,
+                invalidationStatus: invalidated ? "LosingBranch" : nil,
+                isOutgoing: true
+            )
+        }
+
+        let invalidated = message(id: "invalidated", invalidated: true)
+        let live = message(id: "live", invalidated: false)
+
+        #expect(invalidated.supportsChatActions)
+        #expect(invalidated.canRetryDelivery(at: .now))
+
+        let invalidatedKinds = MessageRowAction.all(for: invalidated, workspace: state).map(\.kind)
+        #expect(invalidatedKinds.first == .retry)
+        // Everything a delivered row offers, and nothing withheld: the only difference between the
+        // two lists is the retry a failure earns.
+        #expect(
+            invalidatedKinds.filter { $0 != .retry }
+                == MessageRowAction.all(for: live, workspace: state).map(\.kind)
+        )
+
+        // The destructive action is a real one, not a local-only consolation.
+        #expect(state.messageDeletionCapability(invalidated).canDeleteForEveryone)
+    }
+
+    @MainActor
+    @Test func invalidatedRowRetryReDrivesConvergenceLikeAnyOtherFailedSend() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let invalidated = MessageItem(
+            id: "invalidated",
+            groupIdHex: "group",
+            sourceMessageIdHex: "source-event",
+            senderAccountIdHex: account.accountIdHex,
+            senderName: "Desktop Account",
+            body: "Meet at seven",
+            sentAt: .now,
+            invalidationStatus: "LosingBranch",
+            isOutgoing: true
+        )
+
+        let retry = try #require(
+            MessageRowAction.all(for: invalidated, workspace: state).first { $0.kind == .retry }
+        )
+        retry.run()
+        await Self.waitUntil { runtime.retryGroupConvergenceCallCount == 1 }
+
+        #expect(runtime.retryGroupConvergenceCallCount == 1)
+
+        // An *incoming* invalidated row wears the same marker but is nobody's send to re-drive.
+        let incoming = MessageItem(
+            id: "incoming-invalidated",
+            groupIdHex: "group",
+            sourceMessageIdHex: "source-incoming",
+            senderAccountIdHex: "alice1234567890alice1234567890alice1234567890alice1234567890alic",
+            senderName: "Alice",
+            body: "Bring the keys",
+            sentAt: .now,
+            invalidationStatus: "LosingBranch",
+            isOutgoing: false
+        )
+        #expect(!incoming.canRetryDelivery(at: .now))
+        #expect(!MessageRowAction.all(for: incoming, workspace: state).contains { $0.kind == .retry })
+    }
+
+    @MainActor
+    @Test func retryPutsTheRowBackToSendingInsteadOfHangingAProgressLineUnderIt() async throws {
+        // A retry is a send going out again, so the row wears what a first attempt wears: the clock
+        // in the bubble's own footer. It used to keep the failure marker and grow a "Retrying…"
+        // line underneath instead, which is the one piece of the failure story rendered outside the
+        // bubble. The recovery row rides on the same marker, so it stands down with it.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let sentAt = Date.now.addingTimeInterval(-(MessageItem.pendingDeliveryGrace + 1))
+        let failed = MessageItem(
+            id: "failed",
+            groupIdHex: "group",
+            sourceMessageIdHex: nil,
+            senderAccountIdHex: account.accountIdHex,
+            senderName: "Desktop Account",
+            body: "Say something while I work",
+            sentAt: sentAt,
+            isOutgoing: true
+        )
+        let delivered = MessageItem(
+            id: "delivered",
+            groupIdHex: "group",
+            sourceMessageIdHex: "source-event",
+            senderAccountIdHex: account.accountIdHex,
+            senderName: "Desktop Account",
+            body: "This one landed",
+            sentAt: sentAt,
+            isOutgoing: true
+        )
+
+        #expect(state.deliveryIndicator(for: failed, at: .now) == .failed)
+
+        runtime.messageActionGateEnabled = true
+        let retry = Task { await state.retryDelivery(of: failed) }
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+
+        #expect(state.deliveryIndicator(for: failed, at: .now) == .sending)
+        // Group-scoped, like the core call it wraps: a second failed row in the same chat is being
+        // carried by this same retry and goes back to "Sending" with it.
+        let sibling = MessageItem(
+            id: "sibling",
+            groupIdHex: "group",
+            sourceMessageIdHex: nil,
+            senderAccountIdHex: account.accountIdHex,
+            senderName: "Desktop Account",
+            body: "Me too",
+            sentAt: sentAt,
+            isOutgoing: true
+        )
+        #expect(state.deliveryIndicator(for: sibling, at: .now) == .sending)
+        // A row that was never failed is untouched — the retry does not repaint the whole chat.
+        #expect(state.deliveryIndicator(for: delivered, at: .now) == .delivered)
+
+        runtime.releaseMessageActionGate()
+        await retry.value
+
+        // The row is still unconfirmed once the window closes, so the failure marker comes back
+        // with its recovery row rather than the bubble being left on a clock forever.
+        #expect(state.deliveryIndicator(for: failed, at: .now) == .failed)
+    }
+
+    @MainActor
+    @Test func retriedOutgoingMediaBubbleStillOffersItsOverflowMenuAfterFailingAgain() async throws {
+        // The reported shape of the bug: the ⋯ was missing on a message that had already been
+        // retried, not only on one that had just failed. A retry walks the bubble back through
+        // `.uploading`, so the menu has to come back with the failure rather than being a
+        // first-failure-only affordance.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(
+                fileName: "notes.txt",
+                mediaType: "text/plain",
+                data: Data("hello media".utf8),
+                dim: nil
+            ),
+            for: draftKey
+        )
+        await Self.settleComposerMediaUploads(state)
+
+        runtime.sendMediaAttachmentsError = FakeMarmotRuntimeError.mediaUploadFailed
+        await state.sendDraft()
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        let failed = try #require(state.selectedPendingOutgoingMediaMessages.first)
+
+        // Two failed retries, not one: the menu must survive every trip through `.uploading`, not
+        // just the first.
+        for _ in 0..<2 {
+            let retry = try #require(
+                MessageRowAction.all(for: failed, workspace: state).first { $0.kind == .retry }
+            )
+            retry.run()
+            await Self.settlePendingOutgoingMediaSends(state)
+
+            let retried = try #require(state.selectedPendingOutgoingMediaMessages.first)
+            #expect(retried.state == .failed)
+            #expect(MessageRowAction.all(for: retried, workspace: state).map(\.kind) == [.retry, .delete])
+        }
+
+        #expect(runtime.sendMediaAttachmentsCallCount == 3)
+    }
+
+    @MainActor
     @Test func failedOutgoingMediaMessageCanBeDiscarded() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
@@ -19379,6 +19715,10 @@ struct whitenoise_macTests {
                 isDeleted: true,
                 isOutgoing: false
             ))
+        #expect(copiedText == "initial")
+
+        // An invalidated row is not a placeholder — its body is what the sender actually wrote, so
+        // it copies like any other message.
         state.copyText(
             of: MessageItem(
                 id: "failed",
@@ -19389,7 +19729,7 @@ struct whitenoise_macTests {
                 isOutgoing: true
             ))
 
-        #expect(copiedText == "initial")
+        #expect(copiedText == "Lost the branch")
     }
 
     @MainActor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ellipsis menu for failed outgoing messages and media.
  * Failed sends now offer **Retry** and **Remove** actions.
  * Invalidated outgoing messages retain standard actions when available.
  * Retry controls remain accessible during repeated failures.

* **Bug Fixes**
  * Improved delivery indicators while retries are in progress.
  * Removed irrelevant actions during active uploads and timeline selection.
  * Improved recovery and cleanup after retrying or removing failed media.

* **Tests**
  * Added coverage for failure, retry, removal, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->