### PR TITLE
Clear a failed login's error when the key is replaced

### DIFF
--- a/whitenoise-mac/Core/LoginIdentityDraft.swift
+++ b/whitenoise-mac/Core/LoginIdentityDraft.swift
@@ -52,4 +52,14 @@ enum LoginIdentityDraft: Equatable {
 
     /// Whether the pane's primary action can fire.
     var isSubmittable: Bool { self == .valid }
+
+    /// Whether the line under the field should still carry what the core said about the last
+    /// attempt.
+    ///
+    /// Only the empty draft does. `login()` scrubs the field on every exit path, failures
+    /// included (see issue #32), so an emptied field is what a failed attempt leaves behind and
+    /// is the only draft that complaint is still about. `lastError` itself survives until the
+    /// *next* attempt starts, so without this a key pasted in to replace the one that failed
+    /// would be shown the previous key's error.
+    var showsLastAttemptError: Bool { self == .empty }
 }

--- a/whitenoise-mac/Views/Onboarding/OnboardingSignInView.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingSignInView.swift
@@ -31,14 +31,19 @@ struct OnboardingSignInView: View {
         workspace.authenticationActivity == .login
     }
 
-    /// The field's own complaint first, the core's second. They cannot both be true of the same
-    /// keystroke: typing anything clears `lastError` only on the next attempt, so a stale core
-    /// error would otherwise sit under a field the user has already fixed.
+    /// The field's own complaint first, the core's second — and the core's only while the field
+    /// still holds nothing.
+    ///
+    /// `lastError` is cleared when the next attempt starts, not when the field changes, so on its
+    /// own it outlives the key it is about: `login()` scrubs the field on failure (issue #32), and
+    /// the replacement key pasted into the empty field it leaves behind would inherit the previous
+    /// key's error. `LoginIdentityDraft.showsLastAttemptError` is what decides that the complaint
+    /// is no longer about what is in the field.
     private var message: String? {
         if draft == .invalid {
             return L10n.string("Invalid nsec. Make sure you entered it correctly.")
         }
-        return workspace.lastError
+        return draft.showsLastAttemptError ? workspace.lastError : nil
     }
 
     var body: some View {

--- a/whitenoise-macTests/OnboardingTests.swift
+++ b/whitenoise-macTests/OnboardingTests.swift
@@ -241,6 +241,20 @@ import Testing
         #expect(LoginIdentityDraft("note1abc") == .invalid)
     }
 
+    /// The core's complaint about the last attempt belongs to the field that attempt was made
+    /// from, and `login()` empties that field on failure (issue #32). Anything in the field
+    /// afterwards is a different identity, so the draft stops standing behind the complaint —
+    /// without this a replacement key sits under the rejected key's error, and the pane reads as
+    /// having refused a key it has not been given yet.
+    @Test func onlyAnEmptyDraftStandsBehindTheLastAttemptsError() {
+        #expect(LoginIdentityDraft("").showsLastAttemptError)
+        #expect(LoginIdentityDraft("   \n ").showsLastAttemptError)
+
+        #expect(LoginIdentityDraft("nsec1" + String(repeating: "q", count: 58)).showsLastAttemptError == false)
+        #expect(LoginIdentityDraft("npub1" + String(repeating: "q", count: 58)).showsLastAttemptError == false)
+        #expect(LoginIdentityDraft("hello").showsLastAttemptError == false)
+    }
+
     // MARK: - The sign-up pane fits the window it has to fit
 
     /// The one thing about this pane that fails invisibly.

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1096,6 +1096,42 @@ struct whitenoise_macTests {
         #expect(state.lastError != nil)
     }
 
+    /// The sign-in pane must not show a failed attempt's error under the key entered to replace it.
+    ///
+    /// Both halves that produce that are real state, so both are driven here rather than assumed:
+    /// the scrub above empties the field on failure, and `lastError` is not cleared until the
+    /// *next* attempt starts. Between those two every keystroke inherits the rejected key's
+    /// complaint, and `LoginIdentityDraft.showsLastAttemptError` is the only thing that ends it.
+    @MainActor
+    @Test func aReplacementKeyIsNotShownThePreviousAttemptsError() async throws {
+        // No createdAccount => FakeMarmotRuntime.login throws, exercising the failure path.
+        let runtime = FakeMarmotRuntime(accounts: [])
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        state.showLogin()
+        state.loginIdentity = "nsec1faketestkeyfaketestkeyfaketestkeyfaketestkeyfaketest"
+
+        await state.login()
+
+        // What the failure leaves behind: an emptied field, and a complaint about the key that is
+        // no longer in it. The pane still shows it here — there is nothing else to show.
+        let failure = try #require(state.lastError)
+        #expect(state.loginIdentity == "")
+        #expect(LoginIdentityDraft(state.loginIdentity).showsLastAttemptError)
+
+        // The user pastes a different key. `lastError` deliberately still stands, so the draft is
+        // what has to stop carrying it.
+        state.loginIdentity = "npub1anotherfakekeyanotherfakekeyanotherfakekeyanotherfake"
+        #expect(state.lastError == failure)
+        #expect(LoginIdentityDraft(state.loginIdentity).showsLastAttemptError == false)
+
+        // And a wrong one keeps the field's own complaint in front, unchanged.
+        state.loginIdentity = "hello"
+        #expect(LoginIdentityDraft(state.loginIdentity) == .invalid)
+        #expect(LoginIdentityDraft(state.loginIdentity).showsLastAttemptError == false)
+    }
+
     @MainActor
     @Test func successfulLoginScrubsEnteredNsecFromMemory() async throws {
         let summary = AccountSummaryFfi(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented previous login errors from appearing after a new identity or key is entered.
  - Preserved validation feedback for invalid key input.
  - Ensured failed-login messages remain visible when the sign-in field is empty.

- **Tests**
  - Added coverage for error visibility across empty, valid, and invalid sign-in inputs.
  - Added regression coverage for replacing an identity after a failed login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->