### PR TITLE
Withhold group state notices from hidden notification previews

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState+Notifications.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Notifications.swift
@@ -341,17 +341,24 @@ extension WorkspaceState {
     }
 
     /// Title and body for a group-state notice. The notice itself is the body — it is the
-    /// only content such an update carries — and the group it happened in is the title,
-    /// except under `.hidden`, which withholds the group name the way it withholds a
-    /// sender's name everywhere else. An unknown group (the core reports no name) degrades
-    /// to the same generic title rather than inventing a placeholder.
+    /// only content such an update carries — and the group it happened in is the title. An
+    /// unknown group (the core reports no name) degrades to the generic title rather than
+    /// inventing a placeholder.
+    ///
+    /// `.hidden` withholds the notice as well as the group name: unlike a `.groupInvite`,
+    /// which only names a category, "You were made an admin" would put this account's
+    /// membership and admin status on the lock screen by itself. So a hidden group-state
+    /// banner reads exactly like a withheld message — which is all Settings promises hidden
+    /// previews will ever say.
     func groupStateNotificationText(
         notice: String,
         groupName: String?,
         previewMode: NotificationPreviewMode
     ) -> (title: String, body: String) {
-        let namedTitle = previewMode == .hidden ? nil : groupName
-        return (namedTitle ?? L10n.string("White Noise"), notice)
+        guard previewMode != .hidden else {
+            return (L10n.string("White Noise"), L10n.string("New message"))
+        }
+        return (groupName ?? L10n.string("White Noise"), notice)
     }
 
     func localNotificationUserInfo(for update: NotificationUpdateFfi) -> [String: String] {

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -33026,10 +33026,12 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func hiddenPreviewModeWithholdsTheGroupFromGroupStateNotifications() async throws {
-        // Hidden mode already drops the sender and the group from a message banner; a
-        // group-state notice must lose the group name the same way, keeping only the
-        // category the way `.groupInvite` keeps "New group invite".
+    @Test func hiddenPreviewModeWithholdsTheGroupStateNoticeItself() async throws {
+        // Hidden mode drops the sender and the group from a message banner, and a group-state
+        // notice has to lose more than the group name: "You were made an admin" on a lock screen
+        // discloses membership and admin status on its own. Settings promises hidden previews
+        // "only say a new message arrived", so these read exactly like a withheld message —
+        // the same generic body, with nothing of the event left in it.
         let previousMode = UserDefaults.standard.object(forKey: "whitenoise.mac.notificationPreviewMode")
         defer { restoreDefault(previousMode, forKey: "whitenoise.mac.notificationPreviewMode") }
 
@@ -33039,18 +33041,26 @@ struct whitenoise_macTests {
         await state.bootstrap()
         state.notificationPreviewMode = .hidden
 
-        for trigger in [NotificationTriggerFfi.removedFromGroup, .madeAdmin, .removedAsAdmin] {
+        let notices: [(trigger: NotificationTriggerFfi, notice: String)] = [
+            (.removedFromGroup, L10n.string("You were removed from this group")),
+            (.madeAdmin, L10n.string("You were made an admin")),
+            (.removedAsAdmin, L10n.string("You are no longer an admin")),
+        ]
+
+        for notice in notices {
             let request = state.localNotificationRequest(
                 for: notificationUpdate(
                     account: account,
-                    notificationKey: "hidden-group-state-\(trigger)",
+                    notificationKey: "hidden-group-state-\(notice.trigger)",
                     groupIdHex: "team-group",
                     senderName: "Alice",
                     isDm: false,
                     groupName: "Engineering",
-                    trigger: trigger
+                    trigger: notice.trigger
                 ))
             #expect(request.title == L10n.string("White Noise"))
+            #expect(request.body == L10n.string("New message"))
+            #expect(request.body != notice.notice)
             #expect(!request.body.contains("Engineering"))
             #expect(!request.body.contains("Alice"))
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification privacy when previews are hidden.
  * Group names and group-state details are now replaced with generic “White Noise” and “New message” text.
  * Applied consistently to membership and administrator status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->