### PR TITLE
Fix invite buttons style

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -6434,65 +6434,6 @@
         }
       }
     },
-    "Accept Invite": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einladung annehmen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aceptar invitación"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accepter l’invitation"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accetta invito"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aceitar convite"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Принять приглашение"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Daveti kabul et"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接受邀请"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接受邀請"
-          }
-        }
-      }
-    },
     "Accept invite": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Views/ComposerViews.swift
+++ b/whitenoise-mac/Views/ComposerViews.swift
@@ -1486,48 +1486,10 @@ struct PendingGroupInviteComposerNotice: View {
                 Spacer(minLength: 0)
             }
 
-            HStack(spacing: 10) {
-                Button {
-                    Task { await workspace.acceptGroupInvite(for: chat) }
-                } label: {
-                    HStack(spacing: 8) {
-                        if workspace.isAcceptingGroupInvite {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else {
-                            Image(systemName: "checkmark.circle.fill")
-                        }
-                        Text(workspace.isAcceptingGroupInvite ? L10n.string("Accepting...") : L10n.string("Accept"))
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 40)
-                }
-                .controlSize(.large)
-                .nativeGlassProminentButtonStyle()
-                .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
-                .help(L10n.string("Accept invite"))
-
-                // No destructive `role`: `chat_invite_screen.dart` builds Decline as `outline`,
-                // and the group-details Decline already dropped it. Marking it destructive while
-                // rendering it secondary is a trap — see `WNSecondaryButtonStyle`.
-                Button {
-                    Task { await workspace.declineGroupInvite(for: chat) }
-                } label: {
-                    HStack(spacing: 8) {
-                        if workspace.isDecliningGroupInvite {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else {
-                            Image(systemName: "xmark.circle")
-                        }
-                        Text(workspace.isDecliningGroupInvite ? L10n.string("Declining...") : L10n.string("Decline"))
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 40)
-                }
-                .controlSize(.large)
-                .buttonStyle(.wnSecondary)
-                .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
-                .help(L10n.string("Decline invite"))
-            }
+            PendingInviteActionButtons(
+                accept: { await workspace.acceptGroupInvite(for: chat) },
+                decline: { await workspace.declineGroupInvite(for: chat) }
+            )
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)

--- a/whitenoise-mac/Views/GroupViews.swift
+++ b/whitenoise-mac/Views/GroupViews.swift
@@ -202,33 +202,10 @@ struct GroupDetailsSheet: View {
                                 .foregroundStyle(WNColor.backgroundContentSecondary)
                                 .fixedSize(horizontal: false, vertical: true)
 
-                                HStack(spacing: 10) {
-                                    Button {
-                                        Task { await workspace.acceptSelectedGroupInvite() }
-                                    } label: {
-                                        Label(
-                                            workspace.isAcceptingGroupInvite
-                                                ? L10n.string("Accepting...") : L10n.string("Accept Invite"),
-                                            systemImage: "checkmark.circle"
-                                        )
-                                    }
-                                    .nativeGlassProminentButtonStyle()
-                                    .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
-
-                                    Button {
-                                        Task { await workspace.declineSelectedGroupInvite() }
-                                    } label: {
-                                        Label(
-                                            workspace.isDecliningGroupInvite
-                                                ? L10n.string("Declining...") : L10n.string("Decline"),
-                                            systemImage: "xmark.circle"
-                                        )
-                                    }
-                                    .buttonStyle(.wnSecondary)
-                                    .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
-
-                                    Spacer()
-                                }
+                                PendingInviteActionButtons(
+                                    accept: { await workspace.acceptSelectedGroupInvite() },
+                                    decline: { await workspace.declineSelectedGroupInvite() }
+                                )
                             }
                         }
                     }
@@ -1014,7 +991,7 @@ private struct ContactProfileActionsRow: View {
                 Label(L10n.string("Message"), systemImage: "message")
                     .frame(maxWidth: .infinity)
             }
-            .nativeGlassProminentButtonStyle()
+            .wnPrimaryButtonStyle()
             .disabled(workspace.isCreatingChat)
         }
         .controlSize(.large)

