### PR TITLE
Stop leave and delete confirmations quoting a placeholder name

### DIFF
--- a/whitenoise-mac/Core/ChatDestructiveActions.swift
+++ b/whitenoise-mac/Core/ChatDestructiveActions.swift
@@ -91,6 +91,28 @@ extension GroupDetailsSnapshot {
         ChatDestructiveActions.lastAdminResolution(members: members)
     }
 
+    /// How a leave/delete confirmation names this chat.
+    ///
+    /// Decided from `customName` rather than from `name`, which carries the localized "Unnamed
+    /// group" placeholder the inspector header needs — reading that placeholder back as a title is
+    /// what produced `Leave “Unnamed group”?`.
+    ///
+    /// With no name of its own, the roster decides, exactly the way MDK's `conversation_kind` does:
+    /// a non-blank name makes a conversation a group whatever its size, so only an *unnamed* one
+    /// with a single other member is a direct chat. The peer is named from this snapshot's own
+    /// roster, which is the roster the user is looking at.
+    var confirmationSubject: ChatConfirmationSubject {
+        if let customName { return .namedGroup(customName) }
+        let others = members.filter { !$0.isSelf }
+        guard others.count <= 1 else { return .unnamedGroup }
+        // Nobody else on the roster: an emptied-out direct chat, or the last member of a group
+        // everyone left. Neither has a name and neither has a peer, so the sentence says neither.
+        guard let peerName = others.first.flatMap({ PeerDisplayText.sanitize($0.displayName) }) else {
+            return .unnamedChat
+        }
+        return .directChat(peerName: peerName)
+    }
+
     /// What the inspector says beneath the leave button. Prefers the resolution over the raw
     /// `.lastAdmin` blocker, so a sole admin who can still get out — by promoting someone, or by
     /// dropping the local copy of a chat nobody else is in — is told what to do rather than that
@@ -104,12 +126,134 @@ extension GroupDetailsSnapshot {
     }
 }
 
