### PR TITLE
Restyle profile qr modal

### DIFF
--- a/whitenoise-mac/Core/RemoteImageDisplayPolicy.swift
+++ b/whitenoise-mac/Core/RemoteImageDisplayPolicy.swift
@@ -29,15 +29,16 @@ import Foundation
 ///
 /// So: your own avatar always draws, everyone else's waits for the preference. Pass
 /// `isOwnAccountImage: true` only where the URL provably belongs to an account **signed in** on
-/// this Mac — the profile editor, its picker, Identity & Keys, the account rail, and the account
-/// switcher. Peer avatars (chat rows, message senders, member lists, search results) must keep the
-/// default.
+/// this Mac — the profile editor, its picker, Identity & Keys, the account rail, the account
+/// switcher, and the public-identity QR sheet those last two open. Peer avatars (chat rows,
+/// message senders, member lists, search results) must keep the default.
 ///
 /// "Signed in" is load-bearing rather than decorative, and each of those sites earns its literal
 /// `true` differently. The first three render `activeAccount`, which `restoreOrSelectFirstAccount()`
-/// guarantees is never a signed-out account. The rail and the switcher each render several accounts
-/// at once, but both are fed `signedInAccounts`, so a deactivated identity never reaches an avatar
-/// in either to begin with.
+/// guarantees is never a signed-out account, and so does the QR sheet: every call site that opens
+/// it reads `activeAccount`. The rail and the switcher each render several accounts at once, but
+/// both are fed `signedInAccounts`, so a deactivated identity never reaches an avatar in either to
+/// begin with.
 ///
 /// Both used to pass `!account.signedOut` instead, for the deactivated rows they drew: sign-out
 /// drops an identity's relay key packages, so the app should not then fetch its avatar and put

--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -34773,6 +34773,65 @@
         }
       }
     },
+    "Nostr address": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nostr-Adresse"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dirección Nostr"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adresse Nostr"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indirizzo Nostr"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Endereço Nostr"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Адрес Nostr"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nostr adresi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nostr 地址"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nostr 位址"
+          }
+        }
+      }
+    },
     "Nostr group ID": {
       "extractionState": "manual",
       "localizations": {
@@ -39092,65 +39151,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "公開顯示資訊"
-          }
-        }
-      }
-    },
-    "Public identity": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öffentliche Identität"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identidad pública"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identité publique"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identità pubblica"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Identidade pública"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Публичная личность"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Genel kimlik"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公开身份"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公開身分"
           }
         }
       }
@@ -44709,6 +44709,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "掃描 QR 碼"
+          }
+        }
+      }
+    },
+    "Scan to connect": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zum Verbinden scannen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escanear para conectar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scanner pour se connecter"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scansiona per connetterti"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escaneie para conectar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сканируйте для подключения"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağlanmak için tarayın"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "扫码连接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "掃描即可連結"
           }
         }
       }

--- a/whitenoise-mac/Views/Settings/IdentityKeysSettingsView.swift
+++ b/whitenoise-mac/Views/Settings/IdentityKeysSettingsView.swift
@@ -64,7 +64,7 @@ struct IdentityKeysSettingsView: View {
                             .buttonStyle(.borderless)
 
                             PublicIdentityQRCodeButton(
-                                accountIdHex: account.accountIdHex,
+                                account: account,
                                 displayName: account.displayName
                             )
                         }

--- a/whitenoise-mac/Views/Settings/ProfileSettingsView.swift
+++ b/whitenoise-mac/Views/Settings/ProfileSettingsView.swift
@@ -130,7 +130,7 @@ struct ProfileIdentityHeaderView: View {
                 )
 
                 PublicIdentityQRCodeButton(
-                    accountIdHex: account.accountIdHex,
+                    account: account,
                     displayName: displayName,
                     style: .tile
                 )

--- a/whitenoise-mac/Views/Settings/PublicIdentityViews.swift
+++ b/whitenoise-mac/Views/Settings/PublicIdentityViews.swift
@@ -2,9 +2,9 @@
 //  PublicIdentityViews.swift
 //  whitenoise-mac
 //
