### PR TITLE
Address bindings improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,6 @@ build.
   that the pin and the stamp still agree.
 - The published macOS XCFramework is `aarch64-apple-darwin` only — there is no
   Intel or universal build upstream, so the app stays arm64-only.
-  This is a multi-minute Rust build; run it in the background.
 - `MarmotRuntime` (in `Core/MarmotClient.swift`) is the `nonisolated` protocol the
   app calls; the concrete `MarmotClient` forwards thinly to the generated `Marmot`
   object, and `FakeMarmotRuntime` in the tests mirrors it. **Adding an FFI method

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,9 @@ build.
   The script verifies the binary checksum, the generated Swift source hash, and
   the manifest's `source_sha` before installing anything, then rewrites the pin
   and stamps `Vendored/MarmotKit/MARMOT_VERSION`. `just sanity` cross-checks
-  that the pin and the stamp still agree.
+  that the pin and the stamp still agree, and re-hashes the vendored
+  `MarmotKit.swift` against the stamp — so never hand-edit the generated
+  source, re-run the sync instead.
 - The published macOS XCFramework is `aarch64-apple-darwin` only — there is no
   Intel or universal build upstream, so the app stays arm64-only.
 - `MarmotRuntime` (in `Core/MarmotClient.swift`) is the `nonisolated` protocol the

--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ snapshot form. It then rewrites the pin in `Package.swift` and stamps
 
 Requires only `curl` and Xcode command-line tools — no Rust toolchain, no mdk
 checkout. `scripts/ci/macos-sanity-checks.sh` verifies that the pin in
-`Package.swift` and the provenance in `MARMOT_VERSION` still agree, so editing
-one by hand without the other fails CI.
+`Package.swift` and the provenance in `MARMOT_VERSION` still agree, and that
+the vendored `MarmotKit.swift` still hashes to the `swift-vendored-sha256`
+stamped next to it, so hand-editing either the pin or the generated source
+fails CI.
 
 The generated `MarmotKit.swift` is platform-independent: it is the same source
 `whitenoise-ios` vendors from the same release, save for the trailing

