### PR TITLE
Add wn toggle

### DIFF
--- a/whitenoise-mac/Views/Settings/DataSharingToggleRows.swift
+++ b/whitenoise-mac/Views/Settings/DataSharingToggleRows.swift
@@ -11,11 +11,12 @@
 //  preference some other way — an optimistic move without the rollback, say, or a write that
 //  skipped the credentials guard.
 //
-//  Drawn as `SettingsToggleRow`, the shape every switch in settings takes, so the pair reads on
-//  the prompt exactly as it does on the page it is a shortcut to. That row is a `Toggle` and its
-//  `Label` and nothing else — it carries no page chrome — so it is equally at home in the
-//  prompt's own grouped `Form`. Nothing here explains the toggles: that is the enclosing
-//  section's footer on the page, and the prompt's own copy on the sheet.
+//  Drawn as `WNToggle`, the app's switch, so the pair reads on the prompt exactly as it does on
+//  the page it is a shortcut to. That component is a switch and its `Label` and nothing else — it
+//  carries no page chrome — so it is equally at home in the prompt's own grouped `Form`, and it
+//  names its own `fillPrimary` tint rather than inheriting one, which is what keeps the sheet's
+//  copy of these two switches off the blue system accent. Nothing here explains the toggles: that
+//  is the enclosing section's footer on the page, and the prompt's own copy on the sheet.
 //
 
 import SwiftUI
