### PR TITLE
Remove signed-out accounts from the account switcher

### DIFF
--- a/whitenoise-mac/Core/RemoteImageDisplayPolicy.swift
+++ b/whitenoise-mac/Core/RemoteImageDisplayPolicy.swift
@@ -35,15 +35,15 @@ import Foundation
 ///
 /// "Signed in" is load-bearing rather than decorative, and each of those sites earns its literal
 /// `true` differently. The first three render `activeAccount`, which `restoreOrSelectFirstAccount()`
-/// guarantees is never a signed-out account. The rail renders several accounts at once, but it is
-/// fed `signedInAccounts`, so a deactivated identity never reaches an avatar there to begin with.
+/// guarantees is never a signed-out account. The rail and the switcher each render several accounts
+/// at once, but both are fed `signedInAccounts`, so a deactivated identity never reaches an avatar
+/// in either to begin with.
 ///
-/// The switcher's row list is the one site that still draws signed-out identities — it is where
-/// signing back in lives — and it alone passes `!account.signedOut`: sign-out deactivates an
-/// identity and drops its relay key packages, so the app should not then fetch its avatar and put
-/// traffic on the wire on its behalf. That is a narrower argument than the preference's own — a
-/// signed-out account is still yours, not a peer's — but the exemption should stay as small as the
-/// bug it exists to fix.
+/// Both used to pass `!account.signedOut` instead, for the deactivated rows they drew: sign-out
+/// drops an identity's relay key packages, so the app should not then fetch its avatar and put
+/// traffic on the wire on its behalf. Filtering the lists themselves subsumed that argument — the
+/// one remaining site that lists signed-out identities, `SignedOutAccountsView`, never passes
+/// `isOwnAccountImage` at all, so its avatars stay gated by the preference like any other.
 nonisolated enum RemoteImageDisplayPolicy {
     static func loadsRemoteImage(isOwnAccountImage: Bool, preferenceEnabled: Bool) -> Bool {
         isOwnAccountImage || preferenceEnabled

--- a/whitenoise-mac/Core/WorkspaceState.swift
+++ b/whitenoise-mac/Core/WorkspaceState.swift
@@ -1333,18 +1333,31 @@ final class WorkspaceState {
         return accounts.first { $0.id == activeAccountId }
     }
 
-    /// The identities the account rail draws: the ones that are actually running.
+    /// The identities the account rail and the Settings switcher draw: the ones that are
+    /// actually running.
     ///
-    /// A signed-out account used to sit in the rail dimmed to 0.4 behind a pause glyph, with a
-    /// tap signing it back in. Reactivating an identity is account management, not switching, and
-    /// it belongs with sign-out and removal in Settings' switcher (`AccountSwitcherRow`) rather
-    /// than one misplaced click away in the control the user hits all day.
+    /// A signed-out account used to sit in both of them — dimmed to 0.4 behind a pause glyph in
+    /// the rail, dimmed under a `Signed out` caption in the switcher — with a tap signing it back
+    /// in. Neither control is a place a deactivated identity can be *gone to*: `selectAccount(_:)`
+    /// and `selectAccountFromSettings(_:)` refuse one outright, so those rows were a sign-in
+    /// button wearing a destination's clothes. Both lists now hold destinations only.
     ///
     /// Derived, and deliberately not a filter applied to `accounts` itself: that list is every
-    /// identity on this Mac, and both the switcher's rows and `SignedOutAccountsView` — the whole
-    /// of the way back in when nothing is signed in — need the deactivated ones in it.
+    /// identity on this Mac, and `SignedOutAccountsView` — the way back into a deactivated
+    /// identity, shown when none is signed in — needs the deactivated ones in it.
     var signedInAccounts: [AccountItem] {
         accounts.filter { !$0.signedOut }
+    }
+
+    /// Whether there is another signed-in identity to switch *to* — what decides whether the
+    /// switcher is offered at all.
+    ///
+    /// Not `accounts.count > 1`: with one signed-in identity and one deactivated one, that
+    /// offered `Switch Account` and then opened a list holding only the account already active.
+    /// Asked against `activeAccountId` rather than `signedInAccounts.count`, so it stays right
+    /// while a mutation is mid-flight and the active identity is itself signed out or gone.
+    var hasOtherSignedInAccount: Bool {
+        signedInAccounts.contains { $0.id != activeAccountId }
     }
 
     var activeChats: [ChatItem] {

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -29392,61 +29392,61 @@
         }
       }
     },
