### PR TITLE
fix double loading media issue

### DIFF
--- a/whitenoise-mac/Core/Media/OutgoingMediaWarmPlaintexts.swift
+++ b/whitenoise-mac/Core/Media/OutgoingMediaWarmPlaintexts.swift
@@ -1,0 +1,81 @@
+//
+//  OutgoingMediaWarmPlaintexts.swift
+//  whitenoise-mac
+//
+//  The plaintexts of the media this client is publishing right now, held in memory between the send
+//  and the moment the published row renders them.
+//
+
+import Foundation
+
+/// Just-sent media plaintexts, keyed by the same content-addressed cache key the published row will
+/// look the attachment up by.
+///
+/// Not the durable copy: `cacheOutgoingMediaPlaintext` writes the same bytes into the encrypted disk
+/// cache, and every later render comes from there. This hold exists for the *first* frame of the
+/// published row. Reading the disk cache is asynchronous — open the container, decrypt, verify the
+/// plaintext digest — so a row that lands with a cold download state spends those frames on a
+/// spinner over an image this process is still holding, which is what made the sender's own bubble
+/// blink from loaded back to loading as the placeholder gave way to the real row.
+///
+/// An entry is held from the seed that precedes the publish until the outgoing message that owns it
+/// is retired, so it also survives a mid-send prune of the download-state stores.
+nonisolated struct OutgoingMediaWarmPlaintexts {
+    /// Default ceiling on the held bytes. One send's attachments sit far below it; the cap only
+    /// bounds the pathological case of messages whose rows never arrive — an offline queue, a failed
+    /// publish whose bubble the user leaves sitting there — where the hold would grow per send.
+    static let defaultByteLimit = 64 * 1024 * 1024
+
+    /// Injectable so a test can drive the overflow without allocating the real budget.
+    let byteLimit: Int
+    private var downloads: [MessageMediaDiskCacheKey: MessageMediaDownload] = [:]
+    /// Keys in insertion order, so an overflow drops the oldest hold rather than an arbitrary one.
+    private var order: [MessageMediaDiskCacheKey] = []
+    private(set) var heldByteCount = 0
+
+    init(byteLimit: Int = Self.defaultByteLimit) {
+        self.byteLimit = byteLimit
+    }
+
+    var isEmpty: Bool { downloads.isEmpty }
+
+    /// Holds one attachment's plaintext, evicting the oldest holds while the total is over budget.
+    mutating func hold(_ download: MessageMediaDownload, for key: MessageMediaDiskCacheKey) {
+        remove(for: key)
+        downloads[key] = download
+        order.append(key)
+        heldByteCount += download.payload.byteCount
+        while heldByteCount > byteLimit, let oldest = order.first {
+            remove(for: oldest)
+        }
+    }
+
+    /// The plaintext for a published row's attachment, or `nil` when this client did not send it.
+    ///
+    /// Deliberately non-consuming: the row that reads it may be rebuilt more than once while the
+    /// send is still in flight (a reprojection that changes the message's media prunes the download
+    /// state stores), and each rebuild has to find the bytes again.
+    func download(for key: MessageMediaDiskCacheKey) -> MessageMediaDownload? {
+        downloads[key]
+    }
+
+    mutating func remove(for key: MessageMediaDiskCacheKey) {
+        guard let existing = downloads.removeValue(forKey: key) else { return }
+        heldByteCount -= existing.payload.byteCount
+        order.removeAll { $0 == key }
+    }
+
+    mutating func removeAll() {
+        downloads.removeAll()
+        order.removeAll()
+        heldByteCount = 0
+    }
+
+    mutating func removeAll(forAccountId accountId: String) {
+        for key in order where key.accountId == accountId {
+            downloads[key] = nil
+        }
+        order.removeAll { $0.accountId == accountId }
+        heldByteCount = order.reduce(0) { $0 + (downloads[$1]?.payload.byteCount ?? 0) }
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -440,6 +440,9 @@ extension WorkspaceState {
             purgeRememberedDirectPeers(accountId: removedAccountId)
             await mediaDiskCache.purgeAccount(removedAccountId)
             clearMediaReferenceResolutionCache(forAccountId: removedAccountId)
+            // Purging the account's media must take the plaintexts its in-flight sends were holding
+            // in memory with it, not just the encrypted copies on disk.
+            outgoingMediaWarmPlaintexts.removeAll(forAccountId: removedAccountId)
             accounts = try await accountItemsFromRuntime(client: client)
             removeChats(forAccountId: removedAccountId)
             accountUnreadByIdHex[removedAccountIdHex] = nil

--- a/whitenoise-mac/Core/WorkspaceState+Media.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Media.swift
@@ -254,12 +254,52 @@ extension WorkspaceState {
         for message: MessageItem,
         attachment: MessageMediaAttachment
     ) -> MediaDownloadStateStore {
-        mediaDownloadStateStore(forKey: mediaDownloadKey(message: message, attachment: attachment))
+        let key = mediaDownloadKey(message: message, attachment: attachment)
+        if let store = mediaDownloads[key] {
+            return store
+        }
+        let store = mediaDownloadStateStore(forKey: key)
+        primeOwnSendMediaDownload(store, message: message, attachment: attachment)
+        return store
+    }
+
+    /// Starts a just-sent attachment's download state at `.loaded`, from the plaintext the send is
+    /// still holding.
+    ///
+    /// The send seeds the disk cache before it publishes, so the row that replaces the pending
+    /// bubble does find its bytes — but that read is asynchronous, so the row rendered a spinner
+    /// first and the sender watched their own image blink from loaded back to loading as the
+    /// placeholder gave way. Handing the plaintext over synchronously makes the row's *first* frame
+    /// the image, which is what makes the swap invisible.
+    ///
+    /// Gated on `isMediaDisplayAllowed` exactly like every other published download state: media
+    /// must not appear for an account or a conversation the user is no longer looking at.
+    private func primeOwnSendMediaDownload(
+        _ store: MediaDownloadStateStore,
+        message: MessageItem,
+        attachment: MessageMediaAttachment
+    ) {
+        guard case .idle = store.state,
+            let accountId = activeAccountId,
+            !message.groupIdHex.isEmpty,
+            !outgoingMediaWarmPlaintexts.isEmpty,
+            isMediaDisplayAllowed(forAccountId: accountId, groupIdHex: message.groupIdHex),
+            let download = outgoingMediaWarmPlaintexts.download(
+                for: MessageMediaDiskCacheKey(
+                    accountId: accountId,
+                    groupIdHex: message.groupIdHex,
+                    reference: attachment.reference
+                )
+            )
+        else { return }
+        store.update(.loaded(download))
     }
 
     func loadMediaAttachment(_ attachment: MessageMediaAttachment, for message: MessageItem) async {
         let key = mediaDownloadKey(message: message, attachment: attachment)
-        let stateStore = mediaDownloadStateStore(forKey: key)
+        // The priming variant, so a tap or an automatic download that reaches a just-sent
+        // attachment before its row was ever rendered still resolves from the plaintext in hand.
+        let stateStore = mediaDownloadStateStore(for: message, attachment: attachment)
         if case .loaded = stateStore.state {
             return
         }
@@ -1006,6 +1046,7 @@ extension WorkspaceState {
             store.update(.idle)
         }
         mediaDownloads.removeAll()
+        outgoingMediaWarmPlaintexts.removeAll()
         cancelAllMediaAttachmentDownloadTasks()
         clearMediaReferenceResolutionCache()
         MessageAudioMetadataCache.shared.clear()

--- a/whitenoise-mac/Core/WorkspaceState+PendingOutgoingMedia.swift
+++ b/whitenoise-mac/Core/WorkspaceState+PendingOutgoingMedia.swift
@@ -87,12 +87,14 @@ extension WorkspaceState {
     }
 
     func cancelPendingOutgoingMediaSends(for draftKey: ComposerDraftKey) {
-        for message in pendingOutgoingMediaMessagesByConversation[draftKey] ?? [] {
+        let messages = pendingOutgoingMediaMessagesByConversation[draftKey] ?? []
+        for message in messages {
             pendingOutgoingMediaSendTasks.removeValue(forKey: message.id)?.cancel()
             for upload in pendingOutgoingMediaUploadTasks.removeValue(forKey: message.id) ?? [] {
                 upload.cancel()
             }
         }
+        releaseWarmPlaintexts(ofMessagesMatching: nil, in: messages)
         pendingOutgoingMediaMessagesByConversation[draftKey] = nil
     }
 
@@ -155,14 +157,16 @@ extension WorkspaceState {
         // We are holding the plaintext that produced these references, so the sender's own bubble
         // has no reason to fetch its own image back from Blossom and decrypt it. Seed before
         // publishing: the real row can render the moment the send returns, and it must find a warm
-        // cache when it does.
-        await cacheOutgoingMediaPlaintext(
+        // cache when it does — in memory as well as on disk, so its first frame is the image rather
+        // than a spinner over bytes this process is still holding.
+        let heldPlaintextKeys = await cacheOutgoingMediaPlaintext(
             message.attachments,
             references: references,
             accountId: account.id,
             groupIdHex: draftKey.chatId
         )
         guard !Task.isCancelled, pendingOutgoingMediaMessage(id, in: draftKey) != nil else { return }
+        setPendingOutgoingMediaWarmPlaintextKeys(heldPlaintextKeys, for: id, in: draftKey)
 
         do {
             _ = try await client.sendMediaAttachments(
@@ -181,14 +185,18 @@ extension WorkspaceState {
         }
 
         clearMediaReferenceResolutionCache(forAccountId: account.id, groupIdHex: draftKey.chatId)
-        // Drop the placeholder before the refresh, not after: the core commits an own send locally
-        // as part of publishing, so a subscription delta can already be carrying the real row.
-        removePendingOutgoingMediaMessage(id, in: draftKey)
+        // Re-window first, then drop the placeholder. Either order is safe on the delta path — the
+        // core commits an own send locally as part of publishing, so a subscription delta may
+        // already have put the real row on screen, where the digest match hides this bubble anyway.
+        // What the old order cost was the *other* path: dropping the placeholder before the window
+        // came back left a frame with neither row in it, so the transcript flashed where the
+        // message had been. Retiring it afterwards makes the swap seamless in both directions.
         await refreshSelectedTimelineAfterSend(
             groupIdHex: draftKey.chatId,
             account: account,
             client: client
         )
+        removePendingOutgoingMediaMessage(id, in: draftKey)
     }
 
     /// A Blossom upload owned by an outgoing message rather than by the composer.
@@ -257,6 +265,23 @@ extension WorkspaceState {
         pendingOutgoingMediaMessagesByConversation[draftKey]?[index].publishedPlaintextSHAs = digests
     }
 
+    private func setPendingOutgoingMediaWarmPlaintextKeys(
+        _ keys: [MessageMediaDiskCacheKey],
+        for id: PendingOutgoingMediaMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) {
+        guard let index = pendingOutgoingMediaMessagesByConversation[draftKey]?.firstIndex(where: { $0.id == id })
+        else { return }
+        // A retry re-uploads, so it seeds under fresh keys (a new nonce means a new ciphertext
+        // digest). Let go of the attempt this one replaces, or its plaintexts would be held with
+        // nothing left to claim them.
+        let superseded = pendingOutgoingMediaMessagesByConversation[draftKey]?[index].warmPlaintextKeys ?? []
+        for key in superseded where !keys.contains(key) {
+            outgoingMediaWarmPlaintexts.remove(for: key)
+        }
+        pendingOutgoingMediaMessagesByConversation[draftKey]?[index].warmPlaintextKeys = keys
+    }
+
     private func removePendingOutgoingMediaMessage(
         _ id: PendingOutgoingMediaMessage.ID,
         in draftKey: ComposerDraftKey
@@ -266,7 +291,22 @@ extension WorkspaceState {
             upload.cancel()
         }
         var messages = pendingOutgoingMediaMessagesByConversation[draftKey] ?? []
+        releaseWarmPlaintexts(ofMessagesMatching: id, in: messages)
         messages.removeAll { $0.id == id }
         pendingOutgoingMediaMessagesByConversation[draftKey] = messages.isEmpty ? nil : messages
+    }
+
+    /// Lets go of the plaintexts a retired message was holding for its published row. By this point
+    /// the row has either rendered from them or is about to read the same bytes back from the
+    /// encrypted disk cache, which is where they durably live.
+    private func releaseWarmPlaintexts(
+        ofMessagesMatching id: PendingOutgoingMediaMessage.ID?,
+        in messages: [PendingOutgoingMediaMessage]
+    ) {
+        for message in messages where id == nil || message.id == id {
+            for key in message.warmPlaintextKeys {
+                outgoingMediaWarmPlaintexts.remove(for: key)
+            }
+        }
     }
 }

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -1285,27 +1285,42 @@ extension WorkspaceState {
 
     /// Files the plaintext we just published under the same cache key the bubble will look it up
     /// by, so an outgoing attachment renders from disk instead of round-tripping through Blossom.
+    ///
+    /// The same bytes are also held in memory (`outgoingMediaWarmPlaintexts`) until the outgoing
+    /// message is retired. The disk copy is what every later render reads, but reading it is
+    /// asynchronous, so on its own it still left the published row rendering a spinner for its first
+    /// frames — the sender's own image blinking from loaded back to loading as the pending bubble
+    /// gave way to the real row. The in-memory hold is what the row's first frame resolves from.
+    /// Returns the keys it held, so the outgoing message can release them when it is retired.
+    @discardableResult
     func cacheOutgoingMediaPlaintext(
         _ attachments: [PendingMediaAttachment],
         references: [MediaAttachmentReferenceFfi],
         accountId: String,
         groupIdHex: String
-    ) async {
+    ) async -> [MessageMediaDiskCacheKey] {
+        var heldKeys: [MessageMediaDiskCacheKey] = []
         for (attachment, reference) in zip(attachments, references) {
-            await mediaDiskCache.store(
-                MessageMediaDownload(
-                    data: attachment.data,
-                    fileName: attachment.fileName,
-                    mediaType: attachment.mediaType,
-                    sizeBytes: UInt64(attachment.data.count)
-                ),
-                for: MessageMediaDiskCacheKey(
-                    accountId: accountId,
-                    groupIdHex: groupIdHex,
-                    reference: reference
-                )
+            let cacheKey = MessageMediaDiskCacheKey(
+                accountId: accountId,
+                groupIdHex: groupIdHex,
+                reference: reference
             )
+            // The payload carries the id a disk read would give it, so a row that starts from this
+            // hold and one that later re-reads the same attachment from disk share one decoded
+            // image rather than each rasterizing their own.
+            let download = MessageMediaDownload(
+                data: attachment.data,
+                fileName: attachment.fileName,
+                mediaType: attachment.mediaType,
+                sizeBytes: UInt64(attachment.data.count),
+                payloadId: cacheKey.payloadID
+            )
+            outgoingMediaWarmPlaintexts.hold(download, for: cacheKey)
+            heldKeys.append(cacheKey)
+            await mediaDiskCache.store(download, for: cacheKey)
         }
+        return heldKeys
     }
 
     func startTimelineListener(

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -99,6 +99,10 @@ final class WorkspaceState {
         return result
     }
     @ObservationIgnored var mediaDownloads: [String: MediaDownloadStateStore] = [:]
+    /// Plaintexts of the media this client is publishing right now, held until the row that carries
+    /// them is retired. `@ObservationIgnored` for the same reason `mediaDownloads` is: it is read
+    /// while a download-state store is being created, which happens inside a transcript body pass.
+    @ObservationIgnored var outgoingMediaWarmPlaintexts = OutgoingMediaWarmPlaintexts()
     @ObservationIgnored let mediaDiskCache: MessageMediaDiskCache
     @ObservationIgnored var hiddenMessageStore: (any HiddenMessageStoring)?
     @ObservationIgnored var pinnedChatStore: (any PinnedChatStoring)?

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -948,6 +948,13 @@ nonisolated struct PendingOutgoingMediaMessage: Identifiable, Hashable, Sendable
     /// locally *inside* the publish call, so the real row can arrive through the timeline
     /// subscription while the relay round-trip is still in flight — and until then both rendered.
     var publishedPlaintextSHAs: Set<String> = []
+    /// Cache keys of the plaintexts this message is holding in memory for its published row to
+    /// render from, stamped when the send seeds the media cache.
+    ///
+    /// Kept here so every path that retires the message — publish, discard, account switch — releases
+    /// the hold with it. The bytes are also on disk, so releasing them costs a later render one
+    /// asynchronous cache read, never the attachment.
+    var warmPlaintextKeys: [MessageMediaDiskCacheKey] = []
 
     init(
         id: UUID = UUID(),

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -5148,6 +5148,93 @@ struct PureValueTests {
         #expect(updated.pictureURL == "https://example.com/old.png")
         #expect(updated.sanitizedPictureURL == original.sanitizedPictureURL)
     }
+
+    @Test func warmOutgoingPlaintextsAreHeldPerSendAndReleasedWithIt() {
+        // The hold is what lets a published own-send row show its image on the first frame. It is
+        // keyed by the same content-addressed key the row looks the attachment up by, and reading it
+        // must not consume it: a reprojection that changes a message's media prunes the download
+        // state stores, and the rebuilt row has to find the bytes again.
+        var holds = OutgoingMediaWarmPlaintexts()
+        let key = warmPlaintextKey(
+            accountId: "account-1", groupIdHex: "group", fileName: "photo.png", digestSeed: "1")
+        let other = warmPlaintextKey(
+            accountId: "account-1", groupIdHex: "group", fileName: "clip.mp4", digestSeed: "2")
+
+        holds.hold(warmPlaintextDownload(fileName: "photo.png", byteCount: 32), for: key)
+
+        #expect(holds.download(for: key)?.fileName == "photo.png")
+        #expect(holds.download(for: key)?.fileName == "photo.png")
+        #expect(holds.download(for: other) == nil)
+        #expect(holds.heldByteCount == 32)
+
+        // Re-holding the same key replaces rather than double-counts it.
+        holds.hold(warmPlaintextDownload(fileName: "photo.png", byteCount: 8), for: key)
+        #expect(holds.heldByteCount == 8)
+
+        holds.remove(for: key)
+        #expect(holds.isEmpty)
+        #expect(holds.heldByteCount == 0)
+    }
+
+    @Test func warmOutgoingPlaintextsDropTheOldestHoldOverBudgetAndPurgePerAccount() {
+        // Every hold is released when its message is retired, so the budget only bounds the
+        // pathological case — messages whose rows never arrive. Overflowing must drop the oldest
+        // hold, never the one the newest send is waiting to render.
+        var holds = OutgoingMediaWarmPlaintexts(byteLimit: 64)
+        let oldest = warmPlaintextKey(
+            accountId: "account-1", groupIdHex: "group", fileName: "oldest.png", digestSeed: "3")
+        let newest = warmPlaintextKey(
+            accountId: "account-2", groupIdHex: "group", fileName: "newest.png", digestSeed: "4")
+        let overBudget = 63
+
+        holds.hold(warmPlaintextDownload(fileName: "oldest.png", byteCount: overBudget), for: oldest)
+        holds.hold(warmPlaintextDownload(fileName: "newest.png", byteCount: overBudget), for: newest)
+
+        #expect(holds.download(for: oldest) == nil)
+        #expect(holds.download(for: newest)?.fileName == "newest.png")
+        #expect(holds.heldByteCount == overBudget)
+
+        // Purging an account takes its plaintexts with it, and leaves the byte count honest.
+        holds.removeAll(forAccountId: "account-2")
+        #expect(holds.isEmpty)
+        #expect(holds.heldByteCount == 0)
+    }
+}
+
+private func warmPlaintextKey(
+    accountId: String,
+    groupIdHex: String,
+    fileName: String,
+    digestSeed: String
+) -> MessageMediaDiskCacheKey {
+    MessageMediaDiskCacheKey(
+        accountId: accountId,
+        groupIdHex: groupIdHex,
+        reference: MediaAttachmentReferenceFfi(
+            locators: [MediaLocatorFfi(kind: "blossom", value: "https://blob.example/\(fileName)")],
+            // Distinct 64-hex digests per attachment. No real hashing: nothing here reads the disk
+            // cache, which is the one place a digest has to match the bytes it guards.
+            ciphertextSha256: String(repeating: digestSeed, count: 64),
+            plaintextSha256: String(repeating: digestSeed, count: 64),
+            nonceHex: "cccccccccccccccccccccccc",
+            fileName: fileName,
+            mediaType: "image/png",
+            version: .v1,
+            sourceEpoch: 0,
+            dim: nil,
+            thumbhash: nil
+        )
+    )
+}
+
+private func warmPlaintextDownload(fileName: String, byteCount: Int) -> MessageMediaDownload {
+    let data = Data(repeating: 0x11, count: byteCount)
+    return MessageMediaDownload(
+        data: data,
+        fileName: fileName,
+        mediaType: "image/png",
+        sizeBytes: UInt64(data.count)
+    )
 }
 
 /// 64-char hex built from a short seed, so tests read as `hex("a")` rather than a wall of digits.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -17126,6 +17126,152 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func aPublishedOwnMediaRowRendersItsImageOnTheFirstFrame() async throws {
+        // The bubble the send hands over already shows the picked image, so the row that replaces it
+        // must show it too — immediately. Seeding only the encrypted disk cache was not enough: that
+        // read is asynchronous (open the container, decrypt, verify the digest), so the published row
+        // came up on a spinner and the sender watched their own photo blink from loaded back to
+        // loading as the placeholder gave way to the real row.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        let photo = PendingMediaAttachment(
+            fileName: "photo.png",
+            mediaType: "image/png",
+            data: Data("photo bytes".utf8),
+            dim: "120x80"
+        )
+        state.appendPendingMediaAttachment(photo, for: draftKey)
+        await Self.settleComposerMediaUploads(state)
+
+        // Arm the gate only now, so it holds the publish rather than the upload.
+        runtime.messageActionGateEnabled = true
+        await state.sendDraft()
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+
+        // The row the core commits locally inside the publish carries the reference the send just
+        // published, which is what the held plaintext is keyed by.
+        let publishedReference = try #require(runtime.sentMediaAttachments.last?.attachments.first)
+        runtime.installTimelinePage(
+            TimelinePageFfi(
+                messages: [
+                    timelineMessage(
+                        id: "published-photo",
+                        direction: "outbound",
+                        groupIdHex: "group",
+                        sender: account.accountIdHex,
+                        plaintext: "",
+                        recordedAt: 1_700_000_000,
+                        media: [publishedReference]
+                    )
+                ],
+                hasMoreBefore: false,
+                hasMoreAfter: false
+            ),
+            groupIdHex: "group"
+        )
+        let activeAccount = try #require(state.activeAccount)
+        await state.refreshSelectedTimelineAfterSend(
+            groupIdHex: "group",
+            account: activeAccount,
+            client: runtime
+        )
+
+        let row = try #require(state.selectedMessages.first)
+        let attachment = try #require(row.mediaAttachments.first)
+        let downloadState = state.mediaDownloadStateStore(for: row, attachment: attachment)
+        guard case .loaded(let download) = downloadState.state else {
+            Issue.record("own send's published row must start loaded, not \(downloadState.state)")
+            return
+        }
+        #expect(download.data == photo.data)
+        #expect(download.fileName == "photo.png")
+        // Nothing left to fetch: the bytes never went round-trip, so no spinner and no download.
+        #expect(!downloadState.shouldStartAutomaticDownload)
+
+        runtime.releaseMessageActionGate()
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        // The hold is scoped to the send: once the message is retired the plaintext is released, and
+        // the row keeps rendering from the payload it was handed.
+        #expect(state.outgoingMediaWarmPlaintexts.isEmpty)
+        guard case .loaded = downloadState.state else {
+            Issue.record("retiring the send must not walk its published row back to loading")
+            return
+        }
+    }
+
+    @MainActor
+    @Test func thePlaceholderIsRetiredOnlyOnceTheWindowThatReplacesItIsBack() async throws {
+        // The placeholder used to be dropped before the post-send re-window, which on the path where
+        // no projection delta has arrived yet left a frame with neither row in it: the bubble the
+        // user was looking at disappeared and the published one had not been windowed. Retiring it
+        // after the window comes back means something is always on screen for the message.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        state.appendPendingMediaAttachment(
+            PendingMediaAttachment(
+                fileName: "photo.png",
+                mediaType: "image/png",
+                data: Data("photo bytes".utf8),
+                dim: "120x80"
+            ),
+            for: draftKey
+        )
+        await Self.settleComposerMediaUploads(state)
+        runtime.messageActionGateEnabled = true
+        await state.sendDraft()
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+
+        let publishedReference = try #require(runtime.sentMediaAttachments.last?.attachments.first)
+        let publishedPage = TimelinePageFfi(
+            messages: [
+                timelineMessage(
+                    id: "published-photo",
+                    direction: "outbound",
+                    groupIdHex: "group",
+                    sender: account.accountIdHex,
+                    plaintext: "",
+                    recordedAt: 1_700_000_000,
+                    media: [publishedReference]
+                )
+            ],
+            hasMoreBefore: false,
+            hasMoreAfter: false
+        )
+        // Hold the re-window itself, so the assertion lands in the gap the old order left open.
+        let windowGate = BlockingFfiGate()
+        windowGate.isEnabled = true
+        runtime.timelineMessagesHandler = { _ in
+            windowGate.passIfArmed()
+            return publishedPage
+        }
+
+        runtime.releaseMessageActionGate()
+        await Self.waitUntil { windowGate.didReach }
+
+        #expect(!state.selectedMessages.contains { $0.id == "published-photo" })
+        #expect(state.selectedPendingOutgoingMediaMessages.count == 1)
+
+        windowGate.release()
+        await Self.settlePendingOutgoingMediaSends(state)
+
+        #expect(state.selectedMessages.map(\.id) == ["published-photo"])
+        #expect(state.selectedPendingOutgoingMediaMessages.isEmpty)
+        #expect(state.pendingOutgoingMediaMessagesByConversation.isEmpty)
+        #expect(state.outgoingMediaWarmPlaintexts.isEmpty)
+    }
+
+    @MainActor
     @Test func pendingBubbleStaysUpWhileADifferentAudioIsPublished() async throws {
         // The suppression is keyed on the blob the message actually uploaded. A neighbouring audio
         // row in the same transcript must not retire a bubble whose own publish is still climbing.


### PR DESCRIPTION
When loading message with media files, briefly a duplicated message bubble was shown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Outgoing media now appears immediately after publishing without briefly showing an empty placeholder.
  * Published media remains available while timeline updates complete, avoiding unnecessary downloads.
  * Cancelled, retried, and completed media sends now clean up retained data correctly.
  * Removing an account or resetting media state also clears its retained outgoing media.

* **Tests**
  * Added coverage for media rendering, placeholder transitions, retention limits, replacement, and account cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->