### PR TITLE
Show removed message in last message preview instead of deleted chip

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -195,6 +195,7 @@ extension WorkspaceState {
         clearEnteredLoginIdentity()
         activeAccountId = account.id
         invalidateNotificationSettingsOperations()
+        invalidatePrivacySecurityOperations()
         UserDefaults.standard.set(account.id, forKey: Self.activeAccountKey)
         chatListFilter = .active
         archivingChatId = nil
@@ -969,6 +970,7 @@ extension WorkspaceState {
         observabilityRuntimeConfiguration = nil
         activeAccountId = nil
         invalidateNotificationSettingsOperations()
+        invalidatePrivacySecurityOperations()
         selection = nil
         invalidateSidebarMessageSearch(clearQuery: true)
         isChatListVisible = true

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -241,6 +241,44 @@ extension WorkspaceState {
             && notificationSettingsGeneration == generation
     }
 
+    /// Claims the privacy/security page for one account's save, returning the token that save must
+    /// present to commit anything.
+    func beginPrivacySecuritySave(accountId: String) -> UInt64 {
+        isSavingPrivacySecurity = true
+        privacySecuritySaveAccountId = accountId
+        privacySecuritySettingsGeneration &+= 1
+        return privacySecuritySettingsGeneration
+    }
+
+    /// Whether the save holding this token still speaks for the active account. Checked after every
+    /// suspension point: the FFI write lands in the account that asked for it either way, but the
+    /// published snapshot and `lastError` belong to whoever is on screen now.
+    func ownsPrivacySecuritySave(accountId: String, generation: UInt64) -> Bool {
+        activeAccountId == accountId
+            && privacySecuritySaveAccountId == accountId
+            && privacySecuritySettingsGeneration == generation
+    }
+
+    /// Drops the claim, but only if this save still holds it — an account switch, or the new
+    /// identity's own save, has already taken it over, and clearing it from here would leave that
+    /// save running with the toggles enabled behind it.
+    func endPrivacySecuritySave(accountId: String, generation: UInt64) {
+        guard privacySecuritySaveAccountId == accountId,
+            privacySecuritySettingsGeneration == generation
+        else { return }
+        isSavingPrivacySecurity = false
+        privacySecuritySaveAccountId = nil
+    }
+
+    /// Hands the privacy/security page to a new active account: whatever save was in flight no
+    /// longer owns it, so the incoming identity can load and save on a page the outgoing one was
+    /// midway through writing to.
+    func invalidatePrivacySecurityOperations() {
+        privacySecuritySettingsGeneration &+= 1
+        privacySecuritySaveAccountId = nil
+        isSavingPrivacySecurity = false
+    }
+
     func requestLocalNotificationPermission() async {
         lastError = nil
         do {
@@ -721,7 +759,7 @@ extension WorkspaceState {
     }
 
     func setRelayTelemetryEnabled(_ enabled: Bool) async {
-        guard let client, !isSavingPrivacySecurity else { return }
+        guard let client, let accountId = activeAccountId, !isSavingPrivacySecurity else { return }
         let config = telemetryBuildConfig
         guard enabled == false || config.telemetryCredentialsAvailable else {
             lastError = TelemetrySettingsActionError.telemetryNotConfigured.localizedDescription
@@ -729,9 +767,8 @@ extension WorkspaceState {
         }
 
         lastError = nil
-        isSavingPrivacySecurity = true
-        privacySecuritySettingsGeneration &+= 1
-        defer { isSavingPrivacySecurity = false }
+        let generation = beginPrivacySecuritySave(accountId: accountId)
+        defer { endPrivacySecuritySave(accountId: accountId, generation: generation) }
 
         do {
             try await configureObservabilityRuntime()
@@ -743,16 +780,18 @@ extension WorkspaceState {
                 exportIntervalSeconds: current.exportIntervalSeconds
             )
             let stored = try await client.setRelayTelemetrySettings(settings: settings)
+            guard ownsPrivacySecuritySave(accountId: accountId, generation: generation) else { return }
             privacySecuritySettings.relayTelemetryEnabled = stored.exportEnabled
             privacySecuritySettings.relayTelemetryIntervalSeconds = stored.exportIntervalSeconds
             privacySecuritySettings.telemetryCredentialsAvailable = telemetryBuildConfig.telemetryCredentialsAvailable
         } catch {
+            guard ownsPrivacySecuritySave(accountId: accountId, generation: generation) else { return }
             lastError = error.localizedDescription
         }
     }
 
     func setAuditLoggingEnabled(_ enabled: Bool) async {
-        guard let client, !isSavingPrivacySecurity else { return }
+        guard let client, let accountId = activeAccountId, !isSavingPrivacySecurity else { return }
         let config = telemetryBuildConfig
         guard enabled == false || config.auditLogCredentialsAvailable else {
             lastError = TelemetrySettingsActionError.auditLogNotConfigured.localizedDescription
@@ -760,9 +799,8 @@ extension WorkspaceState {
         }
 
         lastError = nil
-        isSavingPrivacySecurity = true
-        privacySecuritySettingsGeneration &+= 1
-        defer { isSavingPrivacySecurity = false }
+        let generation = beginPrivacySecuritySave(accountId: accountId)
+        defer { endPrivacySecuritySave(accountId: accountId, generation: generation) }
 
         do {
             try await configureObservabilityRuntime()
@@ -772,10 +810,12 @@ extension WorkspaceState {
             let stored = try await client.setAuditLogSettings(
                 settings: AuditLogSettingsFfi(enabled: enabled, dataMode: .obfuscatedSensitiveData)
             )
+            guard ownsPrivacySecuritySave(accountId: accountId, generation: generation) else { return }
             privacySecuritySettings.auditLoggingEnabled = stored.enabled
             privacySecuritySettings.auditLogCredentialsAvailable = telemetryBuildConfig.auditLogCredentialsAvailable
             await loadAuditLogFiles()
         } catch {
+            guard ownsPrivacySecuritySave(accountId: accountId, generation: generation) else { return }
             lastError = error.localizedDescription
         }
     }

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -707,8 +707,14 @@ final class WorkspaceState {
     var notificationSettingsGeneration: UInt64 = 0
     /// Monotonic token for privacy/security settings writes. Each setter bumps it on entry, so a
     /// load whose FFI read resolved before the save committed abandons its stale snapshot instead
-    /// of reverting the just-saved toggle.
+    /// of reverting the just-saved toggle. An active-account transition bumps it too, so a save
+    /// started under the previous identity cannot commit into the new one.
     var privacySecuritySettingsGeneration: UInt64 = 0
+    /// The account whose save currently holds `isSavingPrivacySecurity`, or `nil` when no save is
+    /// in flight. The flag alone cannot say *whose* save it is, and both the page's loader and
+    /// both setters refuse to run while it is raised — so a save left standing across an account
+    /// switch would lock the new identity's toggles out of a page it never saved on.
+    var privacySecuritySaveAccountId: String?
     var timelineTask: Task<Void, Never>?
     var timelineTaskGroupId: String?
     /// Single-owner coalescing for initial timeline loads (issue #332). `loadMessages` can be

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -76,14 +76,32 @@ nonisolated enum ChatSelfMembership: Hashable {
     /// One-line explanation of the ended membership, used by the sidebar badge
     /// tooltip and the composer notice. `nil` while still a member.
     var endedDescription: String? {
+        endedDescription(locale: AppLanguage.currentLocale)
+    }
+
+    /// The same line resolved against a caller-supplied locale, for the surfaces that are not
+    /// rebuilt on a language switch — see `ChatItem.previewNotice(locale:)`.
+    func endedDescription(locale: Locale) -> String? {
         switch self {
         case .member:
             return nil
         case .left:
-            return L10n.string("You left this group")
+            return L10n.string("You left this group", locale: locale)
         case .removed:
-            return L10n.string("You were removed from this group")
+            return L10n.string("You were removed from this group", locale: locale)
         }
+    }
+
+    /// Whether this ended membership says so on the row's preview line instead of in a capsule
+    /// beside the title.
+    ///
+    /// Only removal does. Being removed is the one ended state the reader did not choose, so the
+    /// row spends its widest slot saying it in the same words the chat itself does
+    /// (`MembershipEndedComposerNotice`) rather than compressing it to a "Removed" capsule the
+    /// reader has to hover to expand. Leaving stays a capsule: the reader already knows they left,
+    /// and the last message is still the more useful thing for that row to show.
+    var reportsInChatRowPreviewLine: Bool {
+        self == .removed
     }
 
     /// SF Symbol shown alongside the ended state, `nil` while still a member.
@@ -165,6 +183,19 @@ nonisolated struct ChatItem: Identifiable, Hashable {
 
     /// True when the local account can use the outbound composer for this chat.
     var canUseComposer: Bool { !pendingConfirmation && !isNoLongerMember }
+
+    /// What the row draws where the last message would go, whenever something other than the last
+    /// message belongs there. `nil` means `preview` speaks for itself.
+    ///
+    /// A removal outranks the last message: the chat is closed to the reader, so what the row has
+    /// to report is that fact rather than whatever was said before it. Every other state only
+    /// fills the line when there is no message to draw — see `previewPlaceholder(locale:)`.
+    func previewNotice(locale: Locale = AppLanguage.currentLocale) -> String? {
+        if selfMembership.reportsInChatRowPreviewLine {
+            return selfMembership.endedDescription(locale: locale)
+        }
+        return previewPlaceholder(locale: locale)
+    }
 
     /// What the row draws where the last message would go, for a chat that has no last message.
     /// `nil` means `preview` carries a real message and should be drawn as-is.

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -759,13 +759,15 @@ struct ChatRowContent: View {
                     switch rowStatus {
                     case .leaving:
                         LeavingGroupBadge()
-                    case .membershipEnded(let membership):
+                    case .membershipEnded(let membership)
+                    where !membership.reportsInChatRowPreviewLine:
                         MembershipEndedBadge(membership: membership)
                     // A pending invite reports itself on the line below instead — the invite text
                     // where the last message would be, the `+` badge where the unread count would
                     // be. The two capsules above stay here because they report a settled state
-                    // about the chat rather than something waiting on the reader.
-                    case .pendingInvite, nil:
+                    // about the chat rather than something waiting on the reader. A removal is the
+                    // one settled state that goes to the line below too, in the chat's own words.
+                    case .membershipEnded, .pendingInvite, nil:
                         EmptyView()
                     }
                     if chat.muted {
@@ -793,7 +795,9 @@ struct ChatRowContent: View {
                         .foregroundStyle(WNColor.backgroundContentSecondary)
                         .lineLimit(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                    if searchResult == nil {
+                    // The marker describes the message on this line, so it only appears when the
+                    // line is actually showing one — not beside a removal notice or a placeholder.
+                    if searchResult == nil, chat.previewNotice(locale: locale) == nil {
                         ChatDeliveryStateIcon(state: chat.latestMessageDelivery)
                     }
                     // An unanswered invite takes this slot outright, the way the other clients
@@ -838,9 +842,10 @@ struct ChatRowContent: View {
         // last-message glyph would describe the wrong message.
         guard let searchResult else {
             // What an empty chat says here depends on why it is empty, and an unanswered invite
-            // says so in words rather than in a badge beside the title.
-            if let placeholder = chat.previewPlaceholder(locale: locale) {
-                return Text(placeholder)
+            // says so in words rather than in a badge beside the title — as does a removal, which
+            // takes this line even when the chat has messages behind it.
+            if let notice = chat.previewNotice(locale: locale) {
+                return Text(notice)
             }
             return Self.attributedPreview(for: chat)
         }
@@ -1062,8 +1067,12 @@ struct LeavingGroupBadge: View {
     }
 }
 
-/// "Left" / "Removed" capsule on rows for groups the local account is no longer a
-/// member of; the chat stays listed so the history remains readable.
+/// "Left" capsule on rows for groups the local account walked out of; the chat stays listed so
+/// the history remains readable.
+///
+/// It renders any ended membership it is handed — the label, symbol and tooltip all come from
+/// `ChatSelfMembership` — but the sidebar row only hands it the memberships that
+/// `reportsInChatRowPreviewLine` leaves to a capsule. A removal takes the preview line instead.
 struct MembershipEndedBadge: View {
     let membership: ChatSelfMembership
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -5072,6 +5072,75 @@ struct PureValueTests {
         #expect(spanish != chat.previewPlaceholder(locale: Locale(identifier: "en")))
     }
 
+    /// A removal takes the preview line outright — the chat is closed to the reader, so the row
+    /// reports that instead of whatever was said before it, in the same words the chat's own
+    /// composer notice uses. The "Removed" capsule beside the title goes away with it.
+    @Test func removalTakesThePreviewLineFromTheLastMessage() {
+        let removed = invitePreviewChat(
+            isDirect: false,
+            preview: "Alice: see you Monday",
+            pendingConfirmation: false,
+            membership: .removed
+        )
+
+        #expect(
+            removed.previewNotice(locale: Locale(identifier: "en"))
+                == "You were removed from this group"
+        )
+        #expect(ChatSelfMembership.removed.reportsInChatRowPreviewLine)
+    }
+
+    /// Leaving is the reader's own doing and stays a capsule, so its rows keep showing the last
+    /// message — the one thing a row can say that the reader does not already know.
+    @Test func leavingKeepsItsCapsuleAndItsLastMessage() {
+        let left = invitePreviewChat(
+            isDirect: false,
+            preview: "Alice: see you Monday",
+            pendingConfirmation: false,
+            membership: .left
+        )
+
+        #expect(left.previewNotice(locale: Locale(identifier: "en")) == nil)
+        #expect(ChatSelfMembership.left.reportsInChatRowPreviewLine == false)
+        #expect(ChatSelfMembership.member.reportsInChatRowPreviewLine == false)
+    }
+
+    /// Everything the line said before still reaches it: a chat with no last message keeps the
+    /// placeholder wording, and the removal notice does not displace an unanswered invite's.
+    @Test func previewNoticeStillDefersToThePlaceholderWordingItReplaced() {
+        let english = Locale(identifier: "en")
+
+        #expect(
+            invitePreviewChat(isDirect: true, preview: "").previewNotice(locale: english)
+                == "Has invited you to a secure chat"
+        )
+        #expect(
+            invitePreviewChat(isDirect: false, preview: "", pendingConfirmation: false)
+                .previewNotice(locale: english) == "No messages yet"
+        )
+        #expect(
+            invitePreviewChat(isDirect: true, preview: "Alice: Welcome in")
+                .previewNotice(locale: english) == nil
+        )
+    }
+
+    /// Resolved against the caller's locale for the same reason the invite line is: the chat list
+    /// is not rebuilt on a language switch.
+    @Test func removalPreviewLineFollowsTheRequestedLocale() {
+        let removed = invitePreviewChat(
+            isDirect: false,
+            preview: "Alice: see you Monday",
+            pendingConfirmation: false,
+            membership: .removed
+        )
+        let spanish = removed.previewNotice(
+            locale: Locale(identifier: AppLanguage.spanish.rawValue)
+        )
+
+        #expect(spanish == "Te eliminaron de este grupo")
+        #expect(spanish != removed.previewNotice(locale: Locale(identifier: "en")))
+    }
+
     // MARK: - PeerProfileRefreshGate
 
     @Test func peerProfileGateDedupesInFlightAttemptsForTheSameAccount() {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -30399,6 +30399,79 @@ struct whitenoise_macTests {
         #expect(state.privacySecuritySettings.relayTelemetryEnabled)
     }
 
+    /// A telemetry save that is still mid-flight when the user switches identity must not follow
+    /// them there. `isSavingPrivacySecurity` gates the whole page — the loader and both setters
+    /// refuse to run while it is raised — so a save left owning it locked the incoming account out
+    /// of a page it had never touched, and the outgoing account's answer then published into it.
+    @MainActor
+    @Test func privacySecuritySaveInFlightDoesNotFollowTheUserToTheNextAccount() async throws {
+        let previousActiveAccount = UserDefaults.standard.object(forKey: WorkspaceState.activeAccountKey)
+        defer { restoreDefault(previousActiveAccount, forKey: WorkspaceState.activeAccountKey) }
+
+        let primary = AccountSummaryFfi(
+            label: "Primary Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let backup = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, backup])
+        runtime.storedRelayTelemetrySettings = RelayTelemetrySettingsFfi(
+            exportEnabled: false,
+            exportIntervalSeconds: 120
+        )
+        // Pinned so a value another test left behind cannot decide which account boots active.
+        UserDefaults.standard.set(primary.label, forKey: WorkspaceState.activeAccountKey)
+        let state = WorkspaceState(
+            telemetryBuildConfigProvider: {
+                telemetryBuildConfig(
+                    telemetryToken: "otlp-token",
+                    auditToken: "audit-token",
+                    environment: "production"
+                )
+            },
+            clientFactory: { runtime }
+        )
+
+        await state.bootstrap()
+        #expect(state.activeAccountId == primary.label)
+        #expect(!state.privacySecuritySettings.relayTelemetryEnabled)
+
+        runtime.relayTelemetrySettingsGateEnabled = true
+        async let save: Void = state.setRelayTelemetryEnabled(true)
+        while !runtime.didReachRelayTelemetrySettingsGate {
+            await Task.yield()
+        }
+        #expect(state.isSavingPrivacySecurity)
+
+        let backupAccount = try #require(state.accounts.first { $0.id == backup.label })
+        state.selectAccount(backupAccount)
+
+        // The page is the new identity's from the moment it is active, not once the old save
+        // happens to finish.
+        #expect(state.activeAccountId == backup.label)
+        #expect(!state.isSavingPrivacySecurity)
+
+        runtime.releaseRelayTelemetrySettingsGate()
+        await save
+
+        // The write still lands where the user asked for it — what it must not do is publish into
+        // the account now on screen, re-raise its saving flag, or report its errors there.
+        #expect(runtime.storedRelayTelemetrySettings.exportEnabled)
+        #expect(!state.privacySecuritySettings.relayTelemetryEnabled)
+        #expect(!state.isSavingPrivacySecurity)
+        #expect(state.lastError == nil)
+    }
+
     @MainActor
     @Test func observabilityRuntimeConfigurationSkipsUnchangedRequests() async throws {
         let previousActiveAccount = UserDefaults.standard.object(forKey: "whitenoise.mac.activeAccountId")


### PR DESCRIPTION
|Before| After|
|----|----|
| <img width="382" height="259" alt="Screenshot 2026-08-19 at 9 01 52 PM" src="https://github.com/user-attachments/assets/decc3b67-bee5-4e3c-8f81-5033465bc731" />|<img width="377" height="260" alt="Screenshot 2026-08-19 at 9 00 54 PM" src="https://github.com/user-attachments/assets/bcba4b34-685a-4634-a225-e36cf42569ea" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat previews now display localized membership-ended notices, including removal messages and invitations.
  - Removed-membership notices replace the previous message preview, while other ended memberships retain existing preview behavior.
  - Delivery indicators are hidden when a status notice is shown.

- **Bug Fixes**
  - Privacy and security settings saves remain associated with the correct account when switching accounts, preventing stale results, errors, or telemetry from affecting the newly selected account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->