### PR TITLE
Hide signed out accounts from chatlist sidebar

### DIFF
--- a/whitenoise-mac/Core/RemoteImageDisplayPolicy.swift
+++ b/whitenoise-mac/Core/RemoteImageDisplayPolicy.swift
@@ -29,17 +29,21 @@ import Foundation
 ///
 /// So: your own avatar always draws, everyone else's waits for the preference. Pass
 /// `isOwnAccountImage: true` only where the URL provably belongs to an account **signed in** on
-/// this Mac — the profile editor, its picker, Identity & Keys, and the account switcher. Peer
-/// avatars (chat rows, message senders, member lists, search results) must keep the default.
+/// this Mac — the profile editor, its picker, Identity & Keys, the account rail, and the account
+/// switcher. Peer avatars (chat rows, message senders, member lists, search results) must keep the
+/// default.
 ///
-/// "Signed in" is load-bearing rather than decorative. The first three of those sites render
-/// `activeAccount`, which `restoreOrSelectFirstAccount()` guarantees is never a signed-out account,
-/// so they can pass a literal `true`. The switcher's row list is the one site that also shows
-/// signed-out identities, and it passes `!account.signedOut`: sign-out deactivates an identity and
-/// drops its relay key packages, so the app should not then fetch its avatar and put traffic on the
-/// wire on its behalf. That is a narrower argument than the preference's own — a signed-out account
-/// is still yours, not a peer's — but the exemption should stay as small as the bug it exists to
-/// fix.
+/// "Signed in" is load-bearing rather than decorative, and each of those sites earns its literal
+/// `true` differently. The first three render `activeAccount`, which `restoreOrSelectFirstAccount()`
+/// guarantees is never a signed-out account. The rail renders several accounts at once, but it is
+/// fed `signedInAccounts`, so a deactivated identity never reaches an avatar there to begin with.
+///
+/// The switcher's row list is the one site that still draws signed-out identities — it is where
+/// signing back in lives — and it alone passes `!account.signedOut`: sign-out deactivates an
+/// identity and drops its relay key packages, so the app should not then fetch its avatar and put
+/// traffic on the wire on its behalf. That is a narrower argument than the preference's own — a
+/// signed-out account is still yours, not a peer's — but the exemption should stay as small as the
+/// bug it exists to fix.
 nonisolated enum RemoteImageDisplayPolicy {
     static func loadsRemoteImage(isOwnAccountImage: Bool, preferenceEnabled: Bool) -> Bool {
         isOwnAccountImage || preferenceEnabled

--- a/whitenoise-mac/Core/WorkspaceState+Account.swift
+++ b/whitenoise-mac/Core/WorkspaceState+Account.swift
@@ -293,13 +293,19 @@ extension WorkspaceState {
 
     /// Open the onboarding surface to add an identity alongside the ones already on this Mac.
     ///
-    /// This is the whole of Settings → Add Account, and of the signed-out pane's `Use another
-    /// account`. Both used to have their own answer to "how do you get a second account in" — the
-    /// former a bespoke sheet with its own key field and its own pair of buttons, the latter this
-    /// call — and the sheet's was a second, worse copy of a flow that already exists. There is one
-    /// now: the panes in `Views/Onboarding`, which is what `wn-ios-prototype`'s `AddProfileFlow`
-    /// does too. It presents `WelcomeView` and pushes the *real* `LoginView` and `SignUpView`
-    /// rather than reimplementing either.
+    /// This is the whole of the signed-out pane's `Use another account`, and of Settings'
+    /// `Add Account` row. Both routes once had their own answer to "how do you get a second
+    /// account in" — Settings a bespoke sheet with its own key field and its own pair of buttons,
+    /// the pane this call — and the sheet's was a second, worse copy of a flow that already
+    /// exists. What is left is the panes in `Views/Onboarding`, which is what
+    /// `wn-ios-prototype`'s `AddProfileFlow` does too: it presents `WelcomeView` and pushes the
+    /// *real* `LoginView` and `SignUpView` rather than reimplementing either.
+    ///
+    /// Note where the Settings caller sits: `SettingsAccountSwitcherCard`'s own row, not the
+    /// switcher popover it raises. The popover used to carry an `Add Account` button under its
+    /// row list, and a dropdown for choosing among existing identities is not where a new one
+    /// should be created — the row offers it in the one case the dropdown would be empty anyway,
+    /// when this Mac holds a single identity and there is nothing to switch to.
     ///
     /// Deliberately leaves `selection` alone, so `leaveAccountOnboarding()` puts the user back on
     /// the page they opened this from rather than somewhere merely plausible.
@@ -729,8 +735,9 @@ extension WorkspaceState {
         // whatever order it finishes, so only the newest request may commit.
         pendingInviteCountGeneration &+= 1
         let generation = pendingInviteCountGeneration
-        // The active account is excluded here and answered from its rows; a signed-out account has
-        // no badge count at all (the rail draws it a pause glyph instead).
+        // The active account is excluded here and answered from its rows; a signed-out account
+        // has no badge count at all, and no rail avatar to hang one on — `signedInAccounts`
+        // leaves it out. The switcher's row shows its status in words instead.
         let targets = accounts.filter { !$0.signedOut && $0.id != activeAccountId }
         var counts: [String: Int] = [:]
         for target in targets {

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1333,6 +1333,20 @@ final class WorkspaceState {
         return accounts.first { $0.id == activeAccountId }
     }
 
+    /// The identities the account rail draws: the ones that are actually running.
+    ///
+    /// A signed-out account used to sit in the rail dimmed to 0.4 behind a pause glyph, with a
+    /// tap signing it back in. Reactivating an identity is account management, not switching, and
+    /// it belongs with sign-out and removal in Settings' switcher (`AccountSwitcherRow`) rather
+    /// than one misplaced click away in the control the user hits all day.
+    ///
+    /// Derived, and deliberately not a filter applied to `accounts` itself: that list is every
+    /// identity on this Mac, and both the switcher's rows and `SignedOutAccountsView` — the whole
+    /// of the way back in when nothing is signed in — need the deactivated ones in it.
+    var signedInAccounts: [AccountItem] {
+        accounts.filter { !$0.signedOut }
+    }
+
     var activeChats: [ChatItem] {
         guard let activeAccountId else { return [] }
         return chatsByAccount[activeAccountId] ?? []

--- a/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
@@ -3,9 +3,13 @@
 //  whitenoise-mac
 //
 //  The account switcher that sits at the top of Settings: the card naming the
-//  active identity, and the popover listing every identity on this Mac. Adding
-//  one is not here — `Add Account` opens the onboarding flow, the same panes a
-//  first launch shows. This is where the former Accounts settings page went —
+//  active identity, and the popover listing every identity on this Mac. The
+//  popover switches between them and manages them — sign in, sign out, remove —
+//  and it no longer creates one: the `Add Account` button that used to sit under
+//  its row list opened the onboarding landing pane, which put account creation
+//  in the same dropdown as account switching. Creating one is the card's own
+//  `profileManagementRow` instead, which offers it precisely when there is
+//  nothing to switch to. This is where the former Accounts settings page went —
 //  the iOS and Flutter clients open Settings on the current profile with a
 //  switch control directly underneath it rather than routing identity work
 //  through a separate Accounts tab, and this mirrors that on macOS.
@@ -175,10 +179,6 @@ struct SettingsAccountSwitcherCard: View {
                     isSwitcherPresented = false
                     Task { await workspace.signInAccount(account) }
                 },
-                onAddAccount: {
-                    isSwitcherPresented = false
-                    workspace.showAccountOnboarding()
-                },
                 onSignOut: { account in
                     isSwitcherPresented = false
                     accountPendingSignOut = account
@@ -223,15 +223,15 @@ struct SettingsAccountSwitcherCard: View {
 }
 
 /// The switcher itself: every identity stored on this Mac, with the active one
-/// marked, plus the way in for a new one. Every action is reported to the card that
-/// presents this popover: it is the view that outlives the popover, so it is the one
-/// that can close it and then raise a confirmation or a sheet.
+/// marked. Switching and managing only — creating an identity is not offered here.
+/// Every action is reported to the card that presents this popover: it is the view
+/// that outlives the popover, so it is the one that can close it and then raise a
+/// confirmation or a sheet.
 struct AccountSwitcherPopover: View {
     @Environment(WorkspaceState.self) private var workspace
     @Environment(\.locale) private var locale
     let onSelect: (AccountItem) -> Void
     let onSignIn: (AccountItem) -> Void
-    let onAddAccount: () -> Void
     let onSignOut: (AccountItem) -> Void
     let onRemove: (AccountItem) -> Void
 
@@ -277,19 +277,10 @@ struct AccountSwitcherPopover: View {
                 // against the leading one: the selection ring is drawn *outside* the avatar's
                 // frame, so it came out with a flat left side. The content is inset by the ring's
                 // reach and the scroll view widened by the same amount, which leaves the rows
-                // where they were — aligned with the header and the button — while giving the
-                // chrome somewhere to draw. Insetting alone would indent every row instead.
+                // where they were — aligned with the header above them — while giving the chrome
+                // somewhere to draw. Insetting alone would indent every row instead.
                 .padding(.horizontal, -Self.rowChromeInset)
             }
-
-            Divider()
-
-            Button(action: onAddAccount) {
-                Label(L10n.string("Add Account", locale: locale), systemImage: "plus.circle")
-                    .frame(maxWidth: .infinity)
-            }
-            .nativeGlassProminentButtonStyle()
-            .disabled(workspace.isAuthenticating || workspace.isAccountMutationInProgress)
         }
         .padding(14)
         .frame(width: 320)

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -61,7 +61,7 @@ struct AccountRailView: View {
 
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 10) {
-                    ForEach(workspace.accounts) { account in
+                    ForEach(workspace.signedInAccounts) { account in
                         AccountRailAvatar(account: account)
                     }
                 }
@@ -95,15 +95,20 @@ struct AccountRailView: View {
     }
 }
 
-/// A single account avatar in the rail: selects on tap (or signs back in when the
-/// account is signed out), dims signed-out accounts, and overlays an unread badge.
+/// A single account avatar in the rail: selects that identity on tap, and overlays an
+/// unread badge. Nothing else — the rail switches accounts and does not manage them.
 ///
-/// Deliberately has no context menu. It used to offer Sign In / Sign Out, but both
-/// items were duplicates: signing back in is already this button's primary action for
-/// a signed-out account, and Sign Out lives in Settings behind a confirmation dialog
-/// (`SettingsAccountSwitcherCard`). The rail's copy fired `signOutAccount` straight
-/// from a right-click with no prompt, so an accidental click dropped that identity's
-/// relay key packages. Destructive account actions belong on the confirmed path only.
+/// Deliberately has no context menu, and no signed-out case. It used to offer Sign In /
+/// Sign Out on right-click, where Sign Out fired `signOutAccount` with no prompt at all,
+/// so an accidental click dropped that identity's relay key packages. It also used to
+/// draw deactivated identities, dimmed to 0.4 behind a pause glyph, where one tap signed
+/// one back in. Every one of those is account management, and all of it lives in Settings'
+/// switcher now (`SettingsAccountSwitcherCard`): sign-out and removal behind confirmations,
+/// sign-in on the row itself.
+///
+/// The rail is fed `signedInAccounts`, so `account.signedOut` is false here by
+/// construction. Reintroducing a branch on it would be dead code describing a row that
+/// cannot reach this view.
 private struct AccountRailAvatar: View {
     @Environment(WorkspaceState.self) private var workspace
     let account: AccountItem
@@ -113,11 +118,7 @@ private struct AccountRailAvatar: View {
 
     var body: some View {
         Button {
-            if account.signedOut {
-                Task { await workspace.signInAccount(account) }
-            } else {
-                workspace.selectAccount(account)
-            }
+            workspace.selectAccount(account)
         } label: {
             ProfileImageAvatarView(
                 seed: account.accountIdHex,
@@ -127,39 +128,27 @@ private struct AccountRailAvatar: View {
                 // editor and the account switcher on the exempt side of the "Load Remote Profile
                 // Images" preference — see `RemoteImageDisplayPolicy`. Left on the default, the
                 // rail drew initials for a picture the viewer had just set and could see in
-                // Settings, which reads as a broken avatar rather than as privacy. Signed-out
-                // accounts stay gated, matching the switcher's row list: signing out drops an
-                // identity's relay key packages, so the app should not then put traffic on the
-                // wire on its behalf.
-                isOwnAccountImage: !account.signedOut,
+                // Settings, which reads as a broken avatar rather than as privacy. Unconditional
+                // because every row here is signed in; the switcher's list still gates its
+                // deactivated rows, since signing out drops an identity's relay key packages and
+                // the app should not then put traffic on the wire on its behalf.
+                isOwnAccountImage: true,
                 size: MessagesLayout.accountRailAvatarSize,
                 isSelected: isActive
             )
             .frame(width: MessagesLayout.accountRailAvatarFrameSize, height: MessagesLayout.accountRailAvatarFrameSize)
             .contentShape(Circle())
-            .opacity(account.signedOut ? 0.4 : 1)
             .overlay(alignment: .topTrailing) {
-                badge
+                // A `badge` view builder used to stand here to choose between this and the
+                // signed-out pause glyph. With one case left there is nothing to choose.
+                if unread > 0 {
+                    UnreadCountBadge(count: unread)
+                        .overlay(Capsule().strokeBorder(WNColor.backgroundTertiary, lineWidth: 1.5))
+                }
             }
         }
         .buttonStyle(.plain)
-        .disabled(account.signedOut && workspace.isAccountMutationInProgress)
-        .help(account.signedOut ? "\(account.displayName) — \(L10n.string("Signed out"))" : account.displayName)
-    }
-
-    @ViewBuilder
-    private var badge: some View {
-        if account.signedOut {
-            Image(systemName: "pause.circle.fill")
-                .wnFont(.medium16)
-                .foregroundStyle(WNColor.backgroundContentSecondary)
-                // Punched out of the rail behind it, so it takes the rail's own surface rather
-                // than the system window color.
-                .background(Circle().fill(WNColor.backgroundTertiary))
-        } else if unread > 0 {
-            UnreadCountBadge(count: unread)
-                .overlay(Capsule().strokeBorder(WNColor.backgroundTertiary, lineWidth: 1.5))
-        }
+        .help(account.displayName)
     }
 }
 

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1183,9 +1183,15 @@ struct whitenoise_macTests {
         }
     }
 
-    /// Settings → Add Account is the onboarding flow now, not a sheet of its own. The card used
+    /// Adding an account is the onboarding flow, not a sheet of its own. Settings' switcher used
     /// to raise `AddAccountSheet` — a second key field and a second pair of buttons for the two
-    /// things `Views/Onboarding` already does — and this pins the routing that replaced it.
+    /// things `Views/Onboarding` already does — then its `Add Account` button routed here instead,
+    /// and now that button is gone too: a dropdown for choosing among existing identities is not
+    /// where a new one gets created. `SignedOutAccountsView`'s `Use another account` is the
+    /// remaining caller, so this and the four tests below drive `showAccountOnboarding()` directly.
+    /// They still pin the routing, which is what a caller added later would depend on; the tests
+    /// keep their `addAccount` names because the flow's regressions (#74, #333, #32) are filed
+    /// under it.
     @MainActor
     @Test func addAccountOpensTheOnboardingFlowOnItsLandingPane() async throws {
         let state = WorkspaceState(clientFactory: { Self.addAccountRuntime() })
@@ -1367,6 +1373,38 @@ struct whitenoise_macTests {
         #expect(normalized.contains(".padding(.horizontal,Self.rowChromeInset)"))
         // ...and the scroll view is widened by the same amount so they stay put.
         #expect(normalized.contains(".padding(.horizontal,-Self.rowChromeInset)"))
+    }
+
+    /// The switcher lists the identities already on this Mac; it is no longer the way a new one
+    /// gets made. `Add Account` sat under the row list and opened the onboarding landing pane —
+    /// the one offering Sign Up — which put account *creation* in the same dropdown as account
+    /// switching. Only a source contract can guard an absent control: no behavior test can
+    /// observe a button that is never built. Asserting on the popover's own declaration rather
+    /// than on the file is deliberate, because `signInAccount` must survive elsewhere in it:
+    /// with signed-out identities gone from the rail, the switcher's rows are the only way back
+    /// into one while another account is signed in.
+    @MainActor
+    @Test func accountSwitcherPopoverOffersNoWayToCreateAnAccount() throws {
+        let sourceURL =
+            URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "whitenoise-mac")
+            .appending(path: "Views")
+            .appending(path: "Settings")
+            .appending(path: "SettingsAccountSwitcherViews.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        let popoverStart = try #require(source.range(of: "struct AccountSwitcherPopover: View {"))
+        let popoverEnd = try #require(source.range(of: "struct AccountSwitcherRow: View {"))
+        let normalized = String(source[popoverStart.lowerBound..<popoverEnd.lowerBound])
+            .components(separatedBy: .whitespacesAndNewlines).joined()
+
+        #expect(!normalized.contains("AddAccount"), "account creation does not belong in the switcher")
+        #expect(!normalized.contains("showAccountOnboarding"))
+
+        // The route back into a signed-out identity has to stay: the rail no longer carries one.
+        #expect(source.contains("signInAccount"))
     }
 
     @MainActor
@@ -1759,6 +1797,50 @@ struct whitenoise_macTests {
         // the just-signed-in "Backup Account" over the raced-to "Other Account".
         #expect(state.activeAccountId == "Other Account")
         #expect(UserDefaults.standard.string(forKey: "whitenoise.mac.activeAccountId") == "Other Account")
+    }
+
+    @MainActor
+    @Test func signedInAccountsOmitsDeactivatedIdentitiesFromTheRail() async throws {
+        // What the account rail draws. A signed-out identity used to sit in it dimmed to 0.4
+        // behind a pause glyph, and tapping it signed the identity back in — account management
+        // in the switching control, reached with no confirmation. It lives in Settings' switcher
+        // now, beside sign-out and removal.
+        //
+        // `accounts` must keep every identity on this Mac regardless: the switcher's row list
+        // reads it, and so does `SignedOutAccountsView`, which is the whole of the way back in
+        // when nothing is signed in. Filtering there instead of in the rail would lock the user
+        // out of their own Mac.
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let signedOut = AccountSummaryFfi(
+            label: "Backup Account",
+            accountIdHex: "1111111111111111111111111111111111111111111111111111111111111111",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: true,
+            running: false
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, signedOut])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+
+        #expect(state.accounts.map(\.id) == ["Desktop Account", "Backup Account"])
+        #expect(state.signedInAccounts.map(\.id) == ["Desktop Account"])
+
+        // Signing it back in from the switcher puts it back in the rail — the filter is derived
+        // from the account list, not a separate copy that could fall out of step with it.
+        let backup = try #require(state.accounts.first { $0.id == "Backup Account" })
+        await state.signInAccount(backup)
+
+        #expect(state.signedInAccounts.map(\.id) == ["Desktop Account", "Backup Account"])
     }
 
     @MainActor
@@ -27678,8 +27760,10 @@ struct whitenoise_macTests {
         // and the account switcher on the exempt side of `RemoteImageDisplayPolicy`: leaving it
         // on the default made the sidebar draw initials for the picture the viewer had just set
         // and could see in Settings, which reads as "my avatar is broken" rather than as privacy.
-        // Signed-out accounts stay gated, the same narrower argument the switcher's list makes.
-        // The chat rows next to it are peers and must keep the default.
+        // Unconditional now that the rail draws signed-in accounts only — the narrower
+        // `!account.signedOut` this used to carry has nothing left to exclude, and the switcher's
+        // list is where that argument still applies. The chat rows next to it are peers and must
+        // keep the default.
         let sidebarSource = try String(
             contentsOf:
                 URL(fileURLWithPath: #filePath)
@@ -27704,7 +27788,7 @@ struct whitenoise_macTests {
         }
 
         let railSource = try declarationSource(of: "private struct AccountRailAvatar: View {")
-        #expect(railSource.contains("isOwnAccountImage: !account.signedOut"))
+        #expect(railSource.contains("isOwnAccountImage: true"))
 
         for row in ["struct ChatRowContent: View {", "struct CollapsedChatRowContent: View {"] {
             let rowSource = try declarationSource(of: row)
@@ -27712,15 +27796,16 @@ struct whitenoise_macTests {
         }
     }
 
-    @Test func accountRailAvatarOffersNoContextMenu() throws {
-        // The rail avatar used to carry a Sign In / Sign Out context menu. Both items were
-        // duplicates — signing back in is the button's own primary action for a signed-out
-        // account, and Sign Out lives in Settings behind a confirmation dialog — and the rail's
-        // Sign Out fired `signOutAccount` straight from a right-click with no prompt, so an
-        // accidental click dropped that identity's relay key packages. Only a source contract
-        // can guard an *absent* modifier: no behavior test can observe a menu that isn't built.
-        // The chat rows beside it keep their own menu, which is why this asserts on the rail's
-        // declaration rather than on the file.
+    @Test func accountRailAvatarCarriesNoAccountManagement() throws {
+        // The rail switches identities and does nothing else to them. It used to carry a
+        // Sign In / Sign Out context menu, whose Sign Out fired `signOutAccount` straight from a
+        // right-click with no prompt — an accidental click dropped that identity's relay key
+        // packages. And it used to draw signed-out identities too, dimmed behind a pause glyph,
+        // where a single tap signed one back in. All of it is account management, and all of it
+        // now lives in Settings' switcher: sign-out and removal behind confirmations, sign-in on
+        // the row itself. Only a source contract can guard *absent* chrome: no behavior test can
+        // observe a menu or a branch that is never built. The chat rows beside it keep their own
+        // menu, which is why this asserts on the rail's declaration rather than on the file.
         let sidebarSource = try String(
             contentsOf:
                 URL(fileURLWithPath: #filePath)
@@ -27744,8 +27829,15 @@ struct whitenoise_macTests {
 
         #expect(!railSource.contains(".contextMenu"))
         #expect(!railSource.contains("signOutAccount"), "destructive sign out belongs to the confirmed Settings path")
-        // Tapping a signed-out avatar is the only remaining way back in, so it must stay.
-        #expect(railSource.contains("signInAccount"))
+        #expect(!railSource.contains("signInAccount"), "signing back in belongs to the Settings switcher")
+        // The rail is fed `signedInAccounts`, so the avatar has no signed-out case to branch on:
+        // a leftover branch here would be dead code claiming to handle a row that cannot appear.
+        #expect(!railSource.contains("signedOut"))
+
+        // And the rail is genuinely fed the filtered list — without this, every assertion above
+        // would still pass while the rail iterated `accounts` and drew the deactivated ones
+        // through an avatar that no longer has a branch for them.
+        #expect(sidebarSource.contains("ForEach(workspace.signedInAccounts)"))
     }
 
     @MainActor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer separation between signed-in and signed-out accounts.
  * Account creation is now accessed through the account card or Settings, while the switcher focuses on account switching and management.
  * The account rail now displays only signed-in accounts.
* **Bug Fixes**
  * Improved account avatar behavior and unread badge display.
  * Updated onboarding and pending-invite messaging for signed-out accounts.
* **Tests**
  * Added coverage for account visibility, creation controls, avatar behavior, and account-management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->