-//  The two ways an account's public identity is shown: as a scannable QR code, and as
-//  a truncated, copyable `npub`. Shared by the Profile and Identity & Keys pages and
-//  by the account switcher, so neither owns them.
+//  The ways an account's public identity is shown: as a scannable QR code, as a
+//  truncated, copyable `npub`, and as a NIP-05 Nostr address. Shared by the Profile
+//  and Identity & Keys pages and by the account switcher, so none of them owns them.
 //
 
 import AppKit
@@ -21,16 +21,13 @@ enum PublicIdentityQRCodeButtonStyle {
 }
 
 struct PublicIdentityQRCodeButton: View {
-    @Environment(WorkspaceState.self) private var workspace
     @State private var isPresented = false
     @State private var isHovering = false
-    let accountIdHex: String
+    /// The account whose identity the sheet shows. Carried whole rather than as a hex id so the
+    /// sheet can draw its avatar without looking it back up.
+    let account: AccountItem
     let displayName: String
     var style: PublicIdentityQRCodeButtonStyle = .inline
-
-    private var npub: String {
-        workspace.npub(forAccountIdHex: accountIdHex)
-    }
 
     var body: some View {
         // The two styles differ in their button style as well as their label, and `buttonStyle`
@@ -68,78 +65,166 @@ struct PublicIdentityQRCodeButton: View {
         .help(L10n.string("Show npub QR code"))
         .accessibilityLabel(Text(L10n.string("Show npub QR code")))
         .sheet(isPresented: $isPresented) {
-            PublicIdentityQRCodeSheet(displayName: displayName, npub: npub)
+            PublicIdentityQRCodeSheet(account: account, displayName: displayName)
         }
     }
 }
 
+/// The identity you hand to someone else, drawn the way the other clients draw their Share
+/// Profile screen: avatar, name, Nostr address, npub, then the code, then the caption that says
+/// what the code is for. Ordering, spacing and tokens follow the Flutter client's
+/// `share_profile_screen.dart`, which is the design source of truth for this surface; the iOS
+/// prototype's Share/Connect segmented control and its Share toolbar action are deliberately
+/// absent, because neither has a macOS counterpart — there is no camera scanner here, and
+/// handing the npub on is what the copy card already does.
+///
+/// Only ever shown for an account signed in on this Mac, and in practice only for the active
+/// one: all three call sites read `activeAccount`. `nostrAddress` is read from
+/// `profileDraft` for that reason, and returns nil for any other account rather than showing
+/// the active account's address under someone else's name.
 struct PublicIdentityQRCodeSheet: View {
+    @Environment(WorkspaceState.self) private var workspace
     @Environment(\.dismiss) private var dismiss
+    let account: AccountItem
+    /// The name to draw. Separate from `account.displayName` so the Profile page can show the
+    /// name being typed into its form rather than the last published one.
     let displayName: String
-    let npub: String
+
+    /// The Flutter client's `WnAvatarSize.large`, and the third-of-the-width the prototype's
+    /// header lands on at an iPhone's width.
+    private let avatarSize: CGFloat = 96
+    /// `share_profile_screen.dart` caps the matrix at 256 regardless of the width it is given.
+    private let codeSize: CGFloat = 256
+    /// The prototype hugs its matrix with 12pt inside a card 81% of a phone's width — a hair
+    /// under 4%. Kept as a ratio of *this* card rather than as its 12pt, which would be three
+    /// times the quiet zone at this size.
+    private let codePadding: CGFloat = 10
+    /// `ShareableCodeViews.CompactCopyValueLabel`'s split: enough of the head to recognise the
+    /// key, enough of the tail to check it against another copy of itself.
+    private let npubHead = 14
+    private let npubTail = 4
+
+    private var npub: String {
+        workspace.npub(forAccountIdHex: account.accountIdHex)
+    }
+
+    private var nostrAddress: String? {
+        Self.nostrAddress(
+            for: account.accountIdHex,
+            loadedFor: workspace.activeAccount?.accountIdHex,
+            nip05: workspace.profileDraft.nip05
+        )
+    }
+
+    /// The NIP-05 to draw under `accountIdHex`, given the account `profileDraft` was loaded for.
+    ///
+    /// `profileDraft` holds exactly one account's metadata — whichever `loadSettingsData()` last
+    /// ran — so its `nip05` is only *this* account's address when the two ids agree. Without that
+    /// check a sheet opened for any other identity would caption it with the active account's
+    /// address, which is a wrong claim about who someone is rather than a missing field. NIP-05 is
+    /// not editable anywhere in the app, so when the ids do agree the draft cannot have drifted
+    /// from what was published.
+    nonisolated static func nostrAddress(
+        for accountIdHex: String,
+        loadedFor loadedAccountIdHex: String?,
+        nip05: String
+    ) -> String? {
+        guard loadedAccountIdHex == accountIdHex else { return nil }
+        return nip05.nilIfBlank
+    }
 
     var body: some View {
-        VStack(spacing: 18) {
-            HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(displayName)
-                        .wnFont(.semiBold16)
-                        .lineLimit(1)
-                    Text(L10n.string("Public identity"))
-                        .wnFont(.medium12)
-                        .foregroundStyle(WNColor.backgroundContentSecondary)
-                }
+        VStack(spacing: 0) {
+            ProfileImageAvatarView(
+                seed: account.accountIdHex,
+                initials: displayName,
+                sanitizedPictureURL: account.sanitizedPictureURL,
+                isOwnAccountImage: true,
+                size: avatarSize,
+                isSelected: false
+            )
 
-                Spacer()
+            Text(displayName)
+                .wnFont(.semiBold16)
+                .foregroundStyle(WNColor.backgroundContentPrimary)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .padding(.top, 8)
 
-                // Outline rather than glass: the ✕ is the only way out of this sheet, but it is
-                // not the thing to look at — the code is. See `GlassCircleCloseButton.Appearance`.
-                GlassCircleCloseButton(appearance: .outline) {
-                    dismiss()
-                }
+            if let nostrAddress {
+                NostrAddressLabel(address: nostrAddress)
+                    .padding(.top, 3)
             }
 
-            ZStack {
-                // The same surface the code's own quiet zone is rendered in, so the padding around
-                // it is continuous with it rather than a border. See `QRCodePalette`.
-                WNColor.backgroundPrimary
-                // Encode the marmot:// profile link form so scanners can route the
-                // scheme; the visible text and Copy button keep the bare npub.
-                QRCodeImageView(payload: MarmotProfileLink.qrPayload(npub: npub))
-                    .padding(22)
-            }
-            .frame(width: 320, height: 320)
-            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(WNColor.borderTertiary, lineWidth: 1)
-            }
+            // The compact tier, not the Profile page's full-width card: here the code is the
+            // subject and the npub is the alternative to it, which is the split
+            // `wn-ios-prototype` draws with a capsule under the name.
+            WNCopyCard(
+                displayText: DisplayText.short(npub, head: npubHead, tail: npubTail),
+                value: npub,
+                actionDescription: L10n.string("Copy npub"),
+                style: .pill
+            )
+            .padding(.top, 8)
 
-            // Head and tail are cut to what fits beside the copy glyph on one line at this
-            // sheet's width; the button still copies the whole npub. Same shape as
-            // `CopyableKeyLabel`, which cannot be reused here because the sheet is handed a
-            // resolved npub rather than an account id.
-            HStack(spacing: 8) {
-                Text(DisplayText.short(npub, head: 20, tail: 16))
-                    .font(.system(.callout, design: .monospaced))
-                    .foregroundStyle(WNColor.backgroundContentSecondary)
-                    .textSelection(.enabled)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+            // No stroke, and only a hair of quiet zone. The prototype's card carries no border
+            // either: what makes a QR code read as an object is its own matrix, so an outline
+            // around it only adds an edge to look at. The surface still has to be named — the
+            // code is rasterized into a bitmap with no appearance of its own, so it needs a
+            // ground it is guaranteed to contrast with rather than whatever shows through.
+            QRCodeImageView(payload: MarmotProfileLink.qrPayload(npub: npub))
+                .padding(codePadding)
+                .frame(width: codeSize, height: codeSize)
+                .background(WNColor.backgroundPrimary, in: .rect(cornerRadius: 16, style: .continuous))
+                .padding(.top, 28)
 
-                CopyToClipboardButton(value: npub, actionDescription: L10n.string("Copy npub")) { isConfirming in
-                    Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
-                        .foregroundStyle(
-                            isConfirming ? WNColor.intentionSuccessContent : WNColor.backgroundContentSecondary)
-                }
-                .buttonStyle(.borderless)
-            }
+            Text(L10n.string("Scan to connect"))
+                .wnFont(.medium12)
+                .foregroundStyle(WNColor.backgroundContentTertiary)
+                .multilineTextAlignment(.center)
+                .padding(.top, 6)
         }
-        .padding(22)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 22)
+        .padding(.top, 22)
+        // Deeper than the top: the caption is the last thing on the sheet and the prototype
+        // gives it 32pt of room rather than closing up behind it.
+        .padding(.bottom, 32)
+        .overlay(alignment: .topTrailing) {
+            // Outline rather than glass: the ✕ is the only way out of this sheet, but it is
+            // not the thing to look at — the identity is. See `GlassCircleCloseButton.Appearance`.
+            GlassCircleCloseButton(appearance: .outline) {
+                dismiss()
+            }
+            .padding(22)
+        }
         .frame(width: 420)
-        .background {
-            LiquidGlassBackground()
-        }
+        // Flat, not `LiquidGlassBackground()`. The prototype draws this screen on the grouped
+        // background, and glass resolves near `fillSecondary` in light — which left the npub
+        // capsule sitting on its own colour with nothing to separate them.
+        .background(WNColor.backgroundSecondary)
+    }
+}
+
+/// A NIP-05 Nostr address, drawn under the name it belongs to.
+///
+/// No verification seal, unlike the iOS prototype's `InlineVerifiedNostrAddressValue`: this app
+/// resolves a NIP-05 only to *look someone up* (`NIP05Resolver.accountReference(for:)`), and
+/// stores no verified state for anyone, so a seal here would assert something nothing has
+/// checked. When verification does land, it belongs in this one view rather than at its call
+/// sites.
+struct NostrAddressLabel: View {
+    let address: String
+
+    var body: some View {
+        Text(address)
+            .wnFont(.medium12)
+            .foregroundStyle(WNColor.backgroundContentSecondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .textSelection(.enabled)
+            .accessibilityLabel(Text(L10n.string("Nostr address")))
+            .accessibilityValue(Text(address))
     }
 }
 

--- a/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
+++ b/whitenoise-mac/Views/Settings/SettingsAccountSwitcherViews.swift
@@ -52,8 +52,8 @@ struct SettingsAccountSwitcherCard: View {
         .sheet(isPresented: $isQRPresented) {
             if let account = workspace.activeAccount {
                 PublicIdentityQRCodeSheet(
-                    displayName: account.displayName,
-                    npub: workspace.npub(forAccountIdHex: account.accountIdHex)
+                    account: account,
+                    displayName: account.displayName
                 )
             }
         }

--- a/whitenoise-mac/Views/WNCopyCard.swift
+++ b/whitenoise-mac/Views/WNCopyCard.swift
@@ -3,15 +3,31 @@
 //  whitenoise-mac
 //
 //  The way a public identifier is put on screen when it is the point of the
-//  screen rather than a caption: a filled card, big enough to read, that copies
-//  when clicked anywhere. The macOS twin of `WnCopyCard` on the other clients.
+//  screen rather than a caption: a ground, big enough to read, that copies when
+//  clicked anywhere. The macOS twin of `WnCopyCard` on the other clients.
 //
 
 import SwiftUI
 
-/// A filled card showing a long value at reading size, which copies the value when clicked.
+/// How much room the value is given, and how loudly it asks to be read.
 ///
-/// The card is the button — a value the user is meant to hand to someone else should not make
+/// One atom rather than two components, because both tiers are the same idea — a value you are
+/// meant to hand to someone else, on a ground, that copies when clicked — and splitting them
+/// would let their type, ground and confirmation drift apart.
+enum WNCopyCardStyle {
+    /// A filled card at reading size, wrapping the value over as many lines as it needs. For a
+    /// page whose subject *is* the value: the Profile form's npub.
+    case card
+    /// A compact capsule showing a middle-truncated value on one line. For a surface where the
+    /// value is one element among several and something else is the subject — the identity
+    /// sheet, where the QR code is what the eye should land on. This is the shape
+    /// `wn-ios-prototype` gives the npub under a profile.
+    case pill
+}
+
+/// A ground showing a long value, which copies that value when clicked.
+///
+/// The ground is the button — a value the user is meant to hand to someone else should not make
 /// them aim at a 10pt glyph. The glyph is still drawn, as the affordance, and flips to a
 /// checkmark for the confirmation window because macOS raises none of its own.
 struct WNCopyCard: View {
@@ -21,36 +37,72 @@ struct WNCopyCard: View {
     let value: String
     /// Localized description of the action, e.g. "Copy npub".
     let actionDescription: String
+    var style: WNCopyCardStyle = .card
     var lineLimit: Int = 2
 
     @State private var isHovering = false
 
     var body: some View {
         CopyToClipboardButton(value: value, actionDescription: actionDescription) { isConfirming in
-            HStack(alignment: .center, spacing: 14) {
-                Text(displayText)
-                    .wnFont(.medium14)
-                    .foregroundStyle(WNColor.backgroundContentSecondary)
-                    .lineLimit(lineLimit)
-                    .truncationMode(.middle)
-                    .multilineTextAlignment(.leading)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
-                    .wnFont(.medium18)
-                    .foregroundStyle(
-                        isConfirming ? WNColor.intentionSuccessContent : WNColor.backgroundContentSecondary)
+            switch style {
+            case .card:
+                card(isConfirming: isConfirming)
+            case .pill:
+                pill(isConfirming: isConfirming)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                isHovering ? WNColor.fillSecondaryHover : WNColor.fillSecondary,
-                in: .rect(cornerRadius: 8, style: .continuous)
-            )
-            .contentShape(.rect(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(.plain)
         .onHover { isHovering = $0 }
+    }
+
+    private func card(isConfirming: Bool) -> some View {
+        HStack(alignment: .center, spacing: 14) {
+            Text(displayText)
+                .wnFont(.medium14)
+                .foregroundStyle(WNColor.backgroundContentSecondary)
+                .lineLimit(lineLimit)
+                .truncationMode(.middle)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            glyph(isConfirming: isConfirming)
+                .wnFont(.medium18)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            isHovering ? WNColor.fillSecondaryHover : WNColor.fillSecondary,
+            in: .rect(cornerRadius: 8, style: .continuous)
+        )
+        .contentShape(.rect(cornerRadius: 8, style: .continuous))
+    }
+
+    /// The compact tier. Hugs its value rather than filling the width it is offered — a capsule
+    /// stretched across a sheet reads as a field, which is the opposite of what this tier is for.
+    private func pill(isConfirming: Bool) -> some View {
+        HStack(spacing: 8) {
+            Text(displayText)
+                .font(.system(.subheadline, design: .monospaced))
+                .foregroundStyle(WNColor.backgroundContentSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            glyph(isConfirming: isConfirming)
+                .wnFont(.medium12)
+                // Fixed so the checkmark and `doc.on.doc` occupy the same room and the capsule
+                // does not resize under the pointer at the moment it is clicked.
+                .frame(width: 14, height: 14)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(isHovering ? WNColor.fillSecondaryHover : WNColor.fillSecondary, in: .capsule)
+        .contentShape(.capsule)
+    }
+
+    private func glyph(isConfirming: Bool) -> some View {
+        Image(systemName: isConfirming ? "checkmark" : "doc.on.doc")
+            .foregroundStyle(
+                isConfirming ? WNColor.intentionSuccessContent : WNColor.backgroundContentSecondary)
     }
 }

--- a/whitenoise-macTests/PublicIdentitySheetTests.swift
+++ b/whitenoise-macTests/PublicIdentitySheetTests.swift
@@ -1,0 +1,158 @@
+//
+//  PublicIdentitySheetTests.swift
+//  whitenoise-macTests
+//
+//  The public-identity QR sheet: which address it may caption an identity with, and
+//  the order it puts the identity, the code and the caption in.
+//
+
+import Foundation
+import Testing
+
+@testable import whitenoise_mac
+
+struct PublicIdentitySheetTests {
+
+    // MARK: - Whose Nostr address the sheet is allowed to show
+
+    private static let account = String(repeating: "a1", count: 32)
+    private static let otherAccount = String(repeating: "b2", count: 32)
+
+    @Test func theSheetShowsTheNostrAddressOfTheAccountTheProfileWasLoadedFor() {
+        #expect(
+            PublicIdentityQRCodeSheet.nostrAddress(
+                for: Self.account,
+                loadedFor: Self.account,
+                nip05: "pepi@whitenoise.chat"
+            ) == "pepi@whitenoise.chat"
+        )
+    }
+
+    /// The defect the id check exists to prevent. `profileDraft` carries one account's metadata at
+    /// a time, so reading it unguarded would print the *active* account's address under whichever
+    /// identity the sheet was opened for — a wrong claim about who someone is, not a blank field.
+    @Test func theSheetShowsNoNostrAddressForAnAccountTheProfileWasNotLoadedFor() {
+        #expect(
+            PublicIdentityQRCodeSheet.nostrAddress(
+                for: Self.otherAccount,
+                loadedFor: Self.account,
+                nip05: "pepi@whitenoise.chat"
+            ) == nil
+        )
+        #expect(
+            PublicIdentityQRCodeSheet.nostrAddress(
+                for: Self.account,
+                loadedFor: nil,
+                nip05: "pepi@whitenoise.chat"
+            ) == nil
+        )
+    }
+
+    /// Most accounts have no NIP-05 at all, and `ProfileDraft` spells that as `""` rather than nil.
+    @Test func anAccountWithoutANostrAddressDrawsNoAddressRow() {
+        #expect(
+            PublicIdentityQRCodeSheet.nostrAddress(
+                for: Self.account, loadedFor: Self.account, nip05: "") == nil
+        )
+        #expect(
+            PublicIdentityQRCodeSheet.nostrAddress(
+                for: Self.account, loadedFor: Self.account, nip05: "   ") == nil
+        )
+    }
+
+    // MARK: - What the sheet stacks, and in what order
+
+    /// The layout is the request: the identity — avatar, name, Nostr address, npub — above the
+    /// code, and the caption that says what the code is for below it. That order is the Flutter
+    /// client's `share_profile_screen.dart`, and it is the half of this work that no behavior
+    /// test can see: SwiftUI exposes neither a view's children nor their positions, and a render
+    /// assertion would be pinned to the pixel heights of six elements rather than to their order.
+    ///
+    /// Sliced to the sheet's own declaration rather than matched against the file, because
+    /// `PublicIdentityQRCodeButton` above it and `NostrAddressLabel` below it name several of the
+    /// same symbols.
+    @Test func theSheetStacksTheIdentityAboveTheCodeAndTheCaptionBelowIt() throws {
+        let source = try Self.sheetDeclaration()
+
+        let order = [
+            "ProfileImageAvatarView(",  // the avatar
+            "Text(displayName)",  // the name
+            "NostrAddressLabel(address: nostrAddress)",  // the Nostr address
+            "WNCopyCard(",  // the npub
+            "QRCodeImageView(payload:",  // the code
+            "Text(L10n.string(\"Scan to connect\"))",  // the caption
+        ]
+
+        var cursor = source.startIndex
+        for element in order {
+            let found = try #require(
+                source.range(of: element, range: cursor..<source.endIndex),
+                "\(element) is missing from the sheet, or is above the element before it"
+            )
+            cursor = found.upperBound
+        }
+    }
+
+    /// The npub and the avatar are drawn by the components the rest of the app draws them with,
+    /// rather than by shapes this one sheet owns. `WNCopyCard` is the same card the Profile page
+    /// puts the npub in and the macOS twin of the other clients' `WnCopyCard`; a bespoke capsule
+    /// here — which is what the iOS prototype uses — would be a second way to show one value.
+    @Test func theSheetReusesTheSharedIdentityComponentsRatherThanItsOwn() throws {
+        let source = try Self.sheetDeclaration()
+
+        #expect(source.contains("WNCopyCard("))
+        #expect(source.contains("style: .pill"))
+        #expect(source.contains("ProfileImageAvatarView("))
+        // No hand-rolled ground for either of them.
+        #expect(!source.contains(".capsule"))
+        #expect(!source.contains("fillSecondary"))
+    }
+
+    /// The code card is a shape, not a bordered box. `wn-ios-prototype`'s `ShareableQRCodeView`
+    /// names a 16pt continuous container and no stroke at all: a QR code is already an object
+    /// made of high-contrast marks, so an outline around it only adds an edge competing with the
+    /// matrix. The border this sheet used to draw was there to keep a card from vanishing into
+    /// the glass behind it, and the flat ground removed the reason for it.
+    ///
+    /// A source contract because a stroke is not observable from a rendered assertion that is
+    /// robust: at a 1pt line on a rounded corner, antialiasing against the ground makes "is there
+    /// an edge here" a threshold question rather than a yes-or-no one.
+    @Test func theCodeCardIsAShapeWithNoBorder() throws {
+        let source = try Self.sheetDeclaration()
+
+        #expect(source.contains("cornerRadius: 16, style: .continuous"))
+        #expect(!source.contains(".stroke("))
+        #expect(!source.contains("WNColor.border"))
+    }
+
+    /// The sheet is drawn on a flat surface rather than `LiquidGlassBackground()`. Glass resolves
+    /// close to `fillSecondary` in light, which is the npub capsule's own ground — on glass the
+    /// two were the same colour and the pill had no edge to be seen by.
+    @Test func theSheetIsDrawnOnAFlatGroundRatherThanGlass() throws {
+        let source = try Self.sheetDeclaration()
+
+        #expect(source.contains("WNColor.backgroundSecondary"))
+        #expect(!source.contains("LiquidGlassBackground"))
+    }
+
+    private static func sheetDeclaration() throws -> String {
+        let sourceURL =
+            URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "whitenoise-mac")
+            .appending(path: "Views")
+            .appending(path: "Settings")
+            .appending(path: "PublicIdentityViews.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        let start = try #require(source.range(of: "struct PublicIdentityQRCodeSheet: View {"))
+        let end = try #require(source.range(of: "struct NostrAddressLabel: View {"))
+        // Comments are stripped: the sheet's doc comment names the prototype controls it
+        // deliberately omits, which would satisfy an absence check that read the whole slice.
+        return String(source[start.lowerBound..<end.lowerBound])
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the public identity QR sheet with account avatar, name, copyable public address, optional Nostr address, and a larger QR code.
  - Added localized “Scan to connect” and “Nostr address” labels across supported languages.
  - Nostr addresses appear only when they match the displayed account profile.
  - Added compact pill styling for copyable information cards.

- **Bug Fixes**
  - Ensured QR sheets consistently display the active account’s identity details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->