### PR TITLE
Isolate test storage roots per test and per process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,26 @@ are isolated in the `UIPerformance` test plan, and launch the app with the
 DEBUG-only `-uiFixture heavy-chat` argument for deterministic chat/search/media
 data.
 
+## Test isolation on disk
+
+Tests write real files, so every on-disk root a test double hands out is isolated
+per test and per process by default — see `whitenoise-macTests/Support/TestStorageRoot.swift`.
+
+- `FakeMarmotRuntime(accounts:)` reports a `storageRootPath` unique to the running
+  test. `WorkspaceState` builds a `HiddenMessageFileStore`, `PinnedChatFileStore`,
+  `ContactNicknameFileStore` and `DirectPeerMemoryFileStore` under it for every store
+  the test did not inject, so a test that forgets to inject one now reads an empty
+  directory instead of another test's records. Two doubles built during the *same*
+  test still share a root, which is what a relaunch test needs. Pass
+  `storageRoot: .explicit(path)` only to share a directory on purpose.
+- `MessageMediaDiskCache.shared` — the default for `WorkspaceState`'s `mediaDiskCache`
+  parameter, which almost no test overrides — resolves to a per-process temporary
+  directory and a fixed in-memory key under a test run, never to the user's real
+  Application Support directory or Keychain. A test that asserts on cache contents
+  should still build its own with `MessageMediaDiskCache.makeIsolated()`.
+- Do not reintroduce a fixed shared path. Isolation that has to be remembered is
+  isolation that gets forgotten; `StorageRootIsolationTests` guards these properties.
+
 ## Localization
 
 All user-facing strings live in the single String Catalog

--- a/whitenoise-mac/Core/MessageMediaDiskCache.swift
+++ b/whitenoise-mac/Core/MessageMediaDiskCache.swift
@@ -195,7 +195,51 @@ nonisolated final class MessageMediaDiskCache: @unchecked Sendable {
         }
     }
 
-    static let shared = MessageMediaDiskCache()
+    #if DEBUG
+        /// The app-wide cache.
+        ///
+        /// Under a test run this deliberately resolves somewhere other than the real
+        /// Application Support directory and the real Keychain. `WorkspaceState`'s
+        /// `mediaDiskCache` parameter defaults to this instance, and the overwhelming
+        /// majority of tests never think about media, so a single test that stored one
+        /// payload used to leave an encrypted record in the installed app's cache —
+        /// where a later run would read it back and pass, or fail, for reasons that had
+        /// nothing to do with the test.
+        static let shared = isRunningUnderTest ? testProcessScoped() : MessageMediaDiskCache()
+
+        /// XCTest is only linked into the host process when the host is running tests,
+        /// so its presence is the signal. Swift Testing runs inside that same host here.
+        private static var isRunningUnderTest: Bool {
+            NSClassFromString("XCTestCase") != nil
+                || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        }
+
+        /// A cache scoped to this test process: a fresh temporary directory that no
+        /// later run can name, and a fixed in-memory key so nothing prompts for
+        /// Keychain access mid-suite.
+        ///
+        /// This is the floor, not per-test isolation — a test that asserts on cache
+        /// contents should still build its own with `makeIsolated`.
+        private static func testProcessScoped() -> MessageMediaDiskCache {
+            let root = FileManager.default.temporaryDirectory
+                .appending(path: "whitenoise-mac-tests", directoryHint: .isDirectory)
+                .appending(
+                    path: "shared-media-cache-\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString)",
+                    directoryHint: .isDirectory
+                )
+            return MessageMediaDiskCache(
+                directoryResolver: { root },
+                keyProvider: { SymmetricKey(data: Data(repeating: 0x5A, count: 32)) },
+                keyDeleter: {}
+            )
+        }
+
+        /// The directory this cache reads and writes. Test-only, so a test can prove
+        /// `shared` is not pointed at the user's real Application Support directory.
+        var testingResolvedDirectoryURL: URL? { try? directoryResolver() }
+    #else
+        static let shared = MessageMediaDiskCache()
+    #endif
 
     private static let directoryName = "WhiteNoiseMediaCache"
     private static let versionDirectoryName = "v1"

