### PR TITLE
Remove the logout dropdown from the sidebar avatar

### DIFF
--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -96,8 +96,14 @@ struct AccountRailView: View {
 }
 
 /// A single account avatar in the rail: selects on tap (or signs back in when the
-/// account is signed out), dims signed-out accounts, overlays an unread badge, and
-/// offers Sign In / Sign Out via context menu.
+/// account is signed out), dims signed-out accounts, and overlays an unread badge.
+///
+/// Deliberately has no context menu. It used to offer Sign In / Sign Out, but both
+/// items were duplicates: signing back in is already this button's primary action for
+/// a signed-out account, and Sign Out lives in Settings behind a confirmation dialog
+/// (`SettingsAccountSwitcherCard`). The rail's copy fired `signOutAccount` straight
+/// from a right-click with no prompt, so an accidental click dropped that identity's
+/// relay key packages. Destructive account actions belong on the confirmed path only.
 private struct AccountRailAvatar: View {
     @Environment(WorkspaceState.self) private var workspace
     let account: AccountItem
@@ -139,26 +145,6 @@ private struct AccountRailAvatar: View {
         .buttonStyle(.plain)
         .disabled(account.signedOut && workspace.isAccountMutationInProgress)
         .help(account.signedOut ? "\(account.displayName) — \(L10n.string("Signed out"))" : account.displayName)
-        .contextMenu {
-            Group {
-                if account.signedOut {
-                    Button {
-                        Task { await workspace.signInAccount(account) }
-                    } label: {
-                        Label(L10n.string("Sign In"), systemImage: "person.crop.circle.badge.checkmark")
-                    }
-                    .disabled(workspace.isAccountMutationInProgress)
-                } else {
-                    Button {
-                        Task { await workspace.signOutAccount(account) }
-                    } label: {
-                        Label(L10n.string("Sign Out"), systemImage: "rectangle.portrait.and.arrow.right")
-                    }
-                    .disabled(workspace.isAccountMutationInProgress)
-                }
-            }
-            .menuLabelIcons()
-        }
     }
 
     @ViewBuilder

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -27692,6 +27692,42 @@ struct whitenoise_macTests {
         }
     }
 
+    @Test func accountRailAvatarOffersNoContextMenu() throws {
+        // The rail avatar used to carry a Sign In / Sign Out context menu. Both items were
+        // duplicates — signing back in is the button's own primary action for a signed-out
+        // account, and Sign Out lives in Settings behind a confirmation dialog — and the rail's
+        // Sign Out fired `signOutAccount` straight from a right-click with no prompt, so an
+        // accidental click dropped that identity's relay key packages. Only a source contract
+        // can guard an *absent* modifier: no behavior test can observe a menu that isn't built.
+        // The chat rows beside it keep their own menu, which is why this asserts on the rail's
+        // declaration rather than on the file.
+        let sidebarSource = try String(
+            contentsOf:
+                URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("whitenoise-mac")
+                .appendingPathComponent("Views")
+                .appendingPathComponent("SidebarViews.swift"),
+            encoding: .utf8
+        )
+
+        let start = try #require(sidebarSource.range(of: "private struct AccountRailAvatar: View {")?.upperBound)
+        let rest = sidebarSource[start...]
+        let end =
+            [
+                rest.range(of: "\nprivate struct ")?.lowerBound,
+                rest.range(of: "\nstruct ")?.lowerBound,
+            ]
+            .compactMap { $0 }.min() ?? sidebarSource.endIndex
+        let railSource = String(sidebarSource[start..<end])
+
+        #expect(!railSource.contains(".contextMenu"))
+        #expect(!railSource.contains("signOutAccount"), "destructive sign out belongs to the confirmed Settings path")
+        // Tapping a signed-out avatar is the only remaining way back in, so it must stay.
+        #expect(railSource.contains("signInAccount"))
+    }
+
     @MainActor
     @Test func messageDebugMetadataSummarizesTimelineKindAndId() async throws {
         let message = MessageItem(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified account avatar interactions by removing the Sign In/Sign Out context menu.
  * Signed-out accounts can still sign in through the primary avatar action.
  * Signing out is now available through Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->