### PR TITLE
Add a donate page to settings

### DIFF
--- a/whitenoise-mac/Localizable.xcstrings
+++ b/whitenoise-mac/Localizable.xcstrings
@@ -71,6 +71,65 @@
         }
       }
     },
+    "%@ QR code": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@-QR-Code"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Código QR de %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Code QR %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codice QR %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Código QR de %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "QR-код %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ QR kodu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 二维码"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ QR 碼"
+          }
+        }
+      }
+    },
     "%@ added %@": {
       "extractionState": "manual",
       "localizations": {
@@ -9149,6 +9208,65 @@
         }
       }
     },
+    "As a 501(c)3 non-profit, White Noise exists solely for your privacy and freedom, not for profit. Your support keeps us independent and uncompromised.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Als gemeinnützige 501(c)3-Organisation existiert White Noise ausschließlich für deine Privatsphäre und Freiheit, nicht für Profit. Deine Unterstützung hält uns unabhängig und kompromisslos."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Como organización 501(c)3 sin fines de lucro, White Noise existe únicamente para tu privacidad y libertad, no para obtener ganancias. Tu apoyo nos mantiene independientes y sin concesiones."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En tant qu'organisation à but non lucratif 501(c)3, White Noise existe uniquement pour votre vie privée et votre liberté, pas pour le profit. Votre soutien nous maintient indépendants et sans compromis."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Come organizzazione 501(c)3 senza scopo di lucro, White Noise esiste unicamente per la tua privacy e libertà, non per profitto. Il tuo supporto ci mantiene indipendenti e senza compromessi."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Como uma organização 501(c)3 sem fins lucrativos, o White Noise existe apenas para sua privacidade e liberdade, não para lucro. Seu apoio nos mantém independentes e sem concessões."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Как некоммерческая организация 501(c)3, White Noise существует исключительно для вашей конфиденциальности и свободы, а не для прибыли. Ваша поддержка сохраняет нашу независимость и бескомпромиссность."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kar amacı gütmeyen bir 501(c)3 kuruluşu olarak White Noise, yalnızca gizliliğiniz ve özgürlüğünüz için var, kar için değil. Desteğiniz bizi bağımsız ve taviz vermeden tutar."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作为一家 501(c)3 非营利组织，White Noise 的存在纯粹是为了您的隐私和自由，而非利润。您的支持使我们能够保持独立且不妥协。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "White Noise 是 501(c)3 非營利組織，存在的目的純粹是守護您的隱私與自由，而非追求利潤。您的支持讓我們能保持獨立、不受妥協。"
+          }
+        }
+      }
+    },
     "Attach files": {
       "extractionState": "manual",
       "localizations": {
@@ -10327,6 +10445,124 @@
           "stringUnit": {
             "state": "translated",
             "value": "備份類型"
+          }
+        }
+      }
+    },
+    "Bitcoin": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin"
+          }
+        }
+      }
+    },
+    "Bitcoin Silent Payment": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin Silent Payment"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pago Silencioso de Bitcoin"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paiement Silencieux Bitcoin"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagamento Silenzioso Bitcoin"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagamento Silencioso Bitcoin"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тихий Платёж Bitcoin"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitcoin Sessiz Ödeme"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "比特币静默支付 (Silent Payment)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "比特幣靜默支付 (Silent Payment)"
           }
         }
       }
@@ -18427,6 +18663,183 @@
           "stringUnit": {
             "state": "translated",
             "value": "顯示名稱"
+          }
+        }
+      }
+    },
+    "Donate": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faire un don"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dona"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пожертвовать"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağış yap"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捐赠"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捐款"
+          }
+        }
+      }
+    },
+    "Donate to White Noise": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An White Noise spenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donar a White Noise"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Faire un don à White Noise"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dona a White Noise"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doar para o White Noise"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пожертвовать в пользу White Noise"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "White Noise'a Bağış Yap"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捐赠给 White Noise"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捐款給 White Noise"
+          }
+        }
+      }
+    },
+    "Donation method": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spendenmethode"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Método de donación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode de don"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Metodo di donazione"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Método de doação"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Способ пожертвования"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bağış yöntemi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捐赠方式"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捐款方式"
           }
         }
       }
