### PR TITLE
Keep messages sent behind a failing send visible

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+PendingOutgoingText.swift
+++ b/whitenoise-mac/Core/WorkspaceState+PendingOutgoingText.swift
@@ -1,0 +1,201 @@
+//
+//  WorkspaceState+PendingOutgoingText.swift
+//  whitenoise-mac
+//
+//  The half of a text send that outlives the Send press: waiting its turn behind the sends already
+//  going out of this conversation, then publishing. Send itself never waits for either — it empties
+//  the composer and parks the message here, where the transcript renders it until the core has a row
+//  of its own to show.
+//
+
+import Foundation
+import MarmotKit
+
+@MainActor
+extension WorkspaceState {
+    /// Parks a just-sent text message and queues the publish that will deliver it.
+    ///
+    /// Chained per conversation so back-to-back sends publish in the order Send was pressed. That
+    /// chain is why the parking exists at all: waiting on a predecessor is waiting on a whole relay
+    /// round-trip, and a message waiting out someone else's timeout has not reached the core, so the
+    /// core has nothing to project for it. This row is what stands in for it until it does.
+    func beginPendingOutgoingTextSend(
+        _ message: PendingOutgoingTextMessage,
+        for draftKey: ComposerDraftKey,
+        account: AccountItem,
+        client: any MarmotRuntime
+    ) {
+        pendingOutgoingTextMessagesByConversation[draftKey, default: []].append(message)
+
+        let predecessor = outgoingTextSendTasks[draftKey]
+        outgoingTextSendTasks[draftKey] = Task { [weak self] in
+            // A failed predecessor still releases this one: its task finishes either way, it just
+            // leaves a failed bubble behind it.
+            await predecessor?.value
+            guard !Task.isCancelled else { return }
+            await self?.completePendingOutgoingTextSend(
+                message.id,
+                for: draftKey,
+                account: account,
+                client: client
+            )
+        }
+    }
+
+    /// Re-publishes a failed text message from the row it failed in.
+    ///
+    /// Deliberately not re-queued behind the conversation's chain: the messages in that chain are
+    /// the ones the user has sent *since*, and holding a retry behind them would reorder the
+    /// transcript around the one row the user is trying to rescue.
+    func retryPendingOutgoingTextMessage(_ id: PendingOutgoingTextMessage.ID) {
+        guard let draftKey = selectedComposerDraftKey,
+            let message = pendingOutgoingTextMessage(id, in: draftKey),
+            message.state == .failed,
+            let account = activeAccount,
+            account.id == draftKey.accountId,
+            let client
+        else { return }
+        // Off `.failed` synchronously, so the guard above is what makes this single-flight: the
+        // publishing task only reaches its own transition a main-actor hop later, and until then a
+        // second Retry press reads the same failed row and starts another round-trip. The media
+        // retry relights its bubble the same way.
+        setPendingOutgoingTextMessageState(.publishing, for: id, in: draftKey)
+        pendingOutgoingTextSendTasks[id]?.cancel()
+        pendingOutgoingTextSendTasks[id] = Task { [weak self] in
+            // Checked before publishing, as in `beginPendingOutgoingTextSend`: the cancellation
+            // above is otherwise inert, since nothing downstream of it consults the flag until
+            // after the send has already gone out.
+            guard !Task.isCancelled else { return }
+            await self?.completePendingOutgoingTextSend(
+                id,
+                for: draftKey,
+                account: account,
+                client: client
+            )
+        }
+    }
+
+    /// Drops a failed text message. Only offered once it has failed: a message still on its way out
+    /// has no cancellation story in the core, so the affordance would be a lie.
+    func discardPendingOutgoingTextMessage(_ id: PendingOutgoingTextMessage.ID) {
+        guard let draftKey = selectedComposerDraftKey else { return }
+        removePendingOutgoingTextMessage(id, in: draftKey)
+    }
+
+    func cancelAllPendingOutgoingTextSends() {
+        for key in Array(pendingOutgoingTextMessagesByConversation.keys) {
+            cancelPendingOutgoingTextSends(for: key)
+        }
+        pendingOutgoingTextMessagesByConversation.removeAll()
+    }
+
+    func cancelPendingOutgoingTextSends(for draftKey: ComposerDraftKey) {
+        for message in pendingOutgoingTextMessagesByConversation[draftKey] ?? [] {
+            pendingOutgoingTextSendTasks.removeValue(forKey: message.id)?.cancel()
+        }
+        pendingOutgoingTextMessagesByConversation[draftKey] = nil
+    }
+
+    func cancelPendingOutgoingTextSends(forAccountId accountId: String) {
+        let keys = pendingOutgoingTextMessagesByConversation.keys.filter { $0.accountId == accountId }
+        for draftKey in keys {
+            cancelPendingOutgoingTextSends(for: draftKey)
+        }
+    }
+
+    private func completePendingOutgoingTextSend(
+        _ id: PendingOutgoingTextMessage.ID,
+        for draftKey: ComposerDraftKey,
+        account: AccountItem,
+        client: any MarmotRuntime
+    ) async {
+        guard let message = pendingOutgoingTextMessage(id, in: draftKey) else { return }
+
+        // Stamped before the publish, not after it: the core commits an own send locally as part of
+        // publishing, so the real row can reach the transcript through the subscription while we are
+        // still awaiting the relay. This count is what lets it retire this bubble on arrival instead
+        // of leaving the same sentence rendered twice for the length of the round-trip.
+        setPendingOutgoingTextMessagePublishBaseline(
+            ownBodyCount(of: message.text, inChat: draftKey.chatId),
+            for: id,
+            in: draftKey
+        )
+        setPendingOutgoingTextMessageState(.publishing, for: id, in: draftKey)
+
+        do {
+            if let replyContext = message.replyContext {
+                _ = try await client.replyToMessage(
+                    accountRef: account.accountRef,
+                    groupIdHex: draftKey.chatId,
+                    targetMessageId: replyContext.targetMessageId,
+                    text: message.text
+                )
+            } else {
+                _ = try await client.sendText(
+                    accountRef: account.accountRef,
+                    groupIdHex: draftKey.chatId,
+                    text: message.text
+                )
+            }
+        } catch {
+            // The core rolls its local projection back when a publish fails, so there is no row in
+            // the transcript to carry this message any more — which makes this bubble the only copy
+            // of what the user wrote, and the reason a failure is no longer allowed to fall back on
+            // refilling the composer. That fallback silently dropped the message whenever the
+            // composer was not empty, which it never is once a second send is queued behind a first.
+            lastError = error.localizedDescription
+            setPendingOutgoingTextMessageState(.failed, for: id, in: draftKey)
+            return
+        }
+        guard !Task.isCancelled else { return }
+
+        // One authoritative re-window so the user sees their just-sent message immediately, even if
+        // the live projection for it is momentarily in flight. The follow-on delivery-state
+        // transitions then arrive as projection deltas and are applied incrementally by
+        // `applyTimelineProjection`. Re-window first, then retire the placeholder: dropping it
+        // before the window came back would leave a frame with neither row in it.
+        await refreshSelectedTimelineAfterSend(
+            groupIdHex: draftKey.chatId,
+            account: account,
+            client: client
+        )
+        removePendingOutgoingTextMessage(id, in: draftKey)
+    }
+
+    private func pendingOutgoingTextMessage(
+        _ id: PendingOutgoingTextMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) -> PendingOutgoingTextMessage? {
+        pendingOutgoingTextMessagesByConversation[draftKey]?.first { $0.id == id }
+    }
+
+    private func setPendingOutgoingTextMessageState(
+        _ state: PendingOutgoingTextMessageState,
+        for id: PendingOutgoingTextMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) {
+        guard let index = pendingOutgoingTextMessagesByConversation[draftKey]?.firstIndex(where: { $0.id == id })
+        else { return }
+        pendingOutgoingTextMessagesByConversation[draftKey]?[index].state = state
+    }
+
+    private func setPendingOutgoingTextMessagePublishBaseline(
+        _ count: Int,
+        for id: PendingOutgoingTextMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) {
+        guard let index = pendingOutgoingTextMessagesByConversation[draftKey]?.firstIndex(where: { $0.id == id })
+        else { return }
+        pendingOutgoingTextMessagesByConversation[draftKey]?[index].ownBodyCountBeforePublish = count
+    }
+
+    private func removePendingOutgoingTextMessage(
+        _ id: PendingOutgoingTextMessage.ID,
+        in draftKey: ComposerDraftKey
+    ) {
+        pendingOutgoingTextSendTasks.removeValue(forKey: id)
+        var messages = pendingOutgoingTextMessagesByConversation[draftKey] ?? []
+        messages.removeAll { $0.id == id }
+        pendingOutgoingTextMessagesByConversation[draftKey] = messages.isEmpty ? nil : messages
+    }
+}