@@ -24,8 +25,8 @@ struct DataSharingToggleRows: View {
     @Environment(WorkspaceState.self) private var workspace
 
     var body: some View {
-        SettingsToggleRow(
-            title: L10n.string("Anonymous Telemetry"),
+        WNToggle(
+            L10n.string("Anonymous Telemetry"),
             systemImage: "waveform.path.ecg",
             isOn: Binding(
                 get: { workspace.privacySecuritySettings.relayTelemetryEnabled },
@@ -36,8 +37,8 @@ struct DataSharingToggleRows: View {
         )
         .disabled(workspace.isSavingPrivacySecurity)
 
-        SettingsToggleRow(
-            title: L10n.string("Audit Logging"),
+        WNToggle(
+            L10n.string("Audit Logging"),
             systemImage: "doc.text.magnifyingglass",
             isOn: Binding(
                 get: { workspace.privacySecuritySettings.auditLoggingEnabled },

--- a/whitenoise-mac/Views/Settings/DeveloperModeSettingsView.swift
+++ b/whitenoise-mac/Views/Settings/DeveloperModeSettingsView.swift
@@ -19,14 +19,14 @@ struct DeveloperModeSettingsView: View {
             subtitle: L10n.string("Storage and diagnostics.")
         ) {
             SettingsSection(title: L10n.string("Developer")) {
-                SettingsToggleRow(
-                    title: L10n.string("Developer mode"),
+                WNToggle(
+                    L10n.string("Developer mode"),
                     systemImage: "stethoscope",
                     isOn: $workspace.developerMode
                 )
 
-                SettingsToggleRow(
-                    title: L10n.string("Streaming debug"),
+                WNToggle(
+                    L10n.string("Streaming debug"),
                     systemImage: "waveform.path.ecg",
                     isOn: $workspace.streamingDebugMode
                 )

--- a/whitenoise-mac/Views/Settings/NotificationsSettingsView.swift
+++ b/whitenoise-mac/Views/Settings/NotificationsSettingsView.swift
@@ -19,8 +19,8 @@ struct NotificationsSettingsView: View {
             subtitle: L10n.string("Local alerts for this Mac.")
         ) {
             SettingsSection(title: L10n.string("Local Alerts")) {
-                SettingsToggleRow(
-                    title: L10n.string("Local notifications"),
+                WNToggle(
+                    L10n.string("Local notifications"),
                     systemImage: "bell.badge",
                     isOn: Binding(
                         get: { workspace.notificationSettings.localNotificationsEnabled },

--- a/whitenoise-mac/Views/Settings/PreferencesSettingsView.swift
+++ b/whitenoise-mac/Views/Settings/PreferencesSettingsView.swift
@@ -28,8 +28,8 @@ struct PreferencesSettingsView: View {
                 title: L10n.string("Startup"),
                 footer: L10n.string("Open the White Noise window automatically when you log in to your Mac.")
             ) {
-                SettingsToggleRow(
-                    title: L10n.string("Launch White Noise at Login"),
+                WNToggle(
+                    L10n.string("Launch White Noise at Login"),
                     systemImage: "power",
                     isOn: Binding(
                         get: { launchAtLogin.isEnabled },
@@ -45,8 +45,8 @@ struct PreferencesSettingsView: View {
                     "Return to the last conversation selected for this account, both on launch and when you switch accounts."
                 )
             ) {
-                SettingsToggleRow(
-                    title: L10n.string("Restore last selected chat"),
+                WNToggle(
+                    L10n.string("Restore last selected chat"),
                     systemImage: "bubble.left.and.bubble.right",
                     isOn: Binding(
                         get: { workspace.restoreLastSelectedChat },

--- a/whitenoise-mac/Views/Settings/PrivacySecuritySettingsView.swift
+++ b/whitenoise-mac/Views/Settings/PrivacySecuritySettingsView.swift
@@ -25,8 +25,8 @@ struct PrivacySecuritySettingsView: View {
                     "Off by default. Profile pictures come from URLs other people control, so loading them reveals your IP address and when you're online to whoever sent them. Leave this off unless you trust the senders. Only secure (https) images are ever loaded."
                 )
             ) {
-                SettingsToggleRow(
-                    title: L10n.string("Load Remote Profile Images"),
+                WNToggle(
+                    L10n.string("Load Remote Profile Images"),
                     systemImage: "person.crop.circle.badge.exclamationmark",
                     isOn: Binding(
                         get: { workspace.loadRemoteImages },

--- a/whitenoise-mac/Views/Settings/SettingsGroupedForm.swift
+++ b/whitenoise-mac/Views/Settings/SettingsGroupedForm.swift
@@ -3,7 +3,8 @@
 //  whitenoise-mac
 //
 //  The row vocabulary every grouped settings page is written in: a group, the note under
-//  it, a toggle, a list of choices, a read-only value, and a one-line result.
+//  it, a list of choices, a read-only value, and a one-line result. The switch is not
+//  here — it is `WNToggle`, because settings is not the only surface that shows one.
 //
 //  The one idea here is that a group's explanation belongs *under* the group, not inside
 //  it. Each page used to end a `Section` with a bare `Text` in secondary grey, which put a
@@ -102,23 +103,6 @@ struct SettingsFooterText: View {
             note.textSelection(.enabled)
         } else {
             note
-        }
-    }
-}
-
-/// A toggle labelled with its glyph, the shape every switch in settings takes.
-///
-/// The glyph is what makes a scanned column of toggles legible — it is the same argument the
-/// sidebar row makes one level up. Nothing here explains the toggle: that is the enclosing
-/// `SettingsSection`'s footer.
-struct SettingsToggleRow: View {
-    let title: String
-    let systemImage: String
-    @Binding var isOn: Bool
-
-    var body: some View {
-        Toggle(isOn: $isOn) {
-            Label(title, systemImage: systemImage)
         }
     }
 }

--- a/whitenoise-mac/Views/WNToggle.swift
+++ b/whitenoise-mac/Views/WNToggle.swift
@@ -1,0 +1,82 @@
+//
+//  WNToggle.swift
+//  whitenoise-mac
+//
+//  The app's switch — the one way a boolean setting is drawn, wherever it is drawn.
+//
+//  It exists for the same reason `WNPrimaryButton` does, and it fixes the same defect. A bare
+//  `Toggle` carries no colour of its own and takes its "on" track from the environment's tint,
+//  whose only app-wide source is `ContentView`'s `.tint(WNColor.fillPrimary)`. Settings sits
+//  inside that root and so drew correctly; the "Help Improve White Noise" sheet is a separate
+//  presentation that inherits none of it — same trap as `\.locale` — so its two switches fell
+//  back to the system accent and drew **blue**, the one hue this palette reserves for links and
+//  search hits. Naming the tint on the component makes the switch correct wherever it is used
+//  rather than only under the root.
+//
+//  `wn-ios-prototype` is the reference for the *shape* — a switch for every boolean preference —
+//  but deliberately not for how one is coloured. It tints only its App Security pair, per view,
+//  from a locally computed black/`systemGray`, and leaves its own diagnostics prompt on the
+//  platform default; that split is exactly the inconsistency this component exists to remove. The
+//  colour comes from this app's palette instead: `fillPrimary`, near-black on Light and white on
+//  Dark, the token every other primary surface here already names.
+//
+
+import SwiftUI
+
+/// A boolean setting, drawn as a switch tinted `fillPrimary`.
+///
+/// `.switch` is named rather than inherited. Inside a grouped `Form` macOS already resolves the
+/// default toggle style to a switch, which is why settings looked right, but outside one it
+/// resolves to a checkbox — so a `WNToggle` placed on a bare pane or in a sheet's own layout
+/// would have changed shape depending on what happened to enclose it. The prototype draws one
+/// switch everywhere; naming the style is what makes that true here too.
+///
+/// The label is whatever the call site passes. Settings pairs a title with its SF Symbol — the
+/// glyph is what makes a scanned column of switches legible, the same argument the sidebar row
+/// makes one level up — and `init(_:systemImage:isOn:)` is that shape. Nothing here explains the
+/// setting: that is the enclosing `SettingsSection`'s footer, or the sheet's own copy.
+struct WNToggle<Label: View>: View {
+    @Binding var isOn: Bool
+    @ViewBuilder let label: Label
+
+    var body: some View {
+        Toggle(isOn: $isOn) {
+            label
+        }
+        .toggleStyle(.switch)
+        .tint(WNColor.fillPrimary)
+    }
+}
+
+extension WNToggle where Label == SwiftUI.Label<Text, Image> {
+    /// The common case: a title and its leading SF Symbol, the shape every switch in settings
+    /// takes.
+    init(_ title: String, systemImage: String, isOn: Binding<Bool>) {
+        self.init(isOn: isOn) {
+            SwiftUI.Label(title, systemImage: systemImage)
+        }
+    }
+}
+
+extension WNToggle where Label == Text {
+    /// A switch with no glyph, for a row that is not part of a scanned column.
+    init(_ title: String, isOn: Binding<Bool>) {
+        self.init(isOn: isOn) {
+            Text(title)
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var withGlyph = true
+    @Previewable @State var withoutGlyph = false
+
+    Form {
+        Section {
+            WNToggle("Anonymous Telemetry", systemImage: "waveform.path.ecg", isOn: $withGlyph)
+            WNToggle("Audit Logging", isOn: $withoutGlyph)
+        }
+    }
+    .formStyle(.grouped)
+    .frame(width: 420)
+}

--- a/whitenoise-macTests/WNToggleTintTests.swift
+++ b/whitenoise-macTests/WNToggleTintTests.swift
@@ -1,0 +1,165 @@
+//
+//  WNToggleTintTests.swift
+//  whitenoise-macTests
+//
+
+import AppKit
+import ObjectiveC
+import SwiftUI
+import Testing
+
+@testable import whitenoise_mac
+
+/// The switch draws its own track, with no ambient tint to lean on.
+///
+/// A bare `Toggle` takes its "on" track from the environment, and the app's only source of that
+/// tint is `ContentView`'s `.tint(WNColor.fillPrimary)`. Settings sits under that root and drew
+/// correctly; the "Help Improve White Noise" sheet is a separate presentation that inherits none
+/// of it — same trap as `\.locale` — so its two switches fell back to the system accent and drew
+/// **blue**, the one hue the palette reserves for links and search hits.
+///
+/// Every case below is deliberately given **no** tint, because that is the condition a sheet
+/// actually presents under. A harness that helpfully supplied one is how the defect shipped
+/// looking correct — the same note `WNPrimaryButtonTintTests` carries, for the same reason.
+///
+/// **Why this reads a property instead of pixels.** The obvious test — rasterize and sample the
+/// track — cannot work here, and failed in three different ways before this one: `ImageRenderer`
+/// does not draw a macOS switch at all (it paints a flat yellow placeholder and ignores `.tint`
+/// entirely, so it can distinguish neither tinted from untinted nor Light from Dark), and
+/// `NSHostingView.cacheDisplay` does draw one but only ever in its *inactive* appearance, because
+/// a window in the test host never becomes key — and an inactive control deliberately drops its
+/// accent for grey. Both harnesses therefore render an untinted switch and a correctly tinted one
+/// as the same pixels. `NSSwitch.trackColor` is what the tint actually lands on, so it is what
+/// these read.
+///
+/// `.serialized` and `@MainActor` because these switch `NSAppearance` to resolve colours:
+/// `performAsCurrentDrawingAppearance` off the main thread takes the test host down with it.
+@Suite(.serialized) @MainActor struct WNToggleTintTests {
+
+    /// The track is `fillPrimary` — the value, resolved for the same appearance the switch was
+    /// laid out in, not merely "some neutral". Near-black in Light, white in Dark.
+    @Test(arguments: [NSAppearance.Name.aqua, NSAppearance.Name.darkAqua])
+    func theSwitchNamesFillPrimaryWithNoAmbientTint(appearance: NSAppearance.Name) throws {
+        let track = try #require(
+            Self.trackColor(of: WNToggle("Anonymous Telemetry", isOn: .constant(true)), in: appearance),
+            "The switch left its track to the environment — the blue-in-a-sheet defect."
+        )
+        let expected = try #require(Self.resolve(WNNSColor.fillPrimary, in: appearance))
+
+        #expect(Self.distance(track, expected) < 0.01)
+
+        // …and specifically not the system accent, which is the value an untinted switch takes
+        // and is blue on a default install.
+        let accent = try #require(Self.resolve(.controlAccentColor, in: appearance))
+        #expect(Self.distance(track, accent) > 0.3)
+    }
+
+    /// The negative control, and the reason the test above means anything.
+    ///
+    /// An untinted switch reports `trackColor == nil` — it has nothing of its own and takes the
+    /// accent. Without this case a `trackColor` that had quietly stopped being populated at all
+    /// would read as a passing `nil` everywhere, and both tests would agree on nothing.
+    @Test func anUntintedSwitchHasNoTrackColourOfItsOwn() throws {
+        let bare = Self.trackColor(
+            of: Toggle("Anonymous Telemetry", isOn: .constant(true)).toggleStyle(.switch),
+            in: .aqua
+        )
+        #expect(bare == nil)
+    }
+
+    /// The glyph init is the shape settings uses, and the one the improvements sheet's pair of
+    /// switches reaches the component through, so it has to be tinted identically.
+    @Test func theGlyphLabelledSwitchIsTintedIdentically() throws {
+        let plain = try #require(
+            Self.trackColor(of: WNToggle("Audit Logging", isOn: .constant(true)), in: .aqua))
+        let withGlyph = try #require(
+            Self.trackColor(
+                of: WNToggle("Audit Logging", systemImage: "doc.text.magnifyingglass", isOn: .constant(true)),
+                in: .aqua))
+
+        #expect(Self.distance(plain, withGlyph) < 0.01)
+    }
+
+    /// `.switch` is named by the component rather than inherited, and this is what that buys.
+    ///
+    /// Inside a grouped `Form` macOS already resolves the default toggle style to a switch, which
+    /// is why settings looked right either way. Outside one it resolves to a **checkbox** — so
+    /// without the named style a `WNToggle` would silently change shape depending on what happened
+    /// to enclose it. The bare control is asserted alongside so this records the actual default
+    /// rather than assuming it.
+    @Test func theComponentIsASwitchEvenOutsideAForm() throws {
+        let component = try #require(Self.platformView(of: WNToggle("Audit Logging", isOn: .constant(true))))
+        let bare = try #require(Self.platformView(of: Toggle("Audit Logging", isOn: .constant(true))))
+
+        #expect(String(describing: type(of: component)).contains("Switch"))
+        #expect(
+            String(describing: type(of: bare)).contains("Checkbox")
+                || String(describing: type(of: bare)).contains("Button"))
+    }
+
+    // MARK: - Helpers
+
+    /// Hosts `content` in `appearance`, finds the AppKit switch SwiftUI made for it, and reads the
+    /// track colour the tint landed on.
+    ///
+    /// `trackColor` is read by key rather than by property because `NSSwitch` does not expose it
+    /// in its public interface. The key's existence is checked first: `value(forKey:)` on a
+    /// missing key raises an Objective-C exception, which Swift cannot catch and which would take
+    /// the whole host down instead of failing one test.
+    private static func trackColor(of content: some View, in appearance: NSAppearance.Name) -> NSColor? {
+        guard let view = platformView(of: content, in: appearance) else { return nil }
+        guard class_getProperty(type(of: view), "trackColor") != nil else {
+            Issue.record("NSSwitch no longer has a `trackColor` property — this suite needs a new observable.")
+            return nil
+        }
+        var color: NSColor?
+        NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
+            color = (view.value(forKey: "trackColor") as? NSColor)?.usingColorSpace(.sRGB)
+        }
+        return color
+    }
+
+    /// The AppKit view SwiftUI backs the toggle with — a `PlatformSwitch` for a switch, a button
+    /// for a checkbox. `labelsHidden` so the control is the whole frame and the walk cannot land
+    /// on the label's own backing view.
+    private static func platformView(
+        of content: some View,
+        in appearance: NSAppearance.Name = .aqua
+    ) -> NSView? {
+        let scheme: ColorScheme = appearance == .darkAqua ? .dark : .light
+        let host = NSHostingView(
+            rootView: AnyView(content.labelsHidden().environment(\.colorScheme, scheme)))
+        host.appearance = NSAppearance(named: appearance)
+        host.frame = CGRect(origin: .zero, size: host.fittingSize)
+        host.layoutSubtreeIfNeeded()
+        return leaf(of: host)
+    }
+
+    /// The deepest AppKit control under the host — SwiftUI wraps its platform views a couple of
+    /// layers down, and the wrapper's own type name says nothing about which control it is.
+    private static func leaf(of view: NSView) -> NSView? {
+        for sub in view.subviews {
+            let name = String(describing: type(of: sub))
+            if name.contains("PlatformSwitch") || name.contains("Checkbox") || name.contains("NSButton") {
+                return sub
+            }
+            if let found = leaf(of: sub) { return found }
+        }
+        return nil
+    }
+
+    private static func resolve(_ color: NSColor, in appearance: NSAppearance.Name) -> NSColor? {
+        var resolved: NSColor?
+        NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.sRGB)
+        }
+        return resolved
+    }
+
+    private static func distance(_ lhs: NSColor, _ rhs: NSColor) -> CGFloat {
+        let dr = lhs.redComponent - rhs.redComponent
+        let dg = lhs.greenComponent - rhs.greenComponent
+        let db = lhs.blueComponent - rhs.blueComponent
+        return sqrt(dr * dr + dg * dg + db * db)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated settings switches with a consistent visual style across data sharing, developer, notifications, preferences, and privacy settings.
  * Switches now use consistent primary coloring in both Light and Dark appearances.
  * Added support for labeled switches with optional icons while preserving existing labels, settings, and disabled states.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->