--- a/whitenoise-mac/Views/PendingInviteActionButtons.swift
+++ b/whitenoise-mac/Views/PendingInviteActionButtons.swift
@@ -1,0 +1,97 @@
+//
+//  PendingInviteActionButtons.swift
+//  whitenoise-mac
+//
+//  The two buttons a pending invite is answered with, shared by the composer
+//  prompt and by chat info.
+//
+
+import SwiftUI
+
+/// `Accept` on the app's glass beside `Decline` as an outline button, filling the row between them.
+///
+/// One view for both places an invite can be answered, because it is one decision offered twice —
+/// and the two copies drifted every time they were touched separately: different icons, `Accept`
+/// against `Accept Invite`, and for a while a destructive `role` on one of the two Declines. What
+/// broke visibly was the shape, since only one of them named a radius at all.
+///
+/// Both sibling clients build this pair the same way, and it is the shape that carries over rather
+/// than the metrics: the iOS prototype's `invitationActionBar` puts the two side by side at
+/// `.controlSize(.large)` with `.buttonSizing(.flexible)`, and Flutter's `chat_invite_screen.dart`
+/// stretches `WnButton(type: .outline)` and a default `WnButton` full width, swapping each label for
+/// a spinner while its call is in flight.
+///
+/// The actions arrive as closures because the two prompts answer different invites: the composer
+/// answers the chat it is standing in, chat info answers the details it has open.
+struct PendingInviteActionButtons: View {
+    @Environment(WorkspaceState.self) private var workspace
+    let accept: () async -> Void
+    let decline: () async -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button {
+                Task { await accept() }
+            } label: {
+                PendingInviteActionLabel(
+                    title: L10n.string("Accept"),
+                    inFlightTitle: L10n.string("Accepting..."),
+                    systemImage: "checkmark.circle",
+                    isInFlight: workspace.isAcceptingGroupInvite
+                )
+            }
+            .wnPrimaryButtonStyle()
+            .help(L10n.string("Accept invite"))
+            .accessibilityIdentifier("invite.accept")
+
+            // No destructive `role`: both sibling clients build Decline as their outline button, and
+            // marking it destructive while rendering it secondary is a trap — see the note in
+            // `WNSecondaryButtonStyle`, which is deliberately blind to the role.
+            Button {
+                Task { await decline() }
+            } label: {
+                PendingInviteActionLabel(
+                    title: L10n.string("Decline"),
+                    inFlightTitle: L10n.string("Declining..."),
+                    systemImage: "xmark.circle",
+                    isInFlight: workspace.isDecliningGroupInvite
+                )
+            }
+            .buttonStyle(.wnSecondary)
+            .help(L10n.string("Decline invite"))
+            .accessibilityIdentifier("invite.decline")
+        }
+        .controlSize(.large)
+        // Answering is one commit either way, so neither button is offered while the other is
+        // waiting on the core.
+        .disabled(workspace.isAcceptingGroupInvite || workspace.isDecliningGroupInvite)
+    }
+}
+
+/// One button's label: the action's icon, or a spinner in its place once the call is in flight.
+///
+/// Filling the width it is offered is what makes the pair equal halves of the row — the flexible
+/// sizing the prototype gets from `.buttonSizing(.flexible)`. Height is left to each style, so both
+/// buttons stand at their natural `.large` height; a `minHeight` on the label used to be added to
+/// the outline style's own vertical padding and to nothing on the glass one, which left the pair
+/// mismatched in height as well as in shape.
+private struct PendingInviteActionLabel: View {
+    let title: String
+    let inFlightTitle: String
+    let systemImage: String
+    let isInFlight: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if isInFlight {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Image(systemName: systemImage)
+            }
+
+            Text(isInFlight ? inFlightTitle : title)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/whitenoise-mac/Views/WNButtonMetrics.swift
+++ b/whitenoise-mac/Views/WNButtonMetrics.swift
@@ -1,0 +1,55 @@
+//
+//  WNButtonMetrics.swift
+//  whitenoise-mac
+//
+//  The one radius the two push-button tiers draw at, so a primary button and the
+//  secondary one beside it cannot disagree about their shape. The tiers
+//  themselves are `WNPrimaryButton` and `WNSecondaryButtonStyle`.
+//
+
+import SwiftUI
+
+/// Metrics shared by both push-button tiers.
+///
+/// The radius lives here rather than in either tier because the tiers are almost always seen
+/// *together*: an invite is answered with `Accept` beside `Decline`, and a contact's profile leads
+/// with `Follow` beside `Message`. Each tier used to name its own radius, and a primary button
+/// written as a bare `Button` on `.nativeGlassProminentButtonStyle()` named none at all — with no
+/// `buttonBorderShape` the platform draws a capsule, which is how the invite prompt ended up
+/// offering a pill next to an 8pt rounded rectangle in the same row.
+///
+/// `controlSize` is the key because it is the one thing a pair genuinely shares: it is set on the
+/// row, not on either button, so both read the same value out of the environment.
+enum WNButtonMetrics {
+    /// `WnButton` (`lib/widgets/wn_button.dart`) uses 8 at every size but `xsmall`, which the mac
+    /// app has no use for. `.large` opens it up to 12: the radius that reads as an 8 on a 28pt
+    /// control reads as a hairline crease on a 44pt one.
+    static func cornerRadius(for controlSize: ControlSize) -> CGFloat {
+        controlSize == .large ? 12 : 8
+    }
+}
+
+extension View {
+    /// The primary tier's ground *and* its border shape, for a button that builds its own label
+    /// rather than reaching for `WNPrimaryButton` — the invite pair's `Accept`, whose label carries
+    /// a spinner and has to fill half of its row.
+    ///
+    /// The shape is the whole point. `.glassProminent` on its own draws a capsule, so a primary
+    /// button that skips this will not match the `.wnSecondary` button standing next to it.
+    func wnPrimaryButtonStyle() -> some View {
+        modifier(WNPrimaryButtonChrome())
+    }
+}
+
+/// A `ViewModifier` rather than a plain `View` extension so it can read `controlSize`: the radius
+/// has to track whatever the row set, and a bare `.buttonBorderShape(…)` call site sees no
+/// environment.
+private struct WNPrimaryButtonChrome: ViewModifier {
+    @Environment(\.controlSize) private var controlSize
+
+    func body(content: Content) -> some View {
+        content
+            .buttonBorderShape(.roundedRectangle(radius: WNButtonMetrics.cornerRadius(for: controlSize)))
+            .nativeGlassProminentButtonStyle()
+    }
+}

--- a/whitenoise-mac/Views/WNPrimaryButtonSize.swift
+++ b/whitenoise-mac/Views/WNPrimaryButtonSize.swift
@@ -49,13 +49,10 @@ enum WNPrimaryButtonSize: CaseIterable {
         }
     }
 
