### PR TITLE
Add an account through the onboarding flow, not a sheet of its own

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -291,11 +291,48 @@ extension WorkspaceState {
         lastError = nil
     }
 
+    /// Open the onboarding surface to add an identity alongside the ones already on this Mac.
+    ///
+    /// This is the whole of Settings → Add Account, and of the signed-out pane's `Use another
+    /// account`. Both used to have their own answer to "how do you get a second account in" — the
+    /// former a bespoke sheet with its own key field and its own pair of buttons, the latter this
+    /// call — and the sheet's was a second, worse copy of a flow that already exists. There is one
+    /// now: the panes in `Views/Onboarding`, which is what `wn-ios-prototype`'s `AddProfileFlow`
+    /// does too. It presents `WelcomeView` and pushes the *real* `LoginView` and `SignUpView`
+    /// rather than reimplementing either.
+    ///
+    /// Deliberately leaves `selection` alone, so `leaveAccountOnboarding()` puts the user back on
+    /// the page they opened this from rather than somewhere merely plausible.
     func showAccountOnboarding() {
         authenticationMode = .landing
         clearEnteredLoginIdentity()
         lastError = nil
         phase = .onboarding
+    }
+
+    /// Whether the onboarding surface has an app behind it to return to.
+    ///
+    /// Derived rather than stored, because a flag saying the same thing could fall out of step
+    /// with the phase it describes. Every *other* route into `.onboarding` is taken precisely
+    /// because there is nothing else to show — a first launch, the last account removed, a wipe —
+    /// and each one is guarded by `accounts.isEmpty` or clears the list itself. So a non-empty
+    /// account list in this phase means someone chose to be here and is owed a way out.
+    var canLeaveAccountOnboarding: Bool {
+        phase == .onboarding && !accounts.isEmpty
+    }
+
+    /// Leave the onboarding surface without adding anything — the prototype's `Cancel`.
+    ///
+    /// Restores the phase and nothing else: no account changed hands, so there is no state to
+    /// rebuild and `activateReadyState()`'s reloads would be work done for a user who pressed
+    /// cancel. What it does scrub is the key field, because Cancel is one of the exits #32 is
+    /// about: a typed-but-unsubmitted nsec must not outlive the pane it was typed into.
+    func leaveAccountOnboarding() {
+        guard canLeaveAccountOnboarding, !isAuthenticating else { return }
+        authenticationMode = .landing
+        clearEnteredLoginIdentity()
+        lastError = nil
+        phase = .ready
     }
 
     func cancelLogin() {

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -28384,65 +28384,6 @@
         }
       }
     },
-    "Log in with key": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mit Schlüssel anmelden"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iniciar sesión con llave"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se connecter avec une clé"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Accedi con chiave"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entrar com chave"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Войти с ключом"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anahtarla giriş yap"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用密钥登录"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用金鑰登入"
-          }
-        }
-      }
-    },
     "Logging in...": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Views/Onboarding/OnboardingExitControl.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingExitControl.swift
