### PR TITLE
Count unaccepted invites in the avatar badge

### DIFF
--- a/whitenoise-mac/Core/MarmotClient.swift
+++ b/whitenoise-mac/Core/MarmotClient.swift
@@ -75,6 +75,11 @@ nonisolated protocol MarmotRuntime: Sendable {
     func updateGroupProfile(accountRef: String, groupIdHex: String, name: String?, description: String?) async throws
         -> SendSummaryFfi
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws -> ChatListSubscription
+    /// One-shot read of an account's chat-list projection, for accounts the app is not
+    /// subscribed to. Like `accountUnreadSummary`, this is a local read that materializes the
+    /// projection if needed and never requires the account to be running, so it can answer for
+    /// an account other than the active one.
+    func chatList(accountRef: String, includeArchived: Bool) throws -> [ChatListRowFfi]
     func subscribeNotifications() async throws -> NotificationsSubscription
     /// The one MarmotRuntime call that is not a local DB read: it traverses the searcher's web of
     /// trust over relays and streams matches as each radius resolves. Note the parameter is an
@@ -485,6 +490,10 @@ nonisolated final class MarmotClient: MarmotRuntime, @unchecked Sendable {
 
     func subscribeChatList(accountRef: String, includeArchived: Bool) async throws -> ChatListSubscription {
         try await marmot.subscribeChatList(accountRef: accountRef, includeArchived: includeArchived)
+    }
+
+    func chatList(accountRef: String, includeArchived: Bool) throws -> [ChatListRowFfi] {
+        try marmot.chatList(accountRef: accountRef, includeArchived: includeArchived)
     }
 
     func subscribeNotifications() async throws -> NotificationsSubscription {

--- a/whitenoise-mac/Core/PendingInviteBadgeCount.swift
+++ b/whitenoise-mac/Core/PendingInviteBadgeCount.swift
@@ -1,0 +1,62 @@
+//
+//  PendingInviteBadgeCount.swift
+//  whitenoise-mac
+//
+//  Which chat rows an account's avatar badge counts as an unanswered invitation.
+//
+//  The badge used to show unread messages alone, which left an invitation invisible on it: an
+//  unaccepted invite has no timeline, so it contributes nothing to the unread total no matter how
+//  long it sits there. Each one is worth +1 instead, the way the chat row already gives it the
+//  unread slot's `+` badge.
+//
+//  The rule lives here because two callers must agree on it and they hold different types: the
+//  active account counts its loaded `ChatItem` rows, and every other account is counted straight
+//  off the `ChatListRowFfi` rows a one-shot chat-list read returns.
+//
+
+import Foundation
+import MarmotKit
+
+/// The badge's definition of an unanswered invitation, kept in step with the core's own
+/// `attention_only_conversations` aggregate (mdk `account_unread_total`).
+///
+/// That query counts a row when `pending_confirmation` is set, and only while the row is
+/// unarchived and the local account's membership is neither `left` nor `removed`. Both
+/// exclusions matter for the badge as much as for the core's total: an archived invite has been
+/// put away deliberately, and an ended membership supersedes a pending invite outright — the
+/// sidebar row draws "Left"/"Removed" in place of the invite badge for exactly that reason
+/// (`ChatRowStatus`), so a badge counting it would point at a row that never mentions an invite.
+nonisolated enum PendingInviteBadgeCount {
+    /// Whether one row adds itself to the badge.
+    ///
+    /// `isArchived` is a parameter rather than read off the row because the active account keeps
+    /// its archived chats in a separate list, where the flag is carried by the list and not by the
+    /// item.
+    static func counts(pendingConfirmation: Bool, isArchived: Bool, membership: ChatSelfMembership) -> Bool {
+        pendingConfirmation && !isArchived && membership == .member
+    }
+
+    /// Unanswered invitations among an account's unarchived chat items.
+    static func count(inUnarchived chats: [ChatItem]) -> Int {
+        chats.count { chat in
+            counts(
+                pendingConfirmation: chat.pendingConfirmation,
+                isArchived: false,
+                membership: chat.selfMembership
+            )
+        }
+    }
+
+    /// Unanswered invitations among the raw chat-list rows of an account whose items are not
+    /// loaded. Rows arrive unmapped, so the archived flag is read from the row itself — a
+    /// `includeArchived: false` read should carry none, but the caller does not have to trust that.
+    static func count(inRows rows: [ChatListRowFfi]) -> Int {
+        rows.count { row in
+            counts(
+                pendingConfirmation: row.pendingConfirmation,
+                isArchived: row.archived,
+                membership: ChatSelfMembership(row.selfMembership)
+            )
+        }
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -444,6 +444,7 @@ extension WorkspaceState {
             accounts = try await accountItemsFromRuntime(client: client)
             removeChats(forAccountId: removedAccountId)
             accountUnreadByIdHex[removedAccountIdHex] = nil
+            pendingInviteCountByIdHex[removedAccountIdHex] = nil
 
             // `activeAccountId` may have changed during the await above — e.g. the user
             // selected an account from settings while this removal was in flight. Decide
@@ -529,6 +530,9 @@ extension WorkspaceState {
         // badges the teardown just cleared.
         lastSummarizedAccountUnread = nil
         accountUnreadSummaryGeneration &+= 1
+        // The other half of the same badges, and the same reason for the generation bump.
+        pendingInviteCountByIdHex.removeAll()
+        pendingInviteCountGeneration &+= 1
         // Read markers are keyed by groupIdHex; leaving them behind both retains a
         // record of which messages the signed-out identity read and lets a recurring
         // group id suppress the first legitimate read-mark advance after re-login. The
@@ -667,6 +671,47 @@ extension WorkspaceState {
     /// Refresh per-account unread totals without loading each account's full session.
     func refreshAccountUnreadSummary() async {
         await refreshAccountUnreadSummary(reflecting: currentAccountUnreadSignal())
+        await refreshPendingInviteCounts()
+    }
+
+    /// Re-read the unanswered-invitation counts behind the non-active accounts' avatar badges.
+    ///
+    /// Deliberately absent from `refreshAccountUnreadSummaryIfChatRowsMovedIt`: that gate fires on
+    /// the *active* account's row deltas, and no delta of its rows can move another account's
+    /// invitations, while its own are counted off those very rows. Every path that can move them —
+    /// a full chat-list reload, an account switch, a sign-in, and a notification landing on a
+    /// background account — goes through `refreshAccountUnreadSummary()` above.
+    ///
+    /// The unread summary answers for every account in one call; invitations have no such
+    /// aggregate in this binding, so each account is read separately. That is the same cost class
+    /// (one local projection read per account, no session load, no network), which is why this is
+    /// kept off the per-read-marker path.
+    private func refreshPendingInviteCounts() async {
+        guard let client else { return }
+        // Same race as the unread summary: two refreshes can be in flight and the FFI answers in
+        // whatever order it finishes, so only the newest request may commit.
+        pendingInviteCountGeneration &+= 1
+        let generation = pendingInviteCountGeneration
+        // The active account is excluded here and answered from its rows; a signed-out account has
+        // no badge count at all (the rail draws it a pause glyph instead).
+        let targets = accounts.filter { !$0.signedOut && $0.id != activeAccountId }
+        var counts: [String: Int] = [:]
+        for target in targets {
+            do {
+                let rows = try await FFIExecutor.run {
+                    try client.chatList(accountRef: target.accountRef, includeArchived: false)
+                }
+                counts[target.accountIdHex] = PendingInviteBadgeCount.count(inRows: rows)
+            } catch {
+                // Badges are best-effort: keep this account's previous count rather than dropping
+                // an invitation off the rail because one projection read failed.
+                if let previous = pendingInviteCountByIdHex[target.accountIdHex] {
+                    counts[target.accountIdHex] = previous
+                }
+            }
+        }
+        guard pendingInviteCountGeneration == generation else { return }
+        pendingInviteCountByIdHex = counts
     }
 
     /// Re-run the summary only when the active account's own chat rows have moved its unread total.
@@ -753,9 +798,32 @@ extension WorkspaceState {
         )
     }
 
-    /// Aggregate unread count for an account's avatar badge in the switcher.
+    /// Aggregate attention count for an account's avatar badge in the rail and the switcher:
+    /// unread messages plus one for each invitation the account has not answered yet.
+    ///
+    /// An unaccepted invite has no timeline, so it adds nothing to the unread total however long
+    /// it sits there — the badge said "nothing to see" while the chat list was showing an invite.
+    /// Counting it as +1 matches how the core aggregates its own badge attention
+    /// (`attention_only_conversations`) and how the row already presents it.
     func unreadCount(forAccountIdHex accountIdHex: String) -> Int {
-        accountUnreadByIdHex[accountIdHex] ?? 0
+        let unread = accountUnreadByIdHex[accountIdHex] ?? 0
+        // Wrapping addition: both sides are clamped row totals, so a pathological unread count
+        // must not trap here for the sake of a badge that reads "99+" either way.
+        return unread &+ pendingInviteCount(forAccountIdHex: accountIdHex)
+    }
+
+    /// Unanswered invitations for one account, live for the active account and from the last
+    /// projection read for the others.
+    ///
+    /// The active account is answered from its loaded rows rather than from
+    /// `pendingInviteCountByIdHex`, so accepting or declining an invite — or receiving one —
+    /// moves its badge on the chat-list update that changed the row, with no FFI round trip to
+    /// wait through and no window where the two disagree.
+    func pendingInviteCount(forAccountIdHex accountIdHex: String) -> Int {
+        if let activeAccount, activeAccount.accountIdHex == accountIdHex {
+            return PendingInviteBadgeCount.count(inUnarchived: activeChats)
+        }
+        return pendingInviteCountByIdHex[accountIdHex] ?? 0
     }
 
     func deleteAllData() async {
@@ -958,6 +1026,8 @@ extension WorkspaceState {
         accountUnreadByIdHex.removeAll()
         lastSummarizedAccountUnread = nil
         accountUnreadSummaryGeneration &+= 1
+        pendingInviteCountByIdHex.removeAll()
+        pendingInviteCountGeneration &+= 1
         // "Delete All Local Data" must also evict decoded peer/group avatars held in the
         // process-lifetime decoded-image cache; those images derive from attacker-controlled
         // peer `picture` URLs and would otherwise survive the wipe in memory. See #177.

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -373,6 +373,14 @@ final class WorkspaceState {
     @ObservationIgnored var lastSummarizedAccountUnread: AccountUnreadSignal?
     /// Bumped per summary request so only the newest one may commit its answer.
     @ObservationIgnored var accountUnreadSummaryGeneration: UInt64 = 0
+    /// Unanswered invitations per account, keyed by `accountIdHex`, for the same avatar badges.
+    ///
+    /// Holds only the accounts that are **not** active: the active account's invitations are
+    /// counted off its live chat rows instead (`pendingInviteCount(forAccountIdHex:)`), which
+    /// answers without an FFI hop and cannot go stale between refreshes.
+    var pendingInviteCountByIdHex: [String: Int] = [:]
+    /// Bumped per invitation-count request so only the newest one may commit its answer.
+    @ObservationIgnored var pendingInviteCountGeneration: UInt64 = 0
     var isSavingRelays = false
     var isPublishingKeyPackage = false
     var isRepublishingKeyPackage = false

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2883,6 +2883,170 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func theAvatarBadgeCountsAnUnansweredInviteAsOne() async throws {
+        // An unaccepted invite has no timeline, so it moves no unread total however long it sits in
+        // the chat list: the rail badge read "nothing to see" while rows were asking to be answered.
+        // Each one is worth +1, matching the core's own badge aggregate and the `+` the row draws.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 2)
+        ]
+        let (state, account) = unreadBadgeFixture(
+            runtime: runtime,
+            seededUnreadCount: 2,
+            additionalChats: [
+                pendingInviteChatItem(id: "invite-one"),
+                pendingInviteChatItem(id: "invite-two"),
+            ]
+        )
+
+        await state.refreshAccountUnreadSummary()
+
+        #expect(state.pendingInviteCount(forAccountIdHex: account.accountIdHex) == 2)
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 4)
+    }
+
+    @MainActor
+    @Test func theAvatarBadgeSkipsArchivedAndEndedInvites() async throws {
+        // Parity with the core's `attention_only_conversations`, which counts a pending row only
+        // while it is unarchived and the local membership has not ended. Both exclusions matter to
+        // the badge too: an archived invite was put away deliberately, and an ended membership
+        // supersedes a pending invite outright — the sidebar row draws "Removed" in its place, so a
+        // badge counting it would point at a row that never mentions an invite.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0)
+        ]
+        let (state, account) = unreadBadgeFixture(
+            runtime: runtime,
+            seededUnreadCount: 0,
+            additionalChats: [pendingInviteChatItem(id: "invite-removed", selfMembership: .removed)],
+            archivedChats: [pendingInviteChatItem(id: "invite-archived")]
+        )
+
+        await state.refreshAccountUnreadSummary()
+
+        #expect(state.archivedChats.count == 1)
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+    }
+
+    @MainActor
+    @Test func answeringAnInviteMovesTheBadgeOnTheRowAlone() async throws {
+        // The active account's invites are counted off its live rows rather than off the summary,
+        // so accepting one moves the badge on the chat-row update itself — no FFI round trip to
+        // wait through, and no window where the badge and the list disagree.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0)
+        ]
+        let (state, account) = unreadBadgeFixture(
+            runtime: runtime,
+            seededUnreadCount: 0,
+            additionalChats: [pendingInviteChatItem(id: "invite")]
+        )
+
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 1)
+        let queriesSoFar = runtime.accountUnreadSummaryCallCount
+
+        // The answered invite comes back as an ordinary row.
+        await state.applyChatRow(
+            pendingInviteRow(groupIdHex: "invite", pendingConfirmation: false),
+            account: account,
+            shouldEnrich: false
+        )
+
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+        #expect(runtime.accountUnreadSummaryCallCount == queriesSoFar)
+    }
+
+    @MainActor
+    @Test func aBackgroundAccountsUnansweredInviteMovesItsAvatarBadge() async throws {
+        // Only the active account runs a chat-list subscription, so a background account's invites
+        // can never arrive as row deltas — its badge would have kept counting messages alone. The
+        // full summary pass reads them off that account's projection, which needs no session load.
+        let backup = backupAccountSummary()
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0),
+            unreadSummaryRow(accountIdHex: backup.accountIdHex, unreadCount: 3),
+        ]
+        runtime.chatListRowsByAccountRef = [
+            backup.label: [
+                pendingInviteRow(groupIdHex: "invite-for-backup"),
+                // The exclusions have to hold on this path too, where the rows arrive unmapped.
+                pendingInviteRow(groupIdHex: "invite-archived", archived: true),
+                pendingInviteRow(groupIdHex: "invite-left", selfMembership: .left),
+                unreadBadgeFixtureRow(timelineAt: 1_700_000_000, unreadCount: 3),
+            ]
+        ]
+        let (state, active) = unreadBadgeFixture(runtime: runtime, seededUnreadCount: 0)
+        state.accounts.append(AccountItem(summary: backup))
+
+        await state.refreshAccountUnreadSummary()
+
+        #expect(state.unreadCount(forAccountIdHex: backup.accountIdHex) == 4)
+        #expect(state.unreadCount(forAccountIdHex: active.accountIdHex) == 0)
+        // The active account is answered from its live rows, so it is never read one-shot here.
+        #expect(runtime.chatListAccountRefs == [backup.label])
+    }
+
+    @MainActor
+    @Test func aFailedInviteReadKeepsTheBadgeItLastRecorded() async throws {
+        // Badges are best-effort. One projection read failing must not drop an invitation off the
+        // rail, which would read as the invite having been answered somewhere else.
+        let backup = backupAccountSummary()
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0),
+            unreadSummaryRow(accountIdHex: backup.accountIdHex, unreadCount: 0),
+        ]
+        runtime.chatListRowsByAccountRef = [backup.label: [pendingInviteRow(groupIdHex: "invite-for-backup")]]
+        let (state, _) = unreadBadgeFixture(runtime: runtime, seededUnreadCount: 0)
+        state.accounts.append(AccountItem(summary: backup))
+
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: backup.accountIdHex) == 1)
+
+        runtime.chatListError = FakeMarmotRuntimeError.unused
+        await state.refreshAccountUnreadSummary()
+
+        #expect(state.unreadCount(forAccountIdHex: backup.accountIdHex) == 1)
+    }
+
+    @MainActor
+    @Test func chatRowDeltasDoNotRereadTheOtherAccountsInviteCounts() async throws {
+        // The row-gated refresh exists so the badge does not put an FFI call on every read-marker
+        // advance. Invitations must not reintroduce one: no delta of the active account's rows can
+        // move another account's invites, and its own are counted off those very rows.
+        let backup = backupAccountSummary()
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 3),
+            unreadSummaryRow(accountIdHex: backup.accountIdHex, unreadCount: 0),
+        ]
+        let (state, account) = unreadBadgeFixture(runtime: runtime, seededUnreadCount: 3)
+        state.accounts.append(AccountItem(summary: backup))
+
+        await state.refreshAccountUnreadSummary()
+        let readsSoFar = runtime.chatListCallCount
+
+        // The seeded row, now read: the unread total moved, so the summary itself is re-queried.
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0),
+            unreadSummaryRow(accountIdHex: backup.accountIdHex, unreadCount: 0),
+        ]
+        await state.applyChatRow(
+            unreadBadgeFixtureRow(timelineAt: 1_700_000_100, unreadCount: 0),
+            account: account,
+            shouldEnrich: false
+        )
+
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+        #expect(runtime.chatListCallCount == readsSoFar)
+    }
+
+    @MainActor
     @Test func resetActiveAccountUIStateClearsReadMarkersAndDeliveredNotificationKeys() async throws {
         let primary = AccountSummaryFfi(
             label: "Desktop Account",
@@ -35172,6 +35336,23 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
             .map { chatListRow(for: $0) }
     }
 
+    /// Per-account one-shot chat lists, for the accounts the app never subscribes to. An account
+    /// with no entry answers from the shared `groups`, the way `subscribeChatList` does.
+    var chatListRowsByAccountRef: [String: [ChatListRowFfi]] = [:]
+    var chatListCallCount = 0
+    var chatListAccountRefs: [String] = []
+    var chatListError: Error?
+
+    func chatList(accountRef: String, includeArchived: Bool) throws -> [ChatListRowFfi] {
+        chatListCallCount += 1
+        chatListAccountRefs.append(accountRef)
+        if let chatListError { throw chatListError }
+        guard let installed = chatListRowsByAccountRef[accountRef] else {
+            return chatListRows(includeArchived: includeArchived)
+        }
+        return installed.filter { includeArchived || !$0.archived }
+    }
+
     private func groupMutationResult(groupIdHex: String, messageId: String) throws -> GroupMutationResultFfi {
         guard let details = groupDetailsById[groupIdHex] else {
             throw FakeMarmotRuntimeError.unused
@@ -36650,12 +36831,14 @@ private func chatListRow(
     attachmentCount: UInt32 = 0,
     deleted: Bool = false,
     unreadCount: UInt64 = 0,
-    hasUnread: Bool = false
+    hasUnread: Bool = false,
+    archived: Bool = false,
+    pendingConfirmation: Bool = false
 ) -> ChatListRowFfi {
     ChatListRowFfi(
         groupIdHex: groupIdHex,
-        archived: false,
-        pendingConfirmation: false,
+        archived: archived,
+        pendingConfirmation: pendingConfirmation,
         title: title,
         groupName: "",
         avatarUrl: nil,
@@ -36690,14 +36873,18 @@ private func chatListOrderingTestItem(
     title: String,
     preview: String = "preview",
     updatedAt: UInt64,
-    unreadCount: Int = 1
+    unreadCount: Int = 1,
+    pendingConfirmation: Bool = false,
+    selfMembership: ChatSelfMembership = .member
 ) -> ChatItem {
     chatListOrderingTestItem(
         id: id,
         title: title,
         preview: preview,
         date: Date(timeIntervalSince1970: TimeInterval(updatedAt)),
-        unreadCount: unreadCount
+        unreadCount: unreadCount,
+        pendingConfirmation: pendingConfirmation,
+        selfMembership: selfMembership
     )
 }
 
@@ -36706,7 +36893,9 @@ private func chatListOrderingTestItem(
     title: String,
     preview: String = "preview",
     date: Date?,
-    unreadCount: Int = 1
+    unreadCount: Int = 1,
+    pendingConfirmation: Bool = false,
+    selfMembership: ChatSelfMembership = .member
 ) -> ChatItem {
     ChatItem(
         id: id,
@@ -36718,7 +36907,45 @@ private func chatListOrderingTestItem(
         pictureURL: nil,
         unreadCount: unreadCount,
         isDirect: false,
-        pendingConfirmation: false
+        pendingConfirmation: pendingConfirmation,
+        selfMembership: selfMembership
+    )
+}
+
+/// An unanswered invitation as the chat list holds it: no last message, no unread count, and — by
+/// default — a membership that has not ended, which is what makes it worth a badge.
+private func pendingInviteChatItem(
+    id: String,
+    selfMembership: ChatSelfMembership = .member
+) -> ChatItem {
+    chatListOrderingTestItem(
+        id: id,
+        title: "Invite \(id)",
+        preview: "",
+        updatedAt: 1_700_000_000,
+        unreadCount: 0,
+        pendingConfirmation: true,
+        selfMembership: selfMembership
+    )
+}
+
+/// The same invitation as a raw projection row, for the accounts read one-shot rather than
+/// subscribed to.
+private func pendingInviteRow(
+    groupIdHex: String,
+    pendingConfirmation: Bool = true,
+    archived: Bool = false,
+    selfMembership: SelfMembershipFfi = .member
+) -> ChatListRowFfi {
+    chatListRow(
+        groupIdHex: groupIdHex,
+        title: "Invite \(groupIdHex)",
+        preview: "",
+        sender: unreadBadgeFixtureAccountIdHex,
+        timelineAt: 1_700_000_000,
+        selfMembership: selfMembership,
+        archived: archived,
+        pendingConfirmation: pendingConfirmation
     )
 }
 
@@ -37023,6 +37250,8 @@ private func backupAccountSummary() -> AccountSummaryFfi {
 private func unreadBadgeFixture(
     runtime: FakeMarmotRuntime,
     seededUnreadCount: Int,
+    additionalChats: [ChatItem] = [],
+    archivedChats: [ChatItem] = [],
     localNotificationCenter: (any LocalNotificationCenter)? = nil
 ) -> (state: WorkspaceState, account: AccountItem) {
     let account = AccountItem(
@@ -37039,12 +37268,15 @@ private func unreadBadgeFixture(
     )
     let state = WorkspaceState(
         accounts: [account],
-        chatsByAccount: [account.id: [chat]],
+        chatsByAccount: [account.id: [chat] + additionalChats],
         localNotificationCenter: localNotificationCenter,
         clientFactory: { runtime }
     )
     state.client = runtime
     state.activeAccountId = account.id
+    if !archivedChats.isEmpty {
+        state.setArchivedChats(archivedChats, forAccountId: account.id)
+    }
     return (state, account)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pending invitation counts to account and avatar badges.
  - Counts include active, unanswered invitations while excluding archived or ended conversations.
  - Background account invitation counts are refreshed and preserved when data is temporarily unavailable.
  - Added chat-list retrieval to support invitation status updates.

- **Bug Fixes**
  - Badge counts now refresh correctly after accepting invitations, removing accounts, or resetting account state.
  - Prevented outdated invitation data from replacing newer results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->