-    /// `WnButton` uses 8 at every size but `xsmall`. `large` opens it up to 12: the radius that
-    /// reads as an 8 on a 28pt control reads as a hairline crease on a 44pt one.
+    /// Read from `WNButtonMetrics`, not chosen here: a primary button and the `.wnSecondary` one
+    /// beside it have to draw the same shape, and only a shared table can promise that.
     var cornerRadius: CGFloat {
-        switch self {
-        case .medium: 8
-        case .large: 12
-        }
+        WNButtonMetrics.cornerRadius(for: controlSize)
     }
 
     var controlSize: ControlSize {

--- a/whitenoise-mac/Views/WNSecondaryButtonStyle.swift
+++ b/whitenoise-mac/Views/WNSecondaryButtonStyle.swift
@@ -37,8 +37,9 @@ import SwiftUI
 ///    phone metrics (`large` is 18pt of vertical padding, a thumb-sized full-width CTA). A mac push
 ///    button that tall next to a `.glassProminent` sibling would tower over it. These values are
 ///    matched to AppKit's bordered-button heights instead, so a secondary button and a primary one
-///    on the same row line up. The *visual language* is what carries over — the 8pt continuous
-///    radius, the hairline ring, the `fillSecondary` ground — not the phone's spacing.
+///    on the same row line up. The *visual language* is what carries over — the continuous radius
+///    (`WNButtonMetrics`, shared with the primary tier), the hairline ring, the `fillSecondary`
+///    ground — not the phone's spacing.
 /// 3. **`isHovering` lives on a nested `View`, not on the style.** `makeBody` is not a `View`, so
 ///    `@State` declared on the `ButtonStyle` itself has no identity to attach to and will not
 ///    reliably track. The body is a real view struct for that reason.
@@ -77,14 +78,14 @@ private struct WNSecondaryButtonBody: View {
             .padding(.vertical, verticalPadding)
             .padding(.horizontal, horizontalPadding)
             .background {
-                RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                     .fill(fill)
                     .overlay {
-                        RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                             .stroke(border, lineWidth: 1)
                     }
             }
-            .contentShape(.rect(cornerRadius: Self.cornerRadius, style: .continuous))
+            .contentShape(.rect(cornerRadius: cornerRadius, style: .continuous))
             .onHover { isHovering = $0 }
             .animation(.easeOut(duration: 0.12), value: isHovering)
             .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
@@ -130,8 +131,12 @@ private struct WNSecondaryButtonBody: View {
         }
     }
 
-    /// `WnButton`'s radius at every size but `xsmall`.
-    private static let cornerRadius: CGFloat = 8
+    /// Shared with the primary tier so a pair in one row draws one shape — the radius this style
+    /// used to hold as a flat 8, which is why an outline button beside a `.large` primary one came
+    /// out squarer than its sibling.
+    private var cornerRadius: CGFloat {
+        WNButtonMetrics.cornerRadius(for: controlSize)
+    }
     private static let disabledOpacity: Double = 0.25
 }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -62,6 +62,27 @@ struct PureValueTests {
     }
 
     @MainActor