-    "Manage the identities available on this Mac.": {
+    "Manage the accounts signed in on this Mac.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verwalte die auf diesem Mac verfügbaren Identitäten."
+            "value": "Verwalte die auf diesem Mac angemeldeten Konten."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestiona las identidades disponibles en este dispositivo."
+            "value": "Gestiona las cuentas con sesión iniciada en este dispositivo."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gérez les identités disponibles sur ce Mac."
+            "value": "Gérez les comptes connectés sur ce Mac."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestisci le identità disponibili su questo Mac."
+            "value": "Gestisci gli account connessi su questo Mac."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gerencie as identidades disponíveis neste Mac."
+            "value": "Gerencie as contas com sessão iniciada neste Mac."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Управляйте личностями, доступными на этом Mac."
+            "value": "Управляйте аккаунтами, в которые выполнен вход на этом Mac."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bu Mac’te kullanılabilen kimlikleri yönetin."
+            "value": "Bu Mac’te oturum açılmış hesapları yönetin."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "管理此 Mac 上可用的身份。"
+            "value": "管理此 Mac 上已登录的账户。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "管理此 Mac 上可用的身分。"
+            "value": "管理此 Mac 上已登入的帳號。"
           }
         }
       }
@@ -48211,65 +48211,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "要登出此帳號嗎？"
-          }
-        }
-      }
-    },
-    "Signed out": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abgemeldet"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sesión cerrada"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Déconnecté"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnesso"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sessão encerrada"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Выполнен выход"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oturum kapatıldı"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已退出登录"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已登出"
           }
         }
       }

--- a/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
@@ -3,13 +3,16 @@
 //  whitenoise-mac
 //
 //  The account switcher that sits at the top of Settings: the card naming the
-//  active identity, and the popover listing every identity on this Mac. The
-//  popover switches between them and manages them — sign in, sign out, remove —
-//  and it no longer creates one: the `Add Account` button that used to sit under
-//  its row list opened the onboarding landing pane, which put account creation
-//  in the same dropdown as account switching. Creating one is the card's own
-//  `profileManagementRow` instead, which offers it precisely when there is
-//  nothing to switch to. This is where the former Accounts settings page went —
+//  active identity, and the popover listing the identities signed in on this Mac.
+//  The popover switches between them and manages them — sign out, remove — and it
+//  neither creates one nor reactivates one. The `Add Account` button that used to
+//  sit under its row list opened the onboarding landing pane, which put account
+//  creation in the same dropdown as account switching; creating one is the card's
+//  own `profileManagementRow` instead, which offers it precisely when there is
+//  nothing to switch to. Signed-out identities are not listed at all: a row that
+//  cannot be switched to does not belong in a switcher, and signing one back in
+//  lives on `SignedOutAccountsView`. This is where the former Accounts settings
+//  page went —
 //  the iOS and Flutter clients open Settings on the current profile with a
 //  switch control directly underneath it rather than routing identity work
 //  through a separate Accounts tab, and this mirrors that on macOS.
@@ -132,13 +135,16 @@ struct SettingsAccountSwitcherCard: View {
         }
     }
 