--- a/whitenoise-mac/Core/WorkspaceState+Timeline.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Timeline.swift
@@ -1098,144 +1098,53 @@ extension WorkspaceState {
         // Clearing only once `sendText`/`replyToMessage` returned meant the draft sat in the
         // input for the whole relay round-trip — and since the message's own bubble appears
         // from the local projection as soon as it is stored, the user saw the same text twice.
-        let restorePoint = ComposerSendSnapshot(
-            text: draftTextByConversation[draftKey] ?? "",
-            mentionSelections: composerMentionSelectionsByConversation[draftKey] ?? [],
+        // What the composer gives up, the pending message below takes over: the transcript carries
+        // the message from here until the core has a row of its own for it.
+        let pending = PendingOutgoingTextMessage(
+            text: text,
             replyContext: replyDraftContextByConversation[draftKey]
         )
         clearComposerAfterSend(for: draftKey, mediaAttachments: mediaAttachments)
+        // Parked in the same view update that empties the composer, and before the `await` below:
+        // deleting the persisted draft yields the main actor, so registering the row after it would
+        // leave a frame with the message in neither place — the disappearance this whole path
+        // exists to prevent. The media branch above hands off ahead of its own delete for the
+        // same reason.
+        beginPendingOutgoingTextSend(
+            pending,
+            for: draftKey,
+            account: activeAccount,
+            client: client
+        )
         await deletePersistedComposerDraft(
             for: draftKey,
             accountRef: activeAccount.accountRef,
             client: client
         )
-
-        handOffTextSend(
-            restorePoint,
-            text: text,
-            draftKey: draftKey,
-            groupIdHex: selectedChat.id,
-            account: activeAccount,
-            client: client
-        )
     }
 
-    /// Moves a just-sent text message out of the Send button's hands and into a detached publish,
-    /// then returns — the same hand-off media already does, for the same reason. Waiting here held
-    /// the button spinning and every composer control disabled for the length of the relay
-    /// round-trip, so the user could not start their next message; the wait belongs to the
-    /// message's own bubble, which the local projection has already put on screen carrying its
-    /// delivery state.
-    ///
-    /// Chained per conversation so back-to-back sends publish in the order Send was pressed. A
-    /// failed predecessor still releases its successor — it just leaves `lastError` and a restored
-    /// draft behind it.
-    private func handOffTextSend(
-        _ restorePoint: ComposerSendSnapshot,
-        text: String,
-        draftKey: ComposerDraftKey,
-        groupIdHex: String,
-        account: AccountItem,
-        client: any MarmotRuntime
-    ) {
-        let predecessor = outgoingTextSendTasks[draftKey]
-        outgoingTextSendTasks[draftKey] = Task { [weak self] in
-            await predecessor?.value
-            guard !Task.isCancelled else { return }
-            await self?.completeTextSend(
-                restorePoint,
-                text: text,
-                draftKey: draftKey,
-                groupIdHex: groupIdHex,
-                account: account,
-                client: client
-            )
-        }
-    }
-
-    private func completeTextSend(
-        _ restorePoint: ComposerSendSnapshot,
-        text: String,
-        draftKey: ComposerDraftKey,
-        groupIdHex: String,
-        account: AccountItem,
-        client: any MarmotRuntime
-    ) async {
-        do {
-            if let replyContext = restorePoint.replyContext {
-                _ = try await client.replyToMessage(
-                    accountRef: account.accountRef,
-                    groupIdHex: groupIdHex,
-                    targetMessageId: replyContext.targetMessageId,
-                    text: text
-                )
-            } else {
-                _ = try await client.sendText(
-                    accountRef: account.accountRef,
-                    groupIdHex: groupIdHex,
-                    text: text
-                )
-            }
-        } catch {
-            restoreComposerAfterFailedSend(restorePoint, for: draftKey)
-            lastError = error.localizedDescription
-            return
-        }
-        // One authoritative re-window so the user sees their just-sent message
-        // immediately, even if the live projection for it is momentarily in flight.
-        // The follow-on delivery-state transitions then arrive as projection deltas
-        // and are applied incrementally by `applyTimelineProjection` — no longer a
-        // full re-map per delivery. Guarded on the live selection inside, so a send the
-        // user navigated away from does not re-window whatever they navigated to.
-        await refreshSelectedTimelineAfterSend(groupIdHex: groupIdHex, account: account, client: client)
-    }
-
+    /// Drops both halves of every outgoing text send: the publish chain and the pending rows that
+    /// chain is carrying. They are torn down together because a parked message whose publish task is
+    /// gone is a bubble that can never resolve — it would sit in the transcript claiming to be on its
+    /// way out with nothing left to send it.
     func cancelAllOutgoingTextSends() {
         for task in outgoingTextSendTasks.values {
             task.cancel()
         }
         outgoingTextSendTasks.removeAll()
+        cancelAllPendingOutgoingTextSends()
     }
 
     func cancelOutgoingTextSends(for draftKey: ComposerDraftKey) {
         outgoingTextSendTasks.removeValue(forKey: draftKey)?.cancel()
+        cancelPendingOutgoingTextSends(for: draftKey)
     }
 
     func cancelOutgoingTextSends(forAccountId accountId: String) {
         for draftKey in outgoingTextSendTasks.keys.filter({ $0.accountId == accountId }) {
             outgoingTextSendTasks.removeValue(forKey: draftKey)?.cancel()
         }
-    }
-
-    /// What a text send took out of the composer, kept only long enough to put it back if the
-    /// publish fails. Media sends have no equivalent: their attachments move into a pending
-    /// bubble that owns its own retry.
-    private struct ComposerSendSnapshot {
-        let text: String
-        let mentionSelections: [ComposerMentionSelection]
-        let replyContext: MessageReplyContext?
-    }
-
-    /// Returns a failed text send's draft to the composer it was sent from, so the relay being
-    /// unreachable costs a retry rather than the message.
-    ///
-    /// Skipped when that composer is no longer empty: the user started their next message during
-    /// the round-trip, and overwriting live typing is worse than losing the failed draft, which
-    /// `lastError` reports either way. Keyed by the captured `draftKey` for the same reason
-    /// `clearComposerAfterSend` is — the selection may have moved on.
-    private func restoreComposerAfterFailedSend(
-        _ snapshot: ComposerSendSnapshot,
-        for draftKey: ComposerDraftKey
-    ) {
-        guard (draftTextByConversation[draftKey] ?? "").isEmpty,
-            (pendingMediaAttachmentsByConversation[draftKey] ?? []).isEmpty
-        else { return }
-        draftTextByConversation[draftKey] = snapshot.text.isEmpty ? nil : snapshot.text
-        composerMentionSelectionsByConversation[draftKey] =
-            snapshot.mentionSelections.isEmpty ? nil : snapshot.mentionSelections
-        replyDraftContextByConversation[draftKey] = snapshot.replyContext
-        // Re-persist: the send already deleted the stored draft on the way out.
-        composerDraftDidChange(for: draftKey)
+        cancelPendingOutgoingTextSends(forAccountId: accountId)
     }
 
     /// Moves a media draft out of the composer and into a pending outgoing message, then returns.

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -621,10 +621,23 @@ final class WorkspaceState {
     @ObservationIgnored var pendingOutgoingMediaUploadTasks:
         [PendingOutgoingMediaMessage.ID: [Task<MediaAttachmentReferenceFfi?, Never>]] = [:]
     /// The publish task for the last text message handed off from each conversation's composer.
-    /// Text needs no pending-bubble list the way media does — the local projection puts the real
-    /// row on screen the moment the message is stored — so one entry per composer is enough: it is
-    /// what the *next* send in that conversation chains behind, and what teardown drops.
+    /// One entry per composer is enough: it is what the *next* send in that conversation chains
+    /// behind, and what teardown drops.
     @ObservationIgnored var outgoingTextSendTasks: [ComposerDraftKey: Task<Void, Never>] = [:]
+    /// Text messages the user has already sent that the core cannot yet speak for, keyed by the
+    /// composer they left.
+    ///
+    /// Text used to go without this on the grounds that the local projection puts the real row on
+    /// screen as soon as the message is stored. It does — but only once the send has *reached* the
+    /// core, and a send chained behind a predecessor that is timing out against an unreachable
+    /// relay has not. That message was in neither the composer nor the transcript for the length of
+    /// the failure, and the restore that should have returned it found the composer occupied by the
+    /// predecessor's own restored draft and dropped it.
+    var pendingOutgoingTextMessagesByConversation: [ComposerDraftKey: [PendingOutgoingTextMessage]] = [:]
+    /// The retry task per pending text message. The first attempt runs inside the conversation's
+    /// `outgoingTextSendTasks` chain, so only retries — which deliberately do not re-queue behind
+    /// anything — need a handle of their own.
+    @ObservationIgnored var pendingOutgoingTextSendTasks: [PendingOutgoingTextMessage.ID: Task<Void, Never>] = [:]
     /// Bumped once per send the local user commits from the selected conversation's composer —
     /// text, media or a recording. The transcript scrolls to the live edge off this rather than off
     /// the message that follows it, because neither of the newest-message rules covers a send made
@@ -1736,6 +1749,72 @@ final class WorkspaceState {
             }
         }
         return digests
+    }
+
+    /// Text messages sent from the selected conversation that the core has not committed a visible
+    /// row for, oldest first.
+    ///
+    /// A publishing message is withheld once an own row carrying its exact body has appeared since
+    /// the publish began: the core commits an own send locally *inside* that call, so the real row
+    /// arrives while the relay round-trip is still going and the two would otherwise render the
+    /// same sentence twice. Queued and failed messages are never withheld — in both of those states
+    /// this row is the only copy of the message there is.
+    var selectedPendingOutgoingTextMessages: [PendingOutgoingTextMessage] {
+        guard let selectedComposerDraftKey else { return [] }
+        let pending = pendingOutgoingTextMessagesByConversation[selectedComposerDraftKey] ?? []
+        // Nothing is mid-publish in the common case, so the timeline is never walked.
+        guard pending.contains(where: { $0.state == .publishing && $0.ownBodyCountBeforePublish != nil })
+        else { return pending }
+        return pending.filter { message in
+            guard message.state == .publishing, let before = message.ownBodyCountBeforePublish else { return true }
+            return ownBodyCount(of: message.text, inChat: selectedComposerDraftKey.chatId) <= before
+        }
+    }
+
+    /// How many own rows `chatId`'s timeline holds carrying exactly `body`.
+    ///
+    /// Matched on `wireBody` rather than `body`: that is the text handed to the core, before mention
+    /// npubs are resolved back to display names, so it is the same string the pending message holds.
+    ///
+    /// Keyed by chat rather than read off the selection, so the count a publish stamps and the count
+    /// it is later compared against describe the same conversation even if the user navigated away
+    /// mid-round-trip.
+    func ownBodyCount(of body: String, inChat chatId: String) -> Int {
+        messageTimelineStores[chatId]?.messages.reduce(into: 0) { count, message in
+            if message.isOutgoing, message.wireBody == body {
+                count += 1
+            }
+        } ?? 0
+    }
+
+    /// Both kinds of pending own row in one list, in the order the user sent them — the tail the
+    /// transcript appends after its real rows.
+    ///
+    /// Merged rather than concatenated: each source list is already in send order, so walking them
+    /// together by `createdAt` interleaves a photo and a sentence the way they were actually sent,
+    /// and keeps equal timestamps in list order instead of leaving it to an unstable sort.
+    var selectedPendingOutgoingMessageRows: [PendingOutgoingMessageRow] {
+        let text = selectedPendingOutgoingTextMessages
+        let media = selectedPendingOutgoingMediaMessages
+        if text.isEmpty { return media.map(PendingOutgoingMessageRow.media) }
+        if media.isEmpty { return text.map(PendingOutgoingMessageRow.text) }
+
+        var rows: [PendingOutgoingMessageRow] = []
+        rows.reserveCapacity(text.count + media.count)
+        var textIndex = text.startIndex
+        var mediaIndex = media.startIndex
+        while textIndex < text.endIndex, mediaIndex < media.endIndex {
+            if media[mediaIndex].createdAt < text[textIndex].createdAt {
+                rows.append(.media(media[mediaIndex]))
+                mediaIndex += 1
+            } else {
+                rows.append(.text(text[textIndex]))
+                textIndex += 1
+            }
+        }
+        rows.append(contentsOf: text[textIndex...].map(PendingOutgoingMessageRow.text))
+        rows.append(contentsOf: media[mediaIndex...].map(PendingOutgoingMessageRow.media))
+        return rows
     }
 
     var showsMessengerChrome: Bool {

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -1017,6 +1017,97 @@ nonisolated struct PendingOutgoingMediaMessage: Identifiable, Hashable, Sendable
     }
 }
 
