### PR TITLE
Stop notifying in archived chats

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -58,6 +58,12 @@ extension WorkspaceState {
             return
         }
 
+        // Archiving a chat is the user's word that it should stop interrupting them, so a filed-away
+        // conversation gets no banner however busy it gets. Deliberately below the unread-badge
+        // refresh above: that badge is not a banner preference, and the core already leaves archived
+        // conversations out of the account totals it reports.
+        if await notificationChatIsArchived(update) { return }
+
         if !notificationAuthorizationStatus.canPostNotifications {
             await refreshNotificationAuthorizationStatus()
         }
@@ -183,6 +189,35 @@ extension WorkspaceState {
         return try? await FFIExecutor.run({
             try client.notificationSettings(accountRef: accountRef)
         })
+    }
+
+    /// Whether the conversation an incoming notification belongs to has been archived.
+    ///
+    /// The chat list is the app's only in-memory record of what is filed away, and it is maintained
+    /// for the active account alone — while the notification listener is client-wide. An update for
+    /// a background account therefore asks the core directly; otherwise archiving would only
+    /// silence chats on whichever account happens to be open.
+    ///
+    /// An unreadable archive state answers `false`: a notification the user wanted is worth more
+    /// than one they had already filed away.
+    func notificationChatIsArchived(_ update: NotificationUpdateFfi) async -> Bool {
+        if let activeAccount, activeAccount.accountIdHex == update.accountIdHex {
+            if archivedChatItem(accountId: activeAccount.id, chatId: update.groupIdHex) != nil {
+                return true
+            }
+            // `chatItem(accountId:chatId:)` spans both lists, so a hit once the archived lookup has
+            // missed is a live row — no FFI read needed to know it is not archived.
+            if chatItem(accountId: activeAccount.id, chatId: update.groupIdHex) != nil {
+                return false
+            }
+        }
+
+        guard let client else { return false }
+        let details = try? await client.groupDetails(
+            accountRef: update.accountRef,
+            groupIdHex: update.groupIdHex
+        )
+        return details?.group.archived ?? false
     }
 
     func handleNotificationPermissionError(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -30531,6 +30531,142 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func archivedChatSuppressesIncomingNotification() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: true)
+        var archivedGroup = messageGroup()
+        archivedGroup.archived = true
+        runtime.installGroups([archivedGroup, directGroup()])
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.archivedChats.map(\.id) == [archivedGroup.groupIdHex])
+
+        await state.handleNotificationUpdate(
+            notificationUpdate(
+                account: account,
+                notificationKey: "archived-notice",
+                groupIdHex: archivedGroup.groupIdHex,
+                senderName: "Alice",
+                previewText: "Still talking in here."
+            ))
+
+        #expect(notificationCenter.postedRequests.isEmpty)
+
+        // The gate is per chat, not per account: an unarchived conversation still rings.
+        await state.handleNotificationUpdate(
+            notificationUpdate(
+                account: account,
+                notificationKey: "active-notice",
+                groupIdHex: "direct-group",
+                senderName: "Alice",
+                previewText: "Over here though."
+            ))
+
+        #expect(notificationCenter.postedRequests.map(\.identifier) == ["active-notice"])
+    }
+
+    @MainActor
+    @Test func archivedChatOnBackgroundAccountSuppressesIncomingNotification() async throws {
+        // The notification listener is client-wide, but the chat list — the app's only in-memory
+        // record of what is filed away — is maintained for the active account alone. A background
+        // account's archive state therefore has to come from the core, or archived chats on every
+        // account but the open one keep interrupting.
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+        let accountA = desktopAccount()
+        let accountB = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [accountA, accountB])
+        runtime.installNotificationSettings(
+            accountRef: accountA.label,
+            settings: notificationSettings(for: accountA, localEnabled: true)
+        )
+        runtime.installNotificationSettings(
+            accountRef: accountB.label,
+            settings: notificationSettings(for: accountB, localEnabled: true)
+        )
+        UserDefaults.standard.set(accountA.label, forKey: WorkspaceState.activeAccountKey)
+        var archivedGroup = messageGroup()
+        archivedGroup.archived = true
+        runtime.installGroups([archivedGroup, directGroup()])
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == accountA.label)
+
+        await state.handleNotificationUpdate(
+            notificationUpdate(
+                account: accountB,
+                notificationKey: "background-archived-notice",
+                groupIdHex: archivedGroup.groupIdHex,
+                senderName: "Alice",
+                previewText: "Still talking in here."
+            ))
+
+        #expect(notificationCenter.postedRequests.isEmpty)
+
+        await state.handleNotificationUpdate(
+            notificationUpdate(
+                account: accountB,
+                notificationKey: "background-active-notice",
+                groupIdHex: "direct-group",
+                senderName: "Alice",
+                previewText: "Over here though."
+            ))
+
+        #expect(notificationCenter.postedRequests.map(\.identifier) == ["background-active-notice"])
+    }
+
+    @MainActor
+    @Test func unreadableArchiveStateStillPostsNotification() async throws {
+        // A chat the app has no row for (nothing loaded yet, or a conversation that arrives with
+        // the notification) whose archive state cannot be read must still ring: a notification the
+        // user wanted is worth more than one they had filed away.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.notificationSettings = notificationSettings(for: account, localEnabled: true)
+        runtime.groupDetailsFailureGroupIds.insert("unknown-group")
+        let notificationCenter = FakeLocalNotificationCenter(status: .authorized)
+        let state = WorkspaceState(
+            localNotificationCenter: notificationCenter,
+            appActivityProvider: { false },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.chatItem(accountId: account.label, chatId: "unknown-group") == nil)
+
+        await state.handleNotificationUpdate(
+            notificationUpdate(
+                account: account,
+                notificationKey: "unknown-notice",
+                groupIdHex: "unknown-group",
+                senderName: "Alice",
+                previewText: "Who is this?"
+            ))
+
+        #expect(notificationCenter.postedRequests.map(\.identifier) == ["unknown-notice"])
+    }
+
+    @MainActor
     @Test func notificationPreviewSanitizesAndIsolatesPeerControlledMessageText() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived conversations no longer display incoming notification banners.
  * Notifications continue to appear for unarchived conversations.
  * Notification behavior remains available when archive status cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->