@@ -1,0 +1,54 @@
+//
+//  OnboardingExitControl.swift
+//  whitenoise-mac
+//
+//  The two different ways off an onboarding pane, and what each one looks like.
+//
+
+import Foundation
+
+/// The control in `OnboardingScaffold`'s header row: what it does, and therefore how it draws.
+///
+/// The two are not the same gesture, and `wn-ios-prototype` draws them differently for that
+/// reason. `AddProfileFlow` pushes `LoginView` and `SignUpView` onto a `NavigationStack`, so those
+/// get the nav bar's **back** chevron — the pane behind them is still there. Its root
+/// `WelcomeView` gets a **`Cancel`** toolbar item instead, because there is no pane behind it: the
+/// gesture leaves the flow altogether and returns to the app the flow was opened from.
+///
+/// One value rather than a `backAction` plus a style flag, so the symbol and the action cannot
+/// disagree about which of the two a pane is offering — the same reason the panes set
+/// `controlSize` and `wnButtonShape` once on the pane instead of per button.
+enum OnboardingExitControl {
+    /// Return to the pane behind this one, within the flow. The prototype's nav-bar back.
+    case back(() -> Void)
+    /// Leave the flow for the app it was opened from. The prototype's `Cancel` toolbar item.
+    case cancel(() -> Void)
+
+    var symbol: String {
+        switch self {
+        case .back: "chevron.left"
+        case .cancel: "xmark"
+        }
+    }
+
+    /// A catalog key, not display text: `GlassCircleCloseButton` localizes `help` itself.
+    var helpKey: String {
+        switch self {
+        case .back: "Back"
+        case .cancel: "Cancel"
+        }
+    }
+
+    var accessibilityIdentifier: String {
+        switch self {
+        case .back: "onboarding.back"
+        case .cancel: "onboarding.cancel"
+        }
+    }
+
+    var action: () -> Void {
+        switch self {
+        case .back(let action), .cancel(let action): action
+        }
+    }
+}

--- a/whitenoise-mac/Views/Onboarding/OnboardingScaffold.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingScaffold.swift
@@ -44,9 +44,11 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
     /// both phone clients put the same string: `wn-ios-prototype` as a `navigationTitle`, Flutter
     /// as its `WnSlateNavigationHeader` title, both beside the same back control.
     var title: String?
-    /// Supplied only by a pane that has somewhere to go back to. The welcome pane is the root and
-    /// passes `nil`, which removes the control while keeping the row it stood in.
-    var backAction: (() -> Void)?
+    /// Supplied only by a pane that has somewhere to go. The inner panes pass `.back`; the welcome
+    /// pane passes `.cancel` when the flow was opened from a running app and `nil` when it was
+    /// not, which removes the control while keeping the row it stood in. See
+    /// `OnboardingExitControl`.
+    var exit: OnboardingExitControl?
     /// What the pane is arranged around. Defaults to the mark.
     @ViewBuilder var hero: Hero
     /// Whatever sits between the hero and the actions — the sign-in pane's key field, the sign-up
@@ -57,7 +59,7 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            OnboardingHeaderRow(title: title, backAction: backAction)
+            OnboardingHeaderRow(title: title, exit: exit)
 
             Spacer(minLength: OnboardingLayout.edgePadding)
 