+/// Where a sent-but-not-yet-published text message has got to.
+///
+/// Text has no upload leg, so this looks thinner than the media states — but it carries a wait
+/// media does not: `.queued`. Sends in one conversation publish in the order Send was pressed,
+/// which means a message can be waiting on the one ahead of it without having reached the core at
+/// all. While it is there, nothing else on screen represents it: the composer emptied on the Send
+/// press and the core has no row to project yet.
+nonisolated enum PendingOutgoingTextMessageState: Hashable, Sendable {
+    /// Waiting for the send ahead of it in this conversation. This row is the only thing carrying
+    /// the message — a relay that takes the predecessor thirty seconds to give up on used to be
+    /// thirty seconds with the message nowhere at all.
+    case queued
+    /// Handed to the core, which commits and projects an own send locally *before* it publishes,
+    /// so the real row normally takes this one's place within a frame or two.
+    case publishing
+    /// The publish failed and the core retracted its local projection, leaving this row the only
+    /// copy of what the user wrote. It keeps the text and owns the retry.
+    case failed
+
+    var isInFlight: Bool {
+        self != .failed
+    }
+}
+
+/// A text message the user has already sent, still on its way to the relay.
+///
+/// The counterpart of `PendingOutgoingMediaMessage`, and here for the same reason: Send empties the
+/// composer without waiting, so something has to hold the message in the meantime. Media always
+/// needed it for the uploads; text needs it for the two windows where the core cannot speak for the
+/// message — before the send reaches it, and after a failed publish rolls its projection back.
+nonisolated struct PendingOutgoingTextMessage: Identifiable, Hashable, Sendable {
+    let id: UUID
+    /// Exactly the bytes handed to the core: mentions already canonicalized, ends already trimmed.
+    /// Also how the published row is recognized, the way a media message uses its plaintext
+    /// digests — text is its own digest.
+    let text: String
+    /// Carried so a retry re-sends the message as the reply it was, rather than as a loose message
+    /// under the one it was answering.
+    let replyContext: MessageReplyContext?
+    let createdAt: Date
+    var state: PendingOutgoingTextMessageState
+    /// How many own rows in this transcript already carried `text` when the publish began, or nil
+    /// until it has begun.
+    ///
+    /// The retirement key, and the reason it is a count rather than a flag: the core commits an own
+    /// send locally inside the publish call, so the real row can arrive while the round-trip is
+    /// still going and both would render at once. Comparing against the count taken *before* the
+    /// publish is what distinguishes "the row for this message has arrived" from "this conversation
+    /// already contained an identical message" — a flag would hide the second `ok` of a
+    /// conversation behind the first one.
+    var ownBodyCountBeforePublish: Int?
+
+    init(
+        id: UUID = UUID(),
+        text: String,
+        replyContext: MessageReplyContext? = nil,
+        createdAt: Date = Date(),
+        state: PendingOutgoingTextMessageState = .queued
+    ) {
+        self.id = id
+        self.text = text
+        self.replyContext = replyContext
+        self.createdAt = createdAt
+        self.state = state
+    }
+}
+
+/// One row in the transcript's pending tail, whichever kind of send produced it.
+///
+/// The two pending lists are separate — they wait on entirely different things — but they share one
+/// stretch of transcript, so they cannot each render their own `ForEach`: that orders every text
+/// row before every media row, and a photo sent before a sentence would appear after it.
+nonisolated enum PendingOutgoingMessageRow: Identifiable, Hashable, Sendable {
+    case text(PendingOutgoingTextMessage)
+    case media(PendingOutgoingMediaMessage)
+
+    var id: UUID {
+        switch self {
+        case .text(let message): message.id
+        case .media(let message): message.id
+        }
+    }
+
+    var createdAt: Date {
+        switch self {
+        case .text(let message): message.createdAt
+        case .media(let message): message.createdAt
+        }
+    }
+}
+
 nonisolated struct PendingMediaAttachment: Identifiable, Hashable, Sendable {
     let id: UUID
     let fileName: String

--- a/whitenoise-mac/Views/MessageMediaViews.swift
+++ b/whitenoise-mac/Views/MessageMediaViews.swift
@@ -2385,6 +2385,28 @@ struct MessageRowAction: Identifiable {
             },
         ]
     }