@@ -27197,6 +27610,65 @@
           "stringUnit": {
             "state": "translated",
             "value": "淺色"
+          }
+        }
+      }
+    },
+    "Lightning": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lightning"
           }
         }
       }

--- a/whitenoise-mac/Models/DonationMethod.swift
+++ b/whitenoise-mac/Models/DonationMethod.swift
@@ -1,0 +1,85 @@
+//
+//  DonationMethod.swift
+//  whitenoise-mac
+//
+//  The two ways to send White Noise money: the public address, the caption that names
+//  it, and the short label the Donate page's method switcher shows.
+//
+
+import Foundation
+
+/// A way to donate to White Noise.
+nonisolated enum DonationMethod: String, CaseIterable, Identifiable, Sendable {
+    case lightning
+    case bitcoin
+
+    var id: String { rawValue }
+
+    static let lightningAddress = "whitenoise@donate.ipf.dev"
+
+    static let bitcoinSilentPaymentAddress =
+        "sp1qqvp56mxcj9pz9xudvlch5g4ah5hrc8rj6neu25p34rc9gxhp38cwqqlmld28u57w2srgckr34dkyg3q02phu8tm05cyj483q026xedp0s5f5j40p"
+
+    /// What goes on the pasteboard, and what the QR code encodes. Never a shortened form.
+    var address: String {
+        switch self {
+        case .lightning:
+            Self.lightningAddress
+        case .bitcoin:
+            Self.bitcoinSilentPaymentAddress
+        }
+    }
+
+    /// The method switcher's segment title. A protocol name, so it reads the same in every
+    /// language — the catalog carries it verbatim for all ten rather than leaving it out,
+    /// because `just locales` measures coverage and would count a missing entry as a gap.
+    var switcherLabel: String {
+        switch self {
+        case .lightning:
+            L10n.string("Lightning")
+        case .bitcoin:
+            L10n.string("Bitcoin")
+        }
+    }
+
+    /// The caption under the copy control, naming what the address above it is. Reuses the
+    /// catalog's existing `Lightning address` rather than adding a second entry that differs
+    /// only in capitalization — and that entry is the one whose translations keep "Lightning"
+    /// verbatim, which is this app's rule for a protocol name.
+    var addressLabel: String {
+        switch self {
+        case .lightning:
+            L10n.string("Lightning address")
+        case .bitcoin:
+            L10n.string("Bitcoin Silent Payment")
+        }
+    }
+
+    /// The address as drawn, which is not always the address as copied.
+    ///
+    /// A Lightning address is a human-readable handle at 25 characters — showing it whole is
+    /// the point of it, and it fits the settings column with room to spare. A silent payment
+    /// address is 117 characters of base32 that nobody reads end to end, so it takes the
+    /// head-and-tail form the identity sheet gives an npub. Deciding this here rather than
+    /// leaving both to `truncationMode(.middle)` keeps the capsule a predictable width and
+    /// stops the readable one from being clipped by a column that got narrower.
+    var displayAddress: String {
+        switch self {
+        case .lightning:
+            Self.lightningAddress
+        case .bitcoin:
+            DisplayText.short(Self.bitcoinSilentPaymentAddress, head: 14, tail: 6)
+        }
+    }
+
+    /// Localized description of the copy action, for the button's help tag and VoiceOver.
+    var copyActionDescription: String {
+        String(format: L10n.string("Copy %@"), addressLabel)
+    }
+
+    /// Localized description of the QR code, which is otherwise a bitmap with nothing to
+    /// announce.
+    var qrCodeAccessibilityLabel: String {
+        String(format: L10n.string("%@ QR code"), addressLabel)
+    }
+}