@@ -101,13 +103,13 @@ extension OnboardingScaffold where Hero == OnboardingMarkHero {
     /// The scaffold as both existing panes use it: the mark as the hero.
     init(
         title: String? = nil,
-        backAction: (() -> Void)? = nil,
+        exit: OnboardingExitControl? = nil,
         @ViewBuilder content: () -> Content,
         @ViewBuilder actions: () -> Actions
     ) {
         self.init(
             title: title,
-            backAction: backAction,
+            exit: exit,
             hero: { OnboardingMarkHero() },
             content: content,
             actions: actions
@@ -123,22 +125,22 @@ extension OnboardingScaffold where Hero == OnboardingMarkHero {
 /// the way out.
 private struct OnboardingHeaderRow: View {
     let title: String?
-    let backAction: (() -> Void)?
+    let exit: OnboardingExitControl?
 
     var body: some View {
         // Overlaid rather than a third `HStack` member, so the title is centred on the *pane* and
-        // not on whatever is left of it beside the back control — which would move it sideways
-        // between a pane that has a back control and one that does not.
+        // not on whatever is left of it beside the exit control — which would move it sideways
+        // between a pane that has one and one that does not.
         HStack {
-            if let backAction {
+            if let exit {
                 GlassCircleCloseButton(
-                    symbol: "chevron.left",
-                    help: "Back",
+                    symbol: exit.symbol,
+                    help: exit.helpKey,
                     appearance: .outline,
-                    action: backAction
+                    action: exit.action
                 )
-                .accessibilityLabel(L10n.string("Back"))
-                .accessibilityIdentifier("onboarding.back")
+                .accessibilityLabel(L10n.string(exit.helpKey))
+                .accessibilityIdentifier(exit.accessibilityIdentifier)
             }
 
             Spacer(minLength: 0)

--- a/whitenoise-mac/Views/Onboarding/OnboardingSignInView.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingSignInView.swift
@@ -44,7 +44,7 @@ struct OnboardingSignInView: View {
     var body: some View {
         @Bindable var workspace = workspace
 
-        OnboardingScaffold(backAction: { workspace.cancelLogin() }) {
+        OnboardingScaffold(exit: .back { workspace.cancelLogin() }) {
             VStack(alignment: .leading, spacing: 8) {
                 Text(L10n.string("Private Key"))
                     .wnFont(.semiBold14)

--- a/whitenoise-mac/Views/Onboarding/OnboardingSignUpView.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingSignUpView.swift
@@ -48,7 +48,7 @@ struct OnboardingSignUpView: View {
     var body: some View {
         @Bindable var workspace = workspace
 
-        OnboardingScaffold(title: L10n.string("Set up profile"), backAction: cancel) {
+        OnboardingScaffold(title: L10n.string("Set up profile"), exit: .back(cancel)) {
             OnboardingSignUpAvatar()
         } content: {
             VStack(alignment: .leading, spacing: OnboardingLayout.titleToFieldsSpacing) {

--- a/whitenoise-mac/Views/Onboarding/OnboardingWelcomeView.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingWelcomeView.swift
@@ -9,6 +9,12 @@ import SwiftUI
 
 /// The onboarding landing pane.
 ///
+/// Not only a first launch's: this is also Settings → Add Account, which used to raise a sheet of
+/// its own with a second key field and a second pair of buttons for the same two actions. The
+/// prototype does not have a second one either — `AddProfileFlow` presents this pane and pushes
+/// the real `LoginView` and `SignUpView` behind it. The only thing the two entrances differ by is
+/// the way out; see `exit`.
+///
 /// `wn-ios-prototype`'s `WelcomeView` and Flutter's `WnAuthButtonsContainer` agree on the
 /// ordering, and it is the opposite of what this pane used to do: **the lesser action sits on
 /// top and the primary one sits at the bottom**, closest to the edge the hand or the pointer
@@ -37,8 +43,17 @@ import SwiftUI
 struct OnboardingWelcomeView: View {
     @Environment(WorkspaceState.self) private var workspace
 
+    /// Present only when this pane is not the end of the line — see
+    /// `WorkspaceState.canLeaveAccountOnboarding`. On a first launch there is no app to cancel
+    /// back to, and a control that returned to a blank window would be a lie; reached from
+    /// Settings → Add Account, or from the signed-out pane, there is.
+    private var exit: OnboardingExitControl? {
+        guard workspace.canLeaveAccountOnboarding else { return nil }
+        return .cancel { workspace.leaveAccountOnboarding() }
+    }
+
     var body: some View {
-        OnboardingScaffold {
+        OnboardingScaffold(exit: exit) {
             OnboardingMessageLine(message: workspace.lastError)
         } actions: {
             OnboardingActionButton(

--- a/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
@@ -3,8 +3,9 @@
 //  whitenoise-mac
 //
 //  The account switcher that sits at the top of Settings: the card naming the
-//  active identity, the popover listing every identity on this Mac, and the
-//  add-account sheet. This is where the former Accounts settings page went —
+//  active identity, and the popover listing every identity on this Mac. Adding
+//  one is not here — `Add Account` opens the onboarding flow, the same panes a
+//  first launch shows. This is where the former Accounts settings page went —
 //  the iOS and Flutter clients open Settings on the current profile with a
 //  switch control directly underneath it rather than routing identity work
 //  through a separate Accounts tab, and this mirrors that on macOS.
@@ -25,7 +26,6 @@ struct SettingsAccountSwitcherCard: View {
     // `L10n.string(_:locale:)`.
     @Environment(\.locale) private var locale
     @State private var isSwitcherPresented = false
-    @State private var isAddAccountPresented = false
     @State private var accountPendingRemoval: AccountItem?
     @State private var accountPendingSignOut: AccountItem?
 
@@ -90,7 +90,7 @@ struct SettingsAccountSwitcherCard: View {
                     },
                     onAddAccount: {
                         isSwitcherPresented = false
-                        isAddAccountPresented = true
+                        workspace.showAccountOnboarding()
                     },
                     onSignOut: { account in
                         isSwitcherPresented = false
@@ -116,11 +116,6 @@ struct SettingsAccountSwitcherCard: View {
         }
         .padding(10)
         .glassCard()
-        .sheet(isPresented: $isAddAccountPresented) {
-            AddAccountSheet()
-                .environment(workspace)
-                .environment(\.locale, workspace.preferredLocale)
-        }
         .removeAccountConfirmation(
             account: accountPendingRemoval,
             isPresented: removeConfirmationBinding,
@@ -372,117 +367,5 @@ struct AccountSwitcherRow: View {
         return account.externalSigning
             ? L10n.string("External signing", locale: locale)
             : L10n.string("Watch-only", locale: locale)
-    }
-}
-
-/// Adds an identity without leaving Settings: log in with an existing `nsec`, or
-/// create a new one. Both paths land on the new identity's profile page so the
-/// switcher card visibly reflects the account that is now active.
-struct AddAccountSheet: View {
-    @Environment(WorkspaceState.self) private var workspace
-    @Environment(\.locale) private var locale
-    @Environment(\.dismiss) private var dismiss
-
-    /// Authentication adds an account, so it waits out any other account mutation
-    /// (sign-out, removal, wipe) rather than racing its account-list refresh.
-    private var isAuthenticationBlocked: Bool {
-        workspace.isAuthenticating || workspace.isAccountMutationInProgress
-    }
-
-    private var isLoginDisabled: Bool {
-        workspace.loginIdentity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            || isAuthenticationBlocked
-    }
-
-    var body: some View {
-        @Bindable var workspace = workspace
-
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(L10n.string("Add Account", locale: locale))
-                    .wnFont(.semiBold16)
-
-                Spacer()
-
-                GlassCircleCloseButton {
-                    cancel()
-                }
-            }
-
-            SecureField(
-                L10n.string("nsec1...", locale: locale),
-                text: $workspace.loginIdentity,
-                prompt: Text(L10n.string("nsec1...", locale: locale))
-            )
-            .labelsHidden()
-            .textFieldStyle(.roundedBorder)
-            .disabled(workspace.isAuthenticating)
-
-            HStack(spacing: 10) {
-                Button {
-                    Task { await addAccount { await workspace.login() } }
-                } label: {
-                    Label(
-                        workspace.authenticationActivity == .login
-                            ? L10n.string("Logging in...", locale: locale)
-                            : L10n.string("Log in with key", locale: locale),
-                        systemImage: "key"
-                    )
-                }
-                .nativeGlassProminentButtonStyle()
-                .disabled(isLoginDisabled)
-
-                Button {
-                    workspace.clearEnteredLoginIdentity()
-                    Task { await addAccount { await workspace.signUp() } }
-                } label: {
-                    Label(
-                        workspace.authenticationActivity == .signUp
-                            ? L10n.string("Creating...", locale: locale)
-                            : L10n.string("Create identity", locale: locale),
-                        systemImage: "plus.circle"
-                    )
-                }
-                .buttonStyle(.wnSecondary)
-                .disabled(isAuthenticationBlocked)
-
-                Spacer()
-
-                Button(L10n.string("Cancel", locale: locale)) {
-                    cancel()
-                }
-                .buttonStyle(.wnSecondary)
-                .disabled(workspace.isAuthenticating)
-            }
-
-            SettingsErrorView(error: workspace.lastError)
-        }
-        .padding(22)
-        .frame(width: 420)
-        .background {
-            LiquidGlassBackground()
-        }
-        // Esc, or the presenter going away, dismisses the sheet without running
-        // `cancel()`; the entered nsec must not survive either. See #32.
-        .onDisappear {
-            workspace.clearEnteredLoginIdentity()
-        }
-    }
-
-    /// Runs an authentication path and, when it succeeds, returns to Settings on
-    /// the new account's profile. `login`/`signUp` clear the selection on success,
-    /// so without this the window would jump to the chat list.
-    private func addAccount(_ authenticate: () async -> Void) async {
-        await authenticate()
-        guard workspace.lastError == nil else { return }
-        dismiss()
-        workspace.showSettingsPage(.overview)
-    }
-
-    /// Scrubs the entered nsec (private key) rather than letting it linger in
-    /// observable memory behind a dismissed sheet. See #32.
-    private func cancel() {
-        workspace.clearEnteredLoginIdentity()
-        dismiss()
     }
 }

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1147,26 +1147,125 @@ struct whitenoise_macTests {
         }
     }
 
-    /// #32 one layer up: the Add Account sheet's own teardown has to scrub the key, because Esc
-    /// and a disappearing presenter both dismiss it without running its cancel affordance. Only
-    /// the source can hold that contract — once the sheet is gone there is nothing left to observe.
+    /// Settings → Add Account is the onboarding flow now, not a sheet of its own. The card used
+    /// to raise `AddAccountSheet` — a second key field and a second pair of buttons for the two
+    /// things `Views/Onboarding` already does — and this pins the routing that replaced it.
     @MainActor
-    @Test func addAccountSheetScrubsEnteredNsecWhenItDisappears() throws {
-        let sourceURL =
-            URL(filePath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appending(path: "whitenoise-mac")
-            .appending(path: "Views")
-            .appending(path: "Settings")
-            .appending(path: "SettingsAccountSwitcherViews.swift")
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    @Test func addAccountOpensTheOnboardingFlowOnItsLandingPane() async throws {
+        let state = WorkspaceState(clientFactory: { Self.addAccountRuntime() })
+        await state.bootstrap()
+        #expect(state.phase == .ready)
 
-        let sheetStart = try #require(source.range(of: "struct AddAccountSheet: View {"))
-        let sheetSource = String(source[sheetStart.lowerBound...])
-        let normalized = sheetSource.components(separatedBy: .whitespacesAndNewlines).joined()
+        state.showAccountOnboarding()
 
-        #expect(normalized.contains(".onDisappear{workspace.clearEnteredLoginIdentity()}"))
+        #expect(state.phase == .onboarding)
+        #expect(state.authenticationMode == .landing)
+    }
+
+    /// The welcome pane is the root of the flow, so its way out is a `Cancel` back to the app —
+    /// but only where there is an app behind it. A first launch has none, and a control that
+    /// returned to a blank window would be offering something it cannot do.
+    @MainActor
+    @Test func onlyAnOnboardingFlowWithAccountsBehindItOffersAWayOut() async throws {
+        let empty = WorkspaceState(clientFactory: { FakeMarmotRuntime(accounts: []) })
+        await empty.bootstrap()
+        #expect(empty.phase == .onboarding)
+        #expect(empty.canLeaveAccountOnboarding == false)
+
+        let state = WorkspaceState(clientFactory: { Self.addAccountRuntime() })
+        await state.bootstrap()
+        // Ready, with an account: in the app, so there is nothing to leave.
+        #expect(state.canLeaveAccountOnboarding == false)
+
+        state.showAccountOnboarding()
+        #expect(state.canLeaveAccountOnboarding)
+    }
+
+    /// Cancel returns the user to the page they opened the flow from, which is why
+    /// `showAccountOnboarding()` leaves `selection` alone: restoring the phase is the whole of
+    /// the way back, and nothing else moved while the panes were up.
+    @MainActor
+    @Test func cancellingAddAccountReturnsToThePageItWasOpenedFrom() async throws {
+        let state = WorkspaceState(clientFactory: { Self.addAccountRuntime() })
+        await state.bootstrap()
+        state.showSettings(.overview)
+        let selectionBeforehand = state.selection
+
+        state.showAccountOnboarding()
+        state.leaveAccountOnboarding()
+
+        #expect(state.phase == .ready)
+        #expect(state.authenticationMode == .landing)
+        #expect(state.selection == selectionBeforehand)
+    }
+
+    /// #32 on the exit the sheet's `.onDisappear` used to cover. A key typed into the flow and
+    /// then abandoned must not outlive it — cancelling is exactly the case where the user has
+    /// decided not to submit what they pasted.
+    @MainActor
+    @Test func cancellingAddAccountScrubsTheEnteredNsec() async throws {
+        let state = WorkspaceState(clientFactory: { Self.addAccountRuntime() })
+        await state.bootstrap()
+
+        state.showAccountOnboarding()
+        state.showLogin()
+        state.loginIdentity = "nsec1faketestkeyfaketestkeyfaketestkeyfaketestkeyfaketest"
+
+        // Back out of the key pane first, the way the panes are actually stacked.
+        state.cancelLogin()
+        #expect(state.loginIdentity == "")
+
+        // And again for a key that survived as far as the landing pane.
+        state.loginIdentity = "nsec1anotherfakekeyanotherfakekeyanotherfakekeyanotherfake"
+        state.leaveAccountOnboarding()
+
+        #expect(state.loginIdentity == "")
+        #expect(state.phase == .ready)
+    }
+
+    /// Entering the flow must not carry a failure in from wherever it was opened, and leaving it
+    /// must not carry one back out: `lastError` renders on the landing pane and on every settings
+    /// pane, so a stale one would be read as a complaint about the screen it followed the user to.
+    @MainActor
+    @Test func theAddAccountFlowClearsErrorsOnTheWayInAndOnTheWayOut() async throws {
+        let state = WorkspaceState(clientFactory: { Self.addAccountRuntime() })
+        await state.bootstrap()
+
+        state.lastError = "Something failed in Settings"
+        state.showAccountOnboarding()
+        #expect(state.lastError == nil)
+
+        state.lastError = "Couldn't sign in"
+        state.leaveAccountOnboarding()
+        #expect(state.lastError == nil)
+    }
+
+    /// The exit control's two cases are not interchangeable: `wn-ios-prototype` draws the pushed
+    /// panes' way back as a nav-bar chevron and the root pane's as `Cancel`, and conflating them
+    /// would put a "go back" arrow on a pane with nothing behind it.
+    @MainActor
+    @Test func theOnboardingExitControlDrawsBackAndCancelDifferently() {
+        let back = OnboardingExitControl.back {}
+        let cancel = OnboardingExitControl.cancel {}
+
+        #expect(back.symbol == "chevron.left")
+        #expect(cancel.symbol == "xmark")
+        #expect(back.helpKey != cancel.helpKey)
+        #expect(back.accessibilityIdentifier != cancel.accessibilityIdentifier)
+    }
+
+    /// One signed-in account on a fake runtime, for the add-account flow's tests.
+    private static func addAccountRuntime() -> FakeMarmotRuntime {
+        FakeMarmotRuntime(accounts: [
+            AccountSummaryFfi(
+                label: "Desktop Account",
+                accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+                localSigning: true,
+                externalSigning: false,
+                signedOut: false,
+                running: true
+            )
+        ])
     }
 
     /// The avatar's selection ring and drop shadow are both drawn outside the frame they are


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared account onboarding flow for adding accounts from Settings.
  * Added clear back and cancel controls throughout onboarding.
  * Existing signed-in accounts can now exit account onboarding without disrupting the current selection.

* **Bug Fixes**
  * Improved cancellation behavior by clearing login details and returning to the ready state when authentication is inactive.
  * Ensured onboarding errors and sensitive input are cleared appropriately.

* **Localization**
  * Removed an outdated “Log in with key” translation entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->