--- a/README.md
+++ b/README.md
@@ -113,20 +113,23 @@ just sync-bindings 235c8ade2920414679e59d7a5f1a0e78651756a4  # a master snapshot
 ```
 
 The script downloads the macOS XCFramework, the shared generated Swift source,
-and the release manifest, then refuses to install anything unless all three
-checks pass: `swift package compute-checksum` matches the published
-`.swiftpm-checksum`, the Swift source matches its `sha256` in
-`checksums.txt`, and the manifest's `source_sha` matches the requested SHA. It
-then rewrites the pin in `Package.swift` and stamps `MARMOT_VERSION` and
-`MarmotKitVersion.swift` from the manifest.
+and the release manifest, then refuses to install anything unless two checks
+pass: `swift package compute-checksum` matches the published
+`.swiftpm-checksum`, and the Swift source matches its `sha256` in
+`checksums.txt`. Given a full SHA rather than a version, it additionally
+requires the manifest's `source_sha` to equal the SHA you asked for — a tagged
+version carries no SHA to compare against, so that check only applies to the
+snapshot form. It then rewrites the pin in `Package.swift` and stamps
+`MARMOT_VERSION` and `MarmotKitVersion.swift` from the manifest.
 
 Requires only `curl` and Xcode command-line tools — no Rust toolchain, no mdk
 checkout. `scripts/ci/macos-sanity-checks.sh` verifies that the pin in
 `Package.swift` and the provenance in `MARMOT_VERSION` still agree, so editing
 one by hand without the other fails CI.
 
-The generated `MarmotKit.swift` is platform-independent and byte-identical to
-the copy `whitenoise-ios` vendors from the same release.
+The generated `MarmotKit.swift` is platform-independent: it is the same source
+`whitenoise-ios` vendors from the same release, save for the trailing
+whitespace the install step strips.
 
 ## Testing
 

--- a/Vendored/MarmotKit/MARMOT_VERSION
+++ b/Vendored/MarmotKit/MARMOT_VERSION
@@ -9,6 +9,8 @@ macos-deployment-target: 15.0
 rust-release-opt-level: 3
 rust-release-codegen-units: 16
 swiftpm-checksum: 889834776d9129e658eda04cecc07ae2abfeeab6a116e6052464108c67d5e815
+swift-published-sha256: bd0d57795bd21a88f1457f8476890e09fb3c3b9d04cb53dc7f294480d5e978c5
+swift-vendored-sha256: 275e7e0f5c87db0f3b1919d198ecd07393618e2530b64c7fb770da5454f199fe
 
 Notes:
 - Refresh from a published immutable artifact with:

--- a/scripts/ci/macos-sanity-checks.sh
+++ b/scripts/ci/macos-sanity-checks.sh
@@ -10,6 +10,7 @@ INFO_PLIST="Config/Info.plist"
 ENTITLEMENTS="whitenoise-mac/whitenoise-mac.entitlements"
 MARMOT_PACKAGE="Vendored/MarmotKit/Package.swift"
 MARMOT_VERSION_FILE="Vendored/MarmotKit/MARMOT_VERSION"
+MARMOT_SWIFT_SOURCE="Vendored/MarmotKit/Sources/MarmotKit/MarmotKit.swift"
 
 fail() {
   echo "error: $*" >&2
@@ -128,6 +129,18 @@ stamped_floor="$(sed -nE 's/^macos-deployment-target: (.*)$/\1/p' "$MARMOT_VERSI
   || fail "$MARMOT_VERSION_FILE tag '$stamped_tag' does not match $MARMOT_PACKAGE tag '$marmot_release_tag'"
 [[ "$stamped_checksum" == "$marmot_checksum" ]] \
   || fail "$MARMOT_VERSION_FILE checksum does not match the checksum pinned in $MARMOT_PACKAGE"
+
+# The generated Swift source is the one part of the package that is tracked as
+# text and so can be edited by hand. Nothing else notices if it is: the checks
+# above only compare the pin against the stamp. Note this is the digest of the
+# *installed* file, taken after sync-bindings.sh strips trailing whitespace, not
+# the published digest in the release's checksums.txt.
+stamped_swift_sha="$(sed -nE 's/^swift-vendored-sha256: (.*)$/\1/p' "$MARMOT_VERSION_FILE")"
+[[ "$stamped_swift_sha" =~ ^[0-9a-f]{64}$ ]] \
+  || fail "$MARMOT_VERSION_FILE is missing a valid swift-vendored-sha256 stamp"
+computed_swift_sha="$(shasum -a 256 "$MARMOT_SWIFT_SOURCE" | awk '{ print $1 }')"
+[[ "$computed_swift_sha" == "$stamped_swift_sha" ]] \
+  || fail "$MARMOT_SWIFT_SOURCE digest $computed_swift_sha does not match the $MARMOT_VERSION_FILE stamp $stamped_swift_sha"
 
 # The published macOS artifact is Apple Silicon only. If that ever changes
 # upstream this fires, rather than the app silently staying arm64-only.

--- a/scripts/sync-bindings.sh
+++ b/scripts/sync-bindings.sh
@@ -124,6 +124,11 @@ echo "==> Installing generated Swift source"
 mkdir -p "$PACKAGE_DIR/Sources/MarmotKit"
 cp "$TEMP_DIR/$SWIFT_ASSET" "$PACKAGE_DIR/Sources/MarmotKit/MarmotKit.swift"
 perl -pi -e 's/[ \t]+$//' "$PACKAGE_DIR/Sources/MarmotKit/MarmotKit.swift"
+# The strip above means the installed copy is deliberately *not* byte-identical
+# to the published asset, so its digest has to be taken here, after the rewrite.
+# `just sanity` compares the vendored file against this value; the published
+# digest is stamped alongside it for provenance only.
+VENDORED_SWIFT_SHA="$(shasum -a 256 "$PACKAGE_DIR/Sources/MarmotKit/MarmotKit.swift" | awk '{ print $1 }')"
 
 echo "==> Pinning remote binary target"
 sed -i '' -E \
@@ -148,6 +153,8 @@ macos-deployment-target: $MACOS_DEPLOYMENT_TARGET
 rust-release-opt-level: $RUST_OPT_LEVEL
 rust-release-codegen-units: $RUST_CODEGEN_UNITS
 swiftpm-checksum: $EXPECTED_BINARY_CHECKSUM
+swift-published-sha256: $EXPECTED_SWIFT_SHA
+swift-vendored-sha256: $VENDORED_SWIFT_SHA
 
 Notes:
 - Refresh from a published immutable artifact with:
@@ -172,4 +179,5 @@ echo ""
 echo "Installed MarmotKit $RELEASE_TAG"
 echo "  source:   $SOURCE_SHA"
 echo "  checksum: $EXPECTED_BINARY_CHECKSUM"
+echo "  swift:    $VENDORED_SWIFT_SHA (published $EXPECTED_SWIFT_SHA)"
 echo "  macOS:    $MACOS_TARGETS (deployment target $MACOS_DEPLOYMENT_TARGET)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MarmotKit synchronization guidance and binding validation documentation.
  * Clarified checksum validation, snapshot release handling, provenance stamping, and cross-platform source expectations.

* **Chores**
  * Added SHA-256 checksums for published and vendored Swift sources.
  * Enhanced synchronization output to report recorded source checksums.

* **Bug Fixes**
  * macOS sanity checks now verify the generated Swift source checksum and fail when it is invalid or mismatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->