+    @Test func bothPushButtonTiersDrawOneRadiusAtEveryControlSize() {
+        // The two tiers are seen side by side — `Accept` beside `Decline`, `Message` beside
+        // `Follow` — so the radius has to come out of one table. It did not: the outline style held
+        // a flat 8 while the primary one asked for 12 at `.large`, and a primary button written as a
+        // bare glass `Button` asked for nothing at all and got the platform's capsule.
+        for controlSize in [ControlSize.mini, .small, .regular, .large, .extraLarge] {
+            // `WnButton` uses 8 at every size but `xsmall`, which the mac app has no use for, so 8
+            // is the floor rather than a value any size may drop below.
+            #expect(WNButtonMetrics.cornerRadius(for: controlSize) >= 8)
+        }
+
+        // `.large` is the one size that opens up, and both tiers have to open up with it.
+        #expect(WNButtonMetrics.cornerRadius(for: .large) == 12)
+        #expect(WNButtonMetrics.cornerRadius(for: .regular) == 8)
+
+        for size in WNPrimaryButtonSize.allCases {
+            #expect(size.cornerRadius == WNButtonMetrics.cornerRadius(for: size.controlSize))
+        }
+    }
+
+    @MainActor
     @Test func primaryButtonSizesKeepWnButtonsRadiusFloorAndPositivePadding() {
         for size in WNPrimaryButtonSize.allCases {
             // `WnButton` uses 8 at every size but `xsmall`, which the mac app has no use for, so 8

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -23246,6 +23246,51 @@ struct whitenoise_macTests {
         #expect(source.contains("ContactFollowControl(accountIdHex: contactAccountIdHex)"))
     }
 
+    @Test func bothInvitePromptsAnswerThroughTheSharedActionButtons() throws {
+        // These are private SwiftUI views, so this source-shape regression guards the wiring
+        // directly. The composer prompt and chat info answer the same invite, and answering it was
+        // written out twice — which is how the two came to disagree about the icon, the label and,
+        // visibly, the shape: `Accept` named no border shape at all and drew as the platform's
+        // capsule beside an 8pt rounded-rectangle `Decline`.
+        let viewsDirURL =
+            URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("whitenoise-mac")
+            .appendingPathComponent("Views")
+
+        for (fileName, acceptCall) in [
+            ("ComposerViews.swift", "await workspace.acceptGroupInvite(for: chat)"),
+            ("GroupViews.swift", "await workspace.acceptSelectedGroupInvite()"),
+        ] {
+            let source = try String(
+                contentsOf: viewsDirURL.appendingPathComponent(fileName),
+                encoding: .utf8
+            )
+            #expect(source.contains("PendingInviteActionButtons("))
+            #expect(source.contains(acceptCall))
+        }
+
+        // The pair is one tier each, and the primary half carries the shape modifier rather than the
+        // bare glass style — without it the capsule comes back.
+        let pairSource = try String(
+            contentsOf: viewsDirURL.appendingPathComponent("PendingInviteActionButtons.swift"),
+            encoding: .utf8
+        )
+        #expect(pairSource.contains(".wnPrimaryButtonStyle()"))
+        #expect(pairSource.contains(".buttonStyle(.wnSecondary)"))
+
+        // Neither tier names a radius of its own any more: one table, or they drift apart again.
+        for fileName in ["WNPrimaryButtonSize.swift", "WNSecondaryButtonStyle.swift"] {
+            let source = try String(
+                contentsOf: viewsDirURL.appendingPathComponent(fileName),
+                encoding: .utf8
+            )
+            #expect(source.contains("WNButtonMetrics.cornerRadius(for:"))
+            #expect(!source.contains("cornerRadius: CGFloat = "))
+        }
+    }
+
     @MainActor
     @Test func followStatusReportsLoadingWhileTheReadIsInFlight() async throws {
         let account = desktopAccount()


### PR DESCRIPTION

<img width="1128" height="111" alt="Screenshot 2026-08-19 at 8 39 48 PM" src="https://github.com/user-attachments/assets/71031dc4-74b5-445e-9a2f-a7ea1d7679ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent accept and decline actions for pending group invitations.
  * Added progress indicators, accessibility labels, and disabled states while invitation actions are processing.
  * Standardized primary and secondary button styling and corner radii across control sizes.

* **Bug Fixes**
  * Improved consistency between invitation prompts and contact detail actions.
  * Removed a duplicate “Accept Invite” localization entry.

* **Tests**
  * Added coverage for invitation actions, button styling, and responsive corner-radius behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->