--- a/whitenoise-macTests/StorageRootIsolationTests.swift
+++ b/whitenoise-macTests/StorageRootIsolationTests.swift
@@ -1,0 +1,186 @@
+//
+//  StorageRootIsolationTests.swift
+//  whitenoise-macTests
+//
+//  The guarantees `TestStorageRoot` exists to make. This file lives outside
+//  `whitenoise_macTests.swift` on purpose: constructing `FakeMarmotRuntime` here at
+//  all is half of what is under test.
+//
+
+import Foundation
+import MarmotKit
+import Testing
+
+@testable import whitenoise_mac
+
+/// Roots handed out during this run, so a test can assert it did not receive one that
+/// another test already holds. Serialized, so the appends do not race.
+private nonisolated final class RootLedger: @unchecked Sendable {
+    static let shared = RootLedger()
+    private let lock = NSLock()
+    private var roots: [String: String] = [:]
+
+    /// Records `root` under `owner` and returns the roots every *other* owner holds.
+    func claim(_ root: String, owner: String) -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        roots[owner] = root
+        return roots.filter { $0.key != owner }.map(\.value)
+    }
+}
+
+private func account(_ idHex: String) -> AccountSummaryFfi {
+    AccountSummaryFfi(
+        label: idHex,
+        accountIdHex: idHex,
+        localSigning: true,
+        externalSigning: false,
+        signedOut: false,
+        running: false
+    )
+}
+
+/// A fake built somewhere other than the test body — the case `#function` alone gets
+/// wrong, because it would name this helper for every test that called it.
+private func runtimeFromASharedHelper() -> FakeMarmotRuntime {
+    FakeMarmotRuntime(accounts: [account(String(repeating: "1", count: 64))])
+}
+
+@Suite(.serialized)
+struct StorageRootIsolationTests {
+
+    @Test func aRuntimeBuiltWithNoArgumentsGetsAnIsolatedRoot() {
+        let runtime = FakeMarmotRuntime(accounts: [])
+
+        // The old fixed constant, which every suite shared.
+        #expect(runtime.storageRootPath != "/tmp/whitenoise-mac-tests")
+        #expect(runtime.storageRootPath.hasPrefix(TestStorageRoot.processRoot.path(percentEncoded: false)))
+    }
+
+    @Test func twoRuntimesInOneTestShareARoot() {
+        // A relaunch test builds a second runtime and expects it to read what the first
+        // one wrote, so isolation is per test, not per instance.
+        let first = FakeMarmotRuntime(accounts: [])
+        let second = FakeMarmotRuntime(accounts: [account(String(repeating: "b", count: 64))])
+
+        #expect(first.storageRootPath == second.storageRootPath)
+    }
+
+    @Test func aRuntimeBuiltInsideAHelperStillLandsInTheCallingTestsRoot() {
+        let direct = FakeMarmotRuntime(accounts: [])
+        let viaHelper = runtimeFromASharedHelper()
+
+        #expect(direct.storageRootPath == viaHelper.storageRootPath)
+    }
+
+    @Test func noOtherTestInThisRunHoldsThisTestsRoot() {
+        let root = FakeMarmotRuntime(accounts: []).storageRootPath
+        let othersHold = RootLedger.shared.claim(root, owner: #function)
+
+        #expect(!othersHold.contains(root))
+    }
+
+    /// The twin of the test above: two tests claiming, so whichever runs second is
+    /// actually comparing against something.
+    @Test func noOtherTestInThisRunHoldsThisTestsRootEither() {
+        let root = FakeMarmotRuntime(accounts: []).storageRootPath
+        let othersHold = RootLedger.shared.claim(root, owner: #function)
+
+        #expect(!othersHold.contains(root))
+    }
+
+    @Test func anExplicitRootIsHonouredVerbatim() {
+        let shared = "/tmp/whitenoise-mac-tests"
+        let runtime = FakeMarmotRuntime(accounts: [], storageRoot: .explicit(shared))
+
+        #expect(runtime.storageRootPath == shared)
+    }
+
+    /// What isolation is *for*: a store the test did not inject reads an empty directory
+    /// rather than whatever an earlier test left behind.
+    @Test func anUninjectedStoreStartsEmptyUnderAnIsolatedRoot() throws {
+        let runtime = FakeMarmotRuntime(accounts: [])
+        let owner = String(repeating: "c", count: 64)
+
+        let contact = String(repeating: "d", count: 64)
+
+        let store = ContactNicknameFileStore(storageRootPath: runtime.storageRootPath)
+        #expect(try store.loadAll().isEmpty)
+
+        try store.write([contact: "Mum"], forOwnerAccountIdHex: owner)
+
+        // Written under this test's root, and nowhere near the constant that used to be shared.
+        let reread = ContactNicknameFileStore(storageRootPath: runtime.storageRootPath)
+        #expect(try reread.loadAll()[owner]?[contact] == "Mum")
+    }
+
+    // MARK: - Media cache
+
+    @Test func theSharedMediaCacheNeverResolvesIntoApplicationSupport() throws {
+        let resolved = try #require(MessageMediaDiskCache.shared.testingResolvedDirectoryURL)
+        let applicationSupport = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+
+        #expect(!resolved.path(percentEncoded: false).hasPrefix(applicationSupport.path(percentEncoded: false)))
+        #expect(
+            resolved.path(percentEncoded: false)
+                .hasPrefix(FileManager.default.temporaryDirectory.path(percentEncoded: false))
+        )
+    }
+
+    /// `WorkspaceState` defaults `mediaDiskCache` to `.shared`, which is the parameter
+    /// ~500 tests leave alone. That default must be the test-scoped instance.
+    @MainActor
+    @Test func aWorkspaceBuiltWithNoCacheGetsTheTestScopedOne() throws {
+        let state = WorkspaceState()
+        let resolved = try #require(state.mediaDiskCache.testingResolvedDirectoryURL)
+
+        #expect(
+            resolved.path(percentEncoded: false)
+                .hasPrefix(FileManager.default.temporaryDirectory.path(percentEncoded: false))
+        )
+    }
+
+    @Test func anIsolatedMediaCacheRoundTripsInsideItsOwnRoot() async throws {
+        let root = MessageMediaDiskCache.isolatedDirectoryURL()
+        let cache = MessageMediaDiskCache.makeIsolated()
+        let plaintext = Data("isolated payload".utf8)
+        let key = MessageMediaDiskCacheKey(
+            accountId: String(repeating: "e", count: 64),
+            groupIdHex: "group",
+            reference: MediaAttachmentReferenceFfi(
+                locators: [],
+                ciphertextSha256: String(repeating: "ab", count: 32),
+                // The cache verifies a payload it reads back against this digest, so it has
+                // to be the real hash of the bytes, not a placeholder.
+                plaintextSha256: MessageMediaDiskCacheKey.plaintextDigest(for: plaintext),
+                nonceHex: String(repeating: "00", count: 12),
+                fileName: "notes.txt",
+                mediaType: "text/plain",
+                version: .v1,
+                sourceEpoch: 7,
+                dim: nil,
+                thumbhash: nil
+            )
+        )
+
+        await cache.store(
+            MessageMediaDownload(
+                data: plaintext,
+                fileName: "notes.txt",
+                mediaType: "text/plain",
+                sizeBytes: UInt64(plaintext.count),
+                payloadId: "isolated-root"
+            ),
+            for: key
+        )
+
+        #expect(await cache.cachedDownload(for: key)?.data == plaintext)
+        #expect(FileManager.default.fileExists(atPath: root.path(percentEncoded: false)))
+        #expect(root.path(percentEncoded: false).hasPrefix(TestStorageRoot.processRoot.path(percentEncoded: false)))
+    }
+}

