### PR TITLE
style: resolve the medium rung to Regular weight

### DIFF
--- a/whitenoise-mac/Views/Palette/WNFontWeight.swift
+++ b/whitenoise-mac/Views/Palette/WNFontWeight.swift
@@ -8,17 +8,20 @@
 //  rather than a separate file in the bundle.
 //
 //  The vocabulary stays three deep because the ramp is the Flutter client's ladder
-//  and that ladder names three: body copy is `medium`, and anything a design draws
-//  lighter maps up to it. Each case carries both frameworks' spelling of the same
-//  weight, so `WNTextStyle` and `WNNSFont` cannot drift apart on what "semiBold"
-//  means.
+//  and that ladder names three. The mac client typesets its medium rung one step
+//  lighter than the Flutter source, though: where Flutter draws body copy at Medium
+//  (500), San Francisco reads heavy at that point on a desktop display, so this
+//  app's `.medium` resolves to Regular (400). Each case carries both frameworks'
+//  spelling of the same weight, so `WNTextStyle` and `WNNSFont` cannot drift apart
+//  on what "semiBold" means.
 //
 
 import AppKit
 import SwiftUI
 
 nonisolated enum WNFontWeight: String, CaseIterable, Sendable {
-    /// Medium (500) — body copy and every non-emphasised run.
+    /// Body copy and every non-emphasised run. Named for the Flutter rung it
+    /// descends from (Medium), resolved one step lighter — Regular (400).
     case medium
     /// SemiBold (600) — titles, row headings, and emphasised labels.
     case semiBold
@@ -28,7 +31,7 @@ nonisolated enum WNFontWeight: String, CaseIterable, Sendable {
     /// The SwiftUI spelling of the weight.
     var swiftUI: Font.Weight {
         switch self {
-        case .medium: .medium
+        case .medium: .regular
         case .semiBold: .semibold
         case .bold: .bold
         }
@@ -37,7 +40,7 @@ nonisolated enum WNFontWeight: String, CaseIterable, Sendable {
     /// The AppKit spelling of the same weight, for the TextKit-backed composer.
     var appKit: NSFont.Weight {
         switch self {
-        case .medium: .medium
+        case .medium: .regular
         case .semiBold: .semibold
         case .bold: .bold
         }

--- a/whitenoise-macTests/TypographyTests.swift
+++ b/whitenoise-macTests/TypographyTests.swift
@@ -92,7 +92,7 @@ private let allTokens: [WNTextStyle] = [
     func bothFrameworksSpellTheSameWeight(weight: WNFontWeight) {
         let expected: (Font.Weight, NSFont.Weight) =
             switch weight {
-            case .medium: (.medium, .medium)
+            case .medium: (.regular, .regular)
             case .semiBold: (.semibold, .semibold)
             case .bold: (.bold, .bold)
             }


### PR DESCRIPTION
## Summary
- The type ramp's lightest rung (`WNFontWeight.medium`) now resolves to **Regular (400)** instead of Medium (500) in both framework spellings (`WNFontWeight.swiftUI` / `WNFontWeight.appKit`), so body copy and every non-emphasised run renders one step lighter than before.
- Token names and the three-rung vocabulary are unchanged — `.medium` keeps its name for the Flutter rung it descends from (`lib/theme/app_typography.dart`); only its resolution differs, and the header comment documents that divergence.
- `TypographyTests.bothFrameworksSpellTheSameWeight` updated to pin `.medium` → `.regular` in both frameworks; all 1127 unit tests pass.

## Test plan
- [x] `xcodebuild build-for-testing` succeeds
- [x] `xcodebuild test-without-building` (PR test plan) — 1127 tests pass
- [x] Eyeballed the running app: body text reads lighter than the previous Medium setting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the medium font weight to render as Regular consistently across SwiftUI and AppKit.
  * Improved typography consistency for text using the medium weight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->