### PR TITLE
Show single message for no chats case

### DIFF
--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1343,6 +1343,15 @@ final class WorkspaceState {
         return archivedChatsByAccount[activeAccountId] ?? []
     }
 
+    /// Whether the active account has nothing in either drawer.
+    ///
+    /// Distinct from `activeChats.isEmpty`: an account whose only chats are archived
+    /// still has something to select, and the empty detail pane says so rather than
+    /// inviting a first conversation that already happened.
+    var hasNoChats: Bool {
+        activeChats.isEmpty && archivedChats.isEmpty
+    }
+
     var filteredChats: [ChatItem] {
         filteredChats(matching: searchText)
     }

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -48819,6 +48819,66 @@
         }
       }
     },
+    "Start a conversation": {
+      "comment": "Empty-state invitation shown in the detail pane when the account has no chats.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starte ein Gespräch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicia una conversación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer une conversation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizia una conversazione"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicie uma conversa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начните разговор"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir sohbet başlatın"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始对话"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始對話"
+          }
+        }
+      }
+    },
     "Start a conversation by inviting someone with their npub.": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Views/MessengerShellView.swift
+++ b/whitenoise-mac/Views/MessengerShellView.swift
@@ -1024,27 +1024,57 @@ private struct FailureView: View {
 }
 
 struct EmptyDrawerState: View {
+    @Environment(\.locale) private var locale
+
     var body: some View {
-        ContentUnavailableView("No chats", systemImage: "bubble.left.and.bubble.right")
-            .padding()
+        WNEmptyStateView(
+            title: L10n.string("No chats", locale: locale),
+            systemImage: "bubble.left.and.bubble.right"
+        )
+        .padding()
     }
 }
 
 private struct EmptyConversationView: View {
+    @Environment(\.locale) private var locale
+
     var body: some View {
-        ContentUnavailableView("No messages", systemImage: "text.bubble")
+        WNEmptyStateView(title: L10n.string("No messages", locale: locale), systemImage: "text.bubble")
             .frame(maxWidth: .infinity, minHeight: 360)
     }
 }
 