--- a/whitenoise-macTests/Support/FakeMarmotRuntime.swift
+++ b/whitenoise-macTests/Support/FakeMarmotRuntime.swift
@@ -24,7 +24,11 @@ nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sendable {
     /// the runtime failing to come online (e.g. shutting down). Used to exercise the
     /// add-account failure path that must not commit the active-account switch (#333).
     var startError: Error?
-    let storageRootPath = "/tmp/whitenoise-mac-tests"
+    /// Where the app writes the files it keeps beside the core — the hidden-message,
+    /// pinned-chat, contact-nickname and direct-peer stores `WorkspaceState` builds for
+    /// itself whenever a test does not inject one. Defaulted per test by
+    /// `TestStorageRoot.isolated`; see that type for why it is not one shared constant.
+    let storageRootPath: String
     private var profile = UserProfileMetadataFfi(
         name: "desktop",
         displayName: "Desktop Account",
@@ -668,9 +672,22 @@ nonisolated final class FakeMarmotRuntime: MarmotRuntime, @unchecked Sendable {
     /// use it to advance an injected clock and model a slow batch (whitenoise-mac#181).
     var onUserProfileLookup: (@Sendable (String) -> Void)?
 
-    init(accounts: [AccountSummaryFfi], createdAccount: AccountSummaryFfi? = nil) {
+    /// - Parameters:
+    ///   - storageRoot: Where this fake reports its storage root. Isolated per test by
+    ///     default, so a test that forgets to inject a file store still cannot read
+    ///     another test's records; pass `.explicit` only to share a directory on purpose.
+    ///   - function: Do not pass these. They default at the call site, which is how the
+    ///     isolated root falls back to naming the caller when there is no running test.
+    init(
+        accounts: [AccountSummaryFfi],
+        createdAccount: AccountSummaryFfi? = nil,
+        storageRoot: TestStorageRoot = .isolated,
+        function: StaticString = #function,
+        fileID: StaticString = #fileID
+    ) {
         self.storedAccounts = accounts
         self.createdAccount = createdAccount
+        self.storageRootPath = storageRoot.resolvedPath(function: function, fileID: fileID)
     }
 
     func start() async throws {

--- a/whitenoise-macTests/Support/MessageMediaDiskCacheTestFactory.swift
+++ b/whitenoise-macTests/Support/MessageMediaDiskCacheTestFactory.swift
@@ -1,0 +1,55 @@
+//
+//  MessageMediaDiskCacheTestFactory.swift
+//  whitenoise-macTests
+//
+//  Building a media cache that belongs to one test and nothing else.
+//
+
+import CryptoKit
+import Foundation
+
+@testable import whitenoise_mac
+
+nonisolated extension MessageMediaDiskCache {
+    /// A cache in a directory belonging to the running test alone, keyed by a fixed
+    /// in-memory key rather than the user's Keychain.
+    ///
+    /// Prefer this over constructing `MessageMediaDiskCache` directly: the directory
+    /// resolver is the parameter it is easiest to leave at its default, and its default
+    /// is the user's real Application Support directory.
+    ///
+    /// `function` and `fileID` are the fallback the isolated root uses when it is built
+    /// outside a running test's task — do not pass them.
+    static func makeIsolated(
+        keyData: Data = Data(repeating: 0x42, count: 32),
+        evictionPolicy: EvictionPolicy = .standard,
+        timestampProvider: @escaping TimestampProvider = { Date().timeIntervalSince1970 },
+        sessionStartedAtUnixSeconds: TimeInterval = Date().timeIntervalSince1970,
+        keyDeleter: @escaping KeyDeleter = {},
+        function: StaticString = #function,
+        fileID: StaticString = #fileID
+    ) -> MessageMediaDiskCache {
+        let root = isolatedDirectoryURL(function: function, fileID: fileID)
+        return MessageMediaDiskCache(
+            directoryResolver: { root },
+            keyProvider: { SymmetricKey(data: keyData) },
+            keyDeleter: keyDeleter,
+            timestampProvider: timestampProvider,
+            evictionPolicy: evictionPolicy,
+            sessionStartedAtUnixSeconds: sessionStartedAtUnixSeconds
+        )
+    }
+
+    /// The directory `makeIsolated` would use, for a test that needs to look at the
+    /// files on disk or hand the same root to a second cache instance.
+    static func isolatedDirectoryURL(
+        function: StaticString = #function,
+        fileID: StaticString = #fileID
+    ) -> URL {
+        URL(
+            fileURLWithPath: TestStorageRoot.isolated.resolvedPath(function: function, fileID: fileID),
+            isDirectory: true
+        )
+        .appending(path: "media-cache", directoryHint: .isDirectory)
+    }
+}

--- a/whitenoise-macTests/Support/TestStorageRoot.swift
+++ b/whitenoise-macTests/Support/TestStorageRoot.swift
@@ -1,0 +1,129 @@
+//
+//  TestStorageRoot.swift
+//  whitenoise-macTests
+//
+//  Where a test's on-disk state goes, and why it is never a fixed shared path.
+//
+
+import CryptoKit
+import Foundation
+import Testing
+
+/// The directory a test double writes into.
+///
+/// Tests write real files. `WorkspaceState` builds a `HiddenMessageFileStore`,
+/// `PinnedChatFileStore`, `ContactNicknameFileStore` and `DirectPeerMemoryFileStore`
+/// under `runtime.storageRootPath` for every store the test did not inject, and
+/// `MessageMediaDiskCache` keeps encrypted payloads under a root of its own. While
+/// that path was one fixed constant (`/tmp/whitenoise-mac-tests`), a test that
+/// omitted store injection read whatever an earlier test — or an earlier *run* —
+/// had left there, and could pass for the wrong reason.
+///
+/// Remembering to isolate is not a thing anyone should have to remember, so
+/// `.isolated` is the default everywhere this type is accepted and naming a shared
+/// directory is the case you have to write out.
+nonisolated enum TestStorageRoot: Sendable {
+    /// A directory belonging to the running test alone, inside a directory belonging
+    /// to this process alone.
+    ///
+    /// Two doubles built during the same test share it — a relaunch test needs its
+    /// second runtime to read what the first one wrote — while nothing built during
+    /// another test, or another run of the suite, can reach it.
+    case isolated
+
+    /// An explicit path, for the rare test that needs to name the directory itself
+    /// (asserting on the path, or handing the same directory to something that does
+    /// not take a `TestStorageRoot`).
+    case explicit(String)
+
+    /// The absolute directory path. Nothing is created here: the file stores and the
+    /// media cache each create their own directories on first write.
+    ///
+    /// `function` and `fileID` are defaulted *at this call site* on purpose. Magic
+    /// literals only resolve to the caller when they are direct default arguments, so
+    /// a `TestStorageRoot.isolated` factory could not capture them on its own — the
+    /// initializer that takes the root has to pass them down.
+    func resolvedPath(function: StaticString = #function, fileID: StaticString = #fileID) -> String {
+        switch self {
+        case .explicit(let path):
+            return path
+        case .isolated:
+            return Self.processRoot
+                .appending(path: Self.testToken(function: function, fileID: fileID))
+                .path(percentEncoded: false)
+        }
+    }
+
+    // MARK: - Per-process root
+
+    /// The parent every isolated path hangs off, unique to this process.
+    ///
+    /// Per *process* rather than per *test* is what retires the "passes the first
+    /// time, fails on every later local run" failure: a record written by a previous
+    /// `xcodebuild test` is in a directory this run cannot name.
+    static let processRoot: URL = {
+        let container = FileManager.default.temporaryDirectory
+            .appending(path: "whitenoise-mac-tests", directoryHint: .isDirectory)
+        let root = container.appending(
+            path: "run-\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString)",
+            directoryHint: .isDirectory
+        )
+        sweepStaleRuns(in: container, keeping: root)
+        return root
+    }()
+
+    /// Drops roots left by runs that are long over, so an unattended machine does not
+    /// accumulate one directory tree per `just test`. The cutoff is deliberately far
+    /// past any plausible run length — concurrent sessions on this machine are normal,
+    /// and sweeping a live run's root out from under it would be worse than the litter.
+    private static func sweepStaleRuns(in container: URL, keeping current: URL) {
+        let fileManager = FileManager.default
+        let cutoff = Date(timeIntervalSinceNow: -24 * 60 * 60)
+        let runs =
+            (try? fileManager.contentsOfDirectory(
+                at: container,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+        for run in runs where run.lastPathComponent != current.lastPathComponent {
+            let modified = try? run.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate
+            guard let modified, modified < cutoff else { continue }
+            try? fileManager.removeItem(at: run)
+        }
+    }
+
+    // MARK: - Per-test token
+
+    /// A filesystem-safe name for the running test.
+    ///
+    /// `Test.current` is the test that is running however deep the call is, so a
+    /// double constructed inside a shared helper still lands in the calling test's
+    /// directory. `#function` cannot do that — it would name the helper, and every
+    /// test that called the helper would share one directory again. The literals are
+    /// the fallback for construction outside a test's task, where `Test.current` is nil.
+    static func testToken(function: StaticString, fileID: StaticString) -> String {
+        if let id = Test.current?.id {
+            return sanitized(String(describing: id))
+        }
+        return sanitized("\(fileID).\(function)")
+    }
+
+    /// Path components have to survive being a directory name, and a Swift Testing id
+    /// carries the whole suite path, so long names are truncated onto a digest of the
+    /// full one rather than colliding at the prefix.
+    private static func sanitized(_ token: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        let scrubbed = String(
+            String.UnicodeScalarView(
+                token.unicodeScalars.map { allowed.contains($0) ? $0 : "-" }
+            )
+        )
+        guard scrubbed.count > 120 else { return scrubbed.isEmpty ? "unnamed-test" : scrubbed }
+        let digest = SHA256.hash(data: Data(token.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+            .prefix(16)
+        return "\(scrubbed.prefix(100))-\(digest)"
+    }
+}

--- a/whitenoise-macTests/whitenoise_macTests.swift
+++ b/whitenoise-macTests/whitenoise_macTests.swift
@@ -1019,7 +1019,7 @@ struct whitenoise_macTests {
         let (state, _) = Self.improvementsPromptWorkspace(store: store)
 
         state.isImprovementsPromptPresented = true
-        state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-mac-tests")
+        state.resetToNewInstallState(storageRootPath: TestStorageRoot.isolated.resolvedPath())
 
         #expect(store.clearAllCallCount == 1)
         #expect(store.offered.isEmpty)
@@ -14528,7 +14528,7 @@ struct whitenoise_macTests {
 
         state.setRestoreLastSelectedChat(true)
         #expect(store.targetsByAccount[account.accountIdHex] == chat.id)
-        state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-chat-restoration-reset-test")
+        state.resetToNewInstallState(storageRootPath: TestStorageRoot.isolated.resolvedPath())
         #expect(store.targetsByAccount.isEmpty)
     }
 
@@ -22597,8 +22597,8 @@ struct whitenoise_macTests {
                 lud16: nil
             )
         )
-        // `FakeMarmotRuntime.storageRootPath` is a fixed shared path, so an injected store is what
-        // guarantees this starts with nothing recorded rather than reading another test's file.
+        // `FakeMarmotRuntime.storageRootPath` is already isolated per test, so this injection is
+        // about naming the directory the assertions below reason over, not about isolation.
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
             .appendingPathComponent("whitenoise-direct-peer-\(UUID().uuidString)", isDirectory: true)
@@ -29562,7 +29562,7 @@ struct whitenoise_macTests {
         let state = WorkspaceState.preview()
         let url = try armInProgressVoiceRecording(on: state)
 
-        state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-reset-test")
+        state.resetToNewInstallState(storageRootPath: TestStorageRoot.isolated.resolvedPath())
 
         #expect(!state.isRecordingVoiceMessage)
         #expect(state.voiceRecordingMeterTask == nil)
@@ -29584,7 +29584,7 @@ struct whitenoise_macTests {
         state.isLoadingComposeContacts = true
         state.composeContactsGeneration = 41
 
-        state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-reset-test")
+        state.resetToNewInstallState(storageRootPath: TestStorageRoot.isolated.resolvedPath())
 
         #expect(state.composeContacts.isEmpty)
         #expect(!state.isLoadingComposeContacts)
@@ -29601,7 +29601,7 @@ struct whitenoise_macTests {
         )
         state.conversationMetadataGenerationByChat["shared-group"] = 41
 
-        state.resetToNewInstallState(storageRootPath: "/tmp/whitenoise-reset-test")
+        state.resetToNewInstallState(storageRootPath: TestStorageRoot.isolated.resolvedPath())
 
         // A full local-data wipe must not retain metadata describing the departed identity's
         // group role, membership, or disappearing-message timer. See #628.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by isolating temporary storage and media caches between tests.
  * Preserved shared storage behavior when explicitly requested.
  * Added safeguards to detect unintended storage reuse.

* **Documentation**
  * Documented storage isolation behavior, cache defaults, and options for explicitly sharing test storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->