### PR TITLE
fix accounts dropdown

### DIFF
--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -59,6 +59,23 @@ struct AvatarChromeModifier: ViewModifier {
     /// the selection moves.
     static let selectedScale: CGFloat = 1.15
 
+    /// Blur radius of the drop shadow. Named because `overhang(forAvatarSize:)` has to add it —
+    /// a literal here and a literal there would drift apart.
+    static let shadowRadius: CGFloat = 2
+
+    /// How far this chrome reaches *outside* the avatar's own frame, per side: half of the width
+    /// `selectedScale` adds, plus the shadow's blur.
+    ///
+    /// Both effects draw beyond the frame they are applied to, so an avatar seated flush against
+    /// a clipping container's edge loses that much of its ring — a circle with a flat side, which
+    /// is what it looks like rather than a subtle one. Any container that clips (a `ScrollView`,
+    /// a `clipShape`) has to leave this much slack around an avatar on its edge. The account rail
+    /// buys the slack with a bigger frame (`accountRailAvatarSize` inside
+    /// `accountRailAvatarFrameSize`); the account switcher's rows inset their scroll content.
+    static func overhang(forAvatarSize size: CGFloat) -> CGFloat {
+        size * (selectedScale - 1) / 2 + shadowRadius
+    }
+
     @ViewBuilder
     func body(content: Content) -> some View {
         if isEnabled {
@@ -67,7 +84,7 @@ struct AvatarChromeModifier: ViewModifier {
                     Circle()
                         .strokeBorder(strokeColor, lineWidth: isSelected ? 3 : 1)
                 }
-                .shadow(color: WNColor.shadow.opacity(0.1), radius: 2, y: 1)
+                .shadow(color: WNColor.shadow.opacity(0.1), radius: Self.shadowRadius, y: 1)
                 .scaleEffect(isSelected ? Self.selectedScale : 1)
         } else {
             content

--- a/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
@@ -219,9 +219,17 @@ struct AccountSwitcherPopover: View {
                             )
                         }
                     }
+                    .padding(.horizontal, Self.rowChromeInset)
                 }
                 .scrollIndicators(.hidden)
                 .frame(maxHeight: 260)
+                // A `ScrollView` clips to its bounds, and the active row's avatar is seated flush
+                // against the leading one: the selection ring is drawn *outside* the avatar's
+                // frame, so it came out with a flat left side. The content is inset by the ring's
+                // reach and the scroll view widened by the same amount, which leaves the rows
+                // where they were — aligned with the header and the button — while giving the
+                // chrome somewhere to draw. Insetting alone would indent every row instead.
+                .padding(.horizontal, -Self.rowChromeInset)
             }
 
             Divider()
@@ -236,12 +244,23 @@ struct AccountSwitcherPopover: View {
         .padding(14)
         .frame(width: 320)
     }
