### PR TITLE
Split ci steps into parallel lint, test, build and analyze jobs

### DIFF
--- a/.github/actions/marmotkit-cache/action.yml
+++ b/.github/actions/marmotkit-cache/action.yml
@@ -1,0 +1,18 @@
+name: Cache MarmotKit binary artifact
+description: >-
+  Restore the pinned MarmotKit XCFramework so a job that resolves SwiftPM does
+  not re-download it. Every job that runs xcodebuild needs this; the jobs that
+  only read source (swift-format, the localization catalogs) do not, and should
+  not use it.
+
+runs:
+  using: composite
+  steps:
+    - name: Cache MarmotKit binary artifact
+      uses: actions/cache@v4
+      with:
+        # MarmotKit is a pinned remote binaryTarget; without this each job
+        # re-downloads the XCFramework. The checksum lives in Package.swift,
+        # so the key rotates exactly when the artifact does.
+        path: ~/Library/Caches/org.swift.swiftpm/artifacts
+        key: marmotkit-${{ hashFiles('Vendored/MarmotKit/Package.swift') }}

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -21,33 +21,28 @@ env:
   SCHEME: whitenoise-mac
   DESTINATION: platform=macOS
 
+# The four jobs below are independent by construction, so they run in parallel
+# and the PR's wall clock is the slowest one rather than their sum. Nothing is
+# shared between them to lose: `test` compiles Debug, `build` compiles Release
+# and `analyze` compiles Debug under the analyzer, so even when these steps sat
+# in one job they never reused a single object file.
+#
+# `PR Checks` at the bottom is the aggregate gate. Keep that name: it is what
+# branch protection requires, and it is the only status that has to be green.
 jobs:
-  test-and-build:
-    name: PR Checks
+  checks:
+    name: Static checks
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 15
 
     steps:
       - name: Check out
         uses: actions/checkout@v4
 
-      - name: Cache MarmotKit binary artifact
-        uses: actions/cache@v4
-        with:
-          # MarmotKit is a pinned remote binaryTarget; without this each job
-          # re-downloads the XCFramework. The checksum lives in Package.swift,
-          # so the key rotates exactly when the artifact does.
-          path: ~/Library/Caches/org.swift.swiftpm/artifacts
-          key: marmotkit-${{ hashFiles('Vendored/MarmotKit/Package.swift') }}
-
-      - name: Show Xcode environment
-        run: |
-          sw_vers
-          xcodebuild -version
-          xcodebuild -showsdks
-          xcodebuild -list -project "$PROJECT"
-          xcodebuild -showTestPlans -project "$PROJECT" -scheme "$SCHEME"
-
+      # Ordered cheapest-first, and each one runs even when an earlier one
+      # failed. These three checks are seconds of work apiece, so splitting them
+      # across runners would buy no wall clock -- but letting a formatting slip
+      # hide a missing translation would cost a whole extra round trip.
       - name: Swift format lint
         run: |
           xcrun swift-format lint \
@@ -60,10 +55,38 @@ jobs:
             whitenoise-macUITests
 
       - name: Localization coverage
+        if: ${{ !cancelled() }}
         run: scripts/ci/check-localizations.sh
 
+      # Only the steps below here resolve SwiftPM, so the cache is restored late.
+      - name: Cache MarmotKit binary artifact
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/marmotkit-cache
+
+      - name: Show Xcode environment
+        if: ${{ !cancelled() }}
+        run: |
+          sw_vers
+          xcodebuild -version
+          xcodebuild -showsdks
+          xcodebuild -list -project "$PROJECT"
+          xcodebuild -showTestPlans -project "$PROJECT" -scheme "$SCHEME"
+
       - name: macOS project sanity checks
+        if: ${{ !cancelled() }}
         run: scripts/ci/macos-sanity-checks.sh
+
+  test:
+    name: Unit tests
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Cache MarmotKit binary artifact
+        uses: ./.github/actions/marmotkit-cache
 
       - name: Unit tests
         run: |
@@ -87,6 +110,18 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  build:
+    name: Release build
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Cache MarmotKit binary artifact
+        uses: ./.github/actions/marmotkit-cache
+
       - name: Release build smoke (arm64)
         run: |
           set -o pipefail
@@ -99,8 +134,8 @@ jobs:
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO
 
