### PR TITLE
Scroll to bottom on send

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -1052,6 +1052,10 @@ extension WorkspaceState {
         else { return }
         isSending = true
         defer { isSending = false }
+        // Past the guards, so a send the core would refuse never moves the transcript. Both
+        // branches below empty the composer synchronously from here, so the bubble the user is
+        // scrolled to — pending or real — is part of the same view update.
+        outgoingSendScrollGeneration &+= 1
 
         if !mediaAttachments.isEmpty {
             // Hand the send off and return. Staging started every upload the moment the file

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -605,6 +605,14 @@ final class WorkspaceState {
     /// row on screen the moment the message is stored — so one entry per composer is enough: it is
     /// what the *next* send in that conversation chains behind, and what teardown drops.
     @ObservationIgnored var outgoingTextSendTasks: [ComposerDraftKey: Task<Void, Never>] = [:]
+    /// Bumped once per send the local user commits from the selected conversation's composer —
+    /// text, media or a recording. The transcript scrolls to the live edge off this rather than off
+    /// the message that follows it, because neither of the newest-message rules covers a send made
+    /// while reading history: a media send appends its pending bubble *below* the timeline window,
+    /// so it never moves `messageIDs.last`, and a text send that lands while an older-history
+    /// prepend is in flight is not eligible for the newest-message scroll at all. Sending is an
+    /// explicit local action, so it goes to the bottom whether or not the user was pinned there.
+    var outgoingSendScrollGeneration: UInt64 = 0
     @ObservationIgnored var composerDraftPersistenceTasks: [ComposerDraftKey: Task<Void, Never>] = [:]
     @ObservationIgnored var composerDraftMutationGenerations: [ComposerDraftKey: UInt64] = [:]
     @ObservationIgnored var dirtyComposerDraftKeys: Set<ComposerDraftKey> = []

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -572,12 +572,28 @@ private struct ConversationView: View {
                             return
                         }
                     }
-                    // A pending media bubble is appended below the timeline window, so it never
-                    // moves `messageIDs.last` — without this, a message sent while the user was at
-                    // the bottom could appear just off the bottom edge.
-                    .onChange(of: pendingOutgoingMediaMessages.count) { oldCount, newCount in
-                        guard newCount > oldCount, isPinnedToBottom else { return }
-                        scrollToBottom(with: proxy)
+                    // Pressing Send scrolls to the live edge, off the send itself rather than off
+                    // the message it produces. Neither rule above covers a send made while reading
+                    // history: a media send (a recording included) appends its pending bubble
+                    // *below* the timeline window, so it never moves `messageIDs.last`, and a text
+                    // send that lands while an older-history prepend is in flight is not eligible
+                    // for the newest-message scroll at all. Both left the new message off the
+                    // bottom edge. Unconditional in `isPinnedToBottom`, because sending is an
+                    // explicit local action — the same reason the outgoing branch above ignores it.
+                    .onChange(of: workspace.outgoingSendScrollGeneration) { _, _ in
+                        guard workspace.selectedChat?.id == chat.id else { return }
+                        // A window detached from the live edge (the user jumped to a search result
+                        // or a reply target) has to be re-attached, not merely scrolled: its bottom
+                        // is the foot of a history page, and stopping there would let the
+                        // newer-history paging that the bottom edge triggers walk the user back up
+                        // off the message they just sent. Same path the jump-to-latest button takes.
+                        // Live paging state, not the value captured at body evaluation — an
+                        // `onChange` action runs after it, exactly as the geometry ones do.
+                        if workspace.selectedTimelinePaging.hasMoreAfter {
+                            Task { await jumpToNewest(using: proxy) }
+                        } else {
+                            scrollToBottom(with: proxy)
+                        }
                     }
                     .onChange(of: messageIDs.first) { _, _ in
                         guard let anchorId = pendingPrependAnchorId else { return }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -17018,6 +17018,66 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func sendingScrollsTheTranscriptToTheLiveEdgeFromThePressItself() async throws {
+        // The transcript jumps to the bottom off this generation rather than off the message the
+        // send produces. A recording is the case that needs it: its pending bubble is appended
+        // below the timeline window, so nothing about `messageIDs` moves when Send is pressed, and
+        // a send made while the user was reading history stayed off the bottom edge until the
+        // publish landed seconds later.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+        let beforeAnySend = state.outgoingSendScrollGeneration
+
+        // An empty composer sends nothing, so it must not move the transcript either.
+        await state.sendDraft()
+        #expect(state.outgoingSendScrollGeneration == beforeAnySend)
+
+        state.appendPendingMediaAttachment(recordedVoiceMessage(), for: draftKey)
+        await Self.settleComposerMediaUploads(state)
+        await state.sendDraft()
+        let afterRecording = state.outgoingSendScrollGeneration
+        #expect(afterRecording == beforeAnySend &+ 1)
+        await Self.settlePendingOutgoingMediaSends(state)
+        #expect(runtime.sendMediaAttachmentsCallCount == 1)
+
+        state.draftText = "and one typed after it"
+        await state.sendDraft()
+        #expect(state.outgoingSendScrollGeneration == afterRecording &+ 1)
+        await Self.settleOutgoingTextSends(state)
+        #expect(runtime.publishedTexts.map(\.text) == ["and one typed after it"])
+    }
+
+    @MainActor
+    @Test func editingAMessageLeavesTheTranscriptWhereItIs() async throws {
+        // An edit rewrites a row in place — possibly one well up in the history the user is
+        // reading — so it is the one composer send that must not scroll to the live edge.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let beforeEdit = state.outgoingSendScrollGeneration
+
+        state.startEditingMessage(
+            MessageItem(
+                id: "message-to-edit",
+                senderName: "You",
+                body: "Original text",
+                sentAt: Date(timeIntervalSince1970: 1_700_000_000),
+                isOutgoing: true
+            ))
+        state.draftText = "Updated text"
+        await state.sendDraft()
+
+        #expect(runtime.editedMessage?.targetMessageId == "message-to-edit")
+        #expect(state.outgoingSendScrollGeneration == beforeEdit)
+    }
+
+    @MainActor
     @Test func recordingSentBeforeItsUploadLandsFreesTheComposerToRecordAgain() async throws {
         // Where "a recording is a whole message" meets the hybrid send: the recording keeps
         // uploading from its own bubble, and because the composer empties on the press, the user


### PR DESCRIPTION
I found a bit annoying that after sending a message, if I had scrolled up, then I couldn't immediately see the message I sent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scrolling after sending text, media, or voice messages.
  * Sent messages now reliably bring the active conversation to the latest content, including when newer history must first be loaded.
  * Prevented empty sends and edits from triggering unnecessary scrolling.

* **Tests**
  * Added coverage for message sending, media sending, and transcript scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->