+
+    /// The same two recovery actions again, for a text message that never got out. Text reaches this
+    /// state two ways media cannot: queued behind a send that is still timing out, or rolled back by
+    /// the core after its own publish failed.
+    @MainActor
+    static func all(
+        for message: PendingOutgoingTextMessage,
+        workspace: WorkspaceState,
+        dismiss: @escaping () -> Void = {}
+    ) -> [MessageRowAction] {
+        guard message.state == .failed else { return [] }
+        return [
+            MessageRowAction(kind: .retry, title: L10n.string("Retry"), systemImage: "arrow.clockwise", role: nil) {
+                dismiss()
+                workspace.retryPendingOutgoingTextMessage(message.id)
+            },
+            MessageRowAction(kind: .delete, title: L10n.string("Remove"), systemImage: "trash", role: .destructive) {
+                dismiss()
+                workspace.discardPendingOutgoingTextMessage(message.id)
+            },
+        ]
+    }
 }
 
 struct MessageOverflowPopover: View {

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -396,7 +396,7 @@ private struct ConversationView: View {
         let messageIDs = workspace.selectedMessageIDs
         let paging = workspace.selectedTimelinePaging
         let isLoadingInitialPage = workspace.selectedTimelineIsLoadingInitialPage
-        let pendingOutgoingMediaMessages = workspace.selectedPendingOutgoingMediaMessages
+        let pendingOutgoingRows = workspace.selectedPendingOutgoingMessageRows
 
         ZStack {
             VStack(spacing: 0) {
@@ -416,7 +416,7 @@ private struct ConversationView: View {
                         // class of hang; if a large window's eager build ever costs too much, the fix
                         // is cheaper rows, not a return to lazy estimation.
                         VStack(spacing: 12) {
-                            if messageIDs.isEmpty && pendingOutgoingMediaMessages.isEmpty {
+                            if messageIDs.isEmpty && pendingOutgoingRows.isEmpty {
                                 if isLoadingInitialPage {
                                     TimelineInitialLoadingView()
                                 } else {
@@ -454,16 +454,28 @@ private struct ConversationView: View {
                                 }
                             }
 
-                            // Media the user has already sent whose blobs are still going up.
-                            // Rendered after the real window rather than inside it: these rows
-                            // exist only on this client, and the published message that replaces
-                            // one arrives through the timeline store like any other.
-                            ForEach(pendingOutgoingMediaMessages) { pending in
-                                PendingOutgoingMessageBubble(
-                                    message: pending,
-                                    timestampReferenceDate: timestampReferenceDate,
-                                    timestampLocale: locale
-                                )
+                            // Messages the user has already sent that the core has no row for yet
+                            // — media whose blobs are still going up, and text still queued behind
+                            // an earlier send or rolled back by a failed publish. Rendered after
+                            // the real window rather than inside it: these rows exist only on this
+                            // client, and the published message that replaces one arrives through
+                            // the timeline store like any other. One `ForEach` over both kinds so
+                            // they stay in the order they were sent.
+                            ForEach(pendingOutgoingRows) { pending in
+                                switch pending {
+                                case .text(let message):
+                                    PendingOutgoingTextBubble(
+                                        message: message,
+                                        timestampReferenceDate: timestampReferenceDate,
+                                        timestampLocale: locale
+                                    )
+                                case .media(let message):
+                                    PendingOutgoingMessageBubble(
+                                        message: message,
+                                        timestampReferenceDate: timestampReferenceDate,
+                                        timestampLocale: locale
+                                    )
+                                }
                             }
 
                             // Scroll-to-bottom target. Pure layout: pin/pagination state is

--- a/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
+++ b/whitenoise-mac/Views/PendingOutgoingMessageViews.swift
@@ -18,7 +18,6 @@ struct PendingOutgoingMessageBubble: View {
     @Environment(WorkspaceState.self) private var workspace
     @State private var isHovering = false
     @State private var isOverflowPresented = false
-    @State private var overflowWidth: CGFloat = 0
     let message: PendingOutgoingMediaMessage
     let timestampReferenceDate: Date
     let timestampLocale: Locale
@@ -56,37 +55,11 @@ struct PendingOutgoingMessageBubble: View {
     /// in the transcript carries. This was the one failed row with no ⋯ at all, whichever way its
     /// retry went: a failed retry lands it back on `.failed`, so it stayed a bubble whose only
     /// actions were the link row under it.
-    ///
-    /// Revealed on hover, and held open while its popover is: the pointer leaves the row to reach
-    /// the menu it just opened.
-    @ViewBuilder
     private var overflowControl: some View {
-        if showsOverflowControl {
-            Button {
-                isOverflowPresented = true
-            } label: {
-                MessageInlineActionIcon(systemName: "ellipsis", label: L10n.string("More"))
+        PendingOutgoingOverflowControl(isVisible: showsOverflowControl, isPresented: $isOverflowPresented) {
+            MessageRowAction.all(for: message, workspace: workspace) {
+                isOverflowPresented = false
             }
-            .buttonStyle(.plain)
-            .help(L10n.string("More"))
-            .popover(isPresented: $isOverflowPresented, arrowEdge: .bottom) {
-                MessageOverflowMenu(
-                    actions: MessageRowAction.all(for: message, workspace: workspace) {
-                        isOverflowPresented = false
-                    }
-                )
-            }
-            // Pushed clear of the bubble by the width SwiftUI measured, the way `MessageBubble`
-            // places its own hover strip — `.alignmentGuide` does not survive the `ViewBuilder`
-            // conditional above it, and would leave the control drawn on top of the message.
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.size.width
-            } action: { width in
-                overflowWidth = width
-            }
-            .offset(x: -(overflowWidth + Self.overflowBubbleGap))
-            .opacity(overflowWidth > 0 ? 1 : 0)
-            .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .trailing)))
         }
     }
 
@@ -95,9 +68,6 @@ struct PendingOutgoingMessageBubble: View {
     private var showsOverflowControl: Bool {
         message.state == .failed && (isHovering || isOverflowPresented)
     }
-
-    /// Breathing room between the ⋯ control and the bubble edge, matching `MessageBubble`.
-    private static let overflowBubbleGap: CGFloat = 8
 
     private var accessibilityLabel: String {
         message.state == .failed ? L10n.string("Not delivered") : L10n.string("Sending")
@@ -426,6 +396,155 @@ private struct PendingOutgoingMediaAttachmentRow: View {
             }
 
             Spacer(minLength: 0)
+        }
+    }
+}
+/// The bubble a text message wears while the core cannot speak for it: queued behind an earlier send,
+/// or rolled back after its publish failed.
+///
+/// Shaped by the same `MessageBubbleShape`/`sentBubble` pair as a media caption and a committed own
+/// row, so the swap to the real row does not change the row's shape. Deliberately *not* dimmed the
+/// way a pending media bubble is: there is no preview here whose readiness is in question, only the
+/// user's own sentence, and the footer clock already says it is on its way.
+struct PendingOutgoingTextBubble: View {
+    @Environment(WorkspaceState.self) private var workspace
+    @State private var isHovering = false
+    @State private var isOverflowPresented = false
+    let message: PendingOutgoingTextMessage
+    let timestampReferenceDate: Date
+    let timestampLocale: Locale
+
+    private let maxContentWidth: CGFloat = 660
+    private let bubbleGutter: CGFloat = 72
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            bubble
+
+            if message.state == .failed {
+                MessageSendFailureActions {
+                    workspace.retryPendingOutgoingTextMessage(message.id)
+                }
+            }
+        }
+        .overlay(alignment: .leading) { overflowControl }
+        .animation(.smooth(duration: 0.12), value: showsOverflowControl)
+        .frame(maxWidth: maxContentWidth, alignment: .trailing)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.leading, bubbleGutter)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel)
+        .contentShape(.rect)
+        .onHover { isHovering = $0 }
+    }
+
+    /// The sentence and its footer on the sent-bubble fill.
+    ///
+    /// Not `PendingOutgoingMessageCaption`: that surface stretches its text to the full proposed
+    /// width so a caption lines up with the media grid above it, which for a bubble with no grid
+    /// would render every "ok" as a 540pt-wide slab. The width cap is applied *outside* the
+    /// background here, so the fill hugs the text and the cap only bounds how far it may wrap.
+    private var bubble: some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text(displayText)
+                .wnFont(.medium16)
+                .foregroundStyle(MessagesPalette.sentBubbleContent)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+
+            PendingOutgoingMessageMetadata(
+                createdAt: message.createdAt,
+                isFailed: message.state == .failed,
+                timestampReferenceDate: timestampReferenceDate,
+                timestampLocale: timestampLocale
+            )
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background {
+            // The bubble's own shape, not a copy of it: a pending row and the committed message
+            // that replaces it have to be the same shape.
+            MessageBubbleShape()
+                .fill(MessagesPalette.sentBubble)
+        }
+        .frame(maxWidth: 540, alignment: .trailing)
+    }
+
+    private var overflowControl: some View {
+        PendingOutgoingOverflowControl(isVisible: showsOverflowControl, isPresented: $isOverflowPresented) {
+            MessageRowAction.all(for: message, workspace: workspace) {
+                isOverflowPresented = false
+            }
+        }
+    }
+
+    /// Failed sends only, matching the media bubble: a message still on its way out has nothing to
+    /// retry and no cancellation story in the core.
+    private var showsOverflowControl: Bool {
+        message.state == .failed && (isHovering || isOverflowPresented)
+    }
+
+    private var accessibilityLabel: String {
+        message.state == .failed ? L10n.string("Not delivered") : L10n.string("Sending")
+    }
+
+    /// The message with its mention tokens read back as names.
+    ///
+    /// `message.text` is the wire form — Send canonicalizes every mention to an npub — so rendering
+    /// it raw would put `@npub1…` in the bubble and then swap it for `@Alice` the moment the real row
+    /// arrived. Resolved here rather than stored on the message so a nickname written while the send
+    /// is still out is picked up too, exactly as the committed rows do it.
+    private var displayText: String {
+        guard let groupIdHex = workspace.selectedChat?.id else { return message.text }
+        return MentionDisplayResolver.resolve(
+            in: message.text,
+            mentionNames: workspace.cachedMentionNames(groupIdHex: groupIdHex)
+        )
+    }
+}
+
+/// The ⋯ control both pending bubbles wear, revealed on hover and held open while its popover is:
+/// the pointer leaves the row to reach the menu it just opened.
+///
+/// One implementation for the media and text bubbles because the two had drifted into a copy each,
+/// down to a private gap constant apiece. The visibility gate stays with the caller — each bubble
+/// animates on it, so it has to be readable from the bubble's own body — and the measured width
+/// stays here, where the control that is measured lives.
+private struct PendingOutgoingOverflowControl: View {
+    let isVisible: Bool
+    @Binding var isPresented: Bool
+    /// Built when the menu opens rather than on every body pass, which is the contract
+    /// `MessageRowAction.all` documents for its clock-sensitive actions.
+    let actions: () -> [MessageRowAction]
+
+    @State private var overflowWidth: CGFloat = 0
+
+    /// Breathing room between the ⋯ control and the bubble edge, matching `MessageBubble`.
+    private static let overflowBubbleGap: CGFloat = 8
+
+    var body: some View {
+        if isVisible {
+            Button {
+                isPresented = true
+            } label: {
+                MessageInlineActionIcon(systemName: "ellipsis", label: L10n.string("More"))
+            }
+            .buttonStyle(.plain)
+            .help(L10n.string("More"))
+            .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+                MessageOverflowMenu(actions: actions())
+            }
+            // Pushed clear of the bubble by the width SwiftUI measured, the way `MessageBubble`
+            // places its own hover strip — `.alignmentGuide` does not survive the `ViewBuilder`
+            // conditional above it, and would leave the control drawn on top of the message.
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.width
+            } action: { width in
+                overflowWidth = width
+            }
+            .offset(x: -(overflowWidth + Self.overflowBubbleGap))
+            .opacity(overflowWidth > 0 ? 1 : 0)
+            .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .trailing)))
         }
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -18526,30 +18526,35 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func failedTextSendPutsTheDraftBackInTheComposer() async throws {
-        // Emptying on hand-off must not cost the user their text when the publish fails: the
-        // draft, its mention markers and its reply context all come back for a retry.
+    @Test func failedTextSendKeepsTheMessageInAFailedBubble() async throws {
+        // Emptying on hand-off must not cost the user their text when the publish fails. The text
+        // stays in the transcript as a failed row that owns its retry — not back in the composer,
+        // which is a slot the next message may already have taken.
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
-        runtime.installGroup(messageGroup())
+        // Details, not a bare group: `canonicalizeMentions` bails on an empty roster, so with only
+        // `installGroup` the mention below would be inert and the text would reach the row exactly
+        // as typed — passing for the wrong reason.
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
         let state = WorkspaceState(clientFactory: { runtime })
         await state.bootstrap()
-        let draftKey = try #require(state.selectedComposerDraftKey)
+        state.ensureMentionRosterLoaded()
+        let didWarmRoster = await waitFor { !state.mentionRoster().isEmpty }
+        #expect(didWarmRoster)
 
-        let mentionSelections = [
-            ComposerMentionSelection(
-                range: NSRange(location: 0, length: 6),
-                displayText: "@Alice",
-                npub: "npub1alice"
-            )
-        ]
         state.replyDraftContext = MessageReplyContext(
             targetMessageId: "parent",
             senderName: "Alice",
             body: "The launch plan is ready."
         )
         state.draftText = "@Alice ping"
-        state.composerMentionSelections = mentionSelections
+        state.composerMentionSelections = [
+            ComposerMentionSelection(
+                range: NSRange(location: 0, length: 6),
+                displayText: "@Alice",
+                npub: "npub1alyce"
+            )
+        ]
         runtime.replyToMessageError = NSError(
             domain: "test.reply",
             code: 1,
@@ -18558,42 +18563,236 @@ struct whitenoise_macTests {
         await state.sendDraft()
         await Self.settleOutgoingTextSends(state)
 
-        #expect(state.draftText == "@Alice ping")
-        #expect(state.composerMentionSelections == mentionSelections)
-        #expect(state.replyDraftContext?.targetMessageId == "parent")
+        let failed = try #require(state.selectedPendingOutgoingTextMessages.first)
+        #expect(failed.state == .failed)
+        // The wire form, not what was typed: the bubble reads npubs back as names through
+        // `MentionDisplayResolver`, which only works because this is what the row carries.
+        #expect(failed.text == "@npub1alyce ping")
+        // Carried so the retry re-sends it as the reply it was, not as a loose message.
+        #expect(failed.replyContext?.targetMessageId == "parent")
         #expect(state.lastError == "relay unreachable")
-        // The restored draft is dirty again, so it will be persisted rather than left only in memory.
-        #expect(state.dirtyComposerDraftKeys.contains(draftKey))
-        #expect(state.canSend)
+        // The composer stays free: the failure has a home of its own now, so nothing is pushed back
+        // into an input the user may already be typing their next message into.
+        #expect(state.draftText.isEmpty)
+        #expect(state.composerMentionSelections.isEmpty)
+        #expect(state.replyDraftContext == nil)
+
+        // Retry re-publishes that same row rather than minting a second one, and re-publishes the
+        // canonicalized text — the composer that could have re-derived it is already empty.
+        runtime.replyToMessageError = nil
+        state.retryPendingOutgoingTextMessage(failed.id)
+        await Self.settlePendingOutgoingTextSends(state)
+        #expect(state.selectedPendingOutgoingTextMessages.isEmpty)
+        #expect(runtime.repliedMessage?.text == "@npub1alyce ping")
     }
 
     @MainActor
-    @Test func failedTextSendKeepsWhatTheUserTypedWhileItWasInFlight() async throws {
-        // The restore is a courtesy, not an overwrite. If the emptied composer already holds new
-        // text by the time the failure lands, that text wins — `lastError` reports the loss.
+    @Test func retryingAFailedTextSendTwiceInOneTurnPublishesOnce() async throws {
+        // Both presses land in a single main-actor turn, which is the whole point: the row only
+        // left `.failed` inside the publishing task, a hop later, so a second press read the same
+        // failed row and started a second round-trip. Cancelling the first task did not stop it
+        // either — nothing on that path consults the flag until after the send has gone out.
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])
         runtime.installGroup(messageGroup())
         let state = WorkspaceState(clientFactory: { runtime })
         await state.bootstrap()
 
-        state.draftText = "first message"
+        runtime.sendTextError = NSError(
+            domain: "test.send",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "relay unreachable"]
+        )
+        state.draftText = "ping"
+        await state.sendDraft()
+        await Self.settleOutgoingTextSends(state)
+
+        let failed = try #require(state.selectedPendingOutgoingTextMessages.first)
+        #expect(failed.state == .failed)
+        #expect(runtime.sendTextCallCount == 1)
+
+        runtime.sendTextError = nil
+        state.retryPendingOutgoingTextMessage(failed.id)
+        state.retryPendingOutgoingTextMessage(failed.id)
+        // Read before any suspension point, so this is the synchronous transition itself and not
+        // the task's: leaving `.failed` here is what makes the guard a single-flight lock.
+        #expect(state.selectedPendingOutgoingTextMessages.first?.state == .publishing)
+
+        await Self.settlePendingOutgoingTextSends(state)
+        // The failed attempt plus one retry. Counted at the top of the fake's `sendText`, ahead of
+        // its own error, so a second retry that got as far as the core would be visible here.
+        #expect(runtime.sendTextCallCount == 2)
+        #expect(state.selectedPendingOutgoingTextMessages.isEmpty)
+    }
+
+    @MainActor
+    @Test func textSendQueuedBehindAStuckSendIsVisibleWhileItWaits() async throws {
+        // The reported bug: with the relay unreachable, the first send sits in its round-trip for as
+        // long as the timeout lasts. The composer emptied on the Send press and the core has not been
+        // called for the second message, so it used to be in neither place — the user watched their
+        // message disappear. It is now a queued row in the transcript for that whole window.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
         runtime.sendTextError = NSError(
             domain: "test.send",
             code: 1,
             userInfo: [NSLocalizedDescriptionKey: "relay unreachable"]
         )
         runtime.messageActionGateEnabled = true
+        state.draftText = "first message"
         await state.sendDraft()
         await Self.waitUntil { runtime.didReachMessageActionGate }
 
-        // The user starts the next message while the first one is still in flight.
         state.draftText = "second message"
+        await state.sendDraft()
+        state.draftText = "third message"
+        await state.sendDraft()
+
+        // Both later messages are on screen, in the order Send was pressed, while the first is still
+        // stuck in the core.
+        #expect(state.draftText.isEmpty)
+        #expect(
+            state.selectedPendingOutgoingTextMessages.map(\.text)
+                == ["first message", "second message", "third message"]
+        )
+        #expect(state.selectedPendingOutgoingTextMessages.map(\.state) == [.publishing, .queued, .queued])
+
         runtime.releaseMessageActionGate()
         await Self.settleOutgoingTextSends(state)
 
-        #expect(state.draftText == "second message")
+        // Nothing was dropped: every message that failed still holds its text and its own retry.
+        // The old restore refilled the composer from the *first* failure and then discarded the rest
+        // as "the composer is not empty".
+        #expect(
+            state.selectedPendingOutgoingTextMessages.map(\.text)
+                == ["first message", "second message", "third message"]
+        )
+        #expect(state.selectedPendingOutgoingTextMessages.allSatisfy { $0.state == .failed })
         #expect(state.lastError == "relay unreachable")