-    /// One row that adapts to how many identities are stored, the way the prototype's hub does:
-    /// with a single profile there is nothing to switch to, so the row offers to add one; with
-    /// more, it opens the switcher. A permanent "Switch Account" button was offering a choice
-    /// that, for most people, has exactly one option.
+    /// One row that adapts to how many identities are signed in, the way the prototype's hub
+    /// does: with a single profile there is nothing to switch to, so the row offers to add one;
+    /// with more, it opens the switcher. A permanent "Switch Account" button was offering a
+    /// choice that, for most people, has exactly one option.
+    ///
+    /// Counted over `hasOtherSignedInAccount` rather than the stored identities: a deactivated
+    /// one is not in the switcher's list, so counting it here promised a switch to a list of one.
     private var profileManagementRow: some View {
         Button {
-            if hasOtherAccounts {
+            if workspace.hasOtherSignedInAccount {
                 isSwitcherPresented = true
             } else {
                 workspace.showAccountOnboarding()
@@ -146,7 +152,7 @@ struct SettingsAccountSwitcherCard: View {
         } label: {
             HStack(spacing: SettingsSidebarRowMetrics.glyphSpacing) {
                 Image(
-                    systemName: hasOtherAccounts
+                    systemName: workspace.hasOtherSignedInAccount
                         ? "arrow.up.arrow.down" : "person.crop.circle.badge.plus"
                 )
                 .wnFont(.medium14)
@@ -154,7 +160,7 @@ struct SettingsAccountSwitcherCard: View {
                 .frame(width: SettingsSidebarRowMetrics.glyphWidth)
 
                 Text(
-                    hasOtherAccounts
+                    workspace.hasOtherSignedInAccount
                         ? L10n.string("Switch Account", locale: locale)
                         : L10n.string("Add Account", locale: locale)
                 )
@@ -174,10 +180,6 @@ struct SettingsAccountSwitcherCard: View {
                 onSelect: { account in
                     isSwitcherPresented = false
                     workspace.selectAccountFromSettings(account)
-                },
-                onSignIn: { account in
-                    isSwitcherPresented = false
-                    Task { await workspace.signInAccount(account) }
                 },
                 onSignOut: { account in
                     isSwitcherPresented = false
@@ -199,10 +201,6 @@ struct SettingsAccountSwitcherCard: View {
         }
     }
 
-    private var hasOtherAccounts: Bool {
-        workspace.accounts.count > 1
-    }
-
     private var removeConfirmationBinding: Binding<Bool> {
         Binding(
             get: { accountPendingRemoval != nil },
@@ -222,16 +220,15 @@ struct SettingsAccountSwitcherCard: View {
     }
 }
 
-/// The switcher itself: every identity stored on this Mac, with the active one
-/// marked. Switching and managing only — creating an identity is not offered here.
-/// Every action is reported to the card that presents this popover: it is the view
-/// that outlives the popover, so it is the one that can close it and then raise a
-/// confirmation or a sheet.
+/// The switcher itself: the identities signed in on this Mac, with the active one
+/// marked. Switching and managing only — neither creating an identity nor bringing
+/// a deactivated one back is offered here. Every action is reported to the card that
+/// presents this popover: it is the view that outlives the popover, so it is the one
+/// that can close it and then raise a confirmation or a sheet.
 struct AccountSwitcherPopover: View {
     @Environment(WorkspaceState.self) private var workspace
     @Environment(\.locale) private var locale
     let onSelect: (AccountItem) -> Void
-    let onSignIn: (AccountItem) -> Void
     let onSignOut: (AccountItem) -> Void
     let onRemove: (AccountItem) -> Void
 
@@ -240,7 +237,7 @@ struct AccountSwitcherPopover: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(L10n.string("Accounts", locale: locale))
                     .wnFont(.semiBold14)
-                Text(L10n.string("Manage the identities available on this Mac.", locale: locale))
+                Text(L10n.string("Manage the accounts signed in on this Mac.", locale: locale))
                     .wnFont(.medium10)
                     .foregroundStyle(WNColor.backgroundContentSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -248,7 +245,9 @@ struct AccountSwitcherPopover: View {
 
             Divider()
 
-            if workspace.accounts.isEmpty {
+            // Signed-out identities are filtered out, so this is reachable with accounts still
+            // stored: every one of them deactivated leaves nothing to switch between.
+            if workspace.signedInAccounts.isEmpty {
                 Text(L10n.string("No accounts", locale: locale))
                     .wnFont(.medium12)
                     .foregroundStyle(WNColor.backgroundContentSecondary)
@@ -256,14 +255,13 @@ struct AccountSwitcherPopover: View {
             } else {
                 ScrollView {
                     VStack(spacing: 2) {
-                        ForEach(workspace.accounts) { account in
+                        ForEach(workspace.signedInAccounts) { account in
                             AccountSwitcherRow(
                                 account: account,
                                 isActive: account.id == workspace.activeAccountId,
                                 unreadCount: workspace.unreadCount(forAccountIdHex: account.accountIdHex),
                                 isAccountMutationInProgress: workspace.isAccountMutationInProgress,
                                 onSelect: { onSelect(account) },
-                                onSignIn: { onSignIn(account) },
                                 onSignOut: { onSignOut(account) },
                                 onRemove: { onRemove(account) }
                             )
@@ -294,9 +292,14 @@ struct AccountSwitcherPopover: View {
     }
 }
 
-/// One identity in the switcher. Tapping switches to it (or signs it back in when
-/// it was signed out); the trailing menu carries the actions that need a
-/// confirmation.
+/// One identity in the switcher. Tapping switches to it; the trailing menu carries
+/// the actions that need a confirmation.
+///
+/// The list is fed `signedInAccounts`, so `account.signedOut` is false here by
+/// construction. It used to branch on it — a dimmed avatar under a `Signed out`
+/// caption, whose tap and whose menu item signed the identity back in — and
+/// reintroducing that branch would be dead code describing a row that cannot reach
+/// this view.
 struct AccountSwitcherRow: View {
     /// Diameter of the row's avatar. Read by `AccountSwitcherPopover.rowChromeInset`, which sizes
     /// the scroll inset from it — the chrome's reach scales with the avatar.
@@ -308,28 +311,26 @@ struct AccountSwitcherRow: View {
     let unreadCount: Int
     let isAccountMutationInProgress: Bool
     let onSelect: () -> Void
-    let onSignIn: () -> Void
     let onSignOut: () -> Void
     let onRemove: () -> Void
 
     var body: some View {
         HStack(spacing: 10) {
-            Button(action: account.signedOut ? onSignIn : onSelect) {
+            Button(action: onSelect) {
                 HStack(spacing: 10) {
                     ProfileImageAvatarView(
                         seed: account.accountIdHex,
                         initials: account.initials,
                         sanitizedPictureURL: account.sanitizedPictureURL,
-                        // Every row here is one of this Mac's own accounts, but a signed-out one is
-                        // an identity the user has deliberately deactivated — sign-out even drops
-                        // its relay key packages. Fetching its avatar would put traffic on the wire
-                        // for an identity that is supposed to be off, so it drops back to initials
-                        // (the row is already dimmed to 0.4). Signed-in rows are unaffected.
-                        isOwnAccountImage: !account.signedOut,
+                        // Every row here is one of this Mac's own signed-in accounts, so this is
+                        // unconditional — see `RemoteImageDisplayPolicy`. The narrower
+                        // `!account.signedOut` it used to carry existed for the deactivated rows,
+                        // whose relay key packages sign-out drops; with those rows gone from the
+                        // list there is nothing left for it to exclude.
+                        isOwnAccountImage: true,
                         size: Self.avatarSize,
                         isSelected: isActive
                     )
-                    .opacity(account.signedOut ? 0.4 : 1)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text(account.displayName)
@@ -338,10 +339,7 @@ struct AccountSwitcherRow: View {
 
                         Text(statusText)
                             .wnFont(.medium10)
-                            .foregroundStyle(
-                                account.signedOut
-                                    ? WNColor.intentionWarningContent
-                                    : WNColor.backgroundContentSecondary)
+                            .foregroundStyle(WNColor.backgroundContentSecondary)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -360,24 +358,14 @@ struct AccountSwitcherRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .disabled(account.signedOut && isAccountMutationInProgress)
 
             Menu {
                 Group {
-                    if account.signedOut {
-                        Button(action: onSignIn) {
-                            Label(
-                                L10n.string("Sign In", locale: locale),
-                                systemImage: "person.crop.circle.badge.checkmark"
-                            )
-                        }
-                    } else {
-                        Button(action: onSignOut) {
-                            Label(
-                                L10n.string("Sign Out", locale: locale),
-                                systemImage: "rectangle.portrait.and.arrow.right"
-                            )
-                        }
+                    Button(action: onSignOut) {
+                        Label(
+                            L10n.string("Sign Out", locale: locale),
+                            systemImage: "rectangle.portrait.and.arrow.right"
+                        )
                     }
 
                     Divider()
@@ -404,9 +392,6 @@ struct AccountSwitcherRow: View {
     }
 
     private var statusText: String {
-        if account.signedOut {
-            return L10n.string("Signed out", locale: locale)
-        }
         if account.localSigning {
             return L10n.string("Local signing", locale: locale)
         }

--- a/whitenoise-mac/Views/SidebarViews.swift
+++ b/whitenoise-mac/Views/SidebarViews.swift
@@ -102,9 +102,10 @@ struct AccountRailView: View {
 /// Sign Out on right-click, where Sign Out fired `signOutAccount` with no prompt at all,
 /// so an accidental click dropped that identity's relay key packages. It also used to
 /// draw deactivated identities, dimmed to 0.4 behind a pause glyph, where one tap signed
-/// one back in. Every one of those is account management, and all of it lives in Settings'
-/// switcher now (`SettingsAccountSwitcherCard`): sign-out and removal behind confirmations,
-/// sign-in on the row itself.
+/// one back in. Every one of those is account management: sign-out and removal live in
+/// Settings' switcher behind confirmations (`SettingsAccountSwitcherCard`), and signing a
+/// deactivated identity back in lives on `SignedOutAccountsView`, which is the surface
+/// that exists for exactly that.
 ///
 /// The rail is fed `signedInAccounts`, so `account.signedOut` is false here by
 /// construction. Reintroducing a branch on it would be dead code describing a row that
@@ -129,9 +130,8 @@ private struct AccountRailAvatar: View {
                 // Images" preference — see `RemoteImageDisplayPolicy`. Left on the default, the
                 // rail drew initials for a picture the viewer had just set and could see in
                 // Settings, which reads as a broken avatar rather than as privacy. Unconditional
-                // because every row here is signed in; the switcher's list still gates its
-                // deactivated rows, since signing out drops an identity's relay key packages and
-                // the app should not then put traffic on the wire on its behalf.
+                // because every row here is signed in — the switcher's list is fed the same
+                // filtered collection, so it is unconditional there too.
                 isOwnAccountImage: true,
                 size: MessagesLayout.accountRailAvatarSize,
                 isSelected: isActive

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1375,36 +1375,112 @@ struct whitenoise_macTests {
         #expect(normalized.contains(".padding(.horizontal,-Self.rowChromeInset)"))
     }
 
-    /// The switcher lists the identities already on this Mac; it is no longer the way a new one
-    /// gets made. `Add Account` sat under the row list and opened the onboarding landing pane —
-    /// the one offering Sign Up — which put account *creation* in the same dropdown as account
-    /// switching. Only a source contract can guard an absent control: no behavior test can
-    /// observe a button that is never built. Asserting on the popover's own declaration rather
-    /// than on the file is deliberate, because `signInAccount` must survive elsewhere in it:
-    /// with signed-out identities gone from the rail, the switcher's rows are the only way back
-    /// into one while another account is signed in.
+    /// The switcher switches between signed-in identities; it neither makes a new one nor brings
+    /// a deactivated one back. `Add Account` sat under the row list and opened the onboarding
+    /// landing pane — the one offering Sign Up — which put account *creation* in the same dropdown
+    /// as account switching. Reactivation went the same way with the signed-out rows themselves.
+    /// Only a source contract can guard an absent control: no behavior test can observe a button
+    /// that is never built.
     @MainActor
-    @Test func accountSwitcherPopoverOffersNoWayToCreateAnAccount() throws {
+    @Test func accountSwitcherPopoverOffersNoWayToCreateOrReactivateAnAccount() throws {
+        let source = try Self.accountSwitcherSource()
+        let popoverStart = try #require(source.range(of: "struct AccountSwitcherPopover: View {"))
+        let popoverEnd = try #require(source.range(of: "struct AccountSwitcherRow: View {"))
+        let normalized = Self.strippingCommentLines(source[popoverStart.lowerBound..<popoverEnd.lowerBound])
+            .components(separatedBy: .whitespacesAndNewlines).joined()
+
+        // Scoped to the popover: `Add Account` is still the card's own `profileManagementRow`,
+        // which offers it when there is nothing to switch to.
+        #expect(!normalized.contains("AddAccount"), "account creation does not belong in the switcher")
+        #expect(!normalized.contains("showAccountOnboarding"))
+        // Reactivation, unlike creation, has no home anywhere in this file — the card used to
+        // hand the popover an `onSignIn` closure — so it is asserted over the whole of it.
+        #expect(
+            !Self.strippingCommentLines(source).contains("signInAccount"),
+            "reactivating an identity is not switching to it"
+        )
+    }
+
+    /// The switcher's row list is fed the filtered collection. Only the source can hold which one
+    /// it iterates — SwiftUI's `ForEach` is not observable from a test, and `workspace.accounts`
+    /// compiles just as well — so the filter is pinned where it is written.
+    @MainActor
+    @Test func accountSwitcherListsOnlySignedInAccounts() throws {
+        let source = try Self.accountSwitcherSource()
+        let popoverStart = try #require(source.range(of: "struct AccountSwitcherPopover: View {"))
+        let popoverEnd = try #require(source.range(of: "struct AccountSwitcherRow: View {"))
+        let normalized = Self.strippingCommentLines(source[popoverStart.lowerBound..<popoverEnd.lowerBound])
+            .components(separatedBy: .whitespacesAndNewlines).joined()
+
+        #expect(normalized.contains("ForEach(workspace.signedInAccounts)"))
+        // The empty state has to read the same collection: with every stored identity deactivated
+        // there is nothing to switch between, and `workspace.accounts.isEmpty` would have claimed
+        // a list while rendering no rows at all.
+        #expect(normalized.contains("workspace.signedInAccounts.isEmpty"))
+        #expect(!normalized.contains("workspace.accounts"))
+    }
+
+    /// The row itself keeps no signed-out branch — no dimmed avatar, no warning-colored `Signed
+    /// out` caption, no `Sign In` menu item. Left in place it would read as live behavior for a
+    /// row that cannot reach the view, and would invite the list's filter to be widened back.
+    @MainActor
+    @Test func accountSwitcherRowCarriesNoSignedOutBranch() throws {
+        let source = try Self.accountSwitcherSource()
+        let rowStart = try #require(source.range(of: "struct AccountSwitcherRow: View {"))
+        let row = Self.strippingCommentLines(source[rowStart.lowerBound...])
+
+        #expect(!row.contains("account.signedOut"))
+        #expect(!row.contains("onSignIn"))
+        // Its avatar is exempt from the remote-image preference unconditionally now — the
+        // narrower `!account.signedOut` existed for rows the list no longer produces.
+        #expect(row.contains("isOwnAccountImage: true"))
+    }
+
+    /// `SignedOutAccountsView` is the whole of the way back into a deactivated identity now that
+    /// neither the rail nor the switcher lists one. It reads `accounts`, unfiltered, on purpose:
+    /// fed `signedInAccounts` it would offer nothing at the exact moment nothing is signed in.
+    @MainActor
+    @Test func signedOutAccountsViewIsTheRemainingWayBackIntoADeactivatedIdentity() throws {
         let sourceURL =
             URL(filePath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appending(path: "whitenoise-mac")
             .appending(path: "Views")
-            .appending(path: "Settings")
-            .appending(path: "SettingsAccountSwitcherViews.swift")
+            .appending(path: "MessengerShellView.swift")
         let source = try String(contentsOf: sourceURL, encoding: .utf8)
-
-        let popoverStart = try #require(source.range(of: "struct AccountSwitcherPopover: View {"))
-        let popoverEnd = try #require(source.range(of: "struct AccountSwitcherRow: View {"))
-        let normalized = String(source[popoverStart.lowerBound..<popoverEnd.lowerBound])
+        let start = try #require(source.range(of: "private struct SignedOutAccountsView: View {"))
+        let view = String(source[start.lowerBound...])
             .components(separatedBy: .whitespacesAndNewlines).joined()
 
-        #expect(!normalized.contains("AddAccount"), "account creation does not belong in the switcher")
-        #expect(!normalized.contains("showAccountOnboarding"))
+        #expect(view.contains("workspace.accounts.filter(\\.signedOut)"))
+        #expect(view.contains("workspace.signInAccount(account)"))
+    }
 
-        // The route back into a signed-out identity has to stay: the rail no longer carries one.
-        #expect(source.contains("signInAccount"))
+    /// A source slice with its comment-only lines dropped.
+    ///
+    /// A contract that forbids a token cannot read the comments: these files explain at length
+    /// precisely which branch they no longer carry, and naming it in the explanation is not the
+    /// same as reintroducing it. Dropping the prose is what lets the assertion stay a literal
+    /// token search rather than a pattern that has to out-guess English.
+    private static func strippingCommentLines(_ source: some StringProtocol) -> String {
+        source.split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+    }
+
+    private static func accountSwitcherSource() throws -> String {
+        try String(
+            contentsOf:
+                URL(filePath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appending(path: "whitenoise-mac")
+                .appending(path: "Views")
+                .appending(path: "Settings")
+                .appending(path: "SettingsAccountSwitcherViews.swift"),
+            encoding: .utf8
+        )
     }
 
     @MainActor
@@ -1800,16 +1876,17 @@ struct whitenoise_macTests {
     }
 
     @MainActor
-    @Test func signedInAccountsOmitsDeactivatedIdentitiesFromTheRail() async throws {
-        // What the account rail draws. A signed-out identity used to sit in it dimmed to 0.4
-        // behind a pause glyph, and tapping it signed the identity back in — account management
-        // in the switching control, reached with no confirmation. It lives in Settings' switcher
-        // now, beside sign-out and removal.
+    @Test func signedInAccountsOmitsDeactivatedIdentitiesFromTheRailAndSwitcher() async throws {
+        // What the account rail and the Settings switcher draw. A signed-out identity used to sit
+        // in both — dimmed to 0.4 behind a pause glyph in the rail, dimmed under a `Signed out`
+        // caption in the switcher — and tapping it signed the identity back in. Neither control
+        // can be *switched* to a deactivated identity (`selectAccount` and
+        // `selectAccountFromSettings` both refuse one), so those rows were a sign-in button
+        // wearing a destination's clothes.
         //
-        // `accounts` must keep every identity on this Mac regardless: the switcher's row list
-        // reads it, and so does `SignedOutAccountsView`, which is the whole of the way back in
-        // when nothing is signed in. Filtering there instead of in the rail would lock the user
-        // out of their own Mac.
+        // `accounts` must keep every identity on this Mac regardless: `SignedOutAccountsView`
+        // reads it, and that is the whole of the way back in now. Filtering there too would lock
+        // the user out of their own Mac.
         let primary = AccountSummaryFfi(
             label: "Desktop Account",
             accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
@@ -1834,13 +1911,54 @@ struct whitenoise_macTests {
 
         #expect(state.accounts.map(\.id) == ["Desktop Account", "Backup Account"])
         #expect(state.signedInAccounts.map(\.id) == ["Desktop Account"])
+        // And with the deactivated identity out of the list, there is nothing to switch to: the
+        // management row offers `Add Account` rather than a switcher holding one row.
+        #expect(!state.hasOtherSignedInAccount)
 
-        // Signing it back in from the switcher puts it back in the rail — the filter is derived
-        // from the account list, not a separate copy that could fall out of step with it.
+        // Signing it back in puts it back in both lists — the filter is derived from the account
+        // list, not a separate copy that could fall out of step with it.
         let backup = try #require(state.accounts.first { $0.id == "Backup Account" })
         await state.signInAccount(backup)
 
         #expect(state.signedInAccounts.map(\.id) == ["Desktop Account", "Backup Account"])
+        #expect(state.hasOtherSignedInAccount)
+    }
+
+    /// Signing a background identity out drops it from the switcher instead of turning its row
+    /// into a dimmed `Signed out` entry, and leaves the active session alone.
+    @MainActor
+    @Test func signingOutABackgroundAccountRemovesItFromTheSwitcherList() async throws {
+        let primary = AccountSummaryFfi(
+            label: "Desktop Account",
+            accountIdHex: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let other = AccountSummaryFfi(
+            label: "Other Account",
+            accountIdHex: "2222222222222222222222222222222222222222222222222222222222222222",
+            localSigning: true,
+            externalSigning: false,
+            signedOut: false,
+            running: true
+        )
+        let runtime = FakeMarmotRuntime(accounts: [primary, other])
+        UserDefaults.standard.set("Desktop Account", forKey: "whitenoise.mac.activeAccountId")
+        let state = WorkspaceState(clientFactory: { runtime })
+
+        await state.bootstrap()
+        #expect(state.hasOtherSignedInAccount)
+        let background = try #require(state.accounts.first { $0.id == "Other Account" })
+
+        await state.signOutAccount(background)
+
+        #expect(state.activeAccountId == "Desktop Account")
+        #expect(state.signedInAccounts.map(\.id) == ["Desktop Account"])
+        #expect(!state.hasOtherSignedInAccount)
+        // Still stored, so `SignedOutAccountsView` can offer it once nothing is signed in.
+        #expect(state.accounts.first { $0.id == "Other Account" }?.signedOut == true)
     }
 
     @MainActor
@@ -27761,9 +27879,9 @@ struct whitenoise_macTests {
         // on the default made the sidebar draw initials for the picture the viewer had just set
         // and could see in Settings, which reads as "my avatar is broken" rather than as privacy.
         // Unconditional now that the rail draws signed-in accounts only — the narrower
-        // `!account.signedOut` this used to carry has nothing left to exclude, and the switcher's
-        // list is where that argument still applies. The chat rows next to it are peers and must
-        // keep the default.
+        // `!account.signedOut` this used to carry has nothing left to exclude. The switcher's
+        // rows are fed the same filtered list and are unconditional for the same reason; the chat
+        // rows next to it are peers and must keep the default.
         let sidebarSource = try String(
             contentsOf:
                 URL(fileURLWithPath: #filePath)
@@ -27801,9 +27919,10 @@ struct whitenoise_macTests {
         // Sign In / Sign Out context menu, whose Sign Out fired `signOutAccount` straight from a
         // right-click with no prompt — an accidental click dropped that identity's relay key
         // packages. And it used to draw signed-out identities too, dimmed behind a pause glyph,
-        // where a single tap signed one back in. All of it is account management, and all of it
-        // now lives in Settings' switcher: sign-out and removal behind confirmations, sign-in on
-        // the row itself. Only a source contract can guard *absent* chrome: no behavior test can
+        // where a single tap signed one back in. All of it is account management: sign-out and
+        // removal live in Settings' switcher behind confirmations, and signing a deactivated
+        // identity back in lives on `SignedOutAccountsView`, the surface that exists for exactly
+        // that. Only a source contract can guard *absent* chrome: no behavior test can
         // observe a menu or a branch that is never built. The chat rows beside it keep their own
         // menu, which is why this asserts on the rail's declaration rather than on the file.
         let sidebarSource = try String(
@@ -27829,7 +27948,7 @@ struct whitenoise_macTests {
 
         #expect(!railSource.contains(".contextMenu"))
         #expect(!railSource.contains("signOutAccount"), "destructive sign out belongs to the confirmed Settings path")
-        #expect(!railSource.contains("signInAccount"), "signing back in belongs to the Settings switcher")
+        #expect(!railSource.contains("signInAccount"), "signing back in belongs to SignedOutAccountsView")
         // The rail is fed `signedInAccounts`, so the avatar has no signed-out case to branch on:
         // a leftover branch here would be dead code claiming to handle a row that cannot appear.
         #expect(!railSource.contains("signedOut"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account switching now shows only accounts currently signed in.
  * Added an empty state when no signed-in accounts are available.
  * Account management and reactivation remain available through Settings.

* **Improvements**
  * Clarified account-management messaging and updated translations.
  * Simplified account rail and switcher presentation for signed-in accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->