### PR TITLE
Stop reactions overlapping the timestamp

### DIFF
--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -265,11 +265,6 @@ struct MessageBubble: View {
                 bubbleContent
             }
 
-            if !message.hasBubbleContent {
-                compactMetadata
-                    .padding(.horizontal, 5)
-            }
-
             if message.supportsChatActions && !message.reactions.isEmpty {
                 MessageReactionChips(reactions: message.reactions) { emoji in
                     reactionViewerEmoji = emoji
@@ -280,13 +275,18 @@ struct MessageBubble: View {
                 // The overlap comes from the chip so the pill's height and how much of it rides on
                 // the bubble stay one decision.
                 .padding(.horizontal, 10)
-                .padding(
-                    .top,
-                    usesStickerStyle ? 0 : -(Self.contentSpacing + MessageReactionChips.bubbleOverlap)
-                )
+                .padding(.top, reactionChipPlacement.topPadding(contentSpacing: Self.contentSpacing))
                 .popover(isPresented: $isReactionViewerPresented, arrowEdge: .bottom) {
                     MessageReactionDetailsView(message: message, selectedEmoji: $reactionViewerEmoji)
                 }
+            }
+
+            // After the chips, not before them: the pill rides up onto whatever precedes it, and a
+            // caption-less row's metadata is a bare line of text rather than a surface with an edge
+            // to spare. Emitted first, it was what the pill overlapped.
+            if !message.hasBubbleContent {
+                compactMetadata
+                    .padding(.horizontal, 5)
             }
 
             sendFailureActions
@@ -375,6 +375,16 @@ struct MessageBubble: View {
 
     private var usesStickerStyle: Bool {
         stickerEmoji != nil
+    }
+
+    /// The pill rides the caption bubble when there is one and the media card when there is not.
+    /// A sticker carries no surface, and a row that is only a timestamp offers no edge — both take
+    /// their own row instead of overlapping the text above them.
+    private var reactionChipPlacement: MessageReactionChipPlacement {
+        .value(
+            usesSurface: usesBubbleSurface || !message.mediaAttachments.isEmpty,
+            usesStickerStyle: usesStickerStyle
+        )
     }
 
     /// Incoming messages in a group carry the sender's avatar in a leading gutter; DMs and the

--- a/whitenoise-mac/Views/MessageReactionViews.swift
+++ b/whitenoise-mac/Views/MessageReactionViews.swift
@@ -100,6 +100,43 @@ extension MessageReactionChips {
     static let bubbleOverlap: CGFloat = 7
 }
 
+/// What the reaction pill hangs on in a message row.
+///
+/// The pill is bubble-bound: it rides `MessageReactionChips.bubbleOverlap` up onto the bottom edge
+/// of the thing above it. That thing is the caption bubble when the message has one and the media
+/// card when it does not — never the compact timestamp, which is a bare line of text with no edge
+/// to ride onto. Pulling the pill up over *that* is what drew the reactions on top of the time on
+/// an image sent without a caption: the row ended with the timestamp, so the overlap meant for a
+/// bubble's padding bit into the metadata instead. The row now emits the chips before the
+/// standalone timestamp, and this decides whether they overlap at all.
+enum MessageReactionChipPlacement: Equatable {
+    /// Overlapping the bottom edge of the bubble or media card above it.
+    case ridingSurfaceEdge
+    /// Its own row at the stack's normal spacing, because nothing above it has an edge to take the
+    /// pill: a sticker is drawn with no surface behind it, and a row that is only a timestamp has
+    /// nothing to hang on.
+    case ownRow
+
+    static func value(usesSurface: Bool, usesStickerStyle: Bool) -> Self {
+        usesSurface && !usesStickerStyle ? .ridingSurfaceEdge : .ownRow
+    }
+
+    /// Top padding for the pill inside a stack of `contentSpacing`. The overlap has to cancel that
+    /// spacing before it can bite into the surface, so the two are one number here rather than a
+    /// subtraction repeated at the call site.
+    func topPadding(
+        contentSpacing: CGFloat,
+        overlap: CGFloat = MessageReactionChips.bubbleOverlap
+    ) -> CGFloat {
+        switch self {
+        case .ownRow:
+            return 0
+        case .ridingSurfaceEdge:
+            return -(contentSpacing + overlap)
+        }
+    }
+}
+
 /// Reaction viewer: a horizontal "All / per-emoji" filter row over a list of reactors (avatar +
 /// name + their emoji). Your own row can be tapped to remove your reaction.
 struct MessageReactionDetailsView: View {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -526,6 +526,65 @@ struct whitenoise_macTests {
         }
     }
 
+    @Test func reactionChipRidesOnlyASurfaceWithAnEdge() {
+        // A caption bubble and a bare media card both give the pill an edge to ride on.
+        #expect(
+            MessageReactionChipPlacement.value(usesSurface: true, usesStickerStyle: false)
+                == .ridingSurfaceEdge
+        )
+        // A sticker is drawn with no surface behind it, so the pill sits below it.
+        #expect(
+            MessageReactionChipPlacement.value(usesSurface: true, usesStickerStyle: true) == .ownRow
+        )
+        // Nothing above the pill but a timestamp: the case that drew reactions over the time on an
+        // image with no caption.
+        #expect(
+            MessageReactionChipPlacement.value(usesSurface: false, usesStickerStyle: false) == .ownRow
+        )
+    }
+
+    @Test func reactionChipOverlapCancelsTheStackSpacingBeforeBiting() {
+        // The pill's negative top padding has to eat the stack's own spacing first, or the overlap
+        // it actually achieves is short by that spacing.
+        #expect(
+            MessageReactionChipPlacement.ridingSurfaceEdge.topPadding(contentSpacing: 6, overlap: 7)
+                == -13
+        )
+        #expect(MessageReactionChipPlacement.ownRow.topPadding(contentSpacing: 6, overlap: 7) == 0)
+        // The shipped overlap is the chip's own metric, not a number restated at the call site.
+        #expect(
+            MessageReactionChipPlacement.ridingSurfaceEdge.topPadding(contentSpacing: 6)
+                == -(6 + MessageReactionChips.bubbleOverlap)
+        )
+    }
+
+    @Test func mediaOnlyRowsDrawReactionsAboveTheStandaloneTimestamp() throws {
+        // The reaction pill overlaps whatever is above it. On a message with no caption the row's
+        // last element used to be the compact timestamp, so the pill was pulled up over the time
+        // itself. Guard the order: the standalone metadata row is emitted after the chips, which
+        // leaves the pill riding the media card's bottom edge instead.
+        let viewsURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("MessageMediaViews.swift")
+        let source = try String(contentsOf: viewsURL, encoding: .utf8)
+        let bubbleStart = try #require(source.range(of: "struct MessageBubble: View {"))
+        let rest = source[bubbleStart.upperBound...]
+        let bubbleEnd = try #require(rest.range(of: "\nprivate extension View {")?.lowerBound)
+        let bubbleSource = String(source[bubbleStart.lowerBound..<bubbleEnd])
+
+        let chips = try #require(bubbleSource.range(of: "MessageReactionChips(reactions: message.reactions)"))
+        let standaloneMetadata = try #require(bubbleSource.range(of: "if !message.hasBubbleContent {"))
+        #expect(chips.lowerBound < standaloneMetadata.lowerBound)
+
+        // And the overlap is decided by the placement helper above rather than by an inline
+        // ternary that cannot be tested.
+        #expect(bubbleSource.contains("reactionChipPlacement.topPadding(contentSpacing: Self.contentSpacing)"))
+    }
+
     @MainActor
     @Test func emptyRuntimeBootstrapsToOnboarding() async throws {
         let runtime = FakeMarmotRuntime(accounts: [])


### PR DESCRIPTION
<img width="487" height="548" alt="Screenshot 2026-08-19 at 1 30 24 PM" src="https://github.com/user-attachments/assets/273e50ef-3331-4768-a359-fe0d7a020ddd" />