--- a/whitenoise-mac/Models/MessengerModels.swift
+++ b/whitenoise-mac/Models/MessengerModels.swift
@@ -2860,6 +2860,7 @@ enum SettingsPage: Equatable {
     case privacySecurity
     case notifications
     case storage
+    case donate
     case developerMode
 
     /// The drawer's cards, ported from `wn-ios-prototype`'s hub: a group of destinations per
@@ -2868,11 +2869,15 @@ enum SettingsPage: Equatable {
     ///
     /// The split follows the order that was already here rather than reordering to match the
     /// prototype row for row — the order encodes its own decision (see `sidebarPages`), and it
-    /// falls into these three groups without being disturbed:
+    /// falls into these two groups without being disturbed:
     ///
     /// - who you are and how you reach the network,
-    /// - how the app treats you,
-    /// - and what only a developer wants.
+    /// - and everything that is about the app rather than about your account.
+    ///
+    /// Donate belongs to that second card for the same reason `wn-ios-prototype`'s hub keeps it
+    /// on the support card beside Developer Tools: it is a page about the project, not a setting
+    /// that changes anything for the account signed in. It follows Preferences rather than
+    /// leading, because nobody opens settings to donate.
     static let sidebarGroups: [[SettingsPage]] = [
         [
             .profile,
@@ -2886,6 +2891,7 @@ enum SettingsPage: Equatable {
         ],
         [
             .preferences,
+            .donate,
             .developerMode,
         ],
     ]
@@ -2927,6 +2933,8 @@ enum SettingsPage: Equatable {
             "Notifications"
         case .storage:
             "Storage"
+        case .donate:
+            "Donate"
         case .developerMode:
             "Developer mode"
         }
@@ -2954,6 +2962,10 @@ enum SettingsPage: Equatable {
             "bell"
         case .storage:
             "externaldrive"
+        case .donate:
+            // Outline, not `heart.fill`: the prototype's Donate destination uses the outline
+            // symbol, and every other glyph in this drawer is an outline too.
+            "heart"
         case .developerMode:
             "wrench.and.screwdriver"
         }

--- a/whitenoise-mac/Views/Settings/DonateSettingsView.swift
+++ b/whitenoise-mac/Views/Settings/DonateSettingsView.swift
@@ -1,0 +1,132 @@
+//
+//  DonateSettingsView.swift
+//  whitenoise-mac
+//
+//  The Donate page: why to give, a switcher between the two ways to, and the selected
+//  one's address as both a QR code and something you can click to copy.
+//
+
+import SwiftUI
+
+/// Ported from `wn-ios-prototype`'s Donate destination, whose spec is a centred `heart`
+/// introduction, a palette `Picker` over **Lightning** and **Bitcoin**, and one method on
+/// screen at a time "so the selected QR receives the full visual focus".
+///
+/// Three things are deliberately not ports. The prototype puts the picker in the navigation
+/// bar's `principal` slot; a settings page here has `SettingsHeader` instead of a navigation
+/// bar, so the switcher moves into the content, centred directly above the code it switches.
+/// Its `.palette` style is iOS-only, so it becomes the `.segmented` style this app
+/// already uses for `GroupSharedMediaSection`. And the copy is the Flutter client's, not the
+/// prototype's: "As a 501(c)3 non-profit…" is the shipped product line and is already written
+/// in all ten of this catalog's languages, where the prototype's "free and open source"
+/// sentence exists only in English.
+///
+/// No wallet, payment or network integration — the same boundary the prototype's spec draws.
+struct DonateSettingsView: View {
+    @State private var selectedMethod = DonationMethod.lightning
+
+    var body: some View {
+        SettingsStackScaffold(title: L10n.string("Donate")) {
+            DonateIntroduction()
+
+            // Centred over the code it switches, which is where the prototype's principal
+            // toolbar slot put it. `SettingsStackScaffold` aligns its column leading, so the
+            // switcher has to ask for the centre; `fixedSize` is what keeps it at its natural
+            // two-segment width instead of stretching across the column between the spacers.
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+
+                Picker(L10n.string("Donation method"), selection: $selectedMethod) {
+                    ForEach(DonationMethod.allCases) { method in
+                        Text(method.switcherLabel).tag(method)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .fixedSize()
+
+                Spacer(minLength: 0)
+            }
+
+            DonationMethodDetail(method: selectedMethod)
+        }
+    }
+}
+
+/// The reason to give, before the means of giving.
+///
+/// Centred and transparent, with the outline `heart`: regular informational content rather
+/// than an unavailable state, so it is not a `WNEmptyStateView` and carries no card of its
+/// own. The heading is Flutter's `donateTitle` rather than the prototype's English-only
+/// "Support White Noise" — same job in the layout, and it arrives translated.
+private struct DonateIntroduction: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "heart")
+                .wnFont(.medium24)
+                .foregroundStyle(WNColor.backgroundContentPrimary)
+
+            Text(L10n.string("Donate to White Noise"))
+                .wnFont(.semiBold16)
+                .foregroundStyle(WNColor.backgroundContentPrimary)
+
+            Text(
+                L10n.string(
+                    "As a 501(c)3 non-profit, White Noise exists solely for your privacy and freedom, not for profit. Your support keeps us independent and uncompromised."
+                )
+            )
+            .wnFont(.medium14)
+            .foregroundStyle(WNColor.backgroundContentSecondary)
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 4)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// One donation method, drawn the way the prototype stacks it: the code, then the copy
+/// control, then the caption naming what was copied.
+///
+/// The QR takes the identity sheet's recipe — `QRCodeImageView` on an explicit
+/// `backgroundPrimary` card with a hair of quiet zone and no stroke. The explicit ground is
+/// not decoration: the code is rasterized into a bitmap with no appearance of its own, so it
+/// needs a surface it is guaranteed to contrast with rather than whatever shows through.
+///
+/// The gap above the copy control is wider than the identity sheet's, which is the prototype's
+/// instruction — "the QR-to-copy spacing remains deliberately larger than the compact grouping
+/// used on Share & Connect" — because here the copy control is the second way to do the same
+/// thing rather than a caption on the first.
+private struct DonationMethodDetail: View {
+    let method: DonationMethod
+
+    private let codeSize: CGFloat = 256
+    private let codePadding: CGFloat = 10
+
+    var body: some View {
+        VStack(spacing: 0) {
+            QRCodeImageView(payload: method.address)
+                .padding(codePadding)
+                .frame(width: codeSize, height: codeSize)
+                .background(WNColor.backgroundPrimary, in: .rect(cornerRadius: 16, style: .continuous))
+                .accessibilityElement()
+                .accessibilityLabel(Text(method.qrCodeAccessibilityLabel))
+
+            WNCopyCard(
+                displayText: method.displayAddress,
+                value: method.address,
+                actionDescription: method.copyActionDescription,
+                style: .pill
+            )
+            .padding(.top, 18)
+
+            Text(method.addressLabel)
+                .wnFont(.medium12)
+                .foregroundStyle(WNColor.backgroundContentTertiary)
+                .multilineTextAlignment(.center)
+                .padding(.top, 6)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/whitenoise-mac/Views/Settings/SettingsPanelView.swift
+++ b/whitenoise-mac/Views/Settings/SettingsPanelView.swift
@@ -40,6 +40,8 @@ struct SettingsPanelView: View {
                 NotificationsSettingsView()
             case .storage:
                 StorageSettingsView()
+            case .donate:
+                DonateSettingsView()
             case .developerMode:
                 DeveloperModeSettingsView()
             }

--- a/whitenoise-macTests/DonationMethodTests.swift
+++ b/whitenoise-macTests/DonationMethodTests.swift
@@ -1,0 +1,151 @@
+//
+//  DonationMethodTests.swift
+//  whitenoise-macTests
+//
+//  The Donate page's two methods: the exact addresses, which of them is shown whole,
+//  and the fact that every string the page draws comes out of the catalog.
+//
+
+import CoreImage
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import whitenoise_mac
+
+// `@MainActor` and serialized because `QRCodePalette.resolved(for:)` goes through
+// `performAsCurrentDrawingAppearance`, which takes the test host down if it runs off the main
+// actor or alongside another suite doing the same thing.
+@MainActor
+@Suite(.serialized)
+struct DonationMethodTests {
+
+    // MARK: - The addresses
+
+    // Transcribed from the Flutter client's `lib/screens/donate_screen.dart`, which is where
+    // the shipped pair lives. Spelled out again here rather than read back off
+    // `DonationMethod` so that this is an independent second copy: a test that compares the
+    // type to itself would pass just as happily after a typo.
+    private static let flutterLightningAddress = "whitenoise@donate.ipf.dev"
+    private static let flutterBitcoinAddress =
+        "sp1qqvp56mxcj9pz9xudvlch5g4ah5hrc8rj6neu25p34rc9gxhp38cwqqlmld28u57w2srgckr34dkyg3q02phu8tm05cyj483q026xedp0s5f5j40p"
+
+    /// The one thing on this page that must not drift. A wrong character here does not draw
+    /// badly or throw — it sends a donation to an address nobody controls, with no way to
+    /// notice and no way back.
+    @Test func donationAddressesMatchTheFlutterClientExactly() {
+        #expect(DonationMethod.lightning.address == Self.flutterLightningAddress)
+        #expect(DonationMethod.bitcoin.address == Self.flutterBitcoinAddress)
+    }
+
+    @Test func silentPaymentAddressKeepsItsFullLength() {
+        // 116 characters: the `sp1` human-readable prefix plus 113 of bech32m payload, the
+        // length a BIP-352 silent payment address carrying two 33-byte keys comes out at.
+        // Pinned because the failure mode of a truncated address is a string that still
+        // *looks* like an address.
+        #expect(DonationMethod.bitcoin.address.count == 116)
+        #expect(DonationMethod.bitcoin.address.hasPrefix("sp1"))
+    }
+
+    @Test func bothMethodsAreOfferedInProtocolOrder() {
+        // Lightning first, as in `wn-ios-prototype`'s picker, and the default selection: it is
+        // the address a reader can actually check by eye.
+        #expect(DonationMethod.allCases == [.lightning, .bitcoin])
+    }
+
+    // MARK: - What is drawn, versus what is copied
+
+    /// A Lightning address is a handle someone reads; a silent payment address is 117
+    /// characters nobody reads end to end. The page shows the first whole and shortens the
+    /// second — but copies both whole, which is the part that matters.
+    @Test func onlyTheSilentPaymentAddressIsShortenedForDisplay() {
+        #expect(DonationMethod.lightning.displayAddress == DonationMethod.lightning.address)
+
+        let shortened = DonationMethod.bitcoin.displayAddress
+        #expect(shortened != DonationMethod.bitcoin.address)
+        #expect(shortened.contains("..."))
+        #expect(shortened.hasPrefix("sp1qqvp56mxcj9"))
+        #expect(DonationMethod.bitcoin.address.hasSuffix(shortened.suffix(6)))
+    }
+
+    // MARK: - Localization
+
+    /// Every label the page draws resolves through the catalog. Asserted by key rather than
+    /// against English text: the test host runs with a persisted language preference, so a
+    /// literal comparison here would be a comparison against whatever language that is.
+    @Test func methodLabelsComeFromTheCatalog() {
+        #expect(DonationMethod.lightning.addressLabel == L10n.string("Lightning address"))
+        #expect(DonationMethod.bitcoin.addressLabel == L10n.string("Bitcoin Silent Payment"))
+        #expect(DonationMethod.lightning.switcherLabel == L10n.string("Lightning"))
+        #expect(DonationMethod.bitcoin.switcherLabel == L10n.string("Bitcoin"))
+    }
+
+    /// The protocol names stay themselves in every language — the rule this app already
+    /// follows for `KeyPackage` and the relay terms.
+    @Test func protocolNamesAreNotTranslated() {
+        for locale in [Locale(identifier: "es"), Locale(identifier: "ru"), Locale(identifier: "zh-Hans")] {
+            #expect(L10n.string("Lightning", locale: locale) == "Lightning")
+            #expect(L10n.string("Bitcoin", locale: locale) == "Bitcoin")
+        }
+    }
+
+    /// The copy and QR descriptions are built by formatting a catalog string, so a missing
+    /// entry would leave the raw `%@` on screen.
+    @Test func copyAndQRDescriptionsInterpolateTheMethodName() {
+        for method in DonationMethod.allCases {
+            #expect(!method.copyActionDescription.contains("%@"))
+            #expect(!method.qrCodeAccessibilityLabel.contains("%@"))
+            #expect(method.copyActionDescription.contains(method.addressLabel))
+            #expect(method.qrCodeAccessibilityLabel.contains(method.addressLabel))
+        }
+    }
+
+    // MARK: - The QR code
+
+    /// Each method's code decodes back to that method's *full* address, in both appearances.
+    ///
+    /// Decoded rather than measured, and asserted here rather than by snapshotting the page:
+    /// `QRCodeImageView` rasterizes on a detached task, so a render harness photographs the
+    /// spinner and proves nothing. What this rules out is the failure a reader cannot see — a
+    /// scannable, well-formed code carrying the shortened display string, which would hand a
+    /// wallet an address that can never receive.
+    @Test func everyMethodsCodeDecodesToItsFullAddress() throws {
+        let detector = try #require(
+            CIDetector(
+                ofType: CIDetectorTypeQRCode,
+                context: CIContext(options: nil),
+                options: [CIDetectorAccuracy: CIDetectorAccuracyHigh]))
+
+        for method in DonationMethod.allCases {
+            for scheme in [ColorScheme.light, ColorScheme.dark] {
+                let palette = QRCodePalette.resolved(for: scheme)
+                let image = try #require(
+                    QRCodeImageView.ciImage(for: method.address, palette: palette),
+                    "no code generated for \(method) in \(scheme)")
+                let decoded = detector.features(in: image).compactMap {
+                    ($0 as? CIQRCodeFeature)?.messageString
+                }
+                #expect(
+                    decoded == [method.address],
+                    "\(method) in \(scheme) decoded to \(decoded)")
+
+                // Only meaningful where the two differ: Lightning is displayed whole, so for
+                // that method the display form *is* the address.
+                if method.displayAddress != method.address {
+                    #expect(decoded.first != method.displayAddress)
+                }
+            }
+        }
+    }
+
+    // MARK: - Where the page sits
+
+    /// The prototype's hub keeps Donate on the support card beside Developer Tools, and the
+    /// ask here was the same: the card that already holds Preferences and Developer mode.
+    @Test func donateSitsBetweenPreferencesAndDeveloperMode() throws {
+        let card = try #require(
+            SettingsPage.sidebarGroups.first(where: { $0.contains(.donate) })
+        )
+        #expect(card == [.preferences, .donate, .developerMode])
+    }
+}

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -27443,6 +27443,7 @@ struct whitenoise_macTests {
                 .relays,
                 .keyPackages,
                 .preferences,
+                .donate,
                 .developerMode,
             ]
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Donate section to Settings.
  * Added Lightning and Bitcoin donation options with QR codes, copy actions, and donation addresses.
  * Added support for Bitcoin Silent Payment details.
  * Added localized donation content, nonprofit and privacy messaging, and accessibility labels across multiple languages.
* **Tests**
  * Added coverage for donation displays, localization, QR codes, address handling, and Settings navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->