### PR TITLE
Keep archived chats off the account avatar unread badge

### DIFF
--- a/whitenoise-mac/Core/AccountUnreadSignal.swift
+++ b/whitenoise-mac/Core/AccountUnreadSignal.swift
@@ -13,12 +13,23 @@ import Foundation
 /// The switcher avatar badge shows the backend's per-account summary, which is refreshed far less
 /// often than the rows are. Comparing two of these values answers the only question that matters
 /// for keeping the badge honest: did the rows change unread since the summary was last taken?
+///
+/// Every count here is scoped to the account's *unarchived* chats, matching the scope of the
+/// summary it guards (mdk `account_unread_total` sums `WHERE row.archived = 0`). Counting archived
+/// rows as well made the two disagree in both directions: archiving an unread chat left the totals
+/// identical — the row merely moved between two counted lists — so the gate suppressed the refresh
+/// and the badge kept counting a chat the user had just put away, while a message landing in an
+/// archived chat moved the signal and spent an FFI query on a total that could not have changed.
 struct AccountUnreadSignal: Equatable, Sendable {
     /// The account the counts belong to. A switch alone makes the recorded summary stale, even
     /// when both accounts happen to hold the same totals.
     let accountId: String
-    /// Unread messages across the account's chats, archived ones included.
+    /// Unread messages across the account's unarchived chats.
     let totalUnreadCount: Int
-    /// Chats flagged unread, which includes chats marked unread by hand and so carrying no count.
+    /// Unarchived chats flagged unread, which includes chats marked unread by hand and so carrying
+    /// no count.
     let unreadChatCount: Int
+    /// How many unarchived chats there are, so a chat leaving that list is noticed even when its
+    /// unread messages are coincidentally replaced by another row's in the same snapshot.
+    let chatCount: Int
 }

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -778,9 +778,13 @@ extension WorkspaceState {
     /// displayed summary went stale.
     func currentAccountUnreadSignal() -> AccountUnreadSignal? {
         guard let activeAccountId else { return nil }
-        // Archived chats carry unread counts too, and the chat-list subscription loads them in the
-        // same snapshot, so a signal built from the active list alone would miss their changes.
-        let chats = (chatsByAccount[activeAccountId] ?? []) + (archivedChatsByAccount[activeAccountId] ?? [])
+        // Unarchived chats only, matching what the summary this guards counts: the core sums
+        // unread over `WHERE row.archived = 0`, so an archived chat's unread messages are not in
+        // the displayed total and a change confined to them cannot move it. Counting them here as
+        // well made archiving invisible to the gate — the row moved from one counted list to the
+        // other, leaving the totals identical — so the badge went on counting a chat the user had
+        // just archived until the next full reload or account switch.
+        let chats = chatsByAccount[activeAccountId] ?? []
         var totalUnreadCount = 0
         var unreadChatCount = 0
         for chat in chats {
@@ -794,7 +798,8 @@ extension WorkspaceState {
         return AccountUnreadSignal(
             accountId: activeAccountId,
             totalUnreadCount: totalUnreadCount,
-            unreadChatCount: unreadChatCount
+            unreadChatCount: unreadChatCount,
+            chatCount: chats.count
         )
     }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -2859,6 +2859,147 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func archivingAnUnreadChatDropsItFromTheAvatarBadge() async throws {
+        // The summary counts unarchived conversations alone, so archiving an unread chat has to
+        // take its messages off the rail badge. It did not: the row gate compared totals that
+        // counted the archived list too, so the move left the signal untouched — the chat's unread
+        // was still in it, just under a different key — and the badge kept counting a chat the user
+        // had put away until the next full reload or account switch.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 3)
+        ]
+        let (state, account) = unreadBadgeFixture(runtime: runtime, seededUnreadCount: 3)
+
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 3)
+        let queriesSoFar = runtime.accountUnreadSummaryCallCount
+
+        // The archived row keeps its unread count — the core does not clear it, it stops counting
+        // it — which is exactly what made this move invisible to a signal spanning both lists.
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0)
+        ]
+        await state.applyChatRow(
+            unreadBadgeFixtureRow(timelineAt: 1_700_000_100, unreadCount: 3, archived: true),
+            account: account,
+            shouldEnrich: false
+        )
+
+        #expect(state.activeChats.isEmpty)
+        #expect(state.archivedChats.map(\.unreadCount) == [3])
+        #expect(runtime.accountUnreadSummaryCallCount == queriesSoFar + 1)
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+    }
+
+    @MainActor
+    @Test func unarchivingAnUnreadChatPutsItBackOnTheAvatarBadge() async throws {
+        // The other direction of the same move: restoring a chat that was archived unread returns
+        // its messages to the total the badge shows, and the gate has to notice that too.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0)
+        ]
+        let (state, account) = unreadBadgeFixture(
+            runtime: runtime,
+            seededUnreadCount: 0,
+            archivedChats: [
+                chatListOrderingTestItem(
+                    id: "archived-group",
+                    title: "Archived Group",
+                    updatedAt: 1_700_000_000,
+                    unreadCount: 4
+                )
+            ]
+        )
+
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+        let queriesSoFar = runtime.accountUnreadSummaryCallCount
+
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 4)
+        ]
+        await state.applyChatRow(
+            chatListRow(
+                groupIdHex: "archived-group",
+                title: "Archived Group",
+                preview: "A message from before it was archived",
+                sender: unreadBadgeFixtureAccountIdHex,
+                timelineAt: 1_700_000_100,
+                unreadCount: 4,
+                hasUnread: true
+            ),
+            account: account,
+            shouldEnrich: false
+        )
+
+        #expect(state.archivedChats.isEmpty)
+        #expect(runtime.accountUnreadSummaryCallCount == queriesSoFar + 1)
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 4)
+    }
+
+    @MainActor
+    @Test func readingAnArchivedChatDoesNotRequeryTheAccountUnreadSummary() async throws {
+        // The flip side of scoping the gate to unarchived rows: nothing an archived chat's unread
+        // does can move a total that excludes it, so scrolling through one must not put a summary
+        // query on every read-marker advance it produces.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        runtime.accountUnreadSummaryRows = [
+            unreadSummaryRow(accountIdHex: unreadBadgeFixtureAccountIdHex, unreadCount: 0)
+        ]
+        let (state, account) = unreadBadgeFixture(
+            runtime: runtime,
+            seededUnreadCount: 0,
+            archivedChats: [
+                chatListOrderingTestItem(
+                    id: "archived-group",
+                    title: "Archived Group",
+                    updatedAt: 1_700_000_000,
+                    unreadCount: 6
+                )
+            ]
+        )
+
+        await state.refreshAccountUnreadSummary()
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+        let queriesSoFar = runtime.accountUnreadSummaryCallCount
+
+        // A marker advance inside the archived chat, then a newer message arriving in it.
+        await state.applyChatRow(
+            chatListRow(
+                groupIdHex: "archived-group",
+                title: "Archived Group",
+                preview: "Read now",
+                sender: unreadBadgeFixtureAccountIdHex,
+                timelineAt: 1_700_000_100,
+                unreadCount: 0,
+                archived: true
+            ),
+            account: account,
+            shouldEnrich: false
+        )
+        await state.applyChatRow(
+            chatListRow(
+                groupIdHex: "archived-group",
+                title: "Archived Group",
+                preview: "And a new one",
+                sender: unreadBadgeFixtureAccountIdHex,
+                timelineAt: 1_700_000_200,
+                unreadCount: 1,
+                hasUnread: true,
+                archived: true
+            ),
+            account: account,
+            shouldEnrich: false
+        )
+
+        #expect(state.archivedChats.map(\.unreadCount) == [1])
+        #expect(runtime.accountUnreadSummaryCallCount == queriesSoFar)
+        #expect(state.unreadCount(forAccountIdHex: account.accountIdHex) == 0)
+    }
+
+    @MainActor
     @Test func aLateAccountUnreadSummaryAnswerDoesNotRestoreTheClearedBadge() async throws {
         // A read-marker advance and a chat-list reload race routinely, so two summary queries can
         // be in flight and answer out of order. A late pre-read answer landing last must not put
@@ -37345,8 +37486,13 @@ private func unreadBadgeFixture(
     return (state, account)
 }
 
-/// A delta for the fixture's seeded chat, carrying only a fresh timestamp and unread count.
-private func unreadBadgeFixtureRow(timelineAt: UInt64, unreadCount: UInt64) -> ChatListRowFfi {
+/// A delta for the fixture's seeded chat, carrying only a fresh timestamp, unread count, and
+/// archive flag.
+private func unreadBadgeFixtureRow(
+    timelineAt: UInt64,
+    unreadCount: UInt64,
+    archived: Bool = false
+) -> ChatListRowFfi {
     chatListRow(
         groupIdHex: "group",
         title: "Test Group",
@@ -37354,7 +37500,8 @@ private func unreadBadgeFixtureRow(timelineAt: UInt64, unreadCount: UInt64) -> C
         sender: unreadBadgeFixtureAccountIdHex,
         timelineAt: timelineAt,
         unreadCount: unreadCount,
-        hasUnread: unreadCount > 0
+        hasUnread: unreadCount > 0,
+        archived: archived
     )
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unread counts and badges now reflect only unarchived chats.
  - Archiving or unarchiving chats updates unread indicators correctly, even when the total unread count is unchanged.
  - Changes to read status in archived chats no longer trigger unnecessary unread-summary refreshes.

- **Tests**
  - Added coverage for unread badge updates involving archived and unarchived chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->