+
+    /// Slack the scrolling row list leaves on each side for the avatar chrome that draws outside
+    /// its frame. Vertically the rows' own `.padding(.vertical, 4)` already covers the ring, so
+    /// only the horizontal edges need it.
+    private static var rowChromeInset: CGFloat {
+        AvatarChromeModifier.overhang(forAvatarSize: AccountSwitcherRow.avatarSize)
+    }
 }
 
 /// One identity in the switcher. Tapping switches to it (or signs it back in when
 /// it was signed out); the trailing menu carries the actions that need a
 /// confirmation.
 struct AccountSwitcherRow: View {
+    /// Diameter of the row's avatar. Read by `AccountSwitcherPopover.rowChromeInset`, which sizes
+    /// the scroll inset from it — the chrome's reach scales with the avatar.
+    static let avatarSize: CGFloat = 32
+
     @Environment(\.locale) private var locale
     let account: AccountItem
     let isActive: Bool
@@ -266,7 +285,7 @@ struct AccountSwitcherRow: View {
                         // for an identity that is supposed to be off, so it drops back to initials
                         // (the row is already dimmed to 0.4). Signed-in rows are unaffected.
                         isOwnAccountImage: !account.signedOut,
-                        size: 32,
+                        size: Self.avatarSize,
                         isSelected: isActive
                     )
                     .opacity(account.signedOut ? 0.4 : 1)

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1126,6 +1126,71 @@ struct whitenoise_macTests {
         #expect(normalized.contains(".onDisappear{workspace.clearEnteredLoginIdentity()}"))
     }
 
+    /// The avatar's selection ring and drop shadow are both drawn outside the frame they are
+    /// applied to, so every clipping container has to be told how far they reach. Pinned to the
+    /// effects that produce it: a hand-written literal that stopped tracking `selectedScale`
+    /// would hand those containers a slack that no longer covers the ring.
+    @MainActor
+    @Test func avatarChromeOverhangCoversTheSelectionRingAndTheShadow() {
+        let size: CGFloat = 32
+        // `scaleEffect` grows about the center, so each side moves out by half the added width.
+        let ringReach = size * (AvatarChromeModifier.selectedScale - 1) / 2
+
+        #expect(ringReach > 0)
+        #expect(
+            AvatarChromeModifier.overhang(forAvatarSize: size)
+                == ringReach + AvatarChromeModifier.shadowRadius)
+        // The shadow's blur is on top of the ring, not inside it.
+        #expect(AvatarChromeModifier.overhang(forAvatarSize: size) > ringReach)
+        // A bigger avatar's ring reaches further, so the slack it needs has to scale with it.
+        #expect(
+            AvatarChromeModifier.overhang(forAvatarSize: 64)
+                > AvatarChromeModifier.overhang(forAvatarSize: 32))
+    }
+
+    /// The rail buys its slack with an oversized frame, and `AvatarChromeModifier` documents that
+    /// arrangement as the reason `selectedScale` is safe to apply. Shrinking the frame — or
+    /// raising the scale — without the other would clip the active account's ring against the
+    /// rail's own bounds.
+    @MainActor
+    @Test func accountRailAvatarFrameLeavesRoomForTheSelectedAvatarsChrome() {
+        let slackPerSide =
+            (MessagesLayout.accountRailAvatarFrameSize - MessagesLayout.accountRailAvatarSize) / 2
+
+        #expect(
+            slackPerSide
+                >= AvatarChromeModifier.overhang(
+                    forAvatarSize: MessagesLayout.accountRailAvatarSize))
+    }
+
+    /// The switcher's rows scroll, and a `ScrollView` clips to its bounds — with the avatar seated
+    /// flush against the leading edge, the active account's ring came out with a flat left side.
+    /// Only the source can hold this contract: SwiftUI's clipping is not observable from a test,
+    /// and the fix is a pair of paddings that cancel in layout, so any assertion on the rows'
+    /// position would pass just as well with both of them deleted.
+    @MainActor
+    @Test func accountSwitcherScrollListInsetsItsRowsForTheAvatarChrome() throws {
+        let sourceURL =
+            URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "whitenoise-mac")
+            .appending(path: "Views")
+            .appending(path: "Settings")
+            .appending(path: "SettingsAccountSwitcherViews.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        let popoverStart = try #require(source.range(of: "struct AccountSwitcherPopover: View {"))
+        let popoverEnd = try #require(source.range(of: "struct AccountSwitcherRow: View {"))
+        let normalized = String(source[popoverStart.lowerBound..<popoverEnd.lowerBound])
+            .components(separatedBy: .whitespacesAndNewlines).joined()
+
+        // The rows are inset so the chrome has somewhere to draw...
+        #expect(normalized.contains(".padding(.horizontal,Self.rowChromeInset)"))
+        // ...and the scroll view is widened by the same amount so they stay put.
+        #expect(normalized.contains(".padding(.horizontal,-Self.rowChromeInset)"))
+    }
+
     @MainActor
     @Test func removeActiveAccountCallsRuntimeAndSelectsNextAccount() async throws {
         let primary = AccountSummaryFfi(


### PR DESCRIPTION
Avatars in account dropdown looked cut in the left side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account-switcher layout so avatar selection rings and shadows are no longer clipped.
  * Adjusted horizontal spacing to preserve the full appearance of selected avatars.

* **Tests**
  * Added coverage for avatar effects and account-switcher spacing across supported layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->