+/// The detail pane with no conversation in it.
+///
+/// Which of the three things it has to say is decided here rather than in the rail,
+/// because the rail cannot say the useful one: an account with no chats at all has
+/// nothing to select, so "Select a chat" would be pointing at an empty list. In that
+/// case the invitation to start one takes this pane — the widest, most legible space
+/// in the window — and `ChatListDrawerView` leaves its own copy of the notice off so
+/// the window carries the message once instead of twice.
 private struct EmptyDetailView: View {
     @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.locale) private var locale
 
     var body: some View {
-        ContentUnavailableView {
-            Label(
-                workspace.accounts.isEmpty ? L10n.string("No accounts") : L10n.string("Select a chat"),
-                systemImage: "bubble.left.and.bubble.right")
+        Group {
+            if workspace.accounts.isEmpty {
+                WNEmptyStateView(
+                    title: L10n.string("No accounts", locale: locale),
+                    systemImage: "person.crop.circle.badge.questionmark"
+                )
+            } else if workspace.hasNoChats {
+                WNEmptyStateView(
+                    title: L10n.string("No chats yet", locale: locale),
+                    description: L10n.string("Start a conversation", locale: locale),
+                    systemImage: "bubble.left.and.bubble.right"
+                )
+            } else {
+                WNEmptyStateView(
+                    title: L10n.string("Select a chat", locale: locale),
+                    systemImage: "bubble.left.and.bubble.right"
+                )
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -165,6 +165,7 @@ private struct AccountRailAvatar: View {
 
 struct ChatListDrawerView: View {
     @Environment(WorkspaceState.self) private var workspace
+    @Environment(\.locale) private var locale
 
     private var isShowingSettings: Bool {
         if case .settings = workspace.selection { return true }
@@ -216,16 +217,16 @@ struct ChatListDrawerView: View {
                 }
                 .accessibilityIdentifier(isShowingArchived ? "chat.archived.list" : "chat.list")
                 .overlay {
-                    // `ContentUnavailableView` needs room for an icon over two lines of prose;
-                    // in the collapsed rail it would render as a column of hyphenated fragments.
-                    // An empty rail is legible on its own, and widening it brings the wording back.
+                    // The notice needs room for an icon over a line or two of prose; in the
+                    // collapsed rail it would render as a column of hyphenated fragments. An
+                    // empty rail is legible on its own, and widening it brings the wording back.
                     if visibleChats.isEmpty, !isCollapsed {
                         if workspace.isSearchingSidebarMessages {
                             ProgressView()
                                 .controlSize(.small)
                         } else if !workspace.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            ContentUnavailableView(
-                                L10n.string("No matching chats"),
+                            WNEmptyStateView(
+                                title: L10n.string("No matching chats", locale: locale),
                                 systemImage: "magnifyingglass"
                             )
                             .padding()
@@ -236,7 +237,16 @@ struct ChatListDrawerView: View {
                             case .unread:
                                 UnreadEmptyDrawerState()
                             case .active:
-                                EmptyDrawerState()
+                                // An account with no chats at all is told so by the detail
+                                // pane, which has room for the invitation to start one and
+                                // nothing else to say. Repeating it here left the window
+                                // holding two notices about the same nothing. When the
+                                // active drawer is empty only because everything is
+                                // archived, the detail pane is back to "Select a chat" and
+                                // this rail is the only place that fact can be stated.
+                                if !workspace.hasNoChats {
+                                    EmptyDrawerState()
+                                }
                             }
                         }
                     }
@@ -445,15 +455,19 @@ private struct ChatListFilterMenu: View {
 }
 
 private struct ArchivedEmptyDrawerState: View {
+    @Environment(\.locale) private var locale
+
     var body: some View {
-        ContentUnavailableView(L10n.string("No archived chats"), systemImage: "archivebox")
+        WNEmptyStateView(title: L10n.string("No archived chats", locale: locale), systemImage: "archivebox")
             .padding()
     }
 }
 
 private struct UnreadEmptyDrawerState: View {
+    @Environment(\.locale) private var locale
+
     var body: some View {
-        ContentUnavailableView(L10n.string("No unread chats"), systemImage: "bubble.left")
+        WNEmptyStateView(title: L10n.string("No unread chats", locale: locale), systemImage: "bubble.left")
             .padding()
     }
 }

--- a/whitenoise-mac/Views/WNEmptyStateView.swift
+++ b/whitenoise-mac/Views/WNEmptyStateView.swift
@@ -1,0 +1,51 @@
+//
+//  WNEmptyStateView.swift
+//  whitenoise-mac
+//
+//  The quiet notice a pane shows when it has nothing to list: a glyph, a line
+//  of title, and an optional line of detail.
+//
+//  It exists because `ContentUnavailableView` is drawn for a full iPhone screen
+//  — a ~50pt glyph over a title in the `.title2` range — and the panes that use
+//  it here are a narrow chat rail and a detail pane that already carries a
+//  toolbar. At that scale the notice reads as an error rather than as an empty
+//  shelf. This one is set on the app's own ramp, several rungs down, so it sits
+//  in the space it is given instead of filling it.
+//
+
+import SwiftUI
+
+struct WNEmptyStateView: View {
+    let title: String
+    var description: String?
+    let systemImage: String
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .wnFont(.medium28)
+                .foregroundStyle(WNColor.backgroundContentTertiary)
+
+            VStack(spacing: 3) {
+                Text(title)
+                    .wnFont(.semiBold14)
+                    .foregroundStyle(WNColor.backgroundContentPrimary)
+
+                if let description {
+                    Text(description)
+                        .wnFont(.medium12)
+                        .foregroundStyle(WNColor.backgroundContentSecondary)
+                }
+            }
+            .multilineTextAlignment(.center)
+        }
+        // Every title and detail line in the catalog fits on one line at this width in
+        // all ten languages — the longest measures 199pt ("Nenhuma conversa arquivada")
+        // — while the detail pane, several times wider, is kept from stretching two
+        // short lines into one long rule. A rail narrower than this proposes its own
+        // width instead, and the text wraps as it did before.
+        .frame(maxWidth: 240)
+        .padding(.horizontal, 16)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -25067,6 +25067,30 @@ struct whitenoise_macTests {
     }
 
     @MainActor
+    @Test func hasNoChatsSeparatesAnEmptyActiveDrawerFromAnAccountWithNothingInIt() async throws {
+        let account = desktopAccount()
+        let runtime = FakeMarmotRuntime(accounts: [account])
+        runtime.installGroupDetails(groupDetailsFixture(selfAccountIdHex: account.accountIdHex))
+        let state = WorkspaceState(clientFactory: { runtime })
+        await state.bootstrap()
+
+        let chat = try #require(state.activeChats.first)
+        #expect(!state.hasNoChats)
+
+        // Archiving can empty the active drawer while leaving something to select, which is
+        // what keeps the empty detail pane on "Select a chat" instead of inviting a first
+        // conversation the account has already had.
+        await state.setChatArchived(chat, archived: true)
+        #expect(!state.archivedChats.isEmpty)
+        #expect(!state.hasNoChats)
+
+        let accountId = try #require(state.activeAccountId)
+        state.chatsByAccount[accountId] = []
+        state.archivedChatsByAccount[accountId] = []
+        #expect(state.hasNoChats)
+    }
+
+    @MainActor
     @Test func archivedChatSearchFiltersArchivedSection() async throws {
         let account = desktopAccount()
         let runtime = FakeMarmotRuntime(accounts: [account])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer empty-state screens for accounts, conversations, archived chats, unread chats, and search results.
  * Added a localized “Start a conversation” prompt for accounts without chats.
  * Improved accessibility and visual consistency across empty-state messages.

* **Localization**
  * Expanded empty-state translations for German, Spanish, French, Italian, Portuguese, Russian, Turkish, Simplified Chinese, and Traditional Chinese.

* **Bug Fixes**
  * Prevented misleading empty-chat notices when archived conversations are still available.
  * Improved handling of empty active chat lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->