-  static-analysis:
-    name: Static Analysis
+  analyze:
+    name: Static analysis
     runs-on: macos-26
     timeout-minutes: 30
 
@@ -109,13 +144,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache MarmotKit binary artifact
-        uses: actions/cache@v4
-        with:
-          # MarmotKit is a pinned remote binaryTarget; without this each job
-          # re-downloads the XCFramework. The checksum lives in Package.swift,
-          # so the key rotates exactly when the artifact does.
-          path: ~/Library/Caches/org.swift.swiftpm/artifacts
-          key: marmotkit-${{ hashFiles('Vendored/MarmotKit/Package.swift') }}
+        uses: ./.github/actions/marmotkit-cache
 
       - name: Analyze Debug build
         run: |
@@ -126,3 +155,33 @@ jobs:
             -configuration Debug \
             -destination "$DESTINATION" \
             CODE_SIGNING_ALLOWED=NO
+
+  # Single required status for branch protection. Without this, splitting the
+  # old `PR Checks` job would leave the branch gated on a check that no longer
+  # reports, which reads as "waiting" forever rather than as a failure.
+  pr-checks:
+    name: PR Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs: [checks, test, build, analyze]
+
+    steps:
+      - name: Report job results
+        run: |
+          printf 'static checks   : %s\n' "${{ needs.checks.result }}"
+          printf 'unit tests      : %s\n' "${{ needs.test.result }}"
+          printf 'release build   : %s\n' "${{ needs.build.result }}"
+          printf 'static analysis : %s\n' "${{ needs.analyze.result }}"
+
+      # `success()` is not enough on its own: with `if: always()` a skipped or
+      # cancelled dependency would otherwise let the gate pass.
+      - name: Fail if any job did not succeed
+        if: >-
+          ${{ needs.checks.result != 'success'
+           || needs.test.result != 'success'
+           || needs.build.result != 'success'
+           || needs.analyze.result != 'success' }}
+        run: |
+          echo "::error::One or more Mac CI jobs did not succeed."
+          exit 1

--- a/justfile
+++ b/justfile
@@ -1,6 +1,18 @@
 # Local mirror of .github/workflows/mac-ci.yml.
 # Keep the recipes below in sync with that workflow so `just precommit`
 # stays a faithful predictor of the GitHub Actions result.
+#
+# CI runs these as four independent jobs in parallel; `just precommit` runs the
+# same work serially, cheapest-first, so a formatting slip fails in seconds
+# instead of after a Release build. The recipes map one-to-one:
+#
+#   CI job "Static checks"   -> just checks   (lint, locales, sanity)
+#   CI job "Unit tests"      -> just test
+#   CI job "Release build"   -> just build-release
+#   CI job "Static analysis" -> just analyze
+#
+# CI's "PR Checks" is only an aggregate gate over those four; it has no local
+# counterpart beyond `just precommit` itself.
 
 PROJECT := "whitenoise-mac.xcodeproj"
 SCHEME := "whitenoise-mac"
@@ -15,10 +27,13 @@ default: precommit
 help:
     @just --list
 
-# Run everything CI runs on a PR — both the "PR Checks" and "Static Analysis" jobs
-precommit: lint locales sanity test build-release analyze
+# Run everything CI runs on a PR — all four jobs, serially
+precommit: checks test build-release analyze
     @echo ""
     @echo "✅ precommit passed — mac-ci.yml should be green."
+
+# CI job: Static checks — the three checks that need no compile of their own
+checks: lint locales sanity
 
 # CI step: Swift format lint (strict — warnings fail the build)
 lint:
@@ -71,7 +86,7 @@ build-release:
         ONLY_ACTIVE_ARCH=NO \
         CODE_SIGNING_ALLOWED=NO
 
-# CI job: Static Analysis — analyze the Debug build
+# CI job: Static analysis — analyze the Debug build
 analyze:
     xcodebuild analyze \
         -project "{{PROJECT}}" \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Split macOS validation into dedicated checks, tests, release build, and static analysis jobs.
  - Added a required aggregate status check to report overall pull request readiness.
  - Improved caching for faster MarmotKit-related builds.

- **Developer Experience**
  - Updated local precommit commands to match the CI workflow.
  - Added a consolidated checks command for linting, localization, and sanity checks.
  - Refreshed documentation for local validation recipes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->