### PR TITLE
Drop the Appearance page subtitle

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -12110,65 +12110,6 @@
         }
       }
     },
-    "Choose the theme and language White Noise uses.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wähle das Design und die Sprache, die White Noise verwendet."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elige el tema y el idioma que usa White Noise."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choisissez le thème et la langue utilisés par White Noise."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scegli il tema e la lingua usati da White Noise."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escolha o tema e o idioma que o White Noise usa."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Выберите тему и язык, которые использует White Noise."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "White Noise’un kullandığı temayı ve dili seçin."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择 White Noise 使用的主题和语言。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選擇 White Noise 使用的主題和語言。"
-          }
-        }
-      }
-    },
     "Choose where to save downloads": {
       "comment": "Title of the folder panel shown before the first attachment download.",
       "extractionState": "manual",

--- a/whitenoise-mac/Views/Settings/AppearanceSettingsView.swift
+++ b/whitenoise-mac/Views/Settings/AppearanceSettingsView.swift
@@ -13,10 +13,10 @@ struct AppearanceSettingsView: View {
     var body: some View {
         @Bindable var workspace = workspace
 
-        SettingsScaffold(
-            title: L10n.string("Appearance"),
-            subtitle: L10n.string("Choose the theme and language White Noise uses.")
-        ) {
+        // No subtitle: the two groups below are named "Theme" and "Language", and a line
+        // under the title saying the page is about the theme and the language would only be
+        // reading those two headers back. The reference design titles this screen and stops.
+        SettingsScaffold(title: L10n.string("Appearance")) {
             // Three options, drawn as the three options rather than as a pop-up that hides two
             // of them: what Light and Dark mean is only clear next to System.
             //


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Simplified the Appearance settings screen by removing the explanatory subtitle.
  * Updated localized content across supported languages to reflect the streamlined layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->