### PR TITLE
Tighten the sign up form around its avatar

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -47143,65 +47143,6 @@
         }
       }
     },
-    "Set up profile": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Profil einrichten"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configurar perfil"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configurer le profil"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configura profilo"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configurar perfil"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройка профиля"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Profil oluştur"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "设置个人资料"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定個人檔案"
-          }
-        }
-      }
-    },
     "Settings": {
       "extractionState": "manual",
       "localizations": {

--- a/whitenoise-mac/Views/Onboarding/OnboardingLayout.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingLayout.swift
@@ -26,6 +26,19 @@ import SwiftUI
 /// Not `nonisolated`: `ControlSize` and friends inherit the module's MainActor default. Asserting
 /// these values still needs nothing but the main actor.
 enum OnboardingLayout {
+    /// How far left of the content column the header row's exit control hangs.
+    ///
+    /// The control belongs *to* the column — it is the way back out of the form, not out of the
+    /// window — but it does not belong *in* it. Sitting on the column's leading edge it lines up
+    /// with the Name label and the notice's box and reads as the first item of the form; pinned to
+    /// the pane's own margin instead, it drifts further from the form the wider the window gets.
+    /// So it hangs in the gutter immediately outside the column: clear of the form's left edge, and
+    /// still travelling with it when the window is resized.
+    ///
+    /// One control width plus `actionSpacing`, so the whole circle clears the column with the same
+    /// air between them that the pane puts between two stacked buttons.
+    static let headerControlOverhang: CGFloat = MessagesLayout.circleControlSize + actionSpacing
+
     /// The action column — buttons on the welcome pane, the key field and its CTA on sign-in.
     ///
     /// 360 is the width the sign-in field already used before this pane was rebuilt, and it is
@@ -33,10 +46,17 @@ enum OnboardingLayout {
     /// rather than a desktop form's.
     static let contentWidth: CGFloat = 360
 
-    /// Between the block above the actions — the sign-in pane's key field — and the actions
-    /// themselves. Wider than `actionSpacing` so a field and the button that submits it do not
-    /// read as two members of one stack.
-    static let contentToActionsSpacing: CGFloat = 24
+    /// Between the block above the actions — the sign-in pane's key field, the sign-up pane's form
+    /// — and the actions themselves. Wider than `actionSpacing` so a field and the button that
+    /// submits it do not read as two members of one stack.
+    ///
+    /// 16 rather than the 24 it started at. On both panes the thing directly above the button is
+    /// `OnboardingMessageLine`, whose empty reserved slot is already 32pt of air; 24 on top of that
+    /// put the sign-up pane's Create profile 76pt below the last field it submits, which reads as
+    /// the button having come loose from the form rather than as breathing room. 16 still clears
+    /// `actionSpacing` by the margin this needs to stay a different kind of gap from the one
+    /// between two stacked buttons.
+    static let contentToActionsSpacing: CGFloat = 16
 
     /// Between stacked actions. Flutter's `WnAuthButtonsContainer` puts `Gap(12.h)` between its
     /// two auth buttons; this is that gap.
@@ -63,7 +83,12 @@ enum OnboardingLayout {
     /// which on a default-sized window is well past `edgePadding` again — so the pane a person
     /// normally sees is unchanged, and the pane at the size a person can drag it to keeps its
     /// button on screen.
-    static let signUpEdgePadding: CGFloat = 16
+    ///
+    /// 12 rather than the 16 it started at, and the 4pt is not a saving — it went into
+    /// `signUpAvatarSize`. Two of the three margins this floors are the pane's top and bottom, so
+    /// the trade is 8pt of air that exists only in a 620pt-tall window against a hero that is
+    /// bigger in every window.
+    static let signUpEdgePadding: CGFloat = 12
 
     /// The most air there is between the mark and the column of actions under it.
     ///
@@ -113,18 +138,37 @@ enum OnboardingLayout {
 
     /// The avatar that stands where the mark stands on the other two panes.
     ///
-    /// **This is the number the window's height floor is spent on, so it is smaller than it
-    /// looks like it should be.** The hero is not the avatar alone: it is the avatar, a 10pt gap
-    /// and the `Add photo` pill, and the pane below it — a title, two labelled fields one of
-    /// which is three lines, a reserved error line and a 44pt CTA — leaves about 103pt for the
-    /// whole group inside `ContentView`'s 620pt minimum. Measured, not budgeted: at 88 with the
-    /// pill under it the pane draws 642pt and pushes its own button off a short window's bottom
-    /// edge, which is what `OnboardingTests.theSignUpPaneFitsTheSmallestWindow` fails on.
+    /// **This is the number the window's height floor is spent on, so it is smaller than it looks
+    /// like it should be.** The hero is not the avatar alone: it is the avatar, a 10pt gap and the
+    /// `Add photo` pill, and the pane below it — two labelled fields one of which is three lines,
+    /// a public-profile notice, a reserved error line and a 44pt CTA — has to fit inside
+    /// `ContentView`'s 620pt minimum. Measured, not budgeted: at 88 with the pill under it the
+    /// pane draws 642pt and pushes its own button off a short window's bottom edge, which is what
+    /// `OnboardingTests.theSignUpPaneFitsTheSmallestWindow` fails on.
     ///
-    /// 64 puts the group at 95pt and the pane at 612pt, which leaves the type ramp room to move
-    /// without taking the CTA with it. It is also a size the app already draws avatars at, so the
-    /// hero does not look like a one-off.
-    static let signUpAvatarSize: CGFloat = 64
+    /// 76, up from the 64 this shipped at, and every one of those 12pt was bought rather than
+    /// found: 4 off `signUpHeroToContentSpacing` and 8 off `signUpEdgePadding`. The bill is
+    /// settled by `theSignUpPaneFitsTheSmallestWindowInEveryLanguage`, not by this comment —
+    /// German draws the public-profile notice on three lines, which puts the pane at 614pt of the
+    /// 620pt there is. That 6pt is the whole remaining cushion, so anything added here has to come
+    /// off one of the two numbers above, and re-measuring is the only way to know how much.
+    static let signUpAvatarSize: CGFloat = 76
+
+    /// Between the sign-up hero and the form under it.
+    ///
+    /// Fixed, where the other two panes let this gap breathe up to `markToActionsMaximumSpacing`.
+    /// Their hero is the app's mark, which is a thing in its own right standing above two buttons;
+    /// this one is the face the form immediately under it is describing, and the avatar, the
+    /// `Add photo` pill and the notice that says where the photo ends up are one paragraph. Left
+    /// to the scaffold's default the pane's spare height opens this gap to around 78pt on an
+    /// ordinarily-sized window, which reads as the hero having come loose from the form.
+    ///
+    /// 12, and the 4pt it gave up against the pane's old margin went straight into
+    /// `signUpAvatarSize`: this gap and the avatar above it are the same budget, so the notice
+    /// sitting closer is part of what pays for the bigger face. It stays a step above the 10pt
+    /// between the avatar and its own pill, so the pill still reads as belonging to the avatar
+    /// rather than to the box under it.
+    static let signUpHeroToContentSpacing: CGFloat = 12
 
     /// Between the avatar and the `Add photo` pill under it. `wn-ios-prototype` uses a bare
     /// `.padding(.top)` — the system's 16 on a phone — and the pill here is the smaller of the

--- a/whitenoise-mac/Views/Onboarding/OnboardingScaffold.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingScaffold.swift
@@ -34,16 +34,6 @@ import SwiftUI
 /// and only the thing they are arranged around changes. `OnboardingMarkHero` is the default, so a
 /// pane that says nothing gets the mark.
 struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
-    /// What this pane is called, drawn in the header row. `nil` on the panes that do not need one:
-    /// a screen whose whole content is a mark over two buttons is not asking a question.
-    ///
-    /// The header row is where it goes because the header row is already there — 28pt reserved on
-    /// every pane so the hero cannot jump — and a title inside it therefore costs the column below
-    /// nothing. That matters on the sign-up pane, which is 13pt too tall for a 620pt window with
-    /// its title in the content and comfortably inside it with the title up here. It is also where
-    /// both phone clients put the same string: `wn-ios-prototype` as a `navigationTitle`, Flutter
-    /// as its `WnSlateNavigationHeader` title, both beside the same back control.
-    var title: String?
     /// Supplied only by a pane that has somewhere to go. The inner panes pass `.back`; the welcome
     /// pane passes `.cancel` when the flow was opened from a running app and `nil` when it was
     /// not, which removes the control while keeping the row it stood in. See
@@ -54,6 +44,14 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
     /// is what lets the tallest pane keep its button on screen in the shortest window. See
     /// `OnboardingLayout.signUpEdgePadding`.
     var minimumEdgeSpacing: CGFloat = OnboardingLayout.edgePadding
+    /// The most air there may be between the hero and the column under it.
+    ///
+    /// Defaults to `OnboardingLayout.markToActionsMaximumSpacing`, which is the gap the mark wants
+    /// on a pane whose whole content is that mark and two buttons. The sign-up pane passes a much
+    /// tighter one, because its hero is not a mark standing on its own: it is the face the form
+    /// below it describes, and the two read as one thing only while they are close enough to be
+    /// one thing. See `OnboardingLayout.signUpHeroToContentSpacing`.
+    var maximumHeroToContentSpacing: CGFloat = OnboardingLayout.markToActionsMaximumSpacing
     /// What the pane is arranged around. Defaults to the mark.
     @ViewBuilder var hero: Hero
     /// Whatever sits between the hero and the actions — the sign-in pane's key field, the sign-up
@@ -64,7 +62,7 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            OnboardingHeaderRow(title: title, exit: exit)
+            OnboardingHeaderRow(exit: exit)
 
             Spacer(minLength: minimumEdgeSpacing)
 
@@ -72,9 +70,14 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
 
             // Capped, unlike the `Spacer` above the hero, so the pane's spare height collects at
             // the top instead of being split evenly across the hero. See
-            // `OnboardingLayout.markToActionsMaximumSpacing`.
-            Spacer(minLength: minimumEdgeSpacing)
-                .frame(maxHeight: OnboardingLayout.markToActionsMaximumSpacing)
+            // `maximumHeroToContentSpacing`.
+            //
+            // The floor yields to the ceiling rather than fighting it: a pane that wants this gap
+            // held tighter than its own margins — the sign-up pane does — would otherwise clamp a
+            // `minLength` above `maxHeight`, and the two would disagree about a gap neither is
+            // wrong about.
+            Spacer(minLength: min(minimumEdgeSpacing, maximumHeroToContentSpacing))
+                .frame(maxHeight: maximumHeroToContentSpacing)
 
             VStack(spacing: OnboardingLayout.contentToActionsSpacing) {
                 content
@@ -107,13 +110,11 @@ struct OnboardingScaffold<Hero: View, Content: View, Actions: View>: View {
 extension OnboardingScaffold where Hero == OnboardingMarkHero {
     /// The scaffold as both existing panes use it: the mark as the hero.
     init(
-        title: String? = nil,
         exit: OnboardingExitControl? = nil,
         @ViewBuilder content: () -> Content,
         @ViewBuilder actions: () -> Actions
     ) {
         self.init(
-            title: title,
             exit: exit,
             hero: { OnboardingMarkHero() },
             content: content,
@@ -128,14 +129,22 @@ extension OnboardingScaffold where Hero == OnboardingMarkHero {
 /// the scaffold's two `Spacer`s centre the hero in whatever is left below this row, so a row that
 /// appeared only on sign-in would shift the hero down by its height on the way in and back up on
 /// the way out.
+///
+/// **The control travels with the column, in the gutter beside it.** Everything else on an
+/// onboarding pane — the hero, the fields, the buttons — lives in one `contentWidth` column down
+/// the middle, and the way back out belongs to that column too. Pinned to the pane's own margin
+/// instead, it drifts further from the thing it belongs to the wider the window gets: on a
+/// maximised display it is a lone circle in the top-left corner of an otherwise empty half of the
+/// screen, half a metre from the form it goes back from.
+///
+/// It hangs `OnboardingLayout.headerControlOverhang` outside the column rather than sitting on its
+/// leading edge, because flush with the edge it lines up with the Name label under it and joins the
+/// form instead of standing beside it. The pane's margin stays on as a floor, for the case where
+/// the column and its gutter are wider than the pane has room for.
 private struct OnboardingHeaderRow: View {
-    let title: String?
     let exit: OnboardingExitControl?
 
     var body: some View {
-        // Overlaid rather than a third `HStack` member, so the title is centred on the *pane* and
-        // not on whatever is left of it beside the exit control — which would move it sideways
-        // between a pane that has one and one that does not.
         HStack {
             if let exit {
                 GlassCircleCloseButton(
@@ -150,19 +159,13 @@ private struct OnboardingHeaderRow: View {
 
             Spacer(minLength: 0)
         }
-        .overlay {
-            if let title {
-                Text(title)
-                    .wnFont(.semiBold14)
-                    .foregroundStyle(WNColor.backgroundContentPrimary)
-                    .lineLimit(1)
-                    // Never under the back control, however narrow the pane gets.
-                    .padding(.horizontal, MessagesLayout.circleControlSize + OnboardingLayout.actionSpacing)
-                    .accessibilityAddTraits(.isHeader)
-                    .accessibilityIdentifier("onboarding.title")
-            }
-        }
         .frame(height: MessagesLayout.circleControlSize)
+        // The column plus a gutter at each end, then the centring, then the floor — in that order,
+        // so a pane too narrow for all three loses width from the gutters rather than from the
+        // margin. Centred, a box this much wider than the column puts its leading edge exactly one
+        // overhang left of the column's, which is where the control goes.
+        .frame(maxWidth: OnboardingLayout.contentWidth + 2 * OnboardingLayout.headerControlOverhang)
+        .frame(maxWidth: .infinity)
         .padding(.horizontal, OnboardingLayout.edgePadding)
         // The pane starts at the window's top edge in a `.hiddenTitleBar` window, so this control
         // would otherwise land under the traffic lights — or under the offline band, when one is

--- a/whitenoise-mac/Views/Onboarding/OnboardingSignUpView.swift
+++ b/whitenoise-mac/Views/Onboarding/OnboardingSignUpView.swift
@@ -27,6 +27,12 @@ import SwiftUI
 ///   Openverse search — rather than the prototype's Photos/Files/Web menu, which is a phone's
 ///   three sources. It is the same sheet Settings → Profile opens, pointed at the draft instead
 ///   of at an account; see `WorkspaceState.ProfileImagePickerDestination`.
+/// * **No title.** Both phone clients label this screen — `wn-ios-prototype` with a
+///   `navigationTitle`, Flutter with its `WnSlateNavigationHeader` — because on a phone it is a
+///   pushed screen and the nav bar is already there to carry the way back. In a window there is no
+///   bar, and the pane answers its own question without one: an avatar over a Name field over a
+///   `Create profile` button is not ambiguous about what it is. A heading above it would only be
+///   the pane reading itself out.
 /// * **The privacy callout is quiet, and it does not fold.** Flutter puts a tap-to-expand
 ///   `WnCallout` here. This pane draws the same box Settings → Profile draws, with the same two
 ///   strings, in the neutral gray rather than the info tint — see `OnboardingPublicProfileNote`.
@@ -51,35 +57,44 @@ struct OnboardingSignUpView: View {
         @Bindable var workspace = workspace
 
         OnboardingScaffold(
-            title: L10n.string("Set up profile"),
             exit: .back(cancel),
-            minimumEdgeSpacing: OnboardingLayout.signUpEdgePadding
+            minimumEdgeSpacing: OnboardingLayout.signUpEdgePadding,
+            maximumHeroToContentSpacing: OnboardingLayout.signUpHeroToContentSpacing
         ) {
             OnboardingSignUpAvatar()
         } content: {
             VStack(alignment: .leading, spacing: OnboardingLayout.titleToFieldsSpacing) {
                 OnboardingPublicProfileNote()
 
-                VStack(alignment: .leading, spacing: OnboardingLayout.fieldSpacing) {
-                    OnboardingFormField(
-                        label: L10n.string("Name"),
-                        prompt: L10n.string("Enter your name"),
-                        text: $workspace.signUpDraft.displayName,
-                        isEnabled: !isBusy
-                    )
-                    .accessibilityIdentifier("onboarding.sign-up.name")
+                // The error slot is inside the field block, at the same gap a field's own label
+                // sits at, rather than a third peer of the notice and the fields at
+                // `titleToFieldsSpacing`. Two reasons, and they point the same way: what lands
+                // there is an annotation on the form — `Couldn't publish profile` — which belongs
+                // against the fields it is about, and the 32pt the slot reserves for it is 32pt
+                // the pane is spending whether or not there is anything to say. Held out here at
+                // 20 it put Create profile 76pt below the About field.
+                VStack(alignment: .leading, spacing: OnboardingLayout.fieldLabelSpacing) {
+                    VStack(alignment: .leading, spacing: OnboardingLayout.fieldSpacing) {
+                        OnboardingFormField(
+                            label: L10n.string("Name"),
+                            prompt: L10n.string("Enter your name"),
+                            text: $workspace.signUpDraft.displayName,
+                            isEnabled: !isBusy
+                        )
+                        .accessibilityIdentifier("onboarding.sign-up.name")
 
-                    OnboardingFormField(
-                        label: L10n.string("About"),
-                        prompt: L10n.string("Introduce yourself"),
-                        text: $workspace.signUpDraft.about,
-                        lineLimit: OnboardingLayout.aboutFieldLineLimit,
-                        isEnabled: !isBusy
-                    )
-                    .accessibilityIdentifier("onboarding.sign-up.about")
+                        OnboardingFormField(
+                            label: L10n.string("About"),
+                            prompt: L10n.string("Introduce yourself"),
+                            text: $workspace.signUpDraft.about,
+                            lineLimit: OnboardingLayout.aboutFieldLineLimit,
+                            isEnabled: !isBusy
+                        )
+                        .accessibilityIdentifier("onboarding.sign-up.about")
+                    }
+
+                    OnboardingMessageLine(message: workspace.lastError)
                 }
-
-                OnboardingMessageLine(message: workspace.lastError)
             }
         } actions: {
             OnboardingActionButton(

--- a/whitenoise-macTests/OnboardingTests.swift
+++ b/whitenoise-macTests/OnboardingTests.swift
@@ -523,8 +523,9 @@ import Testing
 
     /// The one thing about this pane that fails invisibly.
     ///
-    /// It is the tallest of the three — an avatar, a title, two labelled fields (one of them three
-    /// lines), a reserved error line and a button, where the other two have a field or nothing —
+    /// It is the tallest of the three — an avatar, a public-profile notice, two labelled fields
+    /// (one of them three lines), a reserved error line and a button, where the other two have a
+    /// field or nothing —
     /// and the window it lives in can be as short as `ContentView`'s `minHeight`. The scaffold's
     /// `Spacer`s have a `minLength` floor and its `VStack` does not scroll, so a pane that grows
     /// past that height does not compress or clip: it pushes its own button off the bottom edge,
@@ -553,9 +554,12 @@ import Testing
     /// shipping a pane whose Create profile button is off the bottom edge in German.
     ///
     /// So the pane is measured once, its own notice is subtracted, and the tallest translation of
-    /// that notice is put back. Nothing else on the pane can take a line it did not take before —
-    /// the title sits in the header row, both field labels are one line, and the error slot is
-    /// reserved at a fixed height.
+    /// that notice is put back. Nothing else on the pane can take a line it did not take before:
+    /// both field labels are one line, and the error slot is reserved at a fixed height.
+    ///
+    /// This is the test that prices `OnboardingLayout.signUpAvatarSize`. German draws the notice
+    /// on three lines and puts the pane at 614pt of the 620pt there is, so the 6pt left over is
+    /// the entire budget for anything the pane grows by next.
     @Test func theSignUpPaneFitsTheSmallestWindowInEveryLanguage() throws {
         let paneHeight = try Self.signUpPaneHeight()
         let hostNotice = try Self.publicProfileNoticeHeight(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Updated the macOS sign-up screen with a larger avatar, tighter spacing, and improved edge alignment.
  - Removed the “Set up profile” heading and related translations.
  - Improved responsive spacing between the hero section and sign-up content.
  - Refined exit control placement within the onboarding content area.
- **Documentation**
  - Clarified onboarding layout behavior and multilingual sizing expectations.
  - Updated sign-up guidance to highlight the public-profile notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->