### PR TITLE
Draw a just-uploaded profile picture without a round trip

### DIFF
--- a/whitenoise-mac/Core/RemoteImageLoader.swift
+++ b/whitenoise-mac/Core/RemoteImageLoader.swift
@@ -391,7 +391,7 @@ struct DownsampledAsyncImage<Content: View, Placeholder: View>: View {
 
     var body: some View {
         ZStack {
-            if let image {
+            if let image = image ?? alreadyDecodedImage {
                 content(image)
             } else {
                 placeholder()
@@ -404,6 +404,19 @@ struct DownsampledAsyncImage<Content: View, Placeholder: View>: View {
 
     private var taskKey: TaskKey {
         TaskKey(url: url, size: DownsampledImageSizing.requestedPixelSize(maxPixelSize))
+    }
+
+    /// The decoded image for this URL and size when the shared cache is already holding one.
+    ///
+    /// `.task` cannot run before the first frame, so a view that appears with a warm cache entry
+    /// draws its placeholder once anyway — for an avatar that is a visible flash of initials over
+    /// an image the process has in memory. Reading the cache synchronously closes that gap. `??`
+    /// short-circuits, so a view that has loaded never gets here, and a miss costs one lookup.
+    private var alreadyDecodedImage: Image? {
+        guard let url = taskKey.url,
+            let loaded = RemoteImageLoader.shared.decodedImage(for: url, maxPixelSize: taskKey.size)
+        else { return nil }
+        return Image(nsImage: loaded.nsImage)
     }
 
     @MainActor
@@ -601,15 +614,28 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         case local
     }
 
+    /// Source bytes the app itself established at a remote URL, held so the first display of
+    /// that URL does not have to fetch what the process already has. See `primeRemoteImage`.
+    private struct PrimedSource {
+        let url: String
+        let data: Data
+    }
+
     static let shared = RemoteImageLoader()
     static let defaultDecodedCacheCountLimit = 512
     static let defaultDecodedCacheTotalCostLimit = 64 * 1024 * 1024
+
+    /// How many primed images to keep source bytes for, oldest evicted first. A handful covers
+    /// setting a picture on more than one account in a sitting; the point of the bound is that a
+    /// long session cannot accumulate them.
+    static let primedSourceLimit = 4
 
     private let cache = NSCache<NSString, NSImage>()
     private let inFlight = RemoteImageLoadRegistry()
     private let cacheStateLock = NSLock()
     private var cacheGenerations: [CacheScope: Int] = [.remote: 0, .local: 0]
     private var localCacheKeys = Set<String>()
+    private var primedSources: [PrimedSource] = []
     private let session: URLSession
 
     var decodedCacheCountLimit: Int { cache.countLimit }
@@ -673,6 +699,47 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     func data(for url: URL) async -> Data? {
         guard RemoteImageURLPolicy.isAllowed(url) else { return nil }
         return await Self.download(url, using: session)
+    }
+
+    /// Registers source bytes the app already holds for `url`, so the first load of that URL
+    /// decodes from memory instead of fetching it.
+    ///
+    /// This exists for one narrow case: the profile picture the user just chose. The app uploaded
+    /// those exact bytes to a Blossom server, took the URL the upload returned, and put it on the
+    /// account — at which point every avatar on screen asked the network for an image the process
+    /// was still holding, and drew initials for the length of a round trip (longer while the
+    /// server is still making a freshly uploaded blob available). This is not a general
+    /// cache-warming hook: prime only bytes whose identity at `url` the app itself established,
+    /// because a wrong pairing here shows one image under another's URL for the whole session.
+    ///
+    /// Priming widens neither what may be fetched nor what may be drawn. `image(for:)` still
+    /// applies `RemoteImageURLPolicy` before it looks here, so a disallowed URL stays unloadable,
+    /// and the consent half of the decision stays with `RemoteImageDisplayPolicy` at the call
+    /// site. Oversized bodies are rejected so `primedSourceLimit` bounds memory and not just a
+    /// count, and `clearCache()` drops these bytes along with the decoded images.
+    func primeRemoteImage(url: URL, data: Data) {
+        guard RemoteImageURLPolicy.isAllowed(url), !data.isEmpty,
+            Int64(data.count) <= RemoteImageURLPolicy.maxResponseBytes
+        else { return }
+
+        cacheStateLock.lock()
+        defer { cacheStateLock.unlock() }
+        primedSources.removeAll { $0.url == url.absoluteString }
+        primedSources.append(PrimedSource(url: url.absoluteString, data: data))
+        if primedSources.count > Self.primedSourceLimit {
+            primedSources.removeFirst(primedSources.count - Self.primedSourceLimit)
+        }
+    }
+
+    /// The decoded image for `url` at `maxPixelSize` if the cache is already holding one.
+    ///
+    /// Synchronous, so a view can draw a warm entry on its first frame rather than flashing its
+    /// placeholder for one pass of the async load. A miss returns nil and starts nothing.
+    func decodedImage(for url: URL, maxPixelSize: CGFloat) -> LoadedImage? {
+        guard RemoteImageURLPolicy.isAllowed(url),
+            let cached = cachedImage(for: Self.cacheKey(for: url, maxPixelSize: maxPixelSize))
+        else { return nil }
+        return LoadedImage(nsImage: cached)
     }
 
     /// Downsamples and caches local/decrypted image bytes.
@@ -762,6 +829,10 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         }
         cache.removeAllObjects()
         localCacheKeys.removeAll(keepingCapacity: true)
+        // The privacy wipes this serves must not leave the user's own uploaded picture behind
+        // in the process either, and a primed URL that outlived its account would go on serving
+        // bytes no fetch could have produced.
+        primedSources.removeAll()
         cacheStateLock.unlock()
     }
 
@@ -781,6 +852,10 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
     }
 
     #if DEBUG
+        func primedSourceByteCount(for url: URL) -> Int? {
+            primedSource(for: url)?.count
+        }
+
         func inFlightWaiterCount(for url: URL, maxPixelSize: CGFloat) -> Int {
             inFlight.waiterCount(
                 for: Self.inFlightKey(
@@ -810,10 +885,16 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
         maxPixelSize: CGFloat,
         cacheGeneration generation: Int
     ) async -> LoadedImage? {
-        guard let data = await Self.download(url, using: session) else { return nil }
+        let source: Data
+        if let primed = primedSource(for: url) {
+            source = primed
+        } else {
+            guard let downloaded = await Self.download(url, using: session) else { return nil }
+            source = downloaded
+        }
         guard !Task.isCancelled, isCurrentCacheGeneration(generation, for: .remote) else { return nil }
         return await loadLocalImage(
-            data: data,
+            data: source,
             cacheKey: cacheKey,
             maxPixelSize: maxPixelSize,
             cacheGeneration: generation,
@@ -845,6 +926,12 @@ nonisolated final class RemoteImageLoader: @unchecked Sendable {
             return nil
         }
         return loaded
+    }
+
+    private func primedSource(for url: URL) -> Data? {
+        cacheStateLock.lock()
+        defer { cacheStateLock.unlock() }
+        return primedSources.last { $0.url == url.absoluteString }?.data
     }
 
     private func cachedImage(for key: String) -> NSImage? {

--- a/whitenoise-mac/Core/WorkspaceState+Settings.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Settings.swift
@@ -746,9 +746,24 @@ extension WorkspaceState {
             guard activeAccountId == uploadContext.accountId,
                 profileImageUploadGeneration == uploadContext.generation
             else { return }
+            primeUploadedProfileImage(url: url, data: attachment.data)
             profileDraft.picture = url
             closeProfileImagePicker()
         }
+    }
+
+    /// Hands the image loader the bytes just uploaded to `url`, so the avatars that are about to
+    /// point at it draw the picture now.
+    ///
+    /// Without this, setting a profile picture reads as broken for as long as the round trip
+    /// takes: the form's own 96pt avatar, the account rail beside the chat list, and the switcher
+    /// all take the new URL at once and every one of them shows initials until Blossom serves back
+    /// the image the app had just finished sending it. Both upload sites call this — the settings
+    /// picker here and `completeSignUp()` — because both are places where the app, and only the
+    /// app, knows that these bytes are what lives at that URL.
+    func primeUploadedProfileImage(url: String, data: Data) {
+        guard let sanitized = RemoteImageURLPolicy.sanitizedURL(from: url) else { return }
+        RemoteImageLoader.shared.primeRemoteImage(url: sanitized, data: data)
     }
 
     func loadNotificationSettings() async {

--- a/whitenoise-mac/Core/WorkspaceState+SignUp.swift
+++ b/whitenoise-mac/Core/WorkspaceState+SignUp.swift
@@ -103,6 +103,9 @@ extension WorkspaceState {
                     mediaType: image.mediaType,
                     blossomServer: nil
                 )
+                // The staged bytes have been drawing the sign-up avatar all along; keep them
+                // drawing it once the account rail switches to the published URL.
+                primeUploadedProfileImage(url: picture, data: image.data)
             }
 
             // Built here rather than by mutating `profileDraft`, so a failed publish leaves the

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -23158,6 +23158,77 @@ struct whitenoise_macTests {
         #expect(!state.isProfileImagePickerPresented)
     }
 
+    /// Setting a profile picture hands the uploaded bytes to the image loader under the URL the
+    /// upload returned. Without it every own-account avatar — the form's own, the account rail
+    /// beside the chat list, the switcher — takes the new URL at once and draws initials until
+    /// Blossom serves back the image the app had just finished sending it.
+    @MainActor
+    @Test func profileImageUploadPrimesTheAvatarLoaderWithTheUploadedBytes() async throws {
+        let account = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        let state = WorkspaceState(clientFactory: { runtime })
+        let imageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("profile-image-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try Self.testPNGData(width: 80, height: 60).write(to: imageURL)
+        defer { try? FileManager.default.removeItem(at: imageURL) }
+        // The loader is a process-wide singleton, so leave it as this test found it.
+        RemoteImageLoader.shared.clearCache()
+        defer { RemoteImageLoader.shared.clearCache() }
+
+        await state.bootstrap()
+        state.showProfileImagePicker()
+        await state.setProfileImage(fileURL: imageURL)
+
+        let uploaded = try #require(runtime.uploadedProfileImageData)
+        let published = try #require(RemoteImageURLPolicy.sanitizedURL(from: state.profileDraft.picture))
+        #expect(published.absoluteString == runtime.uploadedProfileImageURL)
+        #expect(RemoteImageLoader.shared.primedSourceByteCount(for: published) == uploaded.count)
+    }
+
+    /// Same for the sign-up path, where the bytes have been drawing the pane's avatar all along:
+    /// the rail must not lose the picture at the moment the account appears in it.
+    @MainActor
+    @Test func signUpProfileImageUploadPrimesTheAvatarLoaderWithTheUploadedBytes() async throws {
+        let created = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [], createdAccount: created)
+        let state = WorkspaceState(clientFactory: { runtime })
+        let imageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("signup-image-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try Self.testPNGData(width: 80, height: 60).write(to: imageURL)
+        defer { try? FileManager.default.removeItem(at: imageURL) }
+        RemoteImageLoader.shared.clearCache()
+        defer { RemoteImageLoader.shared.clearCache() }
+
+        await state.bootstrap()
+        state.authenticationMode = .signUp
+        state.prepareProfileImageDestination(.signUpDraft)
+        await state.setProfileImage(fileURL: imageURL)
+        let staged = try #require(state.signUpDraft.image)
+        state.signUpDraft.displayName = "Pepi"
+
+        await state.completeSignUp()
+
+        #expect(state.lastError == nil)
+        let published = try #require(RemoteImageURLPolicy.sanitizedURL(from: runtime.uploadedProfileImageURL))
+        #expect(RemoteImageLoader.shared.primedSourceByteCount(for: published) == staged.data.count)
+    }
+
     @MainActor
     @Test func groupImageSearchSelectionEncryptsAndUploadsToBlossom() async throws {
         let account = AccountSummaryFfi(
@@ -27237,6 +27308,155 @@ struct whitenoise_macTests {
         #expect(remote.nsImage !== local.nsImage)
         #expect(localCached.nsImage === local.nsImage)
         #expect(RemoteImageURLProtocolStub.requestCount() == 1)
+    }
+
+    /// The reason the fix exists. Bytes the app already holds for a URL are decoded from memory,
+    /// so the avatar that has just been pointed at a freshly uploaded picture draws it instead of
+    /// spending a round trip on initials. Primed with a 200x120 image while the network serves a
+    /// 1x1, so the decoded size says *which* bytes were used rather than only that nothing was
+    /// fetched.
+    @Test func remoteImageLoaderServesPrimedSourceBytesWithoutFetching() async throws {
+        RemoteImageURLProtocolStub.reset(data: Self.singlePixelPNG, responseDelay: 0)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RemoteImageURLProtocolStub.self]
+        config.urlCache = nil
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://blossom.example/just-uploaded.png"))
+        let uploaded = try Self.testPNGData(width: 200, height: 120)
+
+        loader.primeRemoteImage(url: url, data: uploaded)
+
+        let small = try #require(await loader.image(for: url, maxPixelSize: 64))
+        let smallSize = try #require(Self.pixelSize(of: small.nsImage))
+        #expect(smallSize.width == 64)
+        #expect(RemoteImageURLProtocolStub.requestCount() == 0)
+
+        // A second size is a second decode of the same primed bytes, not a download: the rail,
+        // the form, and the switcher all draw this URL at different sizes.
+        let large = try #require(await loader.image(for: url, maxPixelSize: 128))
+        let largeSize = try #require(Self.pixelSize(of: large.nsImage))
+        #expect(largeSize.width == 128)
+        #expect(RemoteImageURLProtocolStub.requestCount() == 0)
+    }
+
+    /// A decode that is already in the cache is readable synchronously, which is what lets a view
+    /// draw it on its first frame instead of flashing initials for one pass of the async load.
+    /// Keyed by size like the async path, so a warm 64px entry does not answer for a 128px view.
+    @Test func remoteImageLoaderExposesAnAlreadyDecodedImageSynchronously() async throws {
+        RemoteImageURLProtocolStub.reset(data: Self.singlePixelPNG, responseDelay: 0)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RemoteImageURLProtocolStub.self]
+        config.urlCache = nil
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://example.com/avatar.png"))
+
+        #expect(loader.decodedImage(for: url, maxPixelSize: 32) == nil)
+
+        let loaded = try #require(await loader.image(for: url, maxPixelSize: 32))
+
+        let peeked = try #require(loader.decodedImage(for: url, maxPixelSize: 32))
+        #expect(peeked.nsImage === loaded.nsImage)
+        #expect(loader.decodedImage(for: url, maxPixelSize: 64) == nil)
+        #expect(RemoteImageURLProtocolStub.requestCount() == 1)
+    }
+
+    /// A disallowed URL cannot be primed into being loadable. Priming is a shortcut past the
+    /// *network*, never past `RemoteImageURLPolicy`.
+    @Test func remoteImageLoaderRefusesToPrimeADisallowedURL() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://192.168.1.10/avatar.png"))
+        let uploaded = try Self.testPNGData(width: 64, height: 64)
+
+        loader.primeRemoteImage(url: url, data: uploaded)
+
+        #expect(loader.primedSourceByteCount(for: url) == nil)
+        #expect(await loader.image(for: url, maxPixelSize: 32) == nil)
+    }
+
+    /// Empty and oversized bodies are rejected, so `primedSourceLimit` bounds bytes held and not
+    /// merely a count.
+    @Test func remoteImageLoaderRejectsEmptyAndOversizedPrimedBytes() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://blossom.example/just-uploaded.png"))
+
+        loader.primeRemoteImage(url: url, data: Data())
+        #expect(loader.primedSourceByteCount(for: url) == nil)
+
+        let oversized = Data(count: Int(RemoteImageURLPolicy.maxResponseBytes) + 1)
+        loader.primeRemoteImage(url: url, data: oversized)
+        #expect(loader.primedSourceByteCount(for: url) == nil)
+
+        let allowed = try Self.testPNGData(width: 32, height: 32)
+        loader.primeRemoteImage(url: url, data: allowed)
+        #expect(loader.primedSourceByteCount(for: url) == allowed.count)
+    }
+
+    /// Oldest primed entry out first past the limit, and a re-prime of the same URL replaces its
+    /// bytes rather than adding a second copy.
+    @Test func remoteImageLoaderEvictsThePrimedSourceItHeldLongest() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let uploaded = try Self.testPNGData(width: 40, height: 40)
+        let urls = try (0...RemoteImageLoader.primedSourceLimit).map { index in
+            try #require(URL(string: "https://blossom.example/upload-\(index).png"))
+        }
+
+        for url in urls {
+            loader.primeRemoteImage(url: url, data: uploaded)
+        }
+
+        #expect(loader.primedSourceByteCount(for: urls[0]) == nil)
+        #expect(urls.dropFirst().allSatisfy { loader.primedSourceByteCount(for: $0) == uploaded.count })
+
+        let replacement = try Self.testPNGData(width: 48, height: 48)
+        let newest = try #require(urls.last)
+        loader.primeRemoteImage(url: newest, data: replacement)
+
+        #expect(loader.primedSourceByteCount(for: newest) == replacement.count)
+        // The re-prime must not have pushed a still-wanted entry out by occupying a second slot.
+        #expect(loader.primedSourceByteCount(for: urls[1]) == uploaded.count)
+    }
+
+    /// The privacy wipes drop primed bytes too. They are the viewer's own picture, and a primed
+    /// URL that outlived its account would keep serving bytes no fetch could have produced.
+    @Test func remoteImageLoaderClearCacheDropsPrimedSourceBytes() async throws {
+        RemoteImageURLProtocolStub.reset(data: Self.singlePixelPNG, responseDelay: 0)
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RemoteImageURLProtocolStub.self]
+        config.urlCache = nil
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://blossom.example/just-uploaded.png"))
+        let uploaded = try Self.testPNGData(width: 200, height: 120)
+
+        loader.primeRemoteImage(url: url, data: uploaded)
+        _ = try #require(await loader.image(for: url, maxPixelSize: 64))
+        #expect(RemoteImageURLProtocolStub.requestCount() == 0)
+
+        loader.clearCache()
+
+        #expect(loader.primedSourceByteCount(for: url) == nil)
+        let afterClear = try #require(await loader.image(for: url, maxPixelSize: 64))
+        let afterClearSize = try #require(Self.pixelSize(of: afterClear.nsImage))
+        // Served from the network now, which is the 1x1 the stub answers with rather than the
+        // 200-wide upload that decoded to a full 64px above.
+        #expect(afterClearSize.width < 64)
+        #expect(RemoteImageURLProtocolStub.requestCount() == 1)
+    }
+
+    /// `clearLocalCache()` is the media wipe, and it deliberately leaves remote avatars warm — so
+    /// it must not throw away the bytes that keep the account's own picture drawing either.
+    @Test func remoteImageLoaderClearLocalCachePreservesPrimedSourceBytes() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        let loader = RemoteImageLoader(session: URLSession(configuration: config))
+        let url = try #require(URL(string: "https://blossom.example/just-uploaded.png"))
+        let uploaded = try Self.testPNGData(width: 64, height: 64)
+
+        loader.primeRemoteImage(url: url, data: uploaded)
+        loader.clearLocalCache()
+
+        #expect(loader.primedSourceByteCount(for: url) == uploaded.count)
     }
 
     private static let singlePixelPNG = Data([


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile images now appear immediately after upload, reducing visible loading delays.
  * Remote images can load from validated cached data before requiring a network request.
  * Image caching now supports size limits, safe URL validation, cache replacement, and automatic eviction.

* **Bug Fixes**
  * Improved profile-image loading during account updates and sign-up.
  * Clearing local image caches no longer unnecessarily removes prepared remote image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->