+extension ChatItem {
+    /// How a leave/delete confirmation names this chat.
+    ///
+    /// `title` cannot be quoted blind. When nothing has named a conversation, MDK projects its raw
+    /// conversation id as the title (`chat_title` in the storage layer's chat-list projection), and
+    /// every fallback this app layers on top is derived from that same id — so `title == id` is
+    /// precisely "nothing named this row", whether that is a group nobody titled or a direct chat
+    /// whose peer profile has not arrived. Anything else is a real name: the group's own for a
+    /// group, and the peer's — or the private nickname overriding them — for a direct chat.
+    ///
+    /// `nonisolated` because `ChatItem` is, and an extension would otherwise pick up the module's
+    /// MainActor default.
+    nonisolated var confirmationSubject: ChatConfirmationSubject {
+        guard title != id, let name = PeerDisplayText.sanitize(title) else {
+            return isDirect ? .unnamedChat : .unnamedGroup
+        }
+        return isDirect ? .directChat(peerName: name) : .namedGroup(name)
+    }
+}
+
+/// How a destructive-action dialog names the chat it is about.
+///
+/// Deliberately not a `String`. The four cases need *different sentences*, not one sentence with a
+/// different name substituted in, and collapsing them into a display label is what produced
+/// `Leave “Unnamed group”? Are you sure you want to leave…`:
+///
+/// * A group the user named is quoted, because the name is the group's own.
+/// * A group with no name has nothing to quote. Its row label is a stand-in — the localized
+///   "Unnamed group" in the inspector, MDK's raw conversation id in the sidebar — and a stand-in
+///   reads as a name in a list but as noise in a sentence, so the sentence drops the slot instead.
+/// * A one-to-one chat is named by the person on the other end, and a person is addressed rather
+///   than quoted like a group title.
+/// * A one-to-one chat whose peer has never resolved has nobody to address either.
+///
+/// The two "unnamed" cases differ only in whether the sentence may say "group": MDK classifies any
+/// conversation carrying a name as a group whatever its member count, so an *unnamed* conversation
+/// is the one case where member count decides, and calling a two-person chat a group there would
+/// be wrong in the one place the user can see it.
+nonisolated enum ChatConfirmationSubject: Equatable {
+    case namedGroup(String)
+    case unnamedGroup
+    /// `peerName` is non-blank by construction — the factories below fall back to `.unnamedChat`
+    /// rather than interpolating an empty slot.
+    case directChat(peerName: String)
+    case unnamedChat
+
+    /// The dialog title for leaving this chat.
+    var leaveConfirmationTitle: String {
+        switch self {
+        case .namedGroup(let name):
+            return String(format: L10n.string("Leave “%@”?"), PeerDisplayText.templateFragment(name))
+        case .unnamedGroup:
+            return L10n.string("Leave this group?")
+        case .directChat(let peerName):
+            return String(
+                format: L10n.string("Leave your chat with %@?"),
+                PeerDisplayText.templateFragment(peerName)
+            )
+        case .unnamedChat:
+            return L10n.string("Leave this chat?")
+        }
+    }
+
+    /// What leaving costs, spelled for the kind of conversation it is. A direct chat is not a group
+    /// and must not be told it will stop receiving messages "from this group".
+    func leaveConfirmationMessage(requiresSelfDemote: Bool) -> String {
+        switch self {
+        case .namedGroup, .unnamedGroup:
+            return requiresSelfDemote
+                ? L10n.string(
+                    "You'll step down as admin first, then stop receiving messages from this group."
+                )
+                : L10n.string("You will no longer receive messages from this group on this account.")
+        case .directChat, .unnamedChat:
+            return requiresSelfDemote
+                ? L10n.string(
+                    "You'll step down as admin first, then stop receiving messages from this chat."
+                )
+                : L10n.string("You will no longer receive messages from this chat on this account.")
+        }
+    }
+
+    /// The dialog title for dropping this chat's local copy. Reached from a leave as well as from
+    /// the menu: an account alone in a chat it cannot leave is offered this instead.
+    var localDeleteConfirmationTitle: String {
+        switch self {
+        case .namedGroup(let name):
+            return String(
+                format: L10n.string("Delete “%@” from this device?"),
+                PeerDisplayText.templateFragment(name)
+            )
+        case .directChat(let peerName):
+            return String(
+                format: L10n.string("Delete your chat with %@ from this device?"),
+                PeerDisplayText.templateFragment(peerName)
+            )
+        case .unnamedGroup, .unnamedChat:
+            return L10n.string("Remove this conversation from this device?")
+        }
+    }
+
+    /// The successor picker's explanation. Only the named case can quote a title; the rest say
+    /// "this chat", which is true of an unnamed group and of a direct chat alike.
+    var adminHandoffExplanation: String {
+        switch self {
+        case .namedGroup(let name):
+            return String(
+                format: L10n.string(
+                    "You're the only admin of “%@”. Pick who takes over, and you'll leave once they're admin."
+                ),
+                PeerDisplayText.templateFragment(name)
+            )
+        case .unnamedGroup, .directChat, .unnamedChat:
+            return L10n.string(
+                "You're the only admin of this chat. Pick who takes over, and you'll leave once they're admin."
+            )
+        }
+    }
+}
+
 /// Chat awaiting a leave confirmation. `requiresSelfDemote` is captured at preparation time so the
 /// dialog can say so, and re-derived before the leave actually runs — eligibility can move between
 /// the two taps.
 nonisolated struct ChatLeaveTarget: Equatable, Identifiable {
     let groupIdHex: String
-    let title: String
+    /// How the confirmation names this chat. A `ChatConfirmationSubject` rather than the row's
+    /// display label, so the dialog can pick a sentence instead of quoting a placeholder.
+    let subject: ChatConfirmationSubject
     let requiresSelfDemote: Bool
 
     var id: String { groupIdHex }
@@ -123,7 +267,7 @@ nonisolated struct ChatLeaveTarget: Equatable, Identifiable {
 /// of the chat it belongs to, so it cannot read `groupDetailsSnapshot`.
 struct ChatAdminHandoffTarget: Equatable, Identifiable {
     let groupIdHex: String
-    let title: String
+    let subject: ChatConfirmationSubject
     /// Never empty — a target with no candidate is the genuine dead end, reported as the
     /// `.lastAdmin` blocker instead of opening a picker with nothing in it.
     let candidates: [GroupMemberItem]
@@ -147,7 +291,7 @@ struct ChatAdminHandoffTarget: Equatable, Identifiable {
 /// Chat awaiting a local-delete confirmation.
 nonisolated struct ChatLocalDeleteTarget: Equatable, Identifiable {
     let groupIdHex: String
-    let title: String
+    let subject: ChatConfirmationSubject
 
     var id: String { groupIdHex }
 }

--- a/whitenoise-mac/Core/WorkspaceState+Groups.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Groups.swift
@@ -858,15 +858,15 @@ extension WorkspaceState {
     // after the user confirms, re-reading eligibility because it can move between the two taps.
 
     func prepareChatLeave(for chat: ChatItem) async {
-        await prepareChatLeave(groupIdHex: chat.id, title: chat.title)
+        await prepareChatLeave(groupIdHex: chat.id, subject: chat.confirmationSubject)
     }
 
     func prepareSelectedChatLeave() async {
         guard let snapshot = groupDetailsSnapshot else { return }
-        await prepareChatLeave(groupIdHex: snapshot.groupIdHex, title: snapshot.name)
+        await prepareChatLeave(groupIdHex: snapshot.groupIdHex, subject: snapshot.confirmationSubject)
     }
 
-    func prepareChatLeave(groupIdHex: String, title: String) async {
+    func prepareChatLeave(groupIdHex: String, subject: ChatConfirmationSubject) async {
         // One preparation at a time, so two quick clicks on different rows cannot both resolve and
         // leave the confirmation naming whichever eligibility fetch happened to finish last.
         guard let client,
@@ -899,7 +899,7 @@ extension WorkspaceState {
             guard activeAccountId == accountId else { return }
             await presentChatLeaveDecision(
                 groupIdHex: groupIdHex,
-                title: title,
+                subject: subject,
                 state: state
             )
         } catch {
@@ -915,7 +915,7 @@ extension WorkspaceState {
     /// because the sole-admin branch needs its `memberActions` to know who may be promoted.
     private func presentChatLeaveDecision(
         groupIdHex: String,
-        title: String,
+        subject: ChatConfirmationSubject,
         state: GroupManagementStateFfi
     ) async {
         // Both callers only reach here after their surface decided the action was `.leave`, which
@@ -932,20 +932,20 @@ extension WorkspaceState {
         else {
             chatPendingLeave = ChatLeaveTarget(
                 groupIdHex: groupIdHex,
-                title: title,
+                subject: subject,
                 requiresSelfDemote: ChatDestructiveActions.shouldSelfDemoteBeforeLeave(eligibility)
             )
             return
         }
 
-        await reportLeaveBlocker(blocker, groupIdHex: groupIdHex, title: title, state: state)
+        await reportLeaveBlocker(blocker, groupIdHex: groupIdHex, subject: subject, state: state)
     }
 
     /// Both phases resolve the same blocker and must react to it identically, so they share this.
     private func reportLeaveBlocker(
         _ blocker: ChatDestructiveActions.LeaveBlocker,
         groupIdHex: String,
-        title: String,
+        subject: ChatConfirmationSubject,
         state: GroupManagementStateFfi
     ) async {
         switch blocker {
@@ -956,7 +956,11 @@ extension WorkspaceState {
         case .lastAdmin:
             // The one blocker the app can clear on the user's behalf — in one of two ways, decided
             // by who is left in the group. Only the genuine dead end falls through to the alert.
-            if await resolveLastAdminLeaveBlock(groupIdHex: groupIdHex, title: title, state: state) {
+            if await resolveLastAdminLeaveBlock(
+                groupIdHex: groupIdHex,
+                subject: subject,
+                state: state
+            ) {
                 return
             }
             chatActionAlert = .leaveBlocked(blocker)
@@ -983,7 +987,7 @@ extension WorkspaceState {
     /// resolutions have to be about *this* group.
     private func resolveLastAdminLeaveBlock(
         groupIdHex: String,
-        title: String,
+        subject: ChatConfirmationSubject,
         state: GroupManagementStateFfi
     ) async -> Bool {
         guard let client, let activeAccount else { return false }
@@ -1010,7 +1014,7 @@ extension WorkspaceState {
             guard handingOffAdminChatId != groupIdHex else { return false }
             chatPendingAdminHandoff = ChatAdminHandoffTarget(
                 groupIdHex: groupIdHex,
-                title: title,
+                subject: subject,
                 candidates: ChatDestructiveActions.adminHandoffCandidates(from: members)
             )
             return true
@@ -1020,7 +1024,7 @@ extension WorkspaceState {
             // already confirming or running). The resolution was still correct, and a suppressed
             // duplicate dialog is far better than falling through to a `.lastAdmin` alert telling
             // someone alone in a chat to invite a member — which is the bug this branch removes.
-            requestChatLocalDelete(groupIdHex: groupIdHex, title: title)
+            requestChatLocalDelete(groupIdHex: groupIdHex, subject: subject)
             return true
 
         case .blocked:
@@ -1074,7 +1078,7 @@ extension WorkspaceState {
         }
 
         await confirmChatLeave(
-            ChatLeaveTarget(groupIdHex: groupIdHex, title: target.title, requiresSelfDemote: true)
+            ChatLeaveTarget(groupIdHex: groupIdHex, subject: target.subject, requiresSelfDemote: true)
         )
     }
 
@@ -1116,7 +1120,7 @@ extension WorkspaceState {
                 await reportLeaveBlocker(
                     blocker,
                     groupIdHex: groupIdHex,
-                    title: target.title,
+                    subject: target.subject,
                     state: state
                 )
                 return
@@ -1174,17 +1178,17 @@ extension WorkspaceState {
     }
 
     func requestChatLocalDelete(for chat: ChatItem) {
-        requestChatLocalDelete(groupIdHex: chat.id, title: chat.title)
+        requestChatLocalDelete(groupIdHex: chat.id, subject: chat.confirmationSubject)
     }
 
     func requestSelectedChatLocalDelete() {
         guard let snapshot = groupDetailsSnapshot else { return }
-        requestChatLocalDelete(groupIdHex: snapshot.groupIdHex, title: snapshot.name)
+        requestChatLocalDelete(groupIdHex: snapshot.groupIdHex, subject: snapshot.confirmationSubject)
     }
 
-    func requestChatLocalDelete(groupIdHex: String, title: String) {
+    func requestChatLocalDelete(groupIdHex: String, subject: ChatConfirmationSubject) {
         guard !isDeletingGroupLocally, chatPendingLocalDelete == nil else { return }
-        chatPendingLocalDelete = ChatLocalDeleteTarget(groupIdHex: groupIdHex, title: title)
+        chatPendingLocalDelete = ChatLocalDeleteTarget(groupIdHex: groupIdHex, subject: subject)
     }
 
     func confirmChatLocalDelete(_ target: ChatLocalDeleteTarget) async {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1822,11 +1822,13 @@ final class WorkspaceState {
                 return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
             }
         let avatarURL = firstNonBlank([details.group.avatarUrl])
+        let customName = PeerDisplayText.sanitize(details.group.name)
 
         return GroupDetailsSnapshot(
             groupIdHex: details.group.groupIdHex,
             endpoint: details.group.endpoint,
-            name: PeerDisplayText.sanitize(details.group.name) ?? L10n.string("Unnamed group"),
+            name: customName ?? L10n.string("Unnamed group"),
+            customName: customName,
             description: details.group.description,
             avatarURL: avatarURL,
             sanitizedAvatarURL: RemoteImageURLPolicy.sanitizedURL(from: avatarURL),

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -16838,6 +16838,65 @@
         }
       }
     },
+    "Delete your chat with %@ from this device?": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat mit %@ von diesem Gerät löschen?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Eliminar el chat con %@ de este dispositivo?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer votre chat avec %@ de cet appareil ?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminare la chat con %@ da questo dispositivo?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir o bate-papo com %@ deste dispositivo?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить чат с %@ с этого устройства?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ile olan sohbet bu cihazdan silinsin mi?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要将与%@的聊天从此设备删除吗？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要將與%@的聊天從此裝置刪除嗎？"
+          }
+        }
+      }
+    },
     "Delete “%@” from this device?": {
       "extractionState": "manual",
       "localizations": {
@@ -26300,6 +26359,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "離開這個群嗎？"
+          }
+        }
+      }
+    },
+    "Leave your chat with %@?": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deinen Chat mit %@ verlassen?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Salir del chat con %@?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter votre chat avec %@ ?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lasciare la chat con %@?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair do bate-papo com %@?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Покинуть чат с %@?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ile olan sohbetten ayrılmak mı istiyorsunuz?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要离开与%@的聊天吗？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要離開與%@的聊天嗎？"
           }
         }
       }
@@ -56444,6 +56562,65 @@
         }
       }
     },
+    "You will no longer receive messages from this chat on this account.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du erhältst mit diesem Account keine Nachrichten mehr aus diesem Chat."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya no recibirás mensajes de este chat en esta cuenta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous ne recevrez plus les messages de ce chat sur ce compte."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non riceverai più messaggi da questa chat su questo account."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você não receberá mais mensagens deste bate-papo nesta conta."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы больше не будете получать сообщения этого чата в этом аккаунте."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu hesapta bu sohbetten artık mesaj almayacaksınız."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你将不再在此账户中接收此聊天的消息。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你將不再在此帳號中接收此聊天的訊息。"
+          }
+        }
+      }
+    },
     "You will no longer receive messages from this group on this account.": {
       "extractionState": "manual",
       "localizations": {
@@ -56558,6 +56735,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "您將留在群組中，但另一位管理員需要恢復您的管理員狀態。"
+          }
+        }
+      }
+    },
+    "You'll step down as admin first, then stop receiving messages from this chat.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du gibst zuerst deine Admin-Rolle ab und erhältst dann keine Nachrichten mehr aus diesem Chat."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primero dejarás de ser administrador y luego dejarás de recibir mensajes de este chat."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous quitterez d’abord votre poste d’administrateur, puis cesserez de recevoir des messages de ce chat."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prima dimetterai la carica di amministratore, poi smetterai di ricevere messaggi da questa chat."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você primeiro deixará o cargo de administrador e depois deixará de receber mensagens deste bate-papo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сначала вы уйдете с поста администратора, а затем перестанете получать сообщения из этого чата."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Önce yöneticilikten ayrılacaksınız, ardından bu sohbetten mesaj almayı bırakacaksınız."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您将首先辞去管理员身份，然后停止接收来自该聊天的消息。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您將首先辭去管理員身份，然後停止接收來自該聊天的訊息。"
           }
         }
       }
