### PR TITLE
Adjust signup avatar style

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -7496,6 +7496,66 @@
         }
       }
     },
+    "Add photo": {
+      "comment": "The sign-up pane's button for choosing a profile picture, before one has been chosen.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Foto hinzufügen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir foto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter une photo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi foto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar foto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить фото"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fotoğraf ekle"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加照片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增照片"
+          }
+        }
+      }
+    },
     "Add relay": {
       "extractionState": "manual",
       "localizations": {
@@ -11153,6 +11213,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "更改檔案夾"
+          }
+        }
+      }
+    },
+    "Change photo": {
+      "comment": "The sign-up pane's button for replacing the profile picture already chosen.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Foto ändern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar foto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier la photo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia foto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alterar foto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить фото"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fotoğrafı değiştir"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改照片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "變更照片"
           }
         }
       }

--- a/whitenoise-mac/Models/SignUpDraft.swift
+++ b/whitenoise-mac/Models/SignUpDraft.swift
@@ -20,11 +20,6 @@ import Foundation
 /// and let the existing settings plumbing do the upload: an abandoned sign-up leaves nothing
 /// behind.
 nonisolated struct SignUpDraft: Equatable {
-    /// What `AvatarPalette` keys the initials fallback's colour off, in place of the account id
-    /// hex there is not one of yet. A constant rather than the name being typed: a name-derived
-    /// seed would repaint the avatar on every keystroke.
-    static let avatarPaletteSeed = "onboarding.sign-up"
-
     var displayName = ""
     var about = ""
     /// `nil` until the picker hands back bytes. Not a URL: see the type note above.

--- a/whitenoise-mac/Views/Onboarding/OnboardingActionButton.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingActionButton.swift
@@ -36,18 +36,33 @@ struct OnboardingActionButton: View {
     let action: () -> Void
 
     var body: some View {
-        switch tier {
-        case .primary:
-            Button(action: action) { label }
-                .wnPrimaryButtonStyle()
-        case .elevated:
-            Button(action: action) { label }
-                .buttonStyle(.wnElevated)
-        }
+        Button(action: action) { label }
+            .onboardingActionTier(tier)
     }
 
     private var label: some View {
         OnboardingActionLabel(title: title, isLoading: isLoading)
             .frame(minHeight: OnboardingLayout.actionLabelHeight(for: tier))
+    }
+}
+
+extension View {
+    /// Draws the button in this subtree as `tier`.
+    ///
+    /// The tier-to-style mapping, and the only copy of it — `OnboardingActionButton` goes through
+    /// here too. It is split out for the one onboarding control the component itself cannot build:
+    /// the sign-up hero's photo picker, whose press opens a popover rather than running an action
+    /// closure, and which is a control that hugs its two words rather than a full-width action.
+    ///
+    /// What it deliberately does *not* carry is `OnboardingLayout.actionLabelHeight(for:)`. That
+    /// number exists so a stacked pair of full-height actions comes out level; a subordinate
+    /// control is not in that stack and does not want 44pt. Reach for `OnboardingActionButton` for
+    /// anything that is.
+    @ViewBuilder
+    func onboardingActionTier(_ tier: OnboardingActionTier) -> some View {
+        switch tier {
+        case .primary: wnPrimaryButtonStyle()
+        case .elevated: buttonStyle(.wnElevated)
+        }
     }
 }

--- a/whitenoise-mac/Views/Onboarding/OnboardingLayout.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingLayout.swift
@@ -95,16 +95,23 @@ enum OnboardingLayout {
 
     /// The avatar that stands where the mark stands on the other two panes.
     ///
-    /// Sized against the mark rather than against the settings page's 96pt avatar: it is the same
-    /// slot, and a hero that changed height between panes would move the whole column under it.
-    /// At 88 the avatar plus its badge comes out within a few points of `minimumMarkWidth`'s
-    /// 136pt-tall mark, which is as close as two different shapes get.
-    static let signUpAvatarSize: CGFloat = 88
+    /// **This is the number the window's height floor is spent on, so it is smaller than it
+    /// looks like it should be.** The hero is not the avatar alone: it is the avatar, a 10pt gap
+    /// and the `Add photo` pill, and the pane below it — a title, two labelled fields one of
+    /// which is three lines, a reserved error line and a 44pt CTA — leaves about 103pt for the
+    /// whole group inside `ContentView`'s 620pt minimum. Measured, not budgeted: at 88 with the
+    /// pill under it the pane draws 642pt and pushes its own button off a short window's bottom
+    /// edge, which is what `OnboardingTests.theSignUpPaneFitsTheSmallestWindow` fails on.
+    ///
+    /// 64 puts the group at 95pt and the pane at 612pt, which leaves the type ramp room to move
+    /// without taking the CTA with it. It is also a size the app already draws avatars at, so the
+    /// hero does not look like a one-off.
+    static let signUpAvatarSize: CGFloat = 64
 
-    /// The camera badge in the avatar's bottom-trailing corner. 30, the same size Settings →
-    /// Profile draws it: this avatar is 8pt smaller than that page's, so a badge scaled to match
-    /// would only be heavier than the one the app already has.
-    static let signUpAvatarBadgeSize: CGFloat = 30
+    /// Between the avatar and the `Add photo` pill under it. `wn-ios-prototype` uses a bare
+    /// `.padding(.top)` — the system's 16 on a phone — and the pill here is the smaller of the
+    /// two controls, so it sits a step closer than that.
+    static let signUpAvatarToPickerSpacing: CGFloat = 10
 
     /// Between a field's label and the field itself.
     static let fieldLabelSpacing: CGFloat = 6

--- a/whitenoise-mac/Views/Onboarding/OnboardingSignUpAvatar.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingSignUpAvatar.swift
@@ -8,18 +8,21 @@
 
 import SwiftUI
 
-/// The avatar the new identity will have, as the menu of places its picture can come from.
+/// The avatar the new identity will have, over the pill that changes it.
 ///
-/// This stands where the mark stands on the other two panes — see `OnboardingScaffold`. Both the
-/// prototype and Flutter put the picture-picking affordance *on* the avatar rather than beside it
-/// (`WnAvatar(onEditTap:)`, and the prototype's menu hung off a "Change Photo" pill); the mac's
-/// own Settings → Profile page already draws the on-avatar version, so this is that control at
-/// hero size rather than a fourth way to do the same thing.
+/// This stands where the mark stands on the other two panes — see `OnboardingScaffold`.
+///
+/// **The affordance is a pill under the avatar, not a badge on it.** That is what
+/// `wn-ios-prototype`'s `SignUpView` draws: the face is inert, and a capsule beneath it reads
+/// `Add Photo` before a picture has been chosen and `Change Photo` after — the label carrying the
+/// state, which a camera glyph cannot. Drawn as the pane's own secondary tier at a smaller size;
+/// see the two modifiers on it. Settings → Profile keeps the on-avatar badge, because that
+/// page has no room under its avatar for a control and its picture is already published; this pane
+/// is asking for one.
 ///
 /// Pressing it opens `wn-ios-prototype`'s source menu rather than going straight to a window —
-/// see `ProfileImageSourceMenu`, which owns both entries and the file import behind one of them.
-/// The badge stays a camera because that is the glyph both other clients put here for "change
-/// this picture"; nothing on a Mac takes the photo.
+/// see `ProfileImageSourceMenu`, which owns both entries, the file import behind one of them, and
+/// the two appearances the two screens ask for.
 struct OnboardingSignUpAvatar: View {
     @Environment(WorkspaceState.self) private var workspace
 
@@ -27,25 +30,40 @@ struct OnboardingSignUpAvatar: View {
         workspace.isAuthenticating || workspace.isUploadingProfileImage
     }
 
-    var body: some View {
-        ProfileImageSourceMenu(destination: .signUpDraft, isEnabled: !isBusy) {
-            ZStack(alignment: .bottomTrailing) {
-                SignUpAvatarView(size: OnboardingLayout.signUpAvatarSize)
+    private var hasPhoto: Bool {
+        workspace.signUpDraft.image != nil
+    }
 
-                Image(systemName: "camera.fill")
-                    .wnFont(.semiBold12)
-                    .foregroundStyle(WNColor.fillContentQuaternary)
-                    .frame(
-                        width: OnboardingLayout.signUpAvatarBadgeSize,
-                        height: OnboardingLayout.signUpAvatarBadgeSize
-                    )
-                    .background(WNColor.overlayTertiary, in: .circle)
+    var body: some View {
+        VStack(spacing: OnboardingLayout.signUpAvatarToPickerSpacing) {
+            SignUpAvatarView(size: OnboardingLayout.signUpAvatarSize)
+
+            ProfileImageSourceMenu(
+                destination: .signUpDraft, appearance: .pushButton, isEnabled: !isBusy
+            ) {
+                Text(L10n.string(hasPhoto ? "Change photo" : "Add photo"))
+                    .wnFont(.medium12)
             }
-            .contentShape(.circle)
+            // The same tier the welcome pane's `Sign In` wears, handed over rather than named
+            // again here: this is a secondary action standing on a bare onboarding pane, which is
+            // what `OnboardingActionTier.elevated` is for. It is also what the prototype does —
+            // `WelcomeView`'s Sign In and `SignUpView`'s `Add Photo` are both
+            // `.buttonStyle(.glass)`, the same button at two sizes — where this pill was the
+            // *ringed* tier, `.wnSecondary`, so the flow offered two different-looking secondary
+            // buttons one pane apart.
+            .onboardingActionTier(.elevated)
+            // The size is the only thing that differs from the pane's own buttons, and it differs
+            // for the same reason the prototype leaves this control at its default size while its
+            // CTA is `.extraLarge`. The pane sets `.large` on the whole scaffold for its 44pt CTA,
+            // and a subordinate control at that size is a second full-height button under the hero
+            // — it would read as the thing the pane is asking for rather than as the optional step
+            // it is. `.small` draws it at 21pt against the CTA's 44, and those 10pt are also
+            // height the pane does not have; see `OnboardingLayout.signUpAvatarSize`.
+            .controlSize(.small)
+            .accessibilityIdentifier("onboarding.sign-up.photo")
         }
         // The hero is centred by a frame rather than by the scaffold, which lays its children out
         // full-width: without this the avatar sits against the pane's leading edge.
         .frame(maxWidth: .infinity)
-        .accessibilityIdentifier("onboarding.sign-up.photo")
     }
 }

--- a/whitenoise-mac/Views/Onboarding/SignUpAvatarView.swift
+++ b/whitenoise-mac/Views/Onboarding/SignUpAvatarView.swift
@@ -16,51 +16,99 @@ import SwiftUI
 /// The picture comes from bytes rather than a URL. Nothing has been uploaded yet and nothing can
 /// be until there is an account to sign the upload, so `localImagePayload` is the only way in;
 /// see `SignUpDraft`.
+///
+/// **Why this draws its own disc rather than reaching for `ProfileImageAvatarView`.** Every other
+/// avatar in the app identifies a *person*, and `AvatarPalette` is what tells two of them apart:
+/// twelve accent ramps keyed on an account id. A draft has no account id, so the seed was a
+/// constant — one arbitrary accent, picked for an identity that is not yet anybody. Worse, the
+/// ramp's light step is `50`, a pale wash, which is what made the pane's subject the faintest
+/// thing on it.
+///
+/// `wn-ios-prototype`'s `ProfileEditorAvatarView` fills the same disc with `AccentColor`, and that
+/// colorset is black in light and white in dark — the inversion this palette calls `fillPrimary`,
+/// with `fillContentPrimary` for the letters on top of it. Same pairing, both appearances, and no
+/// accent at all: this circle says "you", not "which of twelve people you are".
+///
+/// **One ground, whatever is on it.** The empty first frame used to take the *other* half of the
+/// palette — `fillSecondary` under `fillContentSecondary`, the prototype's `.secondarySystemFill`
+/// — on the reasoning that a filled disc announces an identity that does not exist yet. It read as
+/// the inversion running backwards: in light the pane opened with a near-white circle carrying a
+/// dark glyph, and then went dark-with-light-letters the moment a name was typed into the field
+/// below it. The prototype does not make that switch either — `SignUpView` passes no
+/// `emptySystemImage`, so its disc is `AccentColor` from the first frame — and the switch is what
+/// the hero is judged by, since the empty frame is the one every new account sees.
 struct SignUpAvatarView: View {
     @Environment(WorkspaceState.self) private var workspace
     let size: CGFloat
 
     /// The first frame: no photo and no name.
     ///
-    /// Worth a branch of its own because `AvatarView` derives initials from the name and falls
-    /// back to the *palette seed* when the name is blank — and this seed is a constant, so an
-    /// untouched pane drew the two letters of `SignUpDraft.avatarPaletteSeed`. Initials of nothing
-    /// are not initials. `wn-ios-prototype`'s `ProfileEditorAvatarView` carries the same branch
-    /// for the same reason: `emptySystemImage`, shown only while the image and the name are both
-    /// empty.
+    /// Worth a branch of its own because initials of nothing are not initials. It picks *what* is
+    /// drawn on the disc and no longer what the disc is — see the note on the ground above.
     private var hasNothingToShow: Bool {
         workspace.signUpDraft.image == nil && workspace.signUpDraft.trimmedDisplayName.isEmpty
     }
 
     var body: some View {
-        if hasNothingToShow {
-            Image(systemName: "person.fill")
-                .wnFont(.custom(size: size * Self.glyphScale, weight: .medium))
-                // The glyph sits on `fillSecondary`, so it takes that family's content token
-                // rather than the ambient `backgroundContentPrimary`. See the pairing rule in
-                // `WNNSColor`.
-                .foregroundStyle(WNColor.fillContentSecondary)
-                .frame(width: size, height: size)
-                // `fillSecondary`, the ground the fields under it stand on, and the palette's
-                // reading of the prototype's `.secondarySystemFill`. Deliberately not one of the
-                // twelve accent sets: those identify a person, and this is the absence of one.
-                .background(WNColor.fillSecondary, in: .circle)
-                .modifier(AvatarChromeModifier(isSelected: false))
+        face
+            .frame(width: size, height: size)
+            .clipShape(.circle)
+            .modifier(AvatarChromeModifier(isSelected: false))
+    }
+
+    @ViewBuilder
+    private var face: some View {
+        if let payload = workspace.signUpDraft.image?.preview {
+            // Drawn here rather than through `ProfileImageAvatarView` so the placeholder shown
+            // while the bytes decode is *this* view's disc. That wrapper's placeholder is
+            // `AvatarView`, so routing the photo case through it would flash the palette accent
+            // this file exists to not draw.
+            DownsampledDataImage(payload: payload, maxPixelSize: size * 2) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                disc
+            }
         } else {
-            ProfileImageAvatarView(
-                seed: SignUpDraft.avatarPaletteSeed,
-                initials: workspace.signUpDraft.displayName,
-                sanitizedPictureURL: nil,
-                localImagePayload: workspace.signUpDraft.image?.preview,
-                isOwnAccountImage: true,
-                size: size,
-                isSelected: false
-            )
+            disc
         }
     }
 
-    /// How much of the circle the glyph fills. `AvatarView` sets its monogram at `0.34`; a
-    /// person symbol reads smaller than two capitals at the same point size, so it takes a little
-    /// more.
+    /// The photo-less disc: one ground, and whichever mark the draft has to put on it.
+    ///
+    /// The ground and the ink are named once, outside the branch, because they are the pairing —
+    /// `fillPrimary` carrying `fillContentPrimary`, which is white on `neutral950` in light and
+    /// `neutral950` on white in dark. Splitting them across the branch is how the empty frame
+    /// came to draw the pairing the other way round. See the pairing rule in `WNNSColor`.
+    private var disc: some View {
+        mark
+            .foregroundStyle(WNColor.fillContentPrimary)
+            .frame(width: size, height: size)
+            // Deliberately not one of the twelve accent sets: those identify a person, and this is
+            // an identity that is not anybody yet.
+            .background(WNColor.fillPrimary, in: .circle)
+    }
+
+    /// What the disc carries: the draft's initials, or — with no name to take them from — a person.
+    @ViewBuilder
+    private var mark: some View {
+        if hasNothingToShow {
+            Image(systemName: "person.fill")
+                .wnFont(.custom(size: size * Self.glyphScale, weight: .medium))
+        } else {
+            Text(DisplayText.initials(for: workspace.signUpDraft.displayName, fallback: ""))
+                // `AvatarView`'s monogram ratio, so the draft's letters are the size every other
+                // avatar in the app draws them at.
+                .wnFont(.custom(size: size * Self.monogramScale, weight: .bold))
+        }
+    }
+
+    /// How much of the circle the glyph fills. `AvatarView` sets its monogram at `monogramScale`;
+    /// a person symbol reads smaller than two capitals at the same point size, so it takes a
+    /// little more.
     private static let glyphScale: CGFloat = 0.4
+
+    /// `AvatarView`'s monogram ratio, restated because that one is a literal inside its body.
+    private static let monogramScale: CGFloat = 0.34
 }

--- a/whitenoise-mac/Views/Settings/ProfileImageSourceMenu.swift
+++ b/whitenoise-mac/Views/Settings/ProfileImageSourceMenu.swift
@@ -31,9 +31,35 @@ import UniformTypeIdentifiers
 /// the file path skips `presentProfileImagePicker(destination:)` and has to say where the bytes
 /// land some other way.
 struct ProfileImageSourceMenu<Label: View>: View {
+    /// How the control that opens the source list is drawn.
+    ///
+    /// Two, because the two screens that pick a profile picture ask for the affordance in two
+    /// different shapes and both shapes come from the same place. Settings → Profile hangs it off
+    /// the avatar — the label *is* the picture, so the control has no chrome of its own and
+    /// borrows its name from `help`. The sign-up pane puts a pill under the avatar, which is what
+    /// `wn-ios-prototype`'s `SignUpView` does: its menu hangs off a `Text("Add Photo")` /
+    /// `Text("Change Photo")` button rather than off the face above it.
+    enum Appearance {
+        /// The label draws itself; this adds nothing but a hit area. Settings → Profile.
+        case avatar
+        /// A push button whose label is its own words, wearing whichever tier the screen around it
+        /// asked for. The sign-up hero.
+        ///
+        /// **This case names no style on purpose.** It used to reach for `.wnSecondary` — the
+        /// ringed tier — while the pane it stands on draws its own secondary action, `Sign In`,
+        /// with the *raised* one. Two secondary buttons on one flow, one ringed and one lifted,
+        /// which is the inconsistency; and naming the right style here would be a second copy of a
+        /// decision `OnboardingActionTier` already owns. Leaving the style out lets the caller hand
+        /// it over — `OnboardingSignUpAvatar` does, with `.onboardingActionTier(.elevated)` — so
+        /// the pill and the pane's buttons cannot drift apart again. The capsule comes from
+        /// `wnButtonShape` in the environment, which the pane sets for all of them at once.
+        case pushButton
+    }
+
     @Environment(WorkspaceState.self) private var workspace
 
     let destination: WorkspaceState.ProfileImagePickerDestination
+    var appearance: Appearance = .avatar
     var isEnabled = true
     @ViewBuilder var label: () -> Label
 
@@ -41,30 +67,50 @@ struct ProfileImageSourceMenu<Label: View>: View {
     @State private var isFileImporterPresented = false
 
     var body: some View {
+        control
+            .disabled(!isEnabled)
+            .popover(isPresented: $isSourceListPresented, arrowEdge: .bottom) {
+                ProfileImageSourceList(chooseFile: chooseFile, findOnWeb: showWebPicker)
+            }
+            .fileImporter(
+                isPresented: $isFileImporterPresented,
+                allowedContentTypes: [.image],
+                allowsMultipleSelection: false
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    guard let url = urls.first else { return }
+                    Task { await workspace.setProfileImage(fileURL: url) }
+                case .failure(let error):
+                    workspace.reportUserActionError(error.localizedDescription)
+                }
+            }
+    }
+
+    /// The button, wearing whichever of the two appearances was asked for.
+    ///
+    /// The push button needs no `help` and no `accessibilityLabel`: its label already says what
+    /// pressing it does, and adding either would only repeat that word for word — once as a
+    /// tooltip over a button that is already legible, and once as a VoiceOver name that overrides
+    /// the one the title supplies. It takes no `buttonStyle` either; see `Appearance.pushButton`.
+    @ViewBuilder
+    private var control: some View {
+        switch appearance {
+        case .avatar:
+            button
+                .buttonStyle(.plain)
+                .help(L10n.string("Change profile image"))
+                .accessibilityLabel(L10n.string("Change profile image"))
+        case .pushButton:
+            button
+        }
+    }
+
+    private var button: some View {
         Button {
             isSourceListPresented = true
         } label: {
             label()
-        }
-        .buttonStyle(.plain)
-        .disabled(!isEnabled)
-        .help(L10n.string("Change profile image"))
-        .accessibilityLabel(L10n.string("Change profile image"))
-        .popover(isPresented: $isSourceListPresented, arrowEdge: .bottom) {
-            ProfileImageSourceList(chooseFile: chooseFile, findOnWeb: showWebPicker)
-        }
-        .fileImporter(
-            isPresented: $isFileImporterPresented,
-            allowedContentTypes: [.image],
-            allowsMultipleSelection: false
-        ) { result in
-            switch result {
-            case .success(let urls):
-                guard let url = urls.first else { return }
-                Task { await workspace.setProfileImage(fileURL: url) }
-            case .failure(let error):
-                workspace.reportUserActionError(error.localizedDescription)
-            }
         }
     }
 

--- a/whitenoise-macTests/OnboardingTests.swift
+++ b/whitenoise-macTests/OnboardingTests.swift
@@ -198,8 +198,18 @@ import Testing
 
         // The shadow: pixels in the pane's margin, outside the button's fill, that are darker than
         // the bare pane. The ringed tier casts none, so its margin is flat.
-        let paneLuminance = try #require(
-            NSColor(WNColor.backgroundPrimary).usingColorSpace(.sRGB)?.brightnessComponent)
+        // Resolved *inside* `.aqua`, because that is the appearance `edgeScanline` rasterizes in
+        // and `NSColor(SwiftUI.Color)` resolves a dynamic token against whatever appearance is
+        // current when it is called — the **system's**, here, since nothing else has set one. Read
+        // bare, this comparison silently swaps in `backgroundPrimary`'s dark value (~0.04) and asks
+        // a light render to find a pixel darker than that, which nothing on it can be. It fails
+        // only on a Mac whose appearance is dark at the moment the suite runs, which on the default
+        // "Auto" setting means it fails after sunset and passes in the morning.
+        var paneColor: NSColor?
+        NSAppearance(named: .aqua)?.performAsCurrentDrawingAppearance {
+            paneColor = NSColor(WNColor.backgroundPrimary).usingColorSpace(.sRGB)
+        }
+        let paneLuminance = try #require(paneColor?.brightnessComponent)
         #expect(
             elevated.contains(where: { $0 < paneLuminance - 0.02 && $0 > 0.75 }),
             "the elevated tier cast no shadow")
@@ -253,6 +263,260 @@ import Testing
         #expect(LoginIdentityDraft("nsec1" + String(repeating: "q", count: 58)).showsLastAttemptError == false)
         #expect(LoginIdentityDraft("npub1" + String(repeating: "q", count: 58)).showsLastAttemptError == false)
         #expect(LoginIdentityDraft("hello").showsLastAttemptError == false)
+    }
+
+    // MARK: - The sign-up hero
+
+    /// The draft's face is the *inverted* disc, in both appearances.
+    ///
+    /// This one is invisible in exactly one appearance, which is how it shipped: the draft used to
+    /// be drawn through `AvatarPalette`, and that ramp's light step is `50` — a pale wash that read
+    /// as an empty placeholder rather than as the subject of the pane, while the dark step (`950`)
+    /// looked perfectly deliberate. `wn-ios-prototype`'s `ProfileEditorAvatarView` fills the same
+    /// disc with `AccentColor`, black on light and white on dark, which is `fillPrimary` here.
+    ///
+    /// Sampled off-centre so the probe reads the ground rather than the initials sitting on it, and
+    /// asserted against the ramp step rather than against "is it dark", because the failure this
+    /// guards against is a *different* token that happens to be dark in one appearance.
+    ///
+    /// Both of the disc's states are asserted, and the empty one is the half that shipped wrong:
+    /// it used to take `fillSecondary` — the prototype's `.secondarySystemFill` — so in light the
+    /// pane opened on a near-white circle and turned black the moment a name was typed under it.
+    /// The prototype's `SignUpView` passes no `emptySystemImage`, so its disc is `AccentColor`
+    /// from the first frame; this is that.
+    @Test(arguments: [
+        (NSAppearance.Name.aqua, WNColorRamp.neutral950),
+        (NSAppearance.Name.darkAqua, WNColorRamp.white),
+    ])
+    func theSignUpAvatarIsTheInvertedDisc(appearance: NSAppearance.Name, expected: NSColor) throws {
+        let named = Self.signUpWorkspace()
+        // One word, so `DisplayText.initials` yields a single letter and the probe band below
+        // stays clear of it.
+        named.signUpDraft.displayName = "Pepi"
+
+        try Self.expectDiscGround(
+            of: named,
+            appearance: appearance,
+            is: expected,
+            "the sign-up avatar's ground is not `fillPrimary`")
+
+        try Self.expectDiscGround(
+            of: Self.signUpWorkspace(),
+            appearance: appearance,
+            is: expected,
+            "the *empty* sign-up avatar's ground is not `fillPrimary`")
+    }
+
+    /// And what is *on* the ground runs the other way: light content on a dark disc in light mode,
+    /// dark content on a light one in dark mode.
+    ///
+    /// The inversion is the whole point of the pairing, and it is the half a token swap breaks
+    /// without breaking the other: `fillSecondary` under `fillContentSecondary` is a perfectly
+    /// self-consistent pair that happens to run in the opposite direction, which is what the empty
+    /// frame used to draw. Asserted as a *direction* rather than against two ramp steps, so the
+    /// glyph's antialiasing and `ImageRenderer`'s own colour shifts cannot decide the outcome — a
+    /// pair that inverts clears half a luminance unit; a pair that does not cannot.
+    @Test(arguments: [NSAppearance.Name.aqua, .darkAqua])
+    func theSignUpAvatarsMarkInvertsItsGround(appearance: NSAppearance.Name) throws {
+        // Both marks the disc can carry: the person glyph of the empty first frame, and the
+        // initials that replace it.
+        let named = Self.signUpWorkspace()
+        named.signUpDraft.displayName = "Pepi"
+
+        for (workspace, mark) in [(Self.signUpWorkspace(), "person glyph"), (named, "initials")] {
+            let (ground, ink) = try Self.discGroundAndMarkLuminance(of: workspace, appearance: appearance)
+            // In light the ground is `neutral950` (~0.04) under white ink; in dark it is white
+            // under `neutral950`. Either way the two are nearly a full unit apart, so half a unit
+            // is a threshold no same-direction pair can reach.
+            let inverts = appearance == .aqua ? ink - ground > 0.5 : ground - ink > 0.5
+            #expect(
+                inverts,
+                "the \(mark) is \(ink) on a \(ground) ground in \(appearance.rawValue) — no inversion")
+        }
+    }
+
+    /// The picture-picking affordance is a control *under* the avatar, not a badge on it.
+    ///
+    /// `wn-ios-prototype`'s `SignUpView` hangs its source menu off an `Add Photo` / `Change Photo`
+    /// pill and leaves the face inert; the badge this replaced sat inside the avatar's own frame,
+    /// so the hero was exactly `signUpAvatarSize` tall. Measuring the hero is what tells the two
+    /// apart: a regression to an overlaid badge cannot make the group taller than the avatar.
+    @Test func theSignUpHeroCarriesAPillUnderTheAvatar() throws {
+        let hero = OnboardingSignUpAvatar()
+            .environment(Self.signUpWorkspace())
+            .frame(width: OnboardingLayout.contentWidth)
+
+        let height = try #require(ImageRenderer(content: hero).nsImage?.size.height)
+        let floor = OnboardingLayout.signUpAvatarSize + OnboardingLayout.signUpAvatarToPickerSpacing
+        #expect(
+            height > floor,
+            "the hero is \(height)pt — nothing is drawn below the \(OnboardingLayout.signUpAvatarSize)pt avatar")
+    }
+
+    /// The pill's two labels have to be two different strings in every language, since the whole
+    /// reason it is a label rather than a camera glyph is that it carries the state.
+    @Test func thePickerPillSaysWhetherThereIsAlreadyAPhoto() {
+        #expect(L10n.string("Add photo") != L10n.string("Change photo"))
+    }
+
+    /// And it is the *pane's* secondary tier — the raised one `Sign In` wears — not the ringed
+    /// secondary the rest of the app uses inside its own chrome.
+    ///
+    /// The two tiers differ by exactly one thing, an outline (see
+    /// `theElevatedTierIsShadowedAndTheRingedTierIsNot`), so the ring is what tells them apart
+    /// here too. A ringed copy of the same control stands in as the positive control: without it a
+    /// probe that merely finds no outline would pass just as happily against a pill that drew
+    /// nothing, or against a row the probe was reading in the wrong place.
+    ///
+    /// This is the regression that cannot be seen by looking at the pane on its own — a ringed
+    /// pill under the avatar looks perfectly deliberate until it is put next to the `Sign In`
+    /// button one pane back.
+    @Test func thePhotoPillWearsThePanesElevatedTier() throws {
+        let hero = try Self.pickerEdgeColumns(of: OnboardingSignUpAvatar())
+        let ringed = try Self.pickerEdgeColumns(of: Self.ringedPickerStandIn)
+
+        // `borderSecondary` is `neutral500`, ~0.45, against either tier's resting ground at ~0.96
+        // and up. The same 0.75 the tier test uses.
+        #expect(
+            ringed.contains(where: { $0 < 0.75 }),
+            "the ringed stand-in drew no outline — this probe can no longer tell the two apart")
+        #expect(
+            !hero.contains(where: { $0 < 0.75 }),
+            "the sign-up hero's photo control is ringed, so it is not the pane's elevated tier")
+    }
+
+    /// The hero's picker, drawn as the *ringed* tier and nothing else changed.
+    ///
+    /// A deliberate copy of `OnboardingSignUpAvatar`'s stack rather than the view itself, because
+    /// the view now hands its own tier over from the inside and an outer `.buttonStyle` cannot
+    /// reach past that — which is the property being relied on. Geometry has to match the real one
+    /// point for point, since the probe finds the control by walking a row of the render.
+    private static var ringedPickerStandIn: some View {
+        VStack(spacing: OnboardingLayout.signUpAvatarToPickerSpacing) {
+            SignUpAvatarView(size: OnboardingLayout.signUpAvatarSize)
+
+            ProfileImageSourceMenu(
+                destination: .signUpDraft, appearance: .pushButton, isEnabled: true
+            ) {
+                Text(L10n.string("Add photo"))
+                    .wnFont(.medium12)
+            }
+            .buttonStyle(.wnSecondary)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// The luminance of the avatar's ground, and of the pixel on it that is furthest from it.
+    ///
+    /// The second number is the mark — the initials or the person glyph — found rather than
+    /// sampled at a fixed point, because neither one fills a predictable pixel: a `P` is mostly
+    /// counter and the glyph's shoulders are antialiased. Searching the middle of the disc for the
+    /// pixel that departs furthest from the ground is what a reader's eye does with it, and it
+    /// cannot be fooled by a mark that happens to miss the centre.
+    ///
+    /// The search box is the middle 40% of the frame, which is inside the disc on every row and
+    /// well clear of `AvatarChromeModifier`'s ring.
+    private static func discGroundAndMarkLuminance(
+        of workspace: WorkspaceState,
+        appearance: NSAppearance.Name
+    ) throws -> (ground: CGFloat, mark: CGFloat) {
+        let rep = try rasterize(appearance: appearance) {
+            SignUpAvatarView(size: OnboardingLayout.signUpAvatarSize)
+                .environment(workspace)
+        }
+
+        // The same band `expectDiscGround` reads: on the centre row the disc spans the full width,
+        // and 18% in is past the ring and short of either mark.
+        let ground = try #require(
+            rep.colorAt(x: rep.pixelsWide * 18 / 100, y: rep.pixelsHigh / 2)?.usingColorSpace(.sRGB)
+        ).brightnessComponent
+
+        var mark = ground
+        for y in stride(from: rep.pixelsHigh * 30 / 100, to: rep.pixelsHigh * 70 / 100, by: 1) {
+            for x in stride(from: rep.pixelsWide * 30 / 100, to: rep.pixelsWide * 70 / 100, by: 1) {
+                guard let pixel = rep.colorAt(x: x, y: y)?.usingColorSpace(.sRGB) else { continue }
+                if abs(pixel.brightnessComponent - ground) > abs(mark - ground) {
+                    mark = pixel.brightnessComponent
+                }
+            }
+        }
+
+        return (ground, mark)
+    }
+
+    /// Luminances of the six columns at the left edge of the control under the sign-up avatar.
+    ///
+    /// The edge is *found* rather than computed: the control hugs its own label, so where it starts
+    /// depends on which of the two words is in it and on the language the suite is running in. The
+    /// probe walks in from the pane's margin along the control's centre row and stops at the first
+    /// pixel that is not the pane, then reads 3pt inward from there — far enough to be inside the
+    /// ground whichever tier is drawing it, and nowhere near the label's own ink, which starts a
+    /// further 10pt in at `.small`.
+    ///
+    /// The pane's colour is read off the render rather than resolved from the token, so a shift
+    /// `ImageRenderer` applies to the background applies to the comparison too.
+    private static func pickerEdgeColumns<Hero: View>(of hero: Hero) throws -> [CGFloat] {
+        let rep = try rasterize(appearance: .aqua) {
+            hero
+                .environment(signUpWorkspace())
+                .frame(width: OnboardingLayout.contentWidth)
+                .padding(.horizontal, 20)
+                // What the pane it stands on sets, since the shape decides where the edge is.
+                .wnButtonShape(.capsule)
+                .background(WNColor.backgroundPrimary)
+        }
+
+        // The control is the lowest thing in the hero and draws about 21pt tall at `.small`, so
+        // 10pt up from the bottom edge is its vertical centre — the one row where a capsule's edge
+        // is a straight column of pixels rather than an antialiased curve.
+        let row = rep.pixelsHigh - Int(10 * renderScale)
+        let paneLuminance = try #require(rep.colorAt(x: 0, y: row)?.usingColorSpace(.sRGB))
+            .brightnessComponent
+
+        for x in 0..<(rep.pixelsWide - 6) {
+            let pixel = try #require(rep.colorAt(x: x, y: row)?.usingColorSpace(.sRGB))
+            guard abs(pixel.brightnessComponent - paneLuminance) > 0.02 else { continue }
+            return try (x..<(x + 6)).map {
+                try #require(rep.colorAt(x: $0, y: row)?.usingColorSpace(.sRGB)).brightnessComponent
+            }
+        }
+
+        Issue.record("the picker control drew no edge on the row the probe reads")
+        return []
+    }
+
+    /// Rasterize `SignUpAvatarView` for `workspace` and assert its ground is `expected`.
+    ///
+    /// The probe walks a band along the vertical centre between 12% and 25% of the width. Every
+    /// point of it is inside the circle — on the centre row the disc spans the full width, so the
+    /// only thing near the edge there is the chrome's 1pt ring — and the band stops short of both
+    /// glyphs the disc can carry: at `signUpAvatarSize` the initial starts around 40% of the width
+    /// and `person.fill`, the wider of the two, around 30%.
+    private static func expectDiscGround(
+        of workspace: WorkspaceState,
+        appearance: NSAppearance.Name,
+        is expected: NSColor,
+        _ message: @autoclosure () -> String
+    ) throws {
+        let rep = try rasterize(appearance: appearance) {
+            SignUpAvatarView(size: OnboardingLayout.signUpAvatarSize)
+                .environment(workspace)
+        }
+
+        let target = try #require(expected.usingColorSpace(.sRGB))
+        let row = rep.pixelsHigh / 2
+        var sampled = 0
+
+        for x in stride(from: rep.pixelsWide * 12 / 100, to: rep.pixelsWide * 25 / 100, by: 2) {
+            let pixel = try #require(rep.colorAt(x: x, y: row)?.usingColorSpace(.sRGB))
+            sampled += 1
+            #expect(
+                channelDistance(pixel, target) < 0.04,
+                "\(message()) — pixel at (\(x), \(row)) is \(pixel)")
+        }
+
+        #expect(sampled > 0, "the avatar drew nothing")
     }
 
     // MARK: - The sign-up pane fits the window it has to fit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized “Add photo” and “Change photo” labels in multiple languages.
  - Added a dedicated photo picker button beneath the onboarding avatar.
  - The picker is disabled while authentication or image upload is in progress.

- **Improvements**
  - Reduced the onboarding avatar size and refined spacing and styling.
  - Improved avatar placeholders, initials, colors, and contrast.
  - Added consistent photo-selection behavior across avatar and button appearances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->