+    }
+
+    @MainActor
+    @Test func pendingTextAndMediaRowsInterleaveInTheOrderTheyWereSent() async throws {
+        // The two pending lists wait on different things but share one stretch of transcript. Given
+        // a `ForEach` each, every text row would sort ahead of every media row — a photo sent before
+        // a sentence would appear after it.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+
+        let start = Date()
+        func attachment(_ name: String) -> PendingMediaAttachment {
+            PendingMediaAttachment(
+                fileName: name,
+                mediaType: "text/plain",
+                data: Data(name.utf8),
+                dim: nil
+            )
+        }
+
+        state.pendingOutgoingTextMessagesByConversation[draftKey] = [
+            PendingOutgoingTextMessage(text: "first", createdAt: start),
+            PendingOutgoingTextMessage(text: "third", createdAt: start.addingTimeInterval(2)),
+        ]
+        state.pendingOutgoingMediaMessagesByConversation[draftKey] = [
+            PendingOutgoingMediaMessage(
+                attachments: [attachment("second.txt")],
+                caption: "second",
+                createdAt: start.addingTimeInterval(1)
+            ),
+            PendingOutgoingMediaMessage(
+                attachments: [attachment("fourth.txt")],
+                caption: "fourth",
+                createdAt: start.addingTimeInterval(3)
+            ),
+        ]
+
+        let rows = state.selectedPendingOutgoingMessageRows
+        let labels = rows.map { row in
+            switch row {
+            case .text(let message): message.text
+            case .media(let message): message.caption
+            }
+        }
+        #expect(labels == ["first", "second", "third", "fourth"])
+    }
+
+    @MainActor
+    @Test func queuedTextSendsStillPublishInTheOrderSendWasPressed() async throws {
+        // Parking the messages must not cost the ordering the chain existed for.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        runtime.messageActionGateEnabled = true
+        state.draftText = "first message"
+        await state.sendDraft()
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+        state.draftText = "second message"
+        await state.sendDraft()
+
+        runtime.releaseMessageActionGate()
+        await Self.settleOutgoingTextSends(state)
+
+        #expect(runtime.publishedTexts.map(\.text) == ["first message", "second message"])
+        // Each row retires as its publish lands, so the tail empties on its own.
+        #expect(state.selectedPendingOutgoingTextMessages.isEmpty)
+    }
+
+    @MainActor
+    @Test func aPublishingTextRowIsWithheldOnceItsOwnRowArrives() async throws {
+        // The core commits an own send locally *inside* the publish call, so the real row can reach
+        // the transcript while the relay round-trip is still going. Both rendering would show the
+        // same sentence twice — and the count is taken before the publish so an identical message
+        // already in the conversation cannot pass for this one's arrival.
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroup(messageGroup())
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+        let draftKey = try #require(state.selectedComposerDraftKey)
+        let chatId = draftKey.chatId
+
+        func ownRow(id: String, body: String) -> MessageItem {
+            MessageItem(
+                id: id,
+                groupIdHex: chatId,
+                sourceMessageIdHex: "source-\(id)",
+                senderAccountIdHex: account.accountIdHex,
+                senderName: "Desktop Account",
+                body: body,
+                sentAt: .now,
+                isOutgoing: true
+            )
+        }
+
+        // An identical message the conversation already contained.
+        state.messageTimelineStores[chatId]?.replace(with: [ownRow(id: "old", body: "ok")])
+
+        runtime.messageActionGateEnabled = true
+        state.draftText = "ok"
+        await state.sendDraft()
+        await Self.waitUntil { runtime.didReachMessageActionGate }
+
+        // Still shown: the row on screen is the *earlier* "ok", not this send's.
+        #expect(state.selectedPendingOutgoingTextMessages.map(\.state) == [.publishing])
+
+        // The local projection for this send lands mid-round-trip.
+        state.messageTimelineStores[chatId]?
+            .replace(with: [ownRow(id: "old", body: "ok"), ownRow(id: "new", body: "ok")])
+        #expect(state.selectedPendingOutgoingTextMessages.isEmpty)
+
+        runtime.releaseMessageActionGate()
+        await Self.settleOutgoingTextSends(state)
     }
 
     @MainActor
@@ -26760,6 +26959,15 @@ struct whitenoise_macTests {
     @MainActor
     private static func settleOutgoingTextSends(_ state: WorkspaceState) async {
         for task in state.outgoingTextSendTasks.values {
+            await task.value
+        }
+    }
+
+    /// Retries do not join the conversation's send chain — the messages in it are the ones sent
+    /// *since* the failure — so they are awaited through their own handles.
+    @MainActor
+    private static func settlePendingOutgoingTextSends(_ state: WorkspaceState) async {
+        for task in state.pendingOutgoingTextSendTasks.values {
             await task.value
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outgoing text messages remain visible while queued, publishing, or failed.
  * Failed messages can be retried or removed directly from the conversation.
  * Messages preserve send order and reply context, including when mixed with media.
  * Pending text and media messages appear together in chronological order.
* **Bug Fixes**
  * The composer clears after sending and no longer restores failed text.
  * Pending messages disappear automatically once the published message appears in the timeline.
  * Cancelling outgoing messages now removes their pending conversation entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->