@@ -56680,6 +56916,65 @@
         }
       }
     },
+    "You're the only admin of this chat. Pick who takes over, and you'll leave once they're admin.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du bist der einzige Admin dieses Chats. Wähle aus, wer übernimmt – du verlässt den Chat, sobald diese Person Admin ist."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eres el único administrador de este chat. Elige quién toma el relevo y saldrás en cuanto esa persona sea administradora."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous êtes le seul administrateur de ce chat. Choisissez qui prend le relais : vous quitterez la discussion dès que cette personne sera administratrice."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei l'unico amministratore di questa chat. Scegli chi prende il tuo posto: uscirai appena sarà amministratore."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você é o único administrador deste bate-papo. Escolha quem vai assumir e você sairá assim que essa pessoa for administradora."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы единственный администратор этого чата. Выберите, кто примет эту роль, — вы выйдете, как только этот человек станет администратором."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu sohbetin tek yöneticisisin. Devralacak kişiyi seç; o yönetici olur olmaz sohbetten çıkacaksın."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你是此聊天的唯一管理员。选择接手的人，对方成为管理员后你就会退出。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你是此聊天的唯一管理員。選擇接手的人，對方成為管理員後你就會退出。"
+          }
+        }
+      }
+    },
     "You're the only admin of “%@”. Pick who takes over, and you'll leave once they're admin.": {
       "extractionState": "manual",
       "localizations": {
@@ -56716,7 +57011,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Вы единственный администратор «%@». Выберите, кто примет эту роль, — вы выйдете, как только он станет администратором."
+            "value": "Вы единственный администратор «%@». Выберите, кто примет эту роль, — вы выйдете, как только этот человек станет администратором."
           }
         },
         "tr": {

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -538,7 +538,14 @@ struct GroupMemberItem: Identifiable, Hashable {
 struct GroupDetailsSnapshot: Hashable {
     let groupIdHex: String
     let endpoint: String
+    /// The group's name as the inspector header draws it, falling back to a localized "Unnamed
+    /// group" so the header is never blank. A display label, not a name — read `customName` for
+    /// anything that has to put the group's own name into a sentence.
     let name: String
+    /// The name the group actually carries, or `nil` when it has none. Kept alongside `name`
+    /// because the placeholder above is both localized and indistinguishable from a group somebody
+    /// really did call "Unnamed group".
+    let customName: String?
     let description: String
     let avatarURL: String?
     /// Pre-sanitized once from the group profile avatar URL for details/header rendering.
@@ -565,6 +572,7 @@ struct GroupDetailsSnapshot: Hashable {
         groupIdHex: String,
         endpoint: String,
         name: String,
+        customName: String? = nil,
         description: String,
         avatarURL: String?,
         sanitizedAvatarURL: URL?,
@@ -588,6 +596,7 @@ struct GroupDetailsSnapshot: Hashable {
         self.groupIdHex = groupIdHex
         self.endpoint = endpoint
         self.name = name
+        self.customName = customName
         self.description = description
         self.avatarURL = avatarURL
         self.sanitizedAvatarURL = sanitizedAvatarURL

--- a/whitenoise-mac/Views/ChatAdminHandoffSheet.swift
+++ b/whitenoise-mac/Views/ChatAdminHandoffSheet.swift
@@ -58,20 +58,13 @@ struct ChatAdminHandoffSheet: View {
     }
 
     private var explanation: some View {
-        Text(
-            String(
-                format: L10n.string(
-                    "You're the only admin of “%@”. Pick who takes over, and you'll leave once they're admin."
-                ),
-                PeerDisplayText.templateFragment(target.title)
-            )
-        )
-        .wnFont(.medium12)
-        .foregroundStyle(WNColor.backgroundContentSecondary)
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
+        Text(target.subject.adminHandoffExplanation)
+            .wnFont(.medium12)
+            .foregroundStyle(WNColor.backgroundContentSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
     }
 
     private var candidateList: some View {

--- a/whitenoise-mac/Views/ChatDestructiveActionsConfirmation.swift
+++ b/whitenoise-mac/Views/ChatDestructiveActionsConfirmation.swift
@@ -90,23 +90,22 @@ private struct ChatDestructiveActionsConfirmationModifier: ViewModifier {
             }
     }
 
+    // The wording lives on `ChatConfirmationSubject` rather than here: a group with no name and a
+    // one-to-one chat need different *sentences*, not a different name dropped into one, and that
+    // choice has to be testable without standing up a dialog.
+
     private func leaveTitle(_ target: ChatLeaveTarget?) -> String {
         guard let target else { return L10n.string("Leave this chat?") }
-        return String(format: L10n.string("Leave “%@”?"), target.title)
+        return target.subject.leaveConfirmationTitle
     }
 
     private func leaveMessage(_ target: ChatLeaveTarget) -> String {
-        if target.requiresSelfDemote {
-            return L10n.string(
-                "You'll step down as admin first, then stop receiving messages from this group."
-            )
-        }
-        return L10n.string("You will no longer receive messages from this group on this account.")
+        target.subject.leaveConfirmationMessage(requiresSelfDemote: target.requiresSelfDemote)
     }
 
     private func localDeleteTitle(_ target: ChatLocalDeleteTarget?) -> String {
         guard let target else { return L10n.string("Remove this conversation from this device?") }
-        return String(format: L10n.string("Delete “%@” from this device?"), target.title)
+        return target.subject.localDeleteConfirmationTitle
     }
 }
 

--- a/whitenoise-macTests/PureValueTests.swift
+++ b/whitenoise-macTests/PureValueTests.swift
@@ -4976,6 +4976,105 @@ struct PureValueTests {
         }
     }
 
+    /// Regression for the report that opened this: an unnamed group's leave dialog read
+    /// `Leave “Unnamed group”? Are you sure you want to leave…`.
+    ///
+    /// The assertion is about the *sentences* rather than about one placeholder string, because the
+    /// two surfaces feed the dialog different stand-ins — the localized "Unnamed group" from the
+    /// inspector, MDK's raw conversation id from the sidebar — so pinning either one alone would
+    /// leave the other free to come back.
+    @MainActor
+    @Test func noConfirmationSentenceQuotesAStandInForAnUnnamedChat() {
+        let unnamedId = String(repeating: "a", count: 64)
+        let chat = ChatItem(
+            row: confirmationRow(groupIdHex: unnamedId, groupName: "", conversationKind: .group),
+            activeAccountIdHex: nil
+        )
+        // What the sidebar row shows for a group nobody titled, and exactly why quoting it failed.
+        #expect(chat.title == unnamedId)
+        #expect(chat.confirmationSubject == .unnamedGroup)
+
+        for subject: ChatConfirmationSubject in [.unnamedGroup, .unnamedChat] {
+            for sentence in confirmationSentences(of: subject) {
+                #expect(!sentence.contains(L10n.string("Unnamed group")), "\(subject): \(sentence)")
+                #expect(!sentence.contains(unnamedId), "\(subject): \(sentence)")
+                // The other way a dropped name shows up: the quotes stay and the slot is empty.
+                #expect(!sentence.contains("“”"), "\(subject): \(sentence)")
+            }
+        }
+    }
+
+    /// "If it is only a chat with one person, name the person instead." A one-to-one chat is
+    /// addressed rather than quoted like a group title, and it must not be told it will stop
+    /// receiving messages "from this group" — it is not one.
+    @MainActor
+    @Test func directChatConfirmationsNameThePeerRatherThanTheConversation() {
+        let chat = ChatItem(
+            row: confirmationRow(groupIdHex: "dm", groupName: "", conversationKind: .direct),
+            activeAccountIdHex: nil,
+            directPeer: ChatPeerProfile(accountIdHex: "alice", displayName: "Alice", pictureURL: nil)
+        )
+        #expect(chat.confirmationSubject == .directChat(peerName: "Alice"))
+
+        let subject = ChatConfirmationSubject.directChat(peerName: "Alice")
+        #expect(subject.leaveConfirmationTitle.contains("Alice"))
+        #expect(subject.localDeleteConfirmationTitle.contains("Alice"))
+        // A peer-controlled name is isolated, so it cannot reorder the sentence around it.
+        #expect(subject.leaveConfirmationTitle.contains(PeerDisplayText.templateFragment("Alice")))
+        // Compared against the group wording rather than grepped for the word "group": the
+        // assertion has to hold in every language the catalog carries.
+        for requiresSelfDemote in [false, true] {
+            #expect(
+                subject.leaveConfirmationMessage(requiresSelfDemote: requiresSelfDemote)
+                    != ChatConfirmationSubject.unnamedGroup.leaveConfirmationMessage(
+                        requiresSelfDemote: requiresSelfDemote)
+            )
+        }
+    }
+
+    /// The inspector's own path. `name` keeps the placeholder its header needs, so the subject has
+    /// to be read off `customName` — reading `name` is what put "Unnamed group" in the sentence.
+    @MainActor
+    @Test func snapshotSubjectReadsTheGroupsOwnNameRatherThanItsHeaderLabel() {
+        let alice = handoffMember(id: "Alice")
+        let unnamed = confirmationSnapshot(
+            customName: nil,
+            others: [alice, handoffMember(id: "Bob")]
+        )
+        #expect(unnamed.name == L10n.string("Unnamed group"))
+        #expect(unnamed.confirmationSubject == .unnamedGroup)
+
+        // One other member and no name: MDK calls that a direct chat, and so does the sentence.
+        #expect(
+            confirmationSnapshot(customName: nil, others: [alice]).confirmationSubject
+                == .directChat(peerName: "Alice")
+        )
+        // Nobody else on the roster — an emptied-out chat has no name *and* no peer.
+        #expect(confirmationSnapshot(customName: nil, others: []).confirmationSubject == .unnamedChat)
+
+        // A name makes a conversation a group whatever its size, which is MDK's rule too: a named
+        // two-person chat must not be downgraded to "your chat with Alice".
+        #expect(
+            confirmationSnapshot(customName: "Book club", others: [alice]).confirmationSubject
+                == .namedGroup("Book club")
+        )
+    }
+
+    /// The case that already worked keeps working: a group the user named is still quoted by name
+    /// in all three dialogs.
+    @Test func namedGroupConfirmationsStillQuoteTheName() {
+        let subject = ChatConfirmationSubject.namedGroup("Design team")
+        for sentence in [
+            subject.leaveConfirmationTitle,
+            subject.localDeleteConfirmationTitle,
+            subject.adminHandoffExplanation,
+        ] {
+            #expect(sentence.contains("Design team"), "\(sentence)")
+        }
+        #expect(subject.leaveConfirmationTitle.contains(PeerDisplayText.templateFragment("Design team")))
+        #expect(subject.leaveConfirmationTitle != ChatConfirmationSubject.unnamedGroup.leaveConfirmationTitle)
+    }
+
     /// A direct message is a two-member MLS group here, so it must follow the same rule; the copy
     /// is chat-neutral precisely so no `isDirect` branch is needed.
     @Test func directChatsFollowTheSameDestructiveActionRule() {
@@ -5571,7 +5670,79 @@ private func handoffMember(
 }
 
 private func handoffTarget(candidates: [GroupMemberItem]) -> ChatAdminHandoffTarget {
-    ChatAdminHandoffTarget(groupIdHex: "group", title: "Planning", candidates: candidates)
+    ChatAdminHandoffTarget(
+        groupIdHex: "group",
+        subject: .namedGroup("Planning"),
+        candidates: candidates
+    )
+}
+
+private func confirmationSentences(of subject: ChatConfirmationSubject) -> [String] {
+    [
+        subject.leaveConfirmationTitle,
+        subject.leaveConfirmationMessage(requiresSelfDemote: false),
+        subject.leaveConfirmationMessage(requiresSelfDemote: true),
+        subject.localDeleteConfirmationTitle,
+        subject.adminHandoffExplanation,
+    ]
+}
+
+private func confirmationRow(
+    groupIdHex: String,
+    groupName: String,
+    conversationKind: ChatConversationKindFfi
+) -> ChatListRowFfi {
+    ChatListRowFfi(
+        groupIdHex: groupIdHex,
+        archived: false,
+        pendingConfirmation: false,
+        // MDK's `chat_title`: the conversation id stands in whenever the profile name is blank.
+        title: groupName.isEmpty ? groupIdHex : groupName,
+        groupName: groupName,
+        avatarUrl: nil,
+        avatar: nil,
+        lastMessage: nil,
+        unreadCount: 0,
+        hasUnread: false,
+        unreadMentionCount: 0,
+        unreadMention: false,
+        firstUnreadMessageIdHex: nil,
+        lastReadMessageIdHex: nil,
+        lastReadTimelineAt: nil,
+        updatedAt: 0,
+        selfMembership: .member,
+        conversationKind: conversationKind
+    )
+}
+
+@MainActor
+private func confirmationSnapshot(
+    customName: String?,
+    others: [GroupMemberItem]
+) -> GroupDetailsSnapshot {
+    GroupDetailsSnapshot(
+        groupIdHex: "group",
+        endpoint: "",
+        name: customName ?? L10n.string("Unnamed group"),
+        customName: customName,
+        description: "",
+        avatarURL: nil,
+        sanitizedAvatarURL: nil,
+        avatarDimension: nil,
+        nostrGroupIdHex: "",
+        relays: [],
+        adminIds: [],
+        archived: false,
+        pendingConfirmation: false,
+        selfMembership: .member,
+        members: [handoffMember(id: "self", isSelf: true)] + others,
+        isSelfAdmin: false,
+        isLastAdmin: false,
+        canInvite: false,
+        canLeave: true,
+        requiresSelfDemoteBeforeLeave: false,
+        disappearingMessageSecs: 0
+    )
 }
 
 private func destructiveActionChat(

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -25356,7 +25356,7 @@ struct whitenoise_macTests {
         let state = try await openInstalledGroupDetails(runtime: runtime)
         let target = ChatLeaveTarget(
             groupIdHex: details.group.groupIdHex,
-            title: details.group.name,
+            subject: .namedGroup(details.group.name),
             requiresSelfDemote: false
         )
 
@@ -25416,17 +25416,62 @@ struct whitenoise_macTests {
 
     /// Two quick clicks must not race: whichever eligibility fetch finishes last would otherwise own
     /// the confirmation, so the dialog could name a chat the user did not click.
+    ///
+    /// `preparingChatLeaveId` is the guard under test, and pinning it takes two things the obvious
+    /// version of this test does not have. The second row must be a *real* installed group whose
+    /// eligibility resolves to a leave — an unknown id could only ever fail, so the confirmation
+    /// would stay put no matter what the guard did. And the overlap has to be arranged rather than
+    /// hoped for: the fake returns installed management state without suspending, so two
+    /// `async let` preparations on the main actor would simply run one after the other, and the
+    /// already-open `chatPendingLeave` would be what turned the second one away. Parking the first
+    /// fetch at the gate is what makes `preparingChatLeaveId` the only thing standing in the way.
     @MainActor
     @Test func overlappingLeavePreparationsCannotRetargetTheConfirmation() async throws {
+        let account = desktopAccount()
         let state = try await leavableChatState(canLeave: true)
+        let runtime = try #require(state.client as? FakeMarmotRuntime)
         let chat = try #require(state.activeChats.first)
 
-        async let first: Void = state.prepareChatLeave(groupIdHex: chat.id, title: "First")
-        async let second: Void = state.prepareChatLeave(groupIdHex: "other-group", title: "Second")
-        _ = await (first, second)
+        var secondGroup = messageGroup()
+        secondGroup.groupIdHex = "second-group"
+        secondGroup.name = "Second Group"
+        runtime.installGroupDetailsRecord(
+            GroupDetailsFfi(group: secondGroup, members: []),
+            managementState: GroupManagementStateFfi(
+                myAccountIdHex: account.accountIdHex,
+                isSelfAdmin: false,
+                isLastAdmin: false,
+                canInvite: false,
+                canLeave: true,
+                requiresSelfDemoteBeforeLeave: false,
+                leaveRequestPending: false,
+                memberActions: []
+            )
+        )
+
+        runtime.groupManagementStateGateEnabled = true
+        async let first: Void = state.prepareChatLeave(
+            groupIdHex: chat.id,
+            subject: .namedGroup("First")
+        )
+        while !(state.preparingChatLeaveId == chat.id && runtime.didReachGroupManagementStateGate) {
+            await Task.yield()
+        }
+
+        // The second click lands while the first eligibility fetch is still parked.
+        await state.prepareChatLeave(
+            groupIdHex: secondGroup.groupIdHex,
+            subject: .namedGroup("Second")
+        )
+        #expect(state.preparingChatLeaveId == chat.id)
+        #expect(state.chatPendingLeave == nil)
+        #expect(state.chatActionAlert == nil)
+
+        runtime.releaseGroupManagementStateGate()
+        await first
 
         #expect(state.chatPendingLeave?.groupIdHex == chat.id)
-        #expect(state.chatPendingLeave?.title == "First")
+        #expect(state.chatPendingLeave?.subject == .namedGroup("First"))
         #expect(state.preparingChatLeaveId == nil)
     }
 
@@ -25480,7 +25525,7 @@ struct whitenoise_macTests {
 
         let handoff = try #require(state.chatPendingAdminHandoff)
         #expect(handoff.groupIdHex == chat.id)
-        #expect(handoff.title == chat.title)
+        #expect(handoff.subject == chat.confirmationSubject)
         // Alice only: Bob carries no action state, so the core has not said he may be promoted.
         #expect(handoff.candidates.map(\.npub) == ["npub1alyce"])
         // And because she is the only one, the picker opens with her already chosen — the sheet is a
@@ -25666,7 +25711,7 @@ struct whitenoise_macTests {
         #expect(state.chatPendingLeave == nil)
         let target = try #require(state.chatPendingLocalDelete)
         #expect(target.groupIdHex == chat.id)
-        #expect(target.title == chat.title)
+        #expect(target.subject == chat.confirmationSubject)
 
         // Nothing was sent on the user's behalf while resolving the block.
         #expect(runtime.leaveGroupCallCount == 0)
@@ -25834,7 +25879,7 @@ struct whitenoise_macTests {
         state.requestChatLocalDelete(for: chat)
         state.chatPendingLeave = ChatLeaveTarget(
             groupIdHex: chat.id,
-            title: chat.title,
+            subject: chat.confirmationSubject,
             requiresSelfDemote: false
         )
         state.chatActionAlert = .leaveFailed()
@@ -25866,7 +25911,7 @@ struct whitenoise_macTests {
         state.requestChatLocalDelete(for: chat)
         state.chatPendingLeave = ChatLeaveTarget(
             groupIdHex: chat.id,
-            title: chat.title,
+            subject: chat.confirmationSubject,
             requiresSelfDemote: false
         )
         state.chatActionAlert = .leaveFailed()
@@ -34322,6 +34367,20 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     var didReachGroupDetailsGate: Bool {
         groupDetailsGate.didReach
     }
+    /// Reentrancy-test support for the two-phase chat leave: when armed, the first
+    /// `groupManagementState` FFI call suspends until `releaseGroupManagementStateGate()` is
+    /// invoked, so a test can hold one eligibility fetch in flight and run an overlapping
+    /// preparation to completion against it. Without this the installed-state path returns without
+    /// ever suspending, and two `async let` preparations on the main actor run strictly one after
+    /// the other — never overlapping at all.
+    private let groupManagementStateGate = AsyncFfiGate()
+    var groupManagementStateGateEnabled: Bool {
+        get { groupManagementStateGate.isEnabled }
+        set { groupManagementStateGate.isEnabled = newValue }
+    }
+    var didReachGroupManagementStateGate: Bool {
+        groupManagementStateGate.didReach
+    }
     /// Issue #207 last-request-wins-test support: when armed, the first `accountKeyPackages` FFI
     /// call suspends until `releaseAccountKeyPackagesGate()` is invoked, holding an older
     /// `loadKeyPackages()` in-flight so a test can switch the active account, run a newer load to
@@ -35283,6 +35342,7 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
     }
 
     func groupManagementState(accountRef: String, groupIdHex: String) async throws -> GroupManagementStateFfi {
+        await groupManagementStateGate.passIfArmed()
         if let state = groupManagementStateById[groupIdHex] {
             return state
         }
@@ -35504,6 +35564,10 @@ private nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sen
 
     func releaseGroupMutationGate() {
         groupMutationGate.release()
+    }
+
+    func releaseGroupManagementStateGate() {
+        groupManagementStateGate.release()
     }
 
     func releaseGroupInviteGate() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved leave, delete, and administrator handoff confirmations with chat-specific wording.
  * Added clearer messaging for named and unnamed groups, direct chats, and unnamed chats.
  * Added localized confirmation text in multiple languages.

* **Bug Fixes**
  * Preserved custom group names accurately across chat details and destructive actions.

* **Tests**
  * Added coverage for confirmation wording, unnamed chats, direct-chat names, administrator handoffs, reactions, and unread badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->