### PR TITLE
Keep the group-naming pane title clear of the back arrow

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -31576,6 +31576,65 @@
         }
       }
     },
+    "Name group": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gruppe benennen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombrar grupo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nommer le groupe"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nomina il gruppo"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nomear grupo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назовите группу"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gruba ad verin"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为群组命名"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "為群組命名"
+          }
+        }
+      }
+    },
     "Name or npub": {
       "extractionState": "manual",
       "localizations": {
@@ -31631,65 +31690,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "名稱或 npub"
-          }
-        }
-      }
-    },
-    "Name this group": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diese Gruppe benennen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ponle nombre a este grupo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nommer ce groupe"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Assegna un nome a questo gruppo"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dê um nome a este grupo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Назовите эту группу"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bu gruba ad verin"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "为此群组命名"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "為此群組命名"
           }
         }
       }

--- a/whitenoise-mac/Views/ComposeFlowViews.swift
+++ b/whitenoise-mac/Views/ComposeFlowViews.swift
@@ -320,7 +320,7 @@ struct NameGroupPanelView: View {
         @Bindable var workspace = workspace
 
         VStack(spacing: 0) {
-            ComposePaneHeader(title: L10n.string("Name this group")) {
+            ComposePaneHeader(title: L10n.string("Name group")) {
                 workspace.composeGoBack()
             }
 
@@ -720,12 +720,21 @@ private struct ComposePaneHeader: View {
     var body: some View {
         HStack(spacing: 8) {
             GlassCircleCloseButton(symbol: "chevron.backward", help: "Back", appearance: .outline, action: onBack)
-            Spacer()
-        }
-        .overlay {
+
+            // Laid out beside the back button rather than centred as an overlay over it. As an
+            // overlay the title had no width to fit into, so a long localized title grew until it
+            // ran under the chevron — Spanish and Italian titles overlapped it even at the pane's
+            // full width. Here the title gets the space that is actually free and truncates at its
+            // own edge instead.
             Text(title)
                 .wnFont(MessagesType.paneTitle)
                 .lineLimit(1)
+                .frame(maxWidth: .infinity)
+
+            // Mirrors the back button's footprint so the title stays centred in the pane rather
+            // than in what is left of it.
+            Color.clear
+                .frame(width: MessagesLayout.circleControlSize, height: MessagesLayout.circleControlSize)
         }
         .padding(.horizontal, 12)
         .sidebarTitlebarClearance()

--- a/whitenoise-mac/Views/MessengerDesign.swift
+++ b/whitenoise-mac/Views/MessengerDesign.swift
@@ -392,6 +392,9 @@ enum MessagesLayout {
     /// and the detail pane; it only reaches a few points into each.
     static let chatListResizeGrabWidth: CGFloat = 11
     static let chatListResizeGrabberHeight: CGFloat = 34
+    /// Footprint of `GlassCircleCloseButton`. Named because a pane header has to reserve the
+    /// same width on the opposite side to keep its title centred in the pane.
+    static let circleControlSize: CGFloat = 28
 
     /// Top padding for a header on the window's top edge, given whether a window-level notice
     /// band is already there holding the traffic lights.
@@ -918,7 +921,7 @@ struct GlassCircleCloseButton: View {
             Button(action: action) {
                 Image(systemName: symbol)
                     .wnFont(.semiBold12)
-                    .frame(width: 28, height: 28)
+                    .frame(width: MessagesLayout.circleControlSize, height: MessagesLayout.circleControlSize)
             }
             .nativeGlassCircleButtonStyle()
             .help(L10n.string(helpText))
@@ -932,7 +935,7 @@ struct GlassCircleCloseButton: View {
                     // is `backgroundContentPrimary`, which currently resolves to the same value —
                     // true by coincidence, not by construction. See the pairing rule in `WNNSColor`.
                     .foregroundStyle(WNColor.fillContentSecondary)
-                    .frame(width: 28, height: 28)
+                    .frame(width: MessagesLayout.circleControlSize, height: MessagesLayout.circleControlSize)
                     .background { MessagesCircleControlBackground() }
             }
             .buttonStyle(.plain)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the group naming prompt to “Name group” across supported languages.
  * Improved the group naming header layout to prevent translated titles from overlapping the back button.
  * Standardized the sizing of circular controls for a more consistent appearance.
* **Localization**
  * Added translated text for the “Waiting for internet connection” message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->