### PR TITLE
Adjust style of profile is public warning in signup form

### DIFF
--- a/whitenoise-mac/Views/Onboarding/OnboardingLayout.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingLayout.swift
@@ -47,6 +47,24 @@ enum OnboardingLayout {
     /// pad against, so the pane names them.
     static let edgePadding: CGFloat = 40
 
+    /// The sign-up pane's floor for the same three margins, which is lower because that pane is
+    /// the one with a form in it.
+    ///
+    /// The scaffold spends `3 × edgePadding` — 120pt — on air: above the hero, below it, and
+    /// under the actions. On the welcome and sign-in panes that is most of what is on the screen
+    /// and it should stay generous. The sign-up pane has an avatar, a public-profile callout, two
+    /// labelled fields, a reserved error line and a button, and at a 620pt window it does not fit
+    /// with 120pt of margin. Something has to give, and a margin is the only thing here that can:
+    /// every other candidate is content — a shorter About field, a one-line error slot, a folded
+    /// callout — and shrinking content to make room for a window edge is the wrong way round.
+    ///
+    /// This is a **floor**, not a fixed inset, so it only bites at the smallest window. The
+    /// scaffold's `Spacer`s take back every point of spare height the moment the window has any,
+    /// which on a default-sized window is well past `edgePadding` again — so the pane a person
+    /// normally sees is unchanged, and the pane at the size a person can drag it to keeps its
+    /// button on screen.
+    static let signUpEdgePadding: CGFloat = 16
+
     /// The most air there is between the mark and the column of actions under it.
     ///
     /// A ceiling rather than a fixed gap, because the pane still wants to breathe on a short

--- a/whitenoise-mac/Views/Onboarding/OnboardingScaffold.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingScaffold.swift
@@ -49,6 +49,11 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
     /// not, which removes the control while keeping the row it stood in. See
     /// `OnboardingExitControl`.
     var exit: OnboardingExitControl?
+    /// The floor under each of the pane's three margins — above the hero, below it, and under the
+    /// actions. Defaults to `OnboardingLayout.edgePadding`; the sign-up pane passes its own, which
+    /// is what lets the tallest pane keep its button on screen in the shortest window. See
+    /// `OnboardingLayout.signUpEdgePadding`.
+    var minimumEdgeSpacing: CGFloat = OnboardingLayout.edgePadding
     /// What the pane is arranged around. Defaults to the mark.
     @ViewBuilder var hero: Hero
     /// Whatever sits between the hero and the actions — the sign-in pane's key field, the sign-up
@@ -61,14 +66,14 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
         VStack(spacing: 0) {
             OnboardingHeaderRow(title: title, exit: exit)
 
-            Spacer(minLength: OnboardingLayout.edgePadding)
+            Spacer(minLength: minimumEdgeSpacing)
 
             hero
 
             // Capped, unlike the `Spacer` above the hero, so the pane's spare height collects at
             // the top instead of being split evenly across the hero. See
             // `OnboardingLayout.markToActionsMaximumSpacing`.
-            Spacer(minLength: OnboardingLayout.edgePadding)
+            Spacer(minLength: minimumEdgeSpacing)
                 .frame(maxHeight: OnboardingLayout.markToActionsMaximumSpacing)
 
             VStack(spacing: OnboardingLayout.contentToActionsSpacing) {
@@ -83,9 +88,9 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
             // Flexible, and the twin of the `Spacer` above the hero rather than a fixed inset.
             // A fixed one made every point of spare height land *above* the hero, so a tall
             // window pushed the whole group onto the bottom edge; two flexible ends split it and
-            // the group sits centred with real air under the buttons. `edgePadding` is the floor,
-            // for the short window where there is nothing to split.
-            Spacer(minLength: OnboardingLayout.edgePadding)
+            // the group sits centred with real air under the buttons. `minimumEdgeSpacing`
+            // is the floor, for the short window where there is nothing to split.
+            Spacer(minLength: minimumEdgeSpacing)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background {

--- a/whitenoise-mac/Views/Onboarding/OnboardingSignUpView.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingSignUpView.swift
@@ -27,9 +27,11 @@ import SwiftUI
 ///   Openverse search — rather than the prototype's Photos/Files/Web menu, which is a phone's
 ///   three sources. It is the same sheet Settings → Profile opens, pointed at the draft instead
 ///   of at an account; see `WorkspaceState.ProfileImagePickerDestination`.
-/// * **The privacy line is a hover, not a callout.** Flutter puts a tap-to-expand `WnCallout`
-///   here. A collapsible box costs this pane 60pt of a 620pt window, and a pointer has a cheaper
-///   way to ask: the headline stays, the sentence behind it is the tooltip.
+/// * **The privacy callout is quiet, and it does not fold.** Flutter puts a tap-to-expand
+///   `WnCallout` here. This pane draws the same box Settings → Profile draws, with the same two
+///   strings, in the neutral gray rather than the info tint — see `OnboardingPublicProfileNote`.
+///   The height that buys comes out of the pane's own margins, not out of the form; see
+///   `OnboardingLayout.signUpEdgePadding`.
 ///
 /// The one thing kept exactly is the bar for submitting — a non-blank name, which is Flutter's
 /// `hasName` on `signup_create_profile_button`. Nothing else is required, and nothing is created
@@ -48,7 +50,11 @@ struct OnboardingSignUpView: View {
     var body: some View {
         @Bindable var workspace = workspace
 
-        OnboardingScaffold(title: L10n.string("Set up profile"), exit: .back(cancel)) {
+        OnboardingScaffold(
+            title: L10n.string("Set up profile"),
+            exit: .back(cancel),
+            minimumEdgeSpacing: OnboardingLayout.signUpEdgePadding
+        ) {
             OnboardingSignUpAvatar()
         } content: {
             VStack(alignment: .leading, spacing: OnboardingLayout.titleToFieldsSpacing) {
@@ -106,27 +112,30 @@ struct OnboardingSignUpView: View {
 
 /// The one thing this pane has to say about publishing, above the fields it publishes.
 ///
-/// Both strings are already in the catalog, from the `profileIsPublic` callout Settings → Profile
-/// draws in full: the headline, and the sentence explaining it. Flutter puts the same pair here as
-/// a tap-to-expand `WnCallout`; a collapsible box costs this pane 60pt of a 620pt window, and a
-/// pointer has a cheaper way to ask for the sentence. So the headline stays on the pane and the
-/// sentence is the tooltip — with the same text as the accessibility hint, since a tooltip is
-/// exactly the disclosure VoiceOver cannot hover for.
-private struct OnboardingPublicProfileNote: View {
-    private static let detail = L10n.string(
-        "Name, photo, and bio are visible on the global Nostr network. Use what you're comfortable sharing."
-    )
-
+/// The same `WNCallout` Settings → Profile draws over the same form, with the same two catalog
+/// strings — a reader who sets a name here and edits it there should not have to work out twice
+/// that they are the same warning about the same thing.
+///
+/// What differs is the volume, not the shape: `.quiet` rather than `.info`, so the box keeps the
+/// glyph and the two-tier title and detail but takes the neutral surface and the gray this line
+/// was already drawn in. A tinted box would be the loudest thing on a pane whose loudest thing
+/// has to be Create profile. Flutter puts the same pair here as a tap-to-expand `WnCallout`; the
+/// detail is short enough to simply show, and a disclosure arrow only teaches the reader to leave
+/// it closed.
+///
+/// Internal rather than `private` so `OnboardingTests` can sample the ground it actually draws
+/// on, instead of asserting against a `WNCallout` it built itself — which would go on passing
+/// with this pane wearing the info tint.
+struct OnboardingPublicProfileNote: View {
     var body: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "info.circle")
-            Text(L10n.string("Your profile is public"))
-        }
-        .wnFont(.medium12)
-        .foregroundStyle(WNColor.backgroundContentSecondary)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .help(Self.detail)
+        WNCallout(
+            title: L10n.string("Your profile is public"),
+            message: L10n.string(
+                "Name, photo, and bio are visible on the global Nostr network. Use what you're comfortable sharing."
+            ),
+            intent: .info,
+            emphasis: .quiet
+        )
         .accessibilityElement(children: .combine)
-        .accessibilityHint(Self.detail)
     }
 }

--- a/whitenoise-mac/Views/WNCallout.swift
+++ b/whitenoise-mac/Views/WNCallout.swift
@@ -67,6 +67,45 @@ enum WNCalloutIntent {
     }
 }
 
+/// How loudly a callout says it.
+///
+/// `tinted` is the default, and what Settings draws: the intent's hue, on the intent's tinted
+/// background. `quiet` keeps everything else the callout is — the glyph, the two-tier title and
+/// detail, the box — and drops the hue for the neutral surface and the supporting gray.
+///
+/// It exists for a surface that cannot spend color on a standing notice. The sign-up pane is one:
+/// it is a form with a single primary button on it, and a tinted box above the fields would be
+/// the loudest thing on a pane whose loudest thing has to be the button. See
+/// `OnboardingPublicProfileNote`, which says exactly what Settings → Profile says, in the gray it
+/// already said it in.
+enum WNCalloutEmphasis {
+    case tinted
+    case quiet
+
+    func background(for intent: WNCalloutIntent) -> Color {
+        switch self {
+        case .tinted: intent.background
+        case .quiet: WNColor.backgroundSecondary
+        }
+    }
+
+    /// The glyph and the title.
+    func accent(for intent: WNCalloutIntent) -> Color {
+        switch self {
+        case .tinted: intent.accent
+        case .quiet: WNColor.backgroundContentSecondary
+        }
+    }
+
+    /// The detail text, a step quieter than the title in both emphases.
+    func detail(for intent: WNCalloutIntent) -> Color {
+        switch self {
+        case .tinted: intent.detail
+        case .quiet: WNColor.backgroundContentTertiary
+        }
+    }
+}
+
 /// A titled notice with a line of detail under it.
 ///
 /// The detail is always shown. There is no fold: a notice worth putting on the page is worth
@@ -75,29 +114,31 @@ struct WNCallout: View {
     let title: String
     let message: String
     var intent: WNCalloutIntent = .primary
+    /// Whether the intent brings its hue with it. See `WNCalloutEmphasis`.
+    var emphasis: WNCalloutEmphasis = .tinted
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             Image(systemName: intent.systemImage)
                 .wnFont(.medium18)
-                .foregroundStyle(intent.accent)
+                .foregroundStyle(emphasis.accent(for: intent))
                 .frame(width: 22, height: 22)
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(title)
                     .wnFont(.bold14)
-                    .foregroundStyle(intent.accent)
+                    .foregroundStyle(emphasis.accent(for: intent))
 
                 Text(message)
                     .wnFont(.medium12)
-                    .foregroundStyle(intent.detail)
+                    .foregroundStyle(emphasis.detail(for: intent))
                     .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
-        .background(intent.background, in: .rect(cornerRadius: 8, style: .continuous))
+        .background(emphasis.background(for: intent), in: .rect(cornerRadius: 8, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .stroke(WNColor.borderTertiary, lineWidth: 1)

--- a/whitenoise-macTests/OnboardingTests.swift
+++ b/whitenoise-macTests/OnboardingTests.swift
@@ -273,15 +273,122 @@ import Testing
     /// ideal proposal resolves to exactly this: both `Spacer`s at their floor, which is the
     /// shortest the pane can be drawn.
     @Test func theSignUpPaneFitsTheSmallestWindow() throws {
+        let height = try Self.signUpPaneHeight()
+        #expect(
+            height <= Self.minimumWindowHeight,
+            "the sign-up pane needs \(height)pt in a window that can be \(Self.minimumWindowHeight)pt tall")
+    }
+
+    /// The same fit, in the language that makes the pane tallest rather than the one the test host
+    /// happens to be running in.
+    ///
+    /// The public-profile notice is the pane's only multi-line block, and it is the one string here
+    /// whose length is a translator's decision: its message wraps to two lines in English and to
+    /// three in six of the nine languages this app ships, which is 15pt the pane does not have
+    /// spare. The test above measures the host's language and would therefore pass in English while
+    /// shipping a pane whose Create profile button is off the bottom edge in German.
+    ///
+    /// So the pane is measured once, its own notice is subtracted, and the tallest translation of
+    /// that notice is put back. Nothing else on the pane can take a line it did not take before —
+    /// the title sits in the header row, both field labels are one line, and the error slot is
+    /// reserved at a fixed height.
+    @Test func theSignUpPaneFitsTheSmallestWindowInEveryLanguage() throws {
+        let paneHeight = try Self.signUpPaneHeight()
+        let hostNotice = try Self.publicProfileNoticeHeight(
+            title: L10n.string(Self.publicProfileTitleKey),
+            message: L10n.string(Self.publicProfileMessageKey)
+        )
+
+        var tallest = hostNotice
+        var tallestLanguage = "the host language"
+        for code in Bundle.main.localizations {
+            guard let path = Bundle.main.path(forResource: code, ofType: "lproj"),
+                let bundle = Bundle(path: path)
+            else { continue }
+            let height = try Self.publicProfileNoticeHeight(
+                title: bundle.localizedString(
+                    forKey: Self.publicProfileTitleKey, value: Self.publicProfileTitleKey, table: nil),
+                message: bundle.localizedString(
+                    forKey: Self.publicProfileMessageKey, value: Self.publicProfileMessageKey, table: nil)
+            )
+            if height > tallest {
+                tallest = height
+                tallestLanguage = code
+            }
+        }
+
+        let worstCase = paneHeight - hostNotice + tallest
+        #expect(
+            worstCase <= Self.minimumWindowHeight,
+            """
+            the sign-up pane needs \(worstCase)pt in \(tallestLanguage), \
+            in a window that can be \(Self.minimumWindowHeight)pt tall
+            """)
+    }
+
+    /// The shortest the sign-up pane can be drawn — both margin `Spacer`s at their floor. See
+    /// `OnboardingLayout.signUpEdgePadding`, which is what buys the notice its box.
+    private static func signUpPaneHeight() throws -> CGFloat {
         let workspace = Self.signUpWorkspace()
         let pane = OnboardingSignUpView()
             .environment(workspace)
             .frame(width: Self.minimumWindowWidth)
+        return try #require(ImageRenderer(content: pane).nsImage?.size.height)
+    }
 
-        let height = try #require(ImageRenderer(content: pane).nsImage?.size.height)
+    /// The notice as the pane draws it, at the width the pane draws it in.
+    private static func publicProfileNoticeHeight(title: String, message: String) throws -> CGFloat {
+        let notice = WNCallout(title: title, message: message, intent: .info, emphasis: .quiet)
+            .frame(width: OnboardingLayout.contentWidth)
+        return try #require(ImageRenderer(content: notice).nsImage?.size.height)
+    }
+
+    /// The two catalog keys Settings → Profile and the sign-up pane both draw. Shared literals
+    /// rather than a copy each, because the point of the notice is that they are the same strings.
+    private static let publicProfileTitleKey = "Your profile is public"
+    private static let publicProfileMessageKey =
+        "Name, photo, and bio are visible on the global Nostr network. Use what you're comfortable sharing."
+
+    /// The notice is gray, and stays gray.
+    ///
+    /// It is the same `WNCallout` Settings → Profile draws, and it would be one word — `.info`
+    /// instead of `.quiet` — from arriving in this pane wearing the info tint. That would make a
+    /// standing sentence about privacy the most colorful thing on a pane whose most colorful thing
+    /// is meant to be Create profile, so the neutral ground is asserted rather than assumed.
+    ///
+    /// Sampled against a swatch rendered the same way rather than against the ramp constant:
+    /// `ImageRenderer` does not always hand back the exact token it was given.
+    @Test func theSignUpNoticeIsDrawnOnNeutralGround() throws {
+        let quiet = try Self.noticeGround { OnboardingPublicProfileNote() }
+        let tinted = try Self.noticeGround {
+            WNCallout(
+                title: Self.publicProfileTitleKey,
+                message: Self.publicProfileMessageKey,
+                intent: .info
+            )
+        }
+
+        let swatchRep = try Self.rasterize(appearance: .aqua) {
+            WNColor.backgroundSecondary.frame(width: 40, height: 40)
+        }
+        let neutral = try #require(swatchRep.colorAt(x: 20, y: 20)?.usingColorSpace(.sRGB))
+
         #expect(
-            height <= Self.minimumWindowHeight,
-            "the sign-up pane needs \(height)pt in a window that can be \(Self.minimumWindowHeight)pt tall")
+            Self.channelDistance(quiet, neutral) < 0.02,
+            "the notice drew its box on \(quiet) where the neutral surface is \(neutral)")
+        #expect(
+            Self.channelDistance(quiet, tinted) > 0.02,
+            "the quiet notice and the tinted one drew the same ground, so the emphasis did nothing")
+    }
+
+    /// The color the notice's box is drawn on, sampled in the padding strip left of the glyph —
+    /// the one place inside the box that no glyph or line of text can reach.
+    private static func noticeGround<Notice: View>(@ViewBuilder _ notice: () -> Notice) throws -> NSColor {
+        let rep = try Self.rasterize(appearance: .aqua) {
+            notice().frame(width: OnboardingLayout.contentWidth)
+        }
+        return try #require(
+            rep.colorAt(x: Int(7 * Self.renderScale), y: rep.pixelsHigh / 2)?.usingColorSpace(.sRGB))
     }
 
     /// `ContentView`'s window floor, restated so a pane measured against it fails when the pane


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added quieter, inline privacy guidance during sign-up.
  - Improved sign-up layout spacing with a minimum 16-point edge margin.
  - Added configurable callout emphasis for clearer visual presentation.

- **Bug Fixes**
  - Improved sign-up pane sizing across localized public-profile notices.
  - Ensured privacy guidance